### PR TITLE
chore: strip conda prefix from environment.yml via pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,10 @@ repos:
         entry: bash -c 'cd frontend && npx tsc -b --noEmit'
         pass_filenames: false
         files: ^frontend/src/.*\.(ts|tsx)$
+
+      - id: strip-conda-prefix
+        name: Strip conda environment prefix
+        language: system
+        entry: bash -c 'sed -i "/^prefix:/d" environment.yml'
+        files: ^environment\.yml$
+        pass_filenames: false

--- a/environment.yml
+++ b/environment.yml
@@ -118,5 +118,4 @@ dependencies:
       - watchfiles==1.1.1
       - wcwidth==0.6.0
       - websockets==16.0
-prefix: C:\Users\derek\.conda\envs\weaving_site
 


### PR DESCRIPTION
## Summary

- Removes the `prefix:` line from `environment.yml` (was `C:\Users\derek\.conda\envs\weaving_site`)
- Adds a `strip-conda-prefix` pre-commit hook that strips `prefix:` on any future commit to `environment.yml`

## Why

`conda env export` always writes a `prefix:` line with the local environment path. It's machine-specific and shouldn't be in the repo. The hook prevents it from being re-introduced after any future `conda env export` regeneration.

## Test plan

- [x] CI passes
- [x] `environment.yml` contains no `prefix:` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)