### PR TITLE
feat: replace GitHub repo link placeholders on About and Privacy pages

### DIFF
--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -53,8 +53,16 @@ export function AboutPage() {
           <div className="space-y-3">
             <h2 className="text-lg font-semibold">Source code</h2>
             <p className="text-stone-600 leading-relaxed">
-              The source code will be available on GitHub once the repository is made public.{" "}
-              <span className="text-stone-400 text-sm">[Link coming — see issue #52]</span>
+              The source code is available on{" "}
+              <a
+                href="https://github.com/weftmark/weftmark"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-amber-800 underline hover:text-amber-900 transition-colors"
+              >
+                GitHub
+              </a>
+              .
             </p>
           </div>
         </div>

--- a/frontend/src/pages/PrivacyPage.tsx
+++ b/frontend/src/pages/PrivacyPage.tsx
@@ -49,9 +49,16 @@ export function PrivacyPage() {
           <div className="space-y-3">
             <h2 className="text-lg font-semibold">Questions</h2>
             <p className="text-stone-600 leading-relaxed">
-              If you have questions about your data, reach out through the project's GitHub
-              repository.{" "}
-              <span className="text-stone-400 text-sm">[Link coming — see issue #52]</span>
+              If you have questions about your data, reach out through the{" "}
+              <a
+                href="https://github.com/weftmark/weftmark"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-amber-800 underline hover:text-amber-900 transition-colors"
+              >
+                project's GitHub repository
+              </a>
+              .
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- **`/about`** — source code section now links to `https://github.com/weftmark/weftmark`
- **`/privacy`** — questions section links to the same repo
- Both links open in a new tab with `rel="noopener noreferrer"` and use the amber underline style consistent with the page palette
- Removes the `[Link coming — see issue #52]` placeholder spans

Migrated from Gitea PR #113.

## Test plan
- [ ] Visit `/about` — confirm GitHub link renders and is clickable
- [ ] Visit `/privacy` — confirm GitHub link renders and is clickable
- [ ] Both links open `https://github.com/weftmark/weftmark` in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)