### PR TITLE
docs: update .env.example (M3 task 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@
 # Secret key for signing sessions and tokens (generate with: openssl rand -hex 32)
 APP_SECRET_KEY=
 
+# Runtime environment — controls HSTS, CSP, and other security features
+# Values: "dev" (local development) | "production" (deployed environment)
+APP_ENV=dev
+
 # Set to "true" in development only — enables debug output and auto-reload
 DEBUG=false
 
@@ -48,17 +52,6 @@ POSTGRES_PORT=5432
 POSTGRES_DB=weaving_site
 POSTGRES_USER=weaving_user
 POSTGRES_PASSWORD=
-
-
-# ------------------------------------------------------------
-# Redis
-# Shared between Celery (task queue) and application caching
-# ------------------------------------------------------------
-REDIS_URL=redis://redis:6379/0
-
-# Celery broker and result backend
-CELERY_BROKER_URL=redis://redis:6379/1
-CELERY_RESULT_BACKEND=redis://redis:6379/2
 
 
 # ------------------------------------------------------------


### PR DESCRIPTION
Closes #23

## Summary
- Added `APP_ENV` to Application section (was missing; used by docker-compose as `VITE_APP_ENV` build arg and by the backend to gate security features)
- Removed `REDIS_URL`, `CELERY_BROKER_URL`, `CELERY_RESULT_BACKEND` — Redis and Celery are not in the current stack
- All remaining vars already present and correctly documented

## Test plan
1. Open `.env.example` on GitHub and confirm every variable in your local `.env` has a corresponding entry
2. Confirm `REDIS_URL`, `CELERY_BROKER_URL`, `CELERY_RESULT_BACKEND` are gone
3. Confirm `APP_ENV` is present with a comment describing its values
4. `cp .env.example .env.test && diff .env.example .env.test` — should be identical (smoke test that the file is well-formed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)