### PR TITLE
infra: make local Postgres service conditional on compose profile (M3 task 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,11 @@ APP_SECRET_KEY=
 # Values: "dev" (local development) | "production" (deployed environment)
 APP_ENV=dev
 
+# Docker Compose profiles to activate.
+# Set to "local-db" to start a local PostgreSQL container (no managed DB).
+# Leave blank when using a managed database (e.g. Neon) — the db container will not start.
+COMPOSE_PROFILES=
+
 # Set to "true" in development only — enables debug output and auto-reload
 DEBUG=false
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,19 +41,19 @@ services:
       - internal
     env_file:
       - .env
-    depends_on:
-      db:
-        condition: service_healthy
     volumes:
       - uploads:/app/uploads
     restart: unless-stopped
 
   # ----------------------------------------------------------
-  # Database — PostgreSQL
-  # Never exposed to host or public network.
-  # Exposed: no
+  # Database — PostgreSQL (local dev only)
+  # Only starts when the "local-db" profile is active.
+  # Set COMPOSE_PROFILES=local-db in .env to enable.
+  # When POSTGRES_DSN is set (e.g. Neon), leave COMPOSE_PROFILES
+  # unset — this container will not start.
   # ----------------------------------------------------------
   db:
+    profiles: ["local-db"]
     image: postgres:16-alpine
     container_name: weaving_site_db
     networks:


### PR DESCRIPTION
Closes #20

## Summary
- Added `profiles: ["local-db"]` to the `db` service — it now only starts when the `local-db` profile is active
- Removed `depends_on: db` from `backend` — Docker auto-activates a profiled service when another service depends on it, which would defeat the opt-in behaviour
- Added `COMPOSE_PROFILES` to `.env.example` (and `.env`) with instructions

**To use a local PostgreSQL container** (no managed DB):
```
COMPOSE_PROFILES=local-db
```

**To use Neon or any external DSN** (default):
```
COMPOSE_PROFILES=
```

Connection timing for local-db mode relies on SQLAlchemy pool retries. Explicit migration startup retry logic is tracked in issue #22.

## Test plan
- [x] Confirm `COMPOSE_PROFILES=` (blank) in your `.env`
- [x] Run `docker compose up -d` — verify only `frontend` and `backend` start (`docker compose ps` shows no `weaving_site_db`)
- [x] Confirm the app loads and functions normally at `http://razer.op.rowkar.net:3000`
- [x] Set `COMPOSE_PROFILES=local-db` in `.env`, run `docker compose up -d` — verify `weaving_site_db` now starts and reaches `healthy` status
- [x] Revert `COMPOSE_PROFILES=` before continuing

🤖 Generated with [Claude Code](https://claude.com/claude-code)