### PR TITLE
ci: use GITHUB_TOKEN for ghcr.io publish (fixes package create permission)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -755,22 +755,16 @@ jobs:
     name: Publish — backend (dev)
     runs-on: ubuntu-latest
     needs: [bump-version]
+    permissions:
+      packages: write
     if: >-
       github.event_name == 'push' &&
       github.ref_name == 'dev' &&
       !contains(github.event.head_commit.message || '', '[skip ci]')
     steps:
-      - name: Generate bot token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ secrets.WEFTMARK_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.WEFTMARK_BOT_PRIVATE_KEY }}
-
       - name: Check out code (post-bump)
         uses: actions/checkout@v6
         with:
-          token: ${{ steps.app-token.outputs.token }}
           ref: dev
 
       - name: Read version
@@ -781,8 +775,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: weftmark-bot[bot]
-          password: ${{ steps.app-token.outputs.token }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push backend image
         run: |
@@ -797,22 +791,16 @@ jobs:
     name: Publish — frontend (dev)
     runs-on: ubuntu-latest
     needs: [bump-version]
+    permissions:
+      packages: write
     if: >-
       github.event_name == 'push' &&
       github.ref_name == 'dev' &&
       !contains(github.event.head_commit.message || '', '[skip ci]')
     steps:
-      - name: Generate bot token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ secrets.WEFTMARK_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.WEFTMARK_BOT_PRIVATE_KEY }}
-
       - name: Check out code (post-bump)
         uses: actions/checkout@v6
         with:
-          token: ${{ steps.app-token.outputs.token }}
           ref: dev
 
       - name: Read version
@@ -823,8 +811,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: weftmark-bot[bot]
-          password: ${{ steps.app-token.outputs.token }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push frontend image
         run: |
@@ -846,22 +834,15 @@ jobs:
     name: Publish — backend (main)
     runs-on: ubuntu-latest
     needs: [promote-version-tag]
+    permissions:
+      packages: write
     if: >-
       github.event_name == 'push' &&
       github.ref_name == 'main' &&
       !contains(github.event.head_commit.message || '', '[skip ci]')
     steps:
-      - name: Generate bot token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ secrets.WEFTMARK_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.WEFTMARK_BOT_PRIVATE_KEY }}
-
       - name: Check out code
         uses: actions/checkout@v6
-        with:
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Read version
         id: version
@@ -871,8 +852,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: weftmark-bot[bot]
-          password: ${{ steps.app-token.outputs.token }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push backend image
         run: |
@@ -887,22 +868,15 @@ jobs:
     name: Publish — frontend (main)
     runs-on: ubuntu-latest
     needs: [promote-version-tag]
+    permissions:
+      packages: write
     if: >-
       github.event_name == 'push' &&
       github.ref_name == 'main' &&
       !contains(github.event.head_commit.message || '', '[skip ci]')
     steps:
-      - name: Generate bot token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ secrets.WEFTMARK_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.WEFTMARK_BOT_PRIVATE_KEY }}
-
       - name: Check out code
         uses: actions/checkout@v6
-        with:
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Read version
         id: version
@@ -912,8 +886,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: weftmark-bot[bot]
-          password: ${{ steps.app-token.outputs.token }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push frontend image
         run: |


### PR DESCRIPTION
Fixes the `permission_denied: installation not allowed to Create organization package` error from PR #63's CI run.

## Summary

GitHub App tokens can update existing packages but cannot create new packages under an org namespace — that requires `GITHUB_TOKEN` with an explicit `permissions: packages: write` grant at the job level. This is GitHub's standard recommendation for GHCR publishing.

Switched all 4 publish jobs (`docker-publish-dev-backend`, `docker-publish-dev-frontend`, `docker-publish-main-backend`, `docker-publish-main-frontend`) to use `GITHUB_TOKEN` for docker login. The `weftmark-bot` app token is still used for git operations (version bump commits, tags, SBOM commits) — only the registry login changes.

No secrets to add — `GITHUB_TOKEN` is automatically injected by GitHub into every workflow run.

## Test plan

- [x] Merge this PR to `dev`
- [ ] Watch `Publish — backend (dev)` and `Publish — frontend (dev)` jobs complete successfully
- [ ] Confirm `ghcr.io/weftmark/weftmark-backend` and `ghcr.io/weftmark/weftmark-frontend` packages appear at https://github.com/orgs/weftmark/packages with `:dev` and `:{version}-dev` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)