### PR TITLE
ci: create git tags via GitHub API to produce Verified badges

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -472,9 +472,24 @@ jobs:
           git add VERSION frontend/package.json
           git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }} [skip ci]"
 
-      - name: Push version commit and tag
+      - name: Push version commit
         run: |
           git pull --rebase origin dev
           git push origin dev
-          git tag ${{ steps.version.outputs.tag }}
-          git push origin ${{ steps.version.outputs.tag }}
+
+      - name: Create tag via API (produces Verified tag)
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          COMMIT_SHA=$(git rev-parse HEAD)
+          TAG_SHA=$(gh api repos/${{ github.repository }}/git/tags \
+            --method POST \
+            --field tag="${{ steps.version.outputs.tag }}" \
+            --field message="Release ${{ steps.version.outputs.tag }}" \
+            --field object="$COMMIT_SHA" \
+            --field type="commit" \
+            --jq '.sha')
+          gh api repos/${{ github.repository }}/git/refs \
+            --method POST \
+            --field ref="refs/tags/${{ steps.version.outputs.tag }}" \
+            --field sha="$TAG_SHA"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -277,7 +277,9 @@ jobs:
           git config user.name  "weftmark-bot[bot]"
           git config user.email "weftmark-bot[bot]@users.noreply.github.com"
 
-      - name: Create production tag (idempotent)
+      - name: Create production tag via API (idempotent, produces Verified tag)
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           VERSION=$(cat VERSION)
           TAG="v${VERSION}"
@@ -286,8 +288,19 @@ jobs:
           if git rev-parse "${TAG}" >/dev/null 2>&1; then
             echo "Tag ${TAG} already exists — skipping creation"
           else
-            git tag "${TAG}"
-            git push origin "${TAG}"
+            COMMIT_SHA=$(git rev-parse HEAD)
+            TAG_SHA=$(gh api repos/${{ github.repository }}/git/tags \
+              --method POST \
+              --field tag="${TAG}" \
+              --field message="Release ${TAG}" \
+              --field object="$COMMIT_SHA" \
+              --field type="commit" \
+              --jq '.sha')
+            gh api repos/${{ github.repository }}/git/refs \
+              --method POST \
+              --field ref="refs/tags/${TAG}" \
+              --field sha="$TAG_SHA"
+            echo "Tag ${TAG} created"
           fi
 
   sbom-backend:


### PR DESCRIPTION
## Summary

Closes #72.

Replaces `git tag` + `git push` with the GitHub REST API (`POST /git/tags` → `POST /git/refs`) in both tagging jobs:
- `bump-version` in `ci-dev.yml` — dev tags (e.g. `v0.36.7-dev`)
- `promote-version-tag` in `ci-main.yml` — production tags (e.g. `v0.36.7`)

Tags created via the API authenticated as a GitHub App are automatically signed by GitHub's GPG key, producing the **Verified** badge on releases consistently across both branches.

The `GH_TOKEN` env var is set to the app token so `gh api` uses App authentication rather than the default `GITHUB_TOKEN`.

Idempotency on `promote-version-tag` is preserved — the existing `git rev-parse` check still runs (tags are fetched via `fetch-depth: 0`) and skips creation if the tag already exists.

## Test plan

- [ ] Merge to dev — verify `v{x}-dev` tag shows **Verified** on GitHub
- [ ] Promote to main — verify `v{x}` production tag shows **Verified** on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)