### PR TITLE
ci: replace [skip ci] with bot-actor check to fix PR CI suppression

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -5,7 +5,8 @@ name: Dev CI
 #
 # [skip steps] in a commit message: all validation steps are skipped but
 #   jobs still complete — satisfies branch protection for docs-only commits.
-# [skip ci]   is reserved for bot commits (version bumps, SBOM updates).
+# Bot push detection: when weftmark-bot[bot] pushes (version bumps, SBOM),
+#   runner-check sets skip=true so no validation or post-merge jobs re-run.
 #
 # Required secrets:
 #   WEFTMARK_BOT_CLIENT_ID   — GitHub App client ID
@@ -34,11 +35,14 @@ jobs:
     outputs:
       skip: ${{ steps.detect-skip.outputs.skip }}
     steps:
-      - name: Detect skip-steps marker
+      - name: Detect skip-steps marker or bot push
         id: detect-skip
         run: |
           if [[ "${{ github.event_name }}" == "push" && \
-                "${{ contains(github.event.head_commit.message, '[skip steps]') }}" == "true" ]]; then
+                "${{ github.actor }}" == "weftmark-bot[bot]" ]]; then
+            echo "skip=true"  >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "push" && \
+                  "${{ contains(github.event.head_commit.message, '[skip steps]') }}" == "true" ]]; then
             echo "skip=true"  >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -128,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [backend-lint]
     if: >-
-      !contains(github.event.head_commit.message || '', '[skip ci]')
+      !(github.event_name == 'push' && github.actor == 'weftmark-bot[bot]')
     services:
       postgres:
         image: postgres:16
@@ -162,7 +166,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [backend-lint]
     if: >-
-      !contains(github.event.head_commit.message || '', '[skip ci]')
+      !(github.event_name == 'push' && github.actor == 'weftmark-bot[bot]')
     services:
       postgres:
         image: postgres:16
@@ -205,7 +209,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [backend-tests, migration-smoke-test]
     if: >-
-      !contains(github.event.head_commit.message || '', '[skip ci]')
+      !(github.event_name == 'push' && github.actor == 'weftmark-bot[bot]')
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -218,7 +222,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [frontend-typecheck]
     if: >-
-      !contains(github.event.head_commit.message || '', '[skip ci]')
+      !(github.event_name == 'push' && github.actor == 'weftmark-bot[bot]')
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -231,8 +235,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [runner-check, backend-lint]
     if: >-
-      needs.runner-check.outputs.skip != 'true' &&
-      !contains(github.event.head_commit.message || '', '[skip ci]')
+      needs.runner-check.outputs.skip != 'true'
     steps:
       - uses: actions/checkout@v6
       - run: docker build -f backend/Dockerfile -t weaving-backend-check .
@@ -242,8 +245,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [runner-check, frontend-typecheck]
     if: >-
-      needs.runner-check.outputs.skip != 'true' &&
-      !contains(github.event.head_commit.message || '', '[skip ci]')
+      needs.runner-check.outputs.skip != 'true'
     steps:
       - uses: actions/checkout@v6
       - run: docker build -f frontend/Dockerfile -t weaving-frontend-check ./frontend
@@ -257,7 +259,7 @@ jobs:
     needs: [dependency-audit-backend]
     if: >-
       github.event_name == 'push' &&
-      !contains(github.event.head_commit.message || '', '[skip ci]')
+      github.actor != 'weftmark-bot[bot]'
     steps:
       - name: Generate bot token
         id: app-token
@@ -304,7 +306,7 @@ jobs:
           git config user.email "weftmark-bot[bot]@users.noreply.github.com"
           git add sbom/sbom-backend.json sbom/licenses-backend.json
           if ! git diff --staged --quiet; then
-            git commit -m "chore: update backend SBOM and license manifest [skip ci]"
+            git commit -m "chore: update backend SBOM and license manifest"
             git pull --rebase origin dev
             git push origin dev
           fi
@@ -322,7 +324,7 @@ jobs:
     needs: [dependency-audit-frontend]
     if: >-
       github.event_name == 'push' &&
-      !contains(github.event.head_commit.message || '', '[skip ci]')
+      github.actor != 'weftmark-bot[bot]'
     steps:
       - name: Generate bot token
         id: app-token
@@ -368,7 +370,7 @@ jobs:
           git config user.email "weftmark-bot[bot]@users.noreply.github.com"
           git add sbom/sbom-frontend.json sbom/licenses-frontend.json
           if ! git diff --staged --quiet; then
-            git commit -m "chore: update frontend SBOM and license manifest [skip ci]"
+            git commit -m "chore: update frontend SBOM and license manifest"
             git pull --rebase origin dev
             git push origin dev
           fi
@@ -386,7 +388,7 @@ jobs:
     needs: [docker-build-backend, docker-build-frontend, dependency-audit-backend, dependency-audit-frontend]
     if: >-
       github.event_name == 'push' &&
-      !contains(github.event.head_commit.message || '', '[skip ci]')
+      github.actor != 'weftmark-bot[bot]'
     steps:
       - name: Generate bot token
         id: app-token
@@ -470,7 +472,7 @@ jobs:
       - name: Commit version files
         run: |
           git add VERSION frontend/package.json
-          git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }} [skip ci]"
+          git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }}"
 
       - name: Push version commit
         run: |


### PR DESCRIPTION
## Problem

`[skip ci]` in bot commit messages (version bumps, SBOM updates) suppresses **both** `push` and `pull_request` workflow runs. This means any PR opened with a bot commit as HEAD — including dev→main PRs — gets no CI at all. PR #76 was blocked by this exact issue.

## Fix

Replace all `[skip ci]` commit-message checks with `github.actor` checks:

| Where | Before | After |
|---|---|---|
| `runner-check` skip detection | `[skip steps]` only | Also sets `skip=true` when `actor == weftmark-bot[bot]` |
| `backend-tests`, `migration-smoke-test`, `dependency-audit-*` | `!contains(head_commit.message, '[skip ci]')` | `!(push && actor == bot)` |
| `docker-build-*` | `skip != true && !contains([skip ci])` | `skip != true` (runner-check covers it) |
| `sbom-*`, `bump-version` | `push && !contains([skip ci])` | `push && actor != bot` |
| Bot commit messages | `chore: bump version to x [skip ci]` | `chore: bump version to x` |

## Result

- Bot pushes (version bumps, SBOM updates) are silently skipped via actor detection — no jobs waste runners
- PRs whose HEAD is a bot commit (e.g. dev→main after a version bump) now trigger CI normally
- `[skip steps]` for docs-only commits still works unchanged

## Test plan

- [ ] Merge a PR to dev — confirm version bump fires and subsequent bot push does **not** re-trigger CI
- [ ] Open dev→main PR after the version bump lands — confirm `ci-main.yml` fires immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)