### PR TITLE
feat: add Docker Compose healthcheck directives

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,14 @@ services:
     networks:
       - public
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO /dev/null http://localhost/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
     restart: unless-stopped
 
   # ----------------------------------------------------------
@@ -43,6 +50,16 @@ services:
       - .env
     volumes:
       - uploads:/app/uploads
+    depends_on:
+      db:
+        condition: service_healthy
+        required: false
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
     restart: unless-stopped
 
   # ----------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       backend:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO /dev/null http://localhost/ || exit 1"]
+      test: ["CMD-SHELL", "wget -qO /dev/null http://127.0.0.1/ || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
Closes #26.

## Changes

**`backend`**
- Healthcheck: `python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"` — uses the existing `/health` endpoint which also verifies DB connectivity. Python is always available in the `python:3.12-slim` image; no curl needed.
- `depends_on: db: condition: service_healthy, required: false` — waits for Postgres when the `local-db` profile is active; skipped silently when using a managed DB (Neon).
- `start_period: 15s` — gives uvicorn time to bind and run migrations before the first probe.

**`frontend`**
- Healthcheck: `wget -qO /dev/null http://localhost/` — `wget` is available in `nginx:alpine` without any extra install.
- `depends_on: backend: condition: service_healthy` — nginx only starts routing once the backend is confirmed healthy.
- `start_period: 5s` — nginx binds fast; short window is sufficient.

**`db`** — healthcheck already present; no changes.

## Test plan

- [ ] `docker compose --profile local-db up` → all three services reach `healthy` in `docker compose ps`
- [ ] `docker compose up` (no local-db, using Neon DSN) → backend starts without waiting for db, reaches `healthy`
- [ ] Break `/health` endpoint temporarily → `docker compose ps` shows backend `unhealthy`, frontend stays `starting`/`unhealthy` and does not serve traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)