### PR TITLE
feat: run Alembic migrations automatically on container startup

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,4 +17,6 @@ RUN PYWEAVING_DATA=$(python -c "import pyweaving.render as r, os; print(os.path.
 COPY backend/ .
 COPY VERSION .
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+RUN chmod +x entrypoint.sh
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+echo "Running Alembic migrations..."
+alembic upgrade head
+echo "Migrations complete. Starting server..."
+exec uvicorn app.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- Adds `backend/entrypoint.sh` that runs `alembic upgrade head` before starting uvicorn
- `set -e` ensures a failed migration causes a non-zero exit, preventing the container from starting with a stale schema
- `exec` replaces the shell process with uvicorn so signals (SIGTERM, etc.) are handled correctly
- Updates `backend/Dockerfile` to `COPY`, `chmod +x`, and set as `ENTRYPOINT`

## Test plan
- [x] Docker image builds successfully with `RUN chmod +x entrypoint.sh`
- [x] `ENTRYPOINT ["./entrypoint.sh"]` confirmed via `docker inspect`
- [x] All 27 Alembic migrations ran in order on a fresh Postgres instance
- [x] Uvicorn started and reached `Application startup complete` after migrations

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)