### PR TITLE
chore: replace PolyForm Noncommercial with BSL 1.1; add fix/* to CI

### DIFF
--- a/.github/workflows/ci-feature.yml
+++ b/.github/workflows/ci-feature.yml
@@ -1,12 +1,12 @@
 name: Feature CI
 
-# Runs on every push to feature/* and hotfix/* branches.
+# Runs on every push to feature/*, hotfix/*, and fix/* branches.
 # Provides fast lint/typecheck feedback before a PR is opened.
 # Full test suite runs when the PR is opened (ci-dev.yml or ci-main.yml).
 
 on:
   push:
-    branches: ["feature/*", "hotfix/*"]
+    branches: ["feature/*", "hotfix/*", "fix/*"]
 
 concurrency:
   group: feature-${{ github.ref }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,112 +1,56 @@
-PolyForm Noncommercial License 1.0.0
+License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
 
-<https://polyformproject.org/licenses/noncommercial/1.0.0>
+Parameters
 
-## Acceptance
+Licensor:             Derek Rowland
+Licensed Work:        WeftMark. The Licensed Work is (c) 2025 Derek Rowland.
+Additional Use Grant: None
+Change Date:          2029-01-01
+Change License:       MIT License
 
-In order to get any license under these terms, you must agree
-to them as both strict obligations and conditions to all
-your licenses.
+-----------------------------------------------------------------------------
 
-## Copyright License
+Business Source License 1.1
 
-The licensor grants you a copyright license for the software
-to do everything you might do with the software that would
-otherwise infringe the licensor's copyright in it for any
-permitted purpose. However, you may only distribute the
-software according to _Distribution License_ and make changes
-or new works based on the software according to _Changes and
-New Works License_.
+Terms
 
-## Distribution License
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
 
-The licensor grants you an additional copyright license to
-distribute copies of the software. Your license to distribute
-covers distributing the software with changes and new works
-permitted by _Changes and New Works License_.
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
 
-## Notices
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
 
-You must ensure that anyone who gets a copy of any part of
-the software from you also gets a copy of these terms or the
-URL for them above, as well as copies of any plain-text lines
-beginning with `Required Notice:` that the licensor provided
-with the software. For example:
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
 
-> Required Notice: Copyright Derek Rowland (https://github.com/gx1400)
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
 
-## Changes and New Works License
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
 
-The licensor grants you an additional copyright license to
-make changes and new works based on the software for any
-permitted purpose.
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
 
-## Patent License
-
-The licensor grants you a patent license for the software that
-covers patent claims the licensor can license, or will be able
-to license, that you would infringe by using the software.
-
-## Permitted Purpose
-
-Any noncommercial purpose is a permitted purpose.
-
-## Fair Use
-
-If your use of the software qualifies as fair use, this license
-does not apply, and you do not need a license.
-
-## No Other Rights
-
-These terms do not allow you to sublicense or transfer any of
-your licenses to anyone else, or prevent the licensor from
-granting licenses to anyone else. These terms do not imply
-any other licenses.
-
-## Patent Defense
-
-If you make any written claim that the software infringes or
-contributes to infringement of any patent, your patent license
-for the software granted under these terms ends immediately. If
-your employer makes such a claim, your patent license ends
-immediately for work on behalf of your employer.
-
-## Violations
-
-The first time you are notified in writing that you have
-violated any of these terms, or done anything with the software
-not covered by your licenses, your licenses can nonetheless
-continue if you come into compliance within 32 days after
-receiving notice. Otherwise, all your licenses end immediately.
-
-## No Liability
-
-***As far as the law allows, the software comes as is, without
-any warranty or condition, and the licensor will not be liable
-to you for any damages arising out of these terms or the use
-or nature of the software, under any kind of legal claim.***
-
-## Definitions
-
-The **licensor** is the individual or entity offering these
-terms, and the **software** is the software the licensor makes
-available under these terms.
-
-**You** refers to the individual or entity agreeing to these
-terms.
-
-**Your company** is any legal entity, sole proprietorship,
-or other kind of organization that you work for, plus all
-its affiliates.
-
-**Affiliates** means the other organizations than an
-organization has control over, is under the control of, or is
-under common control with.
-
-**Control** means ownership of substantially all the assets of
-an entity, or the power to direct its management and legal
-affairs.
-
-A **noncommercial purpose** is one that is not primarily
-intended for or directed toward commercial advantage or
-monetary compensation.
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.


### PR DESCRIPTION
## Summary
- Replaces `LICENSE` with Business Source License 1.1 (Licensor: Derek Rowland, Change Date: 2029-01-01, Change License: MIT)
- The BSL commit from PR #83 was pushed to that branch after it was already merged, so it never landed in dev
- Adds `fix/*` to `ci-feature.yml` branch triggers so `fix/` branches get lint/typecheck on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)