### PR TITLE
chore: rename CLERK_PUBLISHABLE_KEY secret to CLERK_PUBLISHABLE_KEY_PROD/_DEV

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -12,7 +12,7 @@ name: Main CI
 # Required secrets:
 #   WEFTMARK_BOT_CLIENT_ID   — GitHub App client ID
 #   WEFTMARK_BOT_PRIVATE_KEY — GitHub App private key
-#   CLERK_PUBLISHABLE_KEY    — Clerk publishable key (baked into frontend image at build time)
+#   CLERK_PUBLISHABLE_KEY_PROD — Clerk publishable key for production (baked into frontend image at build time)
 
 on:
   pull_request:
@@ -454,7 +454,7 @@ jobs:
       - name: Build and push frontend image
         run: |
           docker build -f frontend/Dockerfile \
-            --build-arg VITE_CLERK_PUBLISHABLE_KEY="${{ secrets.CLERK_PUBLISHABLE_KEY }}" \
+            --build-arg VITE_CLERK_PUBLISHABLE_KEY="${{ secrets.CLERK_PUBLISHABLE_KEY_PROD }}" \
             --build-arg VITE_APP_ENV="production" \
             -t ghcr.io/weftmark/weftmark-frontend:${{ steps.version.outputs.version }} \
             -t ghcr.io/weftmark/weftmark-frontend:latest \

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -5,7 +5,7 @@ name: Publish Dev Images
 # branch this workflow is dispatched from.
 #
 # Required secrets:
-#   CLERK_PUBLISHABLE_KEY — Clerk publishable key (baked into frontend image at build time)
+#   CLERK_PUBLISHABLE_KEY_DEV — Clerk publishable key for dev/test (baked into frontend image at build time)
 
 on:
   workflow_dispatch:
@@ -66,7 +66,7 @@ jobs:
       - name: Build and push frontend image
         run: |
           docker build -f frontend/Dockerfile \
-            --build-arg VITE_CLERK_PUBLISHABLE_KEY="${{ secrets.CLERK_PUBLISHABLE_KEY }}" \
+            --build-arg VITE_CLERK_PUBLISHABLE_KEY="${{ secrets.CLERK_PUBLISHABLE_KEY_DEV }}" \
             --build-arg VITE_APP_ENV="dev" \
             -t ghcr.io/weftmark/weftmark-frontend:${{ steps.version.outputs.version }}-dev \
             -t ghcr.io/weftmark/weftmark-frontend:dev \

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ The frontend will be available at `http://localhost:3000` and the API at `http:/
 
 See `.env.example` for all required environment variables and where to obtain them.
 
+> **Note — Clerk key is baked into the frontend image at build time.**
+> `VITE_CLERK_PUBLISHABLE_KEY` is compiled into the static JS bundle by Vite during `docker compose build`. This means the container cannot be reused across Clerk instances (e.g. dev vs prod) without a rebuild, and self-hosted deployments using a different Clerk account must build their own image.
+> Runtime configurability is tracked in [#87](https://github.com/weftmark/weftmark/issues/87) and will be addressed in a future release.
+
 ### Local Development (without Docker)
 
 ```bash


### PR DESCRIPTION
## Summary

- `ci-main.yml`: use `CLERK_PUBLISHABLE_KEY_PROD` for production image builds
- `publish-dev.yml`: use `CLERK_PUBLISHABLE_KEY_DEV` for dev image builds

Both secrets have been added to GitHub Actions. The old `CLERK_PUBLISHABLE_KEY` can be deleted after this merges and the next workflow run confirms the new names work.

Closes #88

## Test plan

- [ ] Trigger `publish-dev.yml` manually — confirm frontend image builds successfully with `CLERK_PUBLISHABLE_KEY_DEV`
- [ ] Merge to main triggers `ci-main.yml` — confirm frontend image builds with `CLERK_PUBLISHABLE_KEY_PROD`
- [ ] Delete old `CLERK_PUBLISHABLE_KEY` secret after both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)