### PR TITLE
feat: structured JSON logging for backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,10 @@ COMPOSE_PROFILES=
 # Set to "true" in development only — enables debug output and auto-reload
 DEBUG=false
 
+# Log level for the backend: DEBUG, INFO, WARNING, ERROR (default: INFO)
+# When APP_ENV=production, output is structured JSON. Otherwise plain text.
+LOG_LEVEL=INFO
+
 # Comma-separated list of allowed CORS origins for the API
 # Dev:  CORS_ORIGINS=https://dev.weftmark.com,http://localhost:3000
 # Prod: CORS_ORIGINS=https://weftmark.com

--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ COMPOSE_PROFILES=
 DEBUG=false
 
 # Log level for the backend: DEBUG, INFO, WARNING, ERROR (default: INFO)
-# When APP_ENV=production, output is structured JSON. Otherwise plain text.
+# Output is always structured JSON for observability platform ingestion.
 LOG_LEVEL=INFO
 
 # Comma-separated list of allowed CORS origins for the API

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -13,6 +13,7 @@ class Settings(BaseSettings):
     app_secret_key: str = "change-me-in-production"
     app_env: str = "dev"
     debug: bool = False
+    log_level: str = "INFO"
     cors_origins: str = "http://localhost:3000"
     frontend_url: str = "http://localhost:3000"
     api_url: str = "http://localhost:8000"

--- a/backend/app/logging_config.py
+++ b/backend/app/logging_config.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        entry: dict = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            entry["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(entry)
+
+
+def configure_logging(log_level: str, app_env: str) -> None:
+    level = getattr(logging, log_level.upper(), logging.INFO)
+    is_production = app_env == "production"
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(JsonFormatter() if is_production else logging.Formatter("%(levelname)s:%(name)s: %(message)s"))
+
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(handler)
+    root.setLevel(level)
+
+    for name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
+        logger = logging.getLogger(name)
+        logger.handlers.clear()
+        logger.addHandler(handler)
+        logger.setLevel(level)
+        logger.propagate = False

--- a/backend/app/logging_config.py
+++ b/backend/app/logging_config.py
@@ -19,12 +19,11 @@ class JsonFormatter(logging.Formatter):
         return json.dumps(entry)
 
 
-def configure_logging(log_level: str, app_env: str) -> None:
+def configure_logging(log_level: str) -> None:
     level = getattr(logging, log_level.upper(), logging.INFO)
-    is_production = app_env == "production"
 
     handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(JsonFormatter() if is_production else logging.Formatter("%(levelname)s:%(name)s: %(message)s"))
+    handler.setFormatter(JsonFormatter())
 
     root = logging.getLogger()
     root.handlers.clear()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,7 +11,7 @@ from app.routers import activities, admin, auth, health, looms, projects, users,
 from app.version import VERSION
 
 settings = get_settings()
-configure_logging(settings.log_level, settings.app_env)
+configure_logging(settings.log_level)
 
 start_time: datetime = datetime.now(timezone.utc)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,10 +6,12 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import get_settings
+from app.logging_config import configure_logging
 from app.routers import activities, admin, auth, health, looms, projects, users, yarn
 from app.version import VERSION
 
 settings = get_settings()
+configure_logging(settings.log_level, settings.app_env)
 
 start_time: datetime = datetime.now(timezone.utc)
 


### PR DESCRIPTION
## Summary

- Adds `backend/app/logging_config.py` with `JsonFormatter` (stdlib only, no new deps) and `configure_logging()`
- Wires root logger + all uvicorn loggers (`uvicorn`, `uvicorn.error`, `uvicorn.access`) to a shared stdout handler
- Always emits structured JSON — format is not gated on `APP_ENV`. Every environment sends the same format so logs are always ready for observability platform ingestion regardless of where the container runs
- `LOG_LEVEL` env var controls verbosity (default `INFO`); documented in `.env.example`
- All existing `logging.getLogger(__name__)` callers in routers/services inherit the formatter automatically — no other files changed

## Why always JSON

The goal is observability platform ingestion (Komodo or similar log aggregator). Gating JSON on `APP_ENV=production` would mean a dev deployment pointing at the same log stack sends plain text. The format is decoupled from the environment — `jq` handles readability locally if needed.

## Sample output

```json
{"timestamp": "2026-04-29T02:30:07.849034+00:00", "level": "INFO", "logger": "uvicorn.error", "message": "Started server process [1]"}
{"timestamp": "2026-04-29T02:30:07.849320+00:00", "level": "INFO", "logger": "uvicorn.error", "message": "Waiting for application startup."}
{"timestamp": "2026-04-29T02:30:08.258909+00:00", "level": "INFO", "logger": "httpx", "message": "HTTP Request: GET https://api.clerk.com/v1/users?limit=1 \"HTTP/1.1 200 OK\""}
{"timestamp": "2026-04-29T02:30:09.359131+00:00", "level": "INFO", "logger": "uvicorn.error", "message": "Application startup complete."}
```

Note: Alembic lines at container startup are plain text — Alembic runs in `entrypoint.sh` before the FastAPI process initialises and owns its own logging config. This is expected.

## Related

- Frontend logging is not yet structured — tracked in #92

Closes #25

## Test plan

- [x] Boot container — confirm every uvicorn/app log line is valid JSON
- [x] Set `LOG_LEVEL=DEBUG` — confirm debug output appears
- [x] Confirm `timestamp`, `level`, `logger`, `message` fields present on all lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)