### PR TITLE
feat: HTTP security headers middleware

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import get_settings
 from app.logging_config import configure_logging
+from app.middleware import SecurityHeadersMiddleware
 from app.routers import activities, admin, auth, health, looms, projects, users, yarn
 from app.version import VERSION
 
@@ -38,6 +39,7 @@ app = FastAPI(
     openapi_url="/api/openapi.json" if settings.debug else None,
 )
 
+app.add_middleware(SecurityHeadersMiddleware, production=settings.app_env == "production")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.cors_origins.split(","),

--- a/backend/app/middleware.py
+++ b/backend/app/middleware.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+_PERMISSIONS_POLICY = "camera=(), microphone=(), geolocation=(), interest-cohort=(), payment=(), usb=()"
+
+# Clerk requires its own origins for script/frame/connect.
+_CSP_PRODUCTION = (
+    "default-src 'self'; "
+    "script-src 'self' https://clerk.com https://*.clerk.accounts.dev https://*.clerk.com; "
+    "style-src 'self' 'unsafe-inline'; "
+    "img-src 'self' data: blob: https://*.clerk.com; "
+    "connect-src 'self' https://clerk.com https://*.clerk.accounts.dev https://*.clerk.com; "
+    "frame-src https://clerk.com https://*.clerk.accounts.dev https://*.clerk.com; "
+    "font-src 'self'; "
+    "object-src 'none'; "
+    "base-uri 'self'; "
+    "form-action 'self'"
+)
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app, production: bool = False) -> None:
+        super().__init__(app)
+        self._production = production
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        response = await call_next(request)
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        response.headers["Permissions-Policy"] = _PERMISSIONS_POLICY
+        if self._production:
+            response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains"
+            response.headers["Content-Security-Policy"] = _CSP_PRODUCTION
+        return response


### PR DESCRIPTION
## Summary

- Adds `backend/app/middleware.py` with `SecurityHeadersMiddleware`
- Applied globally to all API routes via `app.add_middleware()`
- Headers set on every response:
  - `X-Frame-Options: DENY`
  - `X-Content-Type-Options: nosniff`
  - `Referrer-Policy: strict-origin-when-cross-origin`
  - `Permissions-Policy` — camera, microphone, geolocation, payment, usb all disabled
- `APP_ENV=production` additionally sets:
  - `Strict-Transport-Security: max-age=63072000; includeSubDomains`
  - `Content-Security-Policy` — scoped to `'self'` with Clerk origins whitelisted for script/frame/connect

## CSP note

CSP is omitted outside production to avoid blocking dev deployments on non-allowlisted origins. The production CSP includes all Clerk domains required for auth flows (`clerk.com`, `*.clerk.accounts.dev`, `*.clerk.com`).

## Verified

```
x-frame-options: DENY
x-content-type-options: nosniff
referrer-policy: strict-origin-when-cross-origin
permissions-policy: camera=(), microphone=(), geolocation=(), interest-cohort=(), payment=(), usb=()
```
(confirmed via `curl -sI` against running dev container — HSTS/CSP correctly absent with `APP_ENV=dev`)

Closes #28

## Test plan

- [x] `curl -sI /health` — confirm all four static headers present in dev
- [x] Set `APP_ENV=production` — confirm HSTS and CSP also appear
- [x] Confirm no headers duplicated with CORS middleware

🤖 Generated with [Claude Code](https://claude.com/claude-code)