### PR TITLE
ci: auto-label new issues with needs-triage

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,21 @@
+name: Label new issues for triage
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['needs-triage'],
+            });


### PR DESCRIPTION
Adds a GitHub Actions workflow that applies the `needs-triage` label to every newly opened issue, making them immediately visible in a filtered project board view until Priority and Horizon are assigned.