### PR TITLE
feat: Traefik v3 reverse proxy configuration

### DIFF
--- a/.env.traefik.example
+++ b/.env.traefik.example
@@ -1,0 +1,38 @@
+# ============================================================
+# WeftMark — Traefik Environment Variables
+# Copy to .env.traefik and fill in values. Never commit .env.traefik.
+# ============================================================
+
+
+# ------------------------------------------------------------
+# Cloudflare — DNS-01 ACME challenge
+# ------------------------------------------------------------
+
+# API token with Zone / DNS / Edit permission for your zone(s).
+# Create at: https://dash.cloudflare.com/profile/api-tokens
+# Minimal token template: "Edit zone DNS" scoped to your zone.
+CF_DNS_API_TOKEN=
+
+# Email address for Let's Encrypt registration and expiry notifications.
+ACME_EMAIL=
+
+
+# ------------------------------------------------------------
+# Traefik dashboard
+# ------------------------------------------------------------
+# The dashboard is served on 127.0.0.1:8080 only (no public exposure).
+# Access it via SSH tunnel: ssh -L 9090:localhost:9090 user@yourserver
+# Then open: http://localhost:9090/dashboard/
+
+
+# ------------------------------------------------------------
+# CrowdSec (optional)
+# ------------------------------------------------------------
+
+# Activate the crowdsec service profile. Leave blank to skip it.
+# Values: "crowdsec" to enable, blank to disable.
+COMPOSE_PROFILES=
+
+# Bouncer API key generated after first CrowdSec run:
+#   docker exec crowdsec cscli bouncers add traefik-bouncer
+# CROWDSEC_LAPI_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,10 @@
 .env
 .env.dev
 .env.prod
+.env.traefik
 .env.local
 .env.*.local
-# .env.example is intentionally tracked
+# .env.example and .env.*.example are intentionally tracked
 
 
 # ------------------------------------------------------------

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,15 +3,20 @@ services:
   # ----------------------------------------------------------
   # Frontend — React application served via nginx
   # Pulls the dev image from ghcr.io.
-  # Reverse proxy: https://dev.weftmark.com → localhost:3001
+  # Traefik routes https://dev.weftmark.com → this container via traefik_proxy network.
   # ----------------------------------------------------------
   frontend:
     image: ghcr.io/weftmark/weftmark-frontend:dev
     container_name: weftmark_frontend_dev
-    ports:
-      - "127.0.0.1:3001:80"
     networks:
+      - traefik_proxy
       - public
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.weftmark-dev.rule=Host(`dev.weftmark.com`)"
+      - "traefik.http.routers.weftmark-dev.entrypoints=websecure"
+      - "traefik.http.routers.weftmark-dev.tls.certresolver=cloudflare"
+      - "traefik.http.services.weftmark-dev.loadbalancer.server.port=80"
     depends_on:
       backend:
         condition: service_healthy
@@ -81,6 +86,9 @@ services:
     restart: unless-stopped
 
 networks:
+  traefik_proxy:
+    external: true
+    name: traefik_proxy
   public:
     name: weftmark_dev_public
     driver: bridge

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,15 +3,20 @@ services:
   # ----------------------------------------------------------
   # Frontend — React application served via nginx
   # Pulls the published image from ghcr.io.
-  # Reverse proxy: https://weftmark.com → localhost:3000
+  # Traefik routes https://weftmark.com → this container via traefik_proxy network.
   # ----------------------------------------------------------
   frontend:
     image: ghcr.io/weftmark/weftmark-frontend:latest
     container_name: weftmark_frontend_prod
-    ports:
-      - "127.0.0.1:3000:80"
     networks:
+      - traefik_proxy
       - public
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.weftmark-prod.rule=Host(`weftmark.com`) || Host(`www.weftmark.com`)"
+      - "traefik.http.routers.weftmark-prod.entrypoints=websecure"
+      - "traefik.http.routers.weftmark-prod.tls.certresolver=cloudflare"
+      - "traefik.http.services.weftmark-prod.loadbalancer.server.port=80"
     depends_on:
       backend:
         condition: service_healthy
@@ -81,6 +86,9 @@ services:
     restart: unless-stopped
 
 networks:
+  traefik_proxy:
+    external: true
+    name: traefik_proxy
   public:
     name: weftmark_prod_public
     driver: bridge

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -1,0 +1,56 @@
+services:
+
+  # ----------------------------------------------------------
+  # Traefik — reverse proxy, TLS termination, cert management
+  # Handles all inbound HTTP/HTTPS traffic and routes it to
+  # application containers via the traefik_proxy Docker network.
+  # TLS certificates are issued via Cloudflare DNS-01 challenge
+  # (works behind Cloudflare orange cloud, no HTTP challenge needed).
+  # ----------------------------------------------------------
+  traefik:
+    image: traefik:v3
+    container_name: traefik
+    restart: unless-stopped
+    ports:
+      - "0.0.0.0:80:80"
+      - "0.0.0.0:443:443"
+      - "127.0.0.1:9090:8080"  # dashboard — SSH tunnel: ssh -L 9090:localhost:9090 user@host
+    env_file:
+      - .env.traefik
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
+      - ./traefik/dynamic.yml:/etc/traefik/dynamic.yml:ro
+      - ./traefik/acme:/etc/traefik/acme
+    networks:
+      - traefik_proxy
+    labels:
+      - "traefik.enable=false"
+
+  # ----------------------------------------------------------
+  # CrowdSec — threat intelligence and intrusion detection (optional)
+  # Enable with: COMPOSE_PROFILES=crowdsec in .env.traefik (or Komodo env)
+  #
+  # After first run, generate a bouncer key and add it to .env.traefik:
+  #   docker exec crowdsec cscli bouncers add traefik-bouncer
+  #
+  # Then uncomment the plugin block in traefik/traefik.yml and the
+  # crowdsec middleware in traefik/dynamic.yml, and restart Traefik.
+  # ----------------------------------------------------------
+  crowdsec:
+    profiles: ["crowdsec"]
+    image: crowdsecurity/crowdsec:latest
+    container_name: crowdsec
+    restart: unless-stopped
+    environment:
+      COLLECTIONS: crowdsecurity/traefik crowdsecurity/linux
+    volumes:
+      - ./crowdsec/data:/var/lib/crowdsec/data
+      - ./crowdsec/config:/etc/crowdsec
+    networks:
+      - traefik_proxy
+
+networks:
+  traefik_proxy:
+    name: traefik_proxy
+    driver: bridge

--- a/traefik/dynamic.yml
+++ b/traefik/dynamic.yml
@@ -1,0 +1,20 @@
+# Dynamic configuration — loaded live by the file provider (watch: true).
+# Add routers, middlewares, and services here without restarting Traefik.
+
+# CrowdSec bouncer middleware — uncomment after:
+#   1. Enable the plugin in traefik/traefik.yml (experimental.plugins block)
+#   2. Generate a bouncer key: sudo cscli bouncers add traefik-bouncer
+#   3. Set CROWDSEC_LAPI_KEY in .env.traefik
+#   4. Add extra_hosts to the traefik service in docker-compose.traefik.yml:
+#        extra_hosts:
+#          - "host.docker.internal:host-gateway"
+#
+# http:
+#   middlewares:
+#     crowdsec:
+#       plugin:
+#         crowdsec-bouncer:
+#           enabled: true
+#           crowdsecLapiScheme: http
+#           crowdsecLapiHost: host.docker.internal:8080
+#           crowdsecLapiKey: '{{ env "CROWDSEC_LAPI_KEY" }}'

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -1,0 +1,87 @@
+global:
+  checkNewVersion: false
+  sendAnonymousUsage: false
+
+log:
+  level: INFO
+  format: json
+
+accessLog:
+  format: json
+  fields:
+    defaultMode: keep
+    headers:
+      defaultMode: keep
+      names:
+        Authorization: drop
+
+api:
+  dashboard: true
+  insecure: true  # bound to 127.0.0.1:8080 — access via SSH tunnel only
+
+entryPoints:
+  web:
+    address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+          permanent: true
+  websecure:
+    address: ":443"
+    # Restore real client IPs from Cloudflare (orange cloud). Keep this list
+    # current: https://www.cloudflare.com/ips/
+    forwardedHeaders:
+      trustedIPs:
+        - "173.245.48.0/20"
+        - "103.21.244.0/22"
+        - "103.22.200.0/22"
+        - "103.31.4.0/22"
+        - "141.101.64.0/18"
+        - "108.162.192.0/18"
+        - "190.93.240.0/20"
+        - "188.114.96.0/20"
+        - "197.234.240.0/22"
+        - "198.41.128.0/17"
+        - "162.158.0.0/15"
+        - "104.16.0.0/13"
+        - "104.24.0.0/14"
+        - "172.64.0.0/13"
+        - "131.0.72.0/22"
+        - "2400:cb00::/32"
+        - "2606:4700::/32"
+        - "2803:f800::/32"
+        - "2405:b500::/32"
+        - "2405:8100::/32"
+        - "2a06:98c0::/29"
+        - "2c0f:f248::/32"
+
+providers:
+  docker:
+    exposedByDefault: false
+    network: traefik_proxy
+  file:
+    filename: /etc/traefik/dynamic.yml
+    watch: true
+
+certificatesResolvers:
+  cloudflare:
+    acme:
+      email: ${ACME_EMAIL}
+      # acme.json is created by Traefik on first run with 600 permissions
+      storage: /etc/traefik/acme/acme.json
+      dnsChallenge:
+        provider: cloudflare
+        # Use Cloudflare DNS for propagation checks (avoids split-horizon issues)
+        resolvers:
+          - "1.1.1.1:53"
+          - "8.8.8.8:53"
+
+# Uncomment after CrowdSec is running. Pin to a specific version from:
+# https://plugins.traefik.io/plugins/6335346ca4caa9ddeffda116/crowdsec-bouncer-traefik-plugin
+# experimental:
+#   plugins:
+#     crowdsec-bouncer:
+#       moduleName: github.com/crowdsecurity/cs-bouncer-traefik-plugin
+#       version: v1.0.9


### PR DESCRIPTION
## Summary

- Add `docker-compose.traefik.yml` with Traefik v3 reverse proxy and optional CrowdSec profile
- Add `traefik/traefik.yml` static config: Cloudflare DNS-01 ACME, CF trusted IP ranges, JSON access logs
- Add `traefik/dynamic.yml` with commented CrowdSec middleware template
- Update `docker-compose.dev.yml` and `docker-compose.prod.yml` to use `traefik_proxy` network and container labels instead of host port bindings
- Add `.env.traefik.example` template; `.env.traefik` added to `.gitignore`

## Notes

- Dashboard is bound to `127.0.0.1:9090` only — access via SSH tunnel: `ssh -L 9090:localhost:9090 user@host`
- CrowdSec enabled via `COMPOSE_PROFILES=crowdsec` in `.env.traefik`
- Bind mount directories (`traefik/acme`, `crowdsec/`) are created by Komodo pre-deploy commands, not tracked in repo

## Test plan

- [ ] Traefik stack starts cleanly with `docker compose -f docker-compose.traefik.yml up -d`
- [ ] HTTPS certs issued for `dev.weftmark.com` and `weftmark.com` via Cloudflare DNS-01
- [ ] Dashboard accessible via SSH tunnel at `http://localhost:9090/dashboard/`
- [ ] Dev and prod stacks route correctly through Traefik

🤖 Generated with [Claude Code](https://claude.com/claude-code)