### PR TITLE
feat: structured logging for auth failures, webhooks, and frontend relay

### DIFF
--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import AsyncGenerator
 from datetime import datetime, timedelta, timezone
 
@@ -9,6 +10,8 @@ from app.config import get_settings
 from app.database import AsyncSessionLocal
 from app.models.user import User
 from app.services.clerk_auth import jwks_url_from_publishable_key, verify_session_token
+
+log = logging.getLogger(__name__)
 
 _LAST_ACTIVE_THROTTLE = timedelta(minutes=5)
 
@@ -23,9 +26,12 @@ async def get_current_user(
     db: AsyncSession = Depends(get_db),
 ) -> User:
     settings = get_settings()
+    method = request.method
+    path = request.url.path
 
     auth_header = request.headers.get("Authorization", "")
     if not auth_header.startswith("Bearer "):
+        log.info("auth_failure reason=no_token method=%s path=%s", method, path)
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
 
     token = auth_header.removeprefix("Bearer ").strip()
@@ -36,6 +42,7 @@ async def get_current_user(
     jwks_url = jwks_url_from_publishable_key(settings.clerk_publishable_key)
     clerk_user_id = verify_session_token(token, jwks_url)
     if not clerk_user_id:
+        log.info("auth_failure reason=invalid_token method=%s path=%s", method, path)
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired token")
 
     user = await db.scalar(
@@ -46,6 +53,7 @@ async def get_current_user(
         )
     )
     if user is None:
+        log.info("auth_failure reason=user_not_found clerk_user_id=%s method=%s path=%s", clerk_user_id, method, path)
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
 
     now = datetime.now(timezone.utc)

--- a/backend/app/logging_config.py
+++ b/backend/app/logging_config.py
@@ -5,6 +5,34 @@ import logging
 import sys
 from datetime import datetime, timezone
 
+# Standard LogRecord attributes — extras beyond these are included in the output.
+_STDLIB_ATTRS = frozenset(
+    {
+        "args",
+        "created",
+        "exc_info",
+        "exc_text",
+        "filename",
+        "funcName",
+        "levelname",
+        "levelno",
+        "lineno",
+        "message",
+        "module",
+        "msecs",
+        "msg",
+        "name",
+        "pathname",
+        "process",
+        "processName",
+        "relativeCreated",
+        "stack_info",
+        "taskName",
+        "thread",
+        "threadName",
+    }
+)
+
 
 class JsonFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
@@ -16,6 +44,13 @@ class JsonFormatter(logging.Formatter):
         }
         if record.exc_info:
             entry["exc_info"] = self.formatException(record.exc_info)
+        for key, val in record.__dict__.items():
+            if key not in _STDLIB_ATTRS and not key.startswith("_"):
+                try:
+                    json.dumps(val)
+                    entry[key] = val
+                except (TypeError, ValueError):
+                    entry[key] = str(val)
         return json.dumps(entry)
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.config import get_settings
 from app.logging_config import configure_logging
 from app.middleware import SecurityHeadersMiddleware
-from app.routers import activities, admin, auth, health, looms, projects, users, yarn
+from app.routers import activities, admin, auth, health, logs, looms, projects, users, yarn
 from app.version import VERSION
 
 settings = get_settings()
@@ -49,6 +49,7 @@ app.add_middleware(
 )
 
 app.include_router(health.router)
+app.include_router(logs.router)
 app.include_router(auth.router)
 app.include_router(users.eula_router)
 app.include_router(users.router)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -65,20 +65,29 @@ async def clerk_webhook(request: Request, db: AsyncSession = Depends(get_db)) ->
         wh = Webhook(settings.clerk_webhook_secret)
         event = wh.verify(payload, headers)
     except WebhookVerificationError:
+        log.info("webhook_rejected reason=invalid_signature")
         raise HTTPException(status_code=400, detail="Invalid webhook signature")
 
     event_type = event.get("type")
     data = event.get("data", {})
+    clerk_user_id = data.get("id", "unknown")
 
-    if event_type == "user.created":
-        await _handle_user_created(db, data)
-    elif event_type == "user.updated":
-        await _handle_user_updated(db, data)
-    elif event_type == "user.deleted":
-        await _handle_user_deleted(db, data)
-    else:
-        log.debug("Ignoring unhandled Clerk event type: %s", event_type)
+    log.info("webhook_received event_type=%s clerk_user_id=%s", event_type, clerk_user_id)
 
+    try:
+        if event_type == "user.created":
+            await _handle_user_created(db, data)
+        elif event_type == "user.updated":
+            await _handle_user_updated(db, data)
+        elif event_type == "user.deleted":
+            await _handle_user_deleted(db, data)
+        else:
+            log.info("webhook_ignored event_type=%s", event_type)
+    except Exception:
+        log.exception("webhook_processing_failed event_type=%s clerk_user_id=%s", event_type, clerk_user_id)
+        raise
+
+    log.info("webhook_processed event_type=%s clerk_user_id=%s", event_type, clerk_user_id)
     return {"status": "ok"}
 
 

--- a/backend/app/routers/logs.py
+++ b/backend/app/routers/logs.py
@@ -1,0 +1,38 @@
+"""Frontend log relay — accepts structured log events from the browser and
+writes them through the shared JsonFormatter logger so client-side events
+appear in the same JSON log stream as backend events.
+
+Rate limiting is handled at the nginx layer (30 req/s per IP on /api/).
+No authentication required — this endpoint only writes, never reads.
+"""
+
+import logging
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel, Field
+
+log = logging.getLogger("frontend")
+router = APIRouter(tags=["logs"])
+
+_MAX_EVENTS_PER_REQUEST = 50
+
+
+class ClientLogEvent(BaseModel):
+    level: Literal["debug", "info", "warning", "error"]
+    message: str = Field(max_length=2000)
+    context: dict | None = None
+
+
+@router.post("/api/logs", status_code=204)
+async def ingest_client_logs(
+    events: Annotated[list[ClientLogEvent], Field(max_length=_MAX_EVENTS_PER_REQUEST)],
+    request: Request,
+) -> None:
+    client_ip = request.headers.get("X-Real-IP") or (request.client.host if request.client else "unknown")
+    for event in events[:_MAX_EVENTS_PER_REQUEST]:
+        level_fn = getattr(log, event.level, log.info)
+        extra: dict = {"source": "browser", "client_ip": client_ip}
+        if event.context:
+            extra.update(event.context)
+        level_fn(event.message, extra=extra)

--- a/backend/app/services/clerk_auth.py
+++ b/backend/app/services/clerk_auth.py
@@ -42,5 +42,5 @@ def verify_session_token(token: str, jwks_url: str) -> str | None:
         )
         return payload.get("sub")
     except Exception as exc:
-        log.debug("Clerk token verification failed: %s", exc)
+        log.info("jwt_verification_failed type=%s detail=%s", type(exc).__name__, exc)
         return None

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,3 +1,16 @@
+log_format json_combined escape=json
+  '{"timestamp": "$time_iso8601", '
+   '"level": "INFO", '
+   '"source": "nginx", '
+   '"remote_addr": "$remote_addr", '
+   '"method": "$request_method", '
+   '"uri": "$request_uri", '
+   '"status": $status, '
+   '"bytes_sent": $body_bytes_sent, '
+   '"request_time": $request_time, '
+   '"referrer": "$http_referer", '
+   '"user_agent": "$http_user_agent"}';
+
 # Rate-limit zones (http context — this file is included inside http {} by nginx.conf)
 # General API: 30 req/s per IP, burst 60 (handles normal SPA usage comfortably)
 limit_req_zone $binary_remote_addr zone=api:10m rate=30r/s;
@@ -8,6 +21,8 @@ server {
     listen 80;
     root /usr/share/nginx/html;
     index index.html;
+
+    access_log /var/log/nginx/access.log json_combined;
 
     client_max_body_size 25M;
 

--- a/frontend/src/lib/logger.ts
+++ b/frontend/src/lib/logger.ts
@@ -1,0 +1,63 @@
+type Level = "debug" | "info" | "warning" | "error";
+
+interface LogEvent {
+  level: Level;
+  message: string;
+  context?: Record<string, unknown>;
+}
+
+const ENDPOINT = "/api/logs";
+const FLUSH_DELAY_MS = 500;
+const MAX_BUFFER = 50;
+
+const buffer: LogEvent[] = [];
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+function scheduleFlush(): void {
+  if (flushTimer !== null) return;
+  flushTimer = setTimeout(flush, FLUSH_DELAY_MS);
+}
+
+function flush(): void {
+  flushTimer = null;
+  if (buffer.length === 0) return;
+  const events = buffer.splice(0);
+  fetch(ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(events),
+  }).catch(() => {
+    // Silently swallow — never log-loop if /api/logs is down
+  });
+}
+
+function emit(level: Level, message: string, context?: Record<string, unknown>): void {
+  if (buffer.length >= MAX_BUFFER) return;
+  buffer.push({ level, message, context });
+  scheduleFlush();
+}
+
+export const logger = {
+  debug: (message: string, context?: Record<string, unknown>) => emit("debug", message, context),
+  info:  (message: string, context?: Record<string, unknown>) => emit("info",  message, context),
+  warn:  (message: string, context?: Record<string, unknown>) => emit("warning", message, context),
+  error: (message: string, context?: Record<string, unknown>) => emit("error", message, context),
+};
+
+export function initLogger(): void {
+  window.addEventListener("error", (event) => {
+    emit("error", event.message ?? "Uncaught error", {
+      source: "window.onerror",
+      filename: event.filename,
+      lineno: event.lineno,
+      colno: event.colno,
+    });
+  });
+
+  window.addEventListener("unhandledrejection", (event) => {
+    const reason = event.reason instanceof Error
+      ? event.reason.message
+      : String(event.reason);
+    emit("error", reason, { source: "unhandledrejection" });
+  });
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,9 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
+import { initLogger } from "./lib/logger";
+
+initLogger();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary

- `deps.py`: log 401 rejections at INFO with reason (`no_token` / `invalid_token` / `user_not_found`), method, and path
- `clerk_auth.py`: surface JWT verification errors at INFO instead of swallowing silently
- `auth.py`: log webhook receipt, outcome, signature failures, and unhandled event types at INFO; wrap handler in try/except to catch unexpected processing failures
- `logging_config.py`: extend `JsonFormatter` to include extra fields so `source`, `context`, and `client_ip` appear in JSON output
- `routers/logs.py`: new `POST /api/logs` endpoint — accepts batched structured log events from the browser, writes through the shared `frontend` logger; unauthenticated, rate-limited at nginx layer
- `frontend/src/lib/logger.ts`: thin logger utility matching backend JSON schema; buffers and batches POSTs to `/api/logs`; hooks `window.onerror` and `unhandledrejection`
- `frontend/src/main.tsx`: call `initLogger()` at app startup
- `frontend/nginx.conf`: JSON structured access log format aligned with backend (`timestamp`, `level`, `source` fields)

## Test plan

- [x] No-token request → `auth_failure reason=no_token` logged at INFO with method + path
- [x] Invalid Bearer token → `jwt_verification_failed` + `auth_failure reason=invalid_token` logged at INFO
- [x] `POST /api/logs` relay → 204, browser events appear in backend log stream with `source: browser` and context fields
- [x] nginx access logs emit JSON with `timestamp`, `level`, `source` matching backend format

Closes #116, closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)