### PR TITLE
feat: user lifecycle management — deletion service, Celery/Redis, and frontend auth fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,6 +122,14 @@ INVITE_EXPIRY_DAYS_DEFAULT=7
 
 
 # ------------------------------------------------------------
+# Redis — Celery broker and result backend
+# For Docker deployments: redis://redis:6379/0 (service name matches compose)
+# For external Redis: redis://:password@host:6379/0
+# ------------------------------------------------------------
+REDIS_URL=redis://redis:6379/0
+
+
+# ------------------------------------------------------------
 # PyWeaving / Rendering
 # ------------------------------------------------------------
 

--- a/backend/alembic/versions/0029_user_deletion_state.py
+++ b/backend/alembic/versions/0029_user_deletion_state.py
@@ -1,0 +1,24 @@
+"""add deletion_state and deletion_initiated_at to users
+
+Revision ID: 0029
+Revises: 0028
+Create Date: 2026-04-30
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0029"
+down_revision = "0028"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("deletion_state", sa.String(20), nullable=True))
+    op.add_column("users", sa.Column("deletion_initiated_at", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "deletion_initiated_at")
+    op.drop_column("users", "deletion_state")

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -1,0 +1,27 @@
+from celery import Celery
+
+from app.config import get_settings
+
+
+def _make_celery() -> Celery:
+    settings = get_settings()
+    app = Celery(
+        "weftmark",
+        broker=settings.redis_url,
+        backend=settings.redis_url,
+        include=["app.tasks.deletion"],
+    )
+    app.conf.update(
+        task_serializer="json",
+        accept_content=["json"],
+        result_serializer="json",
+        timezone="UTC",
+        enable_utc=True,
+        task_track_started=True,
+        worker_prefetch_multiplier=1,
+        broker_connection_retry_on_startup=True,
+    )
+    return app
+
+
+celery_app = _make_celery()

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -101,6 +101,9 @@ class Settings(BaseSettings):
     s3_bucket_name: str = ""
     s3_region: str = ""
 
+    # Redis / Celery
+    redis_url: str = "redis://redis:6379/0"
+
     # Rendering
     render_max_width: int = 4000
     render_max_height: int = 4000

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -45,15 +45,23 @@ async def get_current_user(
         log.info("auth_failure reason=invalid_token method=%s path=%s", method, path)
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired token")
 
-    user = await db.scalar(
-        select(User).where(
-            User.clerk_user_id == clerk_user_id,
-            User.deleted_at.is_(None),
-            User.is_active.is_(True),
-        )
-    )
+    user = await db.scalar(select(User).where(User.clerk_user_id == clerk_user_id))
     if user is None:
         log.info("auth_failure reason=user_not_found clerk_user_id=%s method=%s path=%s", clerk_user_id, method, path)
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+
+    if user.deleted_at is not None:
+        log.info(
+            "auth_failure reason=user_deleted clerk_user_id=%s deletion_state=%s method=%s path=%s",
+            clerk_user_id,
+            user.deletion_state,
+            method,
+            path,
+        )
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+
+    if not user.is_active:
+        log.info("auth_failure reason=user_inactive clerk_user_id=%s method=%s path=%s", clerk_user_id, method, path)
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
 
     now = datetime.now(timezone.utc)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -7,6 +7,8 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base, SoftDeleteMixin, TimestampMixin
 
+DELETION_STATES = ("pending", "in_progress", "complete", "stalled", "aborted")
+
 
 class User(Base, TimestampMixin, SoftDeleteMixin):
     __tablename__ = "users"
@@ -30,3 +32,5 @@ class User(Base, TimestampMixin, SoftDeleteMixin):
     approved_by_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
     approved_by_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
     clerk_banned: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    deletion_state: Mapped[str | None] = mapped_column(String(20), nullable=True, default=None)
+    deletion_initiated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, default=None)

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -62,6 +62,8 @@ class AdminUserResponse(BaseModel):
     last_active_at: datetime | None
     approved_by_name: str | None
     approved_by_email: str | None
+    deletion_state: str | None
+    deletion_initiated_at: datetime | None
     counts: AdminUserCounts
 
     model_config = {"from_attributes": False}
@@ -371,8 +373,16 @@ async def list_users(
     _: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ) -> list[AdminUserResponse]:
+    from sqlalchemy import or_
+
     users = list(
-        (await db.scalars(select(User).where(User.deleted_at.is_(None)).order_by(User.created_at.asc()))).all()
+        (
+            await db.scalars(
+                select(User)
+                .where(or_(User.deleted_at.is_(None), User.deletion_state.is_not(None)))
+                .order_by(User.created_at.asc())
+            )
+        ).all()
     )
     if not users:
         return []
@@ -452,6 +462,8 @@ async def list_users(
             approved_by_name=u.approved_by_name,
             approved_by_email=u.approved_by_email,
             is_superuser=u.is_superuser,
+            deletion_state=u.deletion_state,
+            deletion_initiated_at=u.deletion_initiated_at,
             counts=AdminUserCounts(
                 projects=project_counts.get(u.id, 0),
                 activities_active=activity_active.get(u.id, 0),
@@ -558,6 +570,8 @@ async def patch_user(
         approved_by_name=user.approved_by_name,
         approved_by_email=user.approved_by_email,
         is_superuser=user.is_superuser,
+        deletion_state=user.deletion_state,
+        deletion_initiated_at=user.deletion_initiated_at,
         counts=AdminUserCounts(
             projects=projects,
             activities_active=act_active,
@@ -608,6 +622,8 @@ async def ban_user(
         approved_by_name=user.approved_by_name,
         approved_by_email=user.approved_by_email,
         is_superuser=user.is_superuser,
+        deletion_state=user.deletion_state,
+        deletion_initiated_at=user.deletion_initiated_at,
         counts=AdminUserCounts(projects=0, activities_active=0, activities_completed=0, looms=0, storage_bytes=0),
     )
 
@@ -643,8 +659,45 @@ async def unban_user(
         approved_by_name=user.approved_by_name,
         approved_by_email=user.approved_by_email,
         is_superuser=user.is_superuser,
+        deletion_state=user.deletion_state,
+        deletion_initiated_at=user.deletion_initiated_at,
         counts=AdminUserCounts(projects=0, activities_active=0, activities_completed=0, looms=0, storage_bytes=0),
     )
+
+
+# ---------------------------------------------------------------------------
+# Delete user
+# ---------------------------------------------------------------------------
+
+
+class DeleteUserRequest(BaseModel):
+    confirm: str
+
+
+@router.post("/users/{user_id}/delete", status_code=202)
+async def delete_user(
+    user_id: uuid.UUID,
+    body: DeleteUserRequest,
+    requesting_user: User = Depends(require_superuser),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    if body.confirm != "DELETE USER":
+        raise HTTPException(status_code=422, detail='confirm must be exactly "DELETE USER"')
+
+    user = await db.scalar(select(User).where(User.id == user_id))
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    if user.id == requesting_user.id:
+        raise HTTPException(status_code=400, detail="Cannot delete your own account via admin panel")
+    if user.deletion_state is not None:
+        raise HTTPException(status_code=409, detail=f"Deletion already in state: {user.deletion_state}")
+
+    from app.services.deletion import initiate_user_deletion
+
+    await initiate_user_deletion(db, user)
+    log.info("admin_delete_initiated user_id=%s by=%s", user_id, requesting_user.email)
+
+    return {"status": "pending", "user_id": str(user_id)}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/deletion.py
+++ b/backend/app/services/deletion.py
@@ -1,0 +1,52 @@
+"""Deletion service — soft-delete a user immediately and dispatch the cascade task.
+
+Called from both the admin panel (superuser-initiated) and the self-service
+endpoint (user-initiated, implemented in a later issue).
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import User
+
+log = logging.getLogger(__name__)
+
+
+async def initiate_user_deletion(db: AsyncSession, user: User) -> None:
+    """Soft-delete the user immediately and queue the background cascade task.
+
+    After this returns the user record has deletion_state='pending' and
+    deleted_at set, so all subsequent API requests return 401.
+    """
+    from app.services.email import send_deletion_created_admin
+    from app.tasks.deletion import run_user_deletion
+
+    user.soft_delete()
+    user.deletion_state = "pending"
+    user.deletion_initiated_at = datetime.now(timezone.utc)
+    await db.commit()
+
+    log.info(
+        "deletion_initiated user_id=%s email=%s initiated_by=admin",
+        user.id,
+        user.email,
+    )
+
+    run_user_deletion.delay(str(user.id))
+
+    # Notify admins that deletion has been queued
+    from sqlalchemy import select
+
+    from app.models.user import User as UserModel
+
+    admin_emails_rows = await db.scalars(
+        select(UserModel).where(UserModel.is_admin.is_(True), UserModel.deleted_at.is_(None))
+    )
+    admin_emails = [u.email for u in admin_emails_rows.all()]
+    if admin_emails:
+        try:
+            await send_deletion_created_admin(admin_emails, user.display_name, user.email)
+        except Exception as exc:
+            log.warning("deletion_notify_failed event=created error=%s", exc)

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -98,6 +98,44 @@ async def send_approval_confirmation_to_admins(
     await _send(admin_emails, f"Account approved — {display_name} ({email})", txt, html)
 
 
+async def send_deletion_created_admin(admin_emails: list[str], display_name: str, email: str) -> None:
+    settings = get_settings()
+    txt, html = _render(
+        "deletion_created_admin",
+        display_name=display_name,
+        email=email,
+        app_name=settings.smtp_from_name,
+        admin_url=f"{settings.frontend_url}/admin",
+    )
+    await _send(admin_emails, f"User deletion queued — {display_name} ({email})", txt, html)
+
+
+async def send_deletion_completed_admin(admin_emails: list[str], display_name: str, email: str) -> None:
+    settings = get_settings()
+    txt, html = _render(
+        "deletion_completed_admin",
+        display_name=display_name,
+        email=email,
+        app_name=settings.smtp_from_name,
+    )
+    await _send(admin_emails, f"User deletion complete — {display_name} ({email})", txt, html)
+
+
+async def send_deletion_stalled_superuser(
+    superuser_emails: list[str], display_name: str, email: str, user_id: str
+) -> None:
+    settings = get_settings()
+    txt, html = _render(
+        "deletion_stalled_superuser",
+        display_name=display_name,
+        email=email,
+        user_id=user_id,
+        app_name=settings.smtp_from_name,
+        admin_url=f"{settings.frontend_url}/admin",
+    )
+    await _send(superuser_emails, f"User deletion stalled — {display_name} ({email})", txt, html)
+
+
 async def send_test_email(to_email: str) -> None:
     settings = get_settings()
     txt = (

--- a/backend/app/tasks/deletion.py
+++ b/backend/app/tasks/deletion.py
@@ -1,0 +1,213 @@
+"""Celery task: cascade-delete all data for a soft-deleted user.
+
+The task is dispatched by the deletion service immediately after soft-delete.
+It creates its own DB session (separate Celery worker process).
+"""
+
+import asyncio
+import logging
+import uuid
+
+from celery import Task
+from celery.exceptions import SoftTimeLimitExceeded
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.celery_app import celery_app
+
+log = logging.getLogger(__name__)
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=3,
+    default_retry_delay=60,
+    soft_time_limit=600,
+    time_limit=660,
+    name="app.tasks.deletion.run_user_deletion",
+)
+def run_user_deletion(self: Task, user_id: str) -> None:
+    asyncio.run(_delete_user(self, uuid.UUID(user_id)))
+
+
+async def _delete_user(task: Task, user_id: uuid.UUID) -> None:
+    from app.config import get_settings
+    from app.models.activity import Activity, ActivityPhoto, ActivityStep
+    from app.models.invite import Invite
+    from app.models.loom import Loom, LoomVersion, LoomVersionAccessory, LoomVersionPhoto, LoomVersionReceipt
+    from app.models.pending_signup import PendingSignup
+    from app.models.project import Project
+    from app.models.user import User
+    from app.models.user_identity import UserIdentity
+    from app.models.yarn import Skein, Yarn
+    from app.services import storage
+
+    settings = get_settings()
+    engine = create_async_engine(settings.database_url, echo=False)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    try:
+        async with async_session() as db:
+            user = await db.get(User, user_id)
+            if user is None:
+                log.warning("deletion_task_skip user_id=%s reason=not_found", user_id)
+                return
+            if user.deletion_state == "complete":
+                log.info("deletion_task_skip user_id=%s reason=already_complete", user_id)
+                return
+
+            user_email = user.email
+            user_display = user.display_name
+
+            try:
+                user.deletion_state = "in_progress"
+                await db.commit()
+                log.info("deletion_task_started user_id=%s", user_id)
+
+                # --- Storage purge ---
+                await _purge_storage(db, user_id, storage)
+
+                # --- DB cascade ---
+                activity_ids_subq = select(Activity.id).where(Activity.owner_id == user_id)
+                await db.execute(delete(ActivityStep).where(ActivityStep.activity_id.in_(activity_ids_subq)))
+                await db.execute(delete(ActivityPhoto).where(ActivityPhoto.activity_id.in_(activity_ids_subq)))
+                await db.execute(delete(Activity).where(Activity.owner_id == user_id))
+
+                yarn_ids_subq = select(Yarn.id).where(Yarn.owner_id == user_id)
+                await db.execute(delete(Skein).where(Skein.yarn_id.in_(yarn_ids_subq)))
+                await db.execute(delete(Yarn).where(Yarn.owner_id == user_id))
+
+                loom_ids_subq = select(Loom.id).where(Loom.owner_id == user_id)
+                version_ids_subq = select(LoomVersion.id).where(LoomVersion.loom_id.in_(loom_ids_subq))
+                await db.execute(
+                    delete(LoomVersionAccessory).where(LoomVersionAccessory.loom_version_id.in_(version_ids_subq))
+                )
+                await db.execute(
+                    delete(LoomVersionReceipt).where(LoomVersionReceipt.loom_version_id.in_(version_ids_subq))
+                )
+                await db.execute(delete(LoomVersionPhoto).where(LoomVersionPhoto.loom_version_id.in_(version_ids_subq)))
+                await db.execute(delete(LoomVersion).where(LoomVersion.loom_id.in_(loom_ids_subq)))
+                await db.execute(delete(Loom).where(Loom.owner_id == user_id))
+
+                await db.execute(delete(Project).where(Project.owner_id == user_id))
+                await db.execute(delete(Invite).where(Invite.created_by_id == user_id))
+                await db.execute(delete(UserIdentity).where(UserIdentity.user_id == user_id))
+
+                # Resolve any lingering pending signups for this Clerk user
+                if user.clerk_user_id:
+                    await db.execute(delete(PendingSignup).where(PendingSignup.clerk_user_id == user.clerk_user_id))
+
+                user.deletion_state = "complete"
+                await db.commit()
+                log.info("deletion_task_complete user_id=%s email=%s", user_id, user_email)
+
+            except SoftTimeLimitExceeded:
+                user.deletion_state = "stalled"
+                await db.commit()
+                log.warning("deletion_task_stalled user_id=%s reason=soft_time_limit", user_id)
+                await _notify_stalled(db, user_id, user_email, user_display)
+                raise
+
+            except Exception as exc:
+                log.exception("deletion_task_error user_id=%s attempt=%s", user_id, task.request.retries + 1)
+                if task.request.retries >= task.max_retries:
+                    user.deletion_state = "stalled"
+                    await db.commit()
+                    await _notify_stalled(db, user_id, user_email, user_display)
+                else:
+                    raise task.retry(exc=exc)
+
+            else:
+                await _notify_admins_complete(db, user_email, user_display)
+
+    finally:
+        await engine.dispose()
+
+
+async def _purge_storage(db: AsyncSession, user_id: uuid.UUID, storage) -> None:
+    from app.models.activity import Activity, ActivityPhoto
+    from app.models.loom import Loom, LoomVersion, LoomVersionPhoto, LoomVersionReceipt
+    from app.models.project import Project
+    from app.models.yarn import Yarn
+
+    photos = await db.scalars(
+        select(ActivityPhoto)
+        .join(Activity, ActivityPhoto.activity_id == Activity.id)
+        .where(Activity.owner_id == user_id)
+    )
+    for p in photos.all():
+        _safe_delete(storage, p.file_path)
+
+    yarns = await db.scalars(select(Yarn).where(Yarn.owner_id == user_id))
+    for y in yarns.all():
+        if y.photo_path:
+            _safe_delete(storage, y.photo_path)
+
+    looms = await db.scalars(select(Loom).where(Loom.owner_id == user_id))
+    loom_ids = []
+    for loom in looms.all():
+        loom_ids.append(loom.id)
+        if loom.photo_path:
+            _safe_delete(storage, loom.photo_path)
+
+    if loom_ids:
+        versions = await db.scalars(select(LoomVersion).where(LoomVersion.loom_id.in_(loom_ids)))
+        version_ids = [v.id for v in versions.all()]
+        if version_ids:
+            vp = await db.scalars(select(LoomVersionPhoto).where(LoomVersionPhoto.loom_version_id.in_(version_ids)))
+            for p in vp.all():
+                _safe_delete(storage, p.path)
+            vr = await db.scalars(select(LoomVersionReceipt).where(LoomVersionReceipt.loom_version_id.in_(version_ids)))
+            for r in vr.all():
+                _safe_delete(storage, r.path)
+
+    projects = await db.scalars(select(Project).where(Project.owner_id == user_id))
+    for proj in projects.all():
+        if proj.wif_path:
+            _safe_delete(storage, proj.wif_path)
+        if proj.preview_path:
+            _safe_delete(storage, proj.preview_path)
+
+
+def _safe_delete(storage, path: str) -> None:
+    try:
+        storage._delete(path)
+    except Exception as exc:
+        log.warning("deletion_storage_error path=%s error=%s", path, exc)
+
+
+async def _get_admin_emails(db: AsyncSession) -> list[str]:
+    from app.models.user import User
+
+    users = await db.scalars(select(User).where(User.is_admin.is_(True), User.deleted_at.is_(None)))
+    return [u.email for u in users.all()]
+
+
+async def _get_superuser_emails(db: AsyncSession) -> list[str]:
+    from app.models.user import User
+
+    users = await db.scalars(select(User).where(User.is_superuser.is_(True), User.deleted_at.is_(None)))
+    return [u.email for u in users.all()]
+
+
+async def _notify_admins_complete(db: AsyncSession, email: str, display_name: str) -> None:
+    from app.services.email import send_deletion_completed_admin
+
+    admin_emails = await _get_admin_emails(db)
+    if admin_emails:
+        try:
+            await send_deletion_completed_admin(admin_emails, display_name, email)
+        except Exception as exc:
+            log.warning("deletion_notify_failed event=completed error=%s", exc)
+
+
+async def _notify_stalled(db: AsyncSession, user_id: uuid.UUID, email: str, display_name: str) -> None:
+    from app.services.email import send_deletion_stalled_superuser
+
+    superuser_emails = await _get_superuser_emails(db)
+    if superuser_emails:
+        try:
+            await send_deletion_stalled_superuser(superuser_emails, display_name, email, str(user_id))
+        except Exception as exc:
+            log.warning("deletion_notify_failed event=stalled error=%s", exc)

--- a/backend/app/templates/email/deletion_completed_admin.html
+++ b/backend/app/templates/email/deletion_completed_admin.html
@@ -1,0 +1,6 @@
+<p>User deletion completed successfully in <strong>{app_name}</strong>.</p>
+
+<table style="border-collapse:collapse;margin:16px 0;">
+  <tr><td style="padding:4px 12px 4px 0;color:#6b7280;">User</td><td style="padding:4px 0;"><strong>{display_name}</strong> ({email})</td></tr>
+  <tr><td style="padding:4px 0;color:#6b7280;">Status</td><td style="padding:4px 0;color:#16a34a;font-weight:bold;">Complete — all data permanently deleted</td></tr>
+</table>

--- a/backend/app/templates/email/deletion_completed_admin.txt
+++ b/backend/app/templates/email/deletion_completed_admin.txt
@@ -1,0 +1,4 @@
+User deletion completed successfully in {app_name}.
+
+User:    {display_name} ({email})
+Status:  Complete — all data has been permanently deleted

--- a/backend/app/templates/email/deletion_created_admin.html
+++ b/backend/app/templates/email/deletion_created_admin.html
@@ -1,0 +1,11 @@
+<p>A user deletion has been queued in <strong>{app_name}</strong>.</p>
+
+<table style="border-collapse:collapse;margin:16px 0;">
+  <tr><td style="padding:4px 12px 4px 0;color:#6b7280;">User</td><td style="padding:4px 0;"><strong>{display_name}</strong> ({email})</td></tr>
+  <tr><td style="padding:4px 12px 4px 0;color:#6b7280;">Status</td><td style="padding:4px 0;">Pending — data cascade in progress</td></tr>
+</table>
+
+<p>All user data (projects, activities, looms, uploads) will be permanently
+deleted by the background task. The user's account is already blocked.</p>
+
+<p><a href="{admin_url}">View Admin Panel</a></p>

--- a/backend/app/templates/email/deletion_created_admin.txt
+++ b/backend/app/templates/email/deletion_created_admin.txt
@@ -1,0 +1,10 @@
+A user deletion has been queued in {app_name}.
+
+User:        {display_name} ({email})
+Status:      Pending — data cascade in progress
+
+All user data (projects, activities, looms, uploads) will be permanently
+deleted by the background task. The user's account is already blocked.
+
+View the admin panel for status updates:
+{admin_url}

--- a/backend/app/templates/email/deletion_stalled_superuser.html
+++ b/backend/app/templates/email/deletion_stalled_superuser.html
@@ -1,0 +1,12 @@
+<p style="color:#b91c1c;font-weight:bold;">A user deletion task has stalled and requires attention in <strong>{app_name}</strong>.</p>
+
+<table style="border-collapse:collapse;margin:16px 0;">
+  <tr><td style="padding:4px 12px 4px 0;color:#6b7280;">User</td><td style="padding:4px 0;"><strong>{display_name}</strong> ({email})</td></tr>
+  <tr><td style="padding:4px 12px 4px 0;color:#6b7280;">User ID</td><td style="padding:4px 0;font-family:monospace;">{user_id}</td></tr>
+  <tr><td style="padding:4px 12px 4px 0;color:#6b7280;">Status</td><td style="padding:4px 0;color:#b91c1c;font-weight:bold;">Stalled — retry limit exceeded</td></tr>
+</table>
+
+<p>The user's account remains blocked but their data has not been fully purged.
+Check the worker logs for details and re-trigger deletion from the admin panel.</p>
+
+<p><a href="{admin_url}">View Admin Panel</a></p>

--- a/backend/app/templates/email/deletion_stalled_superuser.txt
+++ b/backend/app/templates/email/deletion_stalled_superuser.txt
@@ -1,0 +1,11 @@
+A user deletion task has stalled and requires attention in {app_name}.
+
+User:     {display_name} ({email})
+User ID:  {user_id}
+Status:   Stalled — the background task exceeded its retry limit
+
+Manual intervention is required. The user's account remains blocked but their
+data has not been fully purged. Check the worker logs for details and
+re-trigger deletion from the admin panel.
+
+{admin_url}

--- a/backend/tests/models/test_user.py
+++ b/backend/tests/models/test_user.py
@@ -120,3 +120,40 @@ class TestUserFields:
         await db_session.commit()
         await db_session.refresh(user)
         assert user.is_admin is True
+
+
+class TestUserDeletionFields:
+    async def test_deletion_state_defaults_none(self, db_session: AsyncSession):
+        user = User(email="u@example.com", display_name="U", oidc_sub="sub-001")
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+        assert user.deletion_state is None
+
+    async def test_deletion_initiated_at_defaults_none(self, db_session: AsyncSession):
+        user = User(email="u@example.com", display_name="U", oidc_sub="sub-001")
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+        assert user.deletion_initiated_at is None
+
+    async def test_deletion_state_persists(self, db_session: AsyncSession):
+        user = User(email="u@example.com", display_name="U", oidc_sub="sub-001")
+        db_session.add(user)
+        await db_session.commit()
+        user.deletion_state = "pending"
+        await db_session.commit()
+        await db_session.refresh(user)
+        assert user.deletion_state == "pending"
+
+    async def test_deletion_initiated_at_persists(self, db_session: AsyncSession):
+        from datetime import datetime, timezone
+
+        user = User(email="u@example.com", display_name="U", oidc_sub="sub-001")
+        db_session.add(user)
+        await db_session.commit()
+        now = datetime.now(timezone.utc)
+        user.deletion_initiated_at = now
+        await db_session.commit()
+        await db_session.refresh(user)
+        assert user.deletion_initiated_at is not None

--- a/backend/tests/routers/test_admin.py
+++ b/backend/tests/routers/test_admin.py
@@ -1047,3 +1047,92 @@ class TestSendTestEmail:
     async def test_unauthenticated_returns_401(self, raw_client: AsyncClient):
         resp = await raw_client.post("/api/admin/test-email")
         assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# POST /api/admin/users/{user_id}/delete
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteUser:
+    @pytest.fixture(autouse=True)
+    def mock_deletion_service(self):
+        with patch("app.services.deletion.initiate_user_deletion", new_callable=AsyncMock) as m:
+            yield m
+
+    async def _create_target(self, db_session: AsyncSession) -> User:
+        user = User(
+            email=f"del-target-{uuid.uuid4().hex[:6]}@test.com",
+            display_name="Delete Target",
+            oidc_sub=f"del-sub-{uuid.uuid4().hex}",
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+        return user
+
+    async def test_returns_202(self, superuser_client: AsyncClient, db_session: AsyncSession):
+        target = await self._create_target(db_session)
+        resp = await superuser_client.post(f"/api/admin/users/{target.id}/delete", json={"confirm": "DELETE USER"})
+        assert resp.status_code == 202
+
+    async def test_returns_pending_status_and_user_id(self, superuser_client: AsyncClient, db_session: AsyncSession):
+        target = await self._create_target(db_session)
+        resp = await superuser_client.post(f"/api/admin/users/{target.id}/delete", json={"confirm": "DELETE USER"})
+        data = resp.json()
+        assert data["status"] == "pending"
+        assert data["user_id"] == str(target.id)
+
+    async def test_wrong_confirm_returns_422(self, superuser_client: AsyncClient, db_session: AsyncSession):
+        target = await self._create_target(db_session)
+        resp = await superuser_client.post(f"/api/admin/users/{target.id}/delete", json={"confirm": "WRONG STRING"})
+        assert resp.status_code == 422
+
+    async def test_empty_confirm_returns_422(self, superuser_client: AsyncClient, db_session: AsyncSession):
+        target = await self._create_target(db_session)
+        resp = await superuser_client.post(f"/api/admin/users/{target.id}/delete", json={"confirm": ""})
+        assert resp.status_code == 422
+
+    async def test_nonexistent_user_returns_404(self, superuser_client: AsyncClient):
+        resp = await superuser_client.post(f"/api/admin/users/{uuid.uuid4()}/delete", json={"confirm": "DELETE USER"})
+        assert resp.status_code == 404
+
+    async def test_self_delete_returns_400(self, superuser_client: AsyncClient, superuser_user: User):
+        resp = await superuser_client.post(
+            f"/api/admin/users/{superuser_user.id}/delete", json={"confirm": "DELETE USER"}
+        )
+        assert resp.status_code == 400
+
+    async def test_already_pending_returns_409(self, superuser_client: AsyncClient, db_session: AsyncSession):
+        target = await self._create_target(db_session)
+        target.deletion_state = "pending"
+        await db_session.commit()
+        resp = await superuser_client.post(f"/api/admin/users/{target.id}/delete", json={"confirm": "DELETE USER"})
+        assert resp.status_code == 409
+
+    async def test_already_in_progress_returns_409(self, superuser_client: AsyncClient, db_session: AsyncSession):
+        target = await self._create_target(db_session)
+        target.deletion_state = "in_progress"
+        await db_session.commit()
+        resp = await superuser_client.post(f"/api/admin/users/{target.id}/delete", json={"confirm": "DELETE USER"})
+        assert resp.status_code == 409
+
+    async def test_non_superuser_returns_403(self, admin_client: AsyncClient, db_session: AsyncSession):
+        target = await self._create_target(db_session)
+        resp = await admin_client.post(f"/api/admin/users/{target.id}/delete", json={"confirm": "DELETE USER"})
+        assert resp.status_code == 403
+
+    async def test_unauthenticated_returns_401(self, raw_client: AsyncClient, db_session: AsyncSession):
+        target = await self._create_target(db_session)
+        resp = await raw_client.post(f"/api/admin/users/{target.id}/delete", json={"confirm": "DELETE USER"})
+        assert resp.status_code == 401
+
+    async def test_calls_initiate_user_deletion(
+        self,
+        superuser_client: AsyncClient,
+        db_session: AsyncSession,
+        mock_deletion_service: AsyncMock,
+    ):
+        target = await self._create_target(db_session)
+        await superuser_client.post(f"/api/admin/users/{target.id}/delete", json={"confirm": "DELETE USER"})
+        mock_deletion_service.assert_called_once()

--- a/backend/tests/services/test_deletion.py
+++ b/backend/tests/services/test_deletion.py
@@ -1,0 +1,98 @@
+import uuid
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import User
+from app.services.deletion import initiate_user_deletion
+
+
+class TestInitiateUserDeletion:
+    async def _create_user(self, db_session: AsyncSession) -> User:
+        user = User(
+            email=f"todelete-{uuid.uuid4().hex[:6]}@test.com",
+            display_name="To Delete",
+            oidc_sub=f"todelete-sub-{uuid.uuid4().hex}",
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+        return user
+
+    def _make_mocks(self):
+        mock_task = MagicMock()
+        mock_task.delay = MagicMock()
+        mock_email = AsyncMock()
+        return mock_task, mock_email
+
+    async def test_sets_deletion_state_pending(self, db_session: AsyncSession):
+        mock_task, mock_email = self._make_mocks()
+        user = await self._create_user(db_session)
+        with (
+            patch("app.tasks.deletion.run_user_deletion", mock_task),
+            patch("app.services.email.send_deletion_created_admin", mock_email),
+        ):
+            await initiate_user_deletion(db_session, user)
+        assert user.deletion_state == "pending"
+
+    async def test_sets_deleted_at(self, db_session: AsyncSession):
+        mock_task, mock_email = self._make_mocks()
+        user = await self._create_user(db_session)
+        with (
+            patch("app.tasks.deletion.run_user_deletion", mock_task),
+            patch("app.services.email.send_deletion_created_admin", mock_email),
+        ):
+            await initiate_user_deletion(db_session, user)
+        assert user.deleted_at is not None
+
+    async def test_sets_deletion_initiated_at(self, db_session: AsyncSession):
+        mock_task, mock_email = self._make_mocks()
+        user = await self._create_user(db_session)
+        with (
+            patch("app.tasks.deletion.run_user_deletion", mock_task),
+            patch("app.services.email.send_deletion_created_admin", mock_email),
+        ):
+            await initiate_user_deletion(db_session, user)
+        assert user.deletion_initiated_at is not None
+        assert isinstance(user.deletion_initiated_at, datetime)
+
+    async def test_dispatches_celery_task(self, db_session: AsyncSession):
+        mock_task, mock_email = self._make_mocks()
+        user = await self._create_user(db_session)
+        with (
+            patch("app.tasks.deletion.run_user_deletion", mock_task),
+            patch("app.services.email.send_deletion_created_admin", mock_email),
+        ):
+            await initiate_user_deletion(db_session, user)
+        mock_task.delay.assert_called_once_with(str(user.id))
+
+    async def test_notifies_admins_when_present(self, db_session: AsyncSession):
+        mock_task, mock_email = self._make_mocks()
+        admin = User(
+            email="notify-admin@del-test.com",
+            display_name="Notify Admin",
+            oidc_sub=f"notify-admin-sub-{uuid.uuid4().hex}",
+            is_admin=True,
+        )
+        db_session.add(admin)
+        await db_session.commit()
+        user = await self._create_user(db_session)
+        with (
+            patch("app.tasks.deletion.run_user_deletion", mock_task),
+            patch("app.services.email.send_deletion_created_admin", mock_email),
+        ):
+            await initiate_user_deletion(db_session, user)
+        mock_email.assert_called_once()
+        called_emails = mock_email.call_args[0][0]
+        assert admin.email in called_emails
+
+    async def test_no_notification_when_no_admins(self, db_session: AsyncSession):
+        mock_task, mock_email = self._make_mocks()
+        user = await self._create_user(db_session)
+        with (
+            patch("app.tasks.deletion.run_user_deletion", mock_task),
+            patch("app.services.email.send_deletion_created_admin", mock_email),
+        ):
+            await initiate_user_deletion(db_session, user)
+        mock_email.assert_not_called()

--- a/backend/tests/tasks/test_deletion_task.py
+++ b/backend/tests/tasks/test_deletion_task.py
@@ -1,0 +1,272 @@
+"""Tests for app.tasks.deletion._delete_user — the async core of the cascade task.
+
+We call _delete_user directly rather than through run_user_deletion so we can
+run it in the test event loop.  create_async_engine and sessionmaker are patched
+so the task uses the test db_session instead of opening its own connection.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from celery.exceptions import SoftTimeLimitExceeded
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.loom import Loom
+from app.models.project import Project
+from app.models.user import User
+from app.models.yarn import Yarn
+from app.tasks.deletion import _delete_user
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _task_mock(retries: int = 0, max_retries: int = 3) -> MagicMock:
+    t = MagicMock()
+    t.request = MagicMock()
+    t.request.retries = retries
+    t.max_retries = max_retries
+    return t
+
+
+def _session_factory(db: AsyncSession):
+    """Return a sessionmaker-compatible callable that yields db as the session."""
+
+    class _Ctx:
+        async def __aenter__(self):
+            return db
+
+        async def __aexit__(self, *args):
+            pass
+
+    class _Factory:
+        def __call__(self):
+            return _Ctx()
+
+    return _Factory()
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_db(db_session: AsyncSession):
+    """Patch engine/session creation so _delete_user runs against db_session."""
+    fake_engine = MagicMock()
+    fake_engine.dispose = AsyncMock()
+    with (
+        patch("app.tasks.deletion.create_async_engine", return_value=fake_engine),
+        patch("app.tasks.deletion.sessionmaker", return_value=_session_factory(db_session)),
+    ):
+        yield
+
+
+@pytest.fixture()
+def mock_storage():
+    with patch("app.tasks.deletion._purge_storage", new_callable=AsyncMock):
+        yield
+
+
+@pytest.fixture()
+def mock_emails():
+    with (
+        patch("app.services.email.send_deletion_completed_admin", new_callable=AsyncMock),
+        patch("app.services.email.send_deletion_stalled_superuser", new_callable=AsyncMock),
+    ):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# TestDeleteUserHappyPath
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteUserHappyPath:
+    async def _pending_user(self, db: AsyncSession) -> User:
+        user = User(
+            email=f"cascade-{uuid.uuid4().hex[:6]}@test.com",
+            display_name="Cascade User",
+            oidc_sub=f"cascade-sub-{uuid.uuid4().hex}",
+            deletion_state="pending",
+        )
+        user.soft_delete()
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
+        return user
+
+    async def test_sets_state_complete(self, db_session, mock_db, mock_storage, mock_emails):
+        user = await self._pending_user(db_session)
+        await _delete_user(_task_mock(), user.id)
+        await db_session.refresh(user)
+        assert user.deletion_state == "complete"
+
+    async def test_deletes_projects(self, db_session, mock_db, mock_storage, mock_emails):
+        user = await self._pending_user(db_session)
+        db_session.add(Project(owner_id=user.id, name="P", wif_filename="p.wif", wif_path="p/p.wif"))
+        await db_session.commit()
+
+        await _delete_user(_task_mock(), user.id)
+
+        assert await db_session.scalar(select(Project).where(Project.owner_id == user.id)) is None
+
+    async def test_deletes_yarn(self, db_session, mock_db, mock_storage, mock_emails):
+        user = await self._pending_user(db_session)
+        db_session.add(Yarn(owner_id=user.id, brand="B", name="Y"))
+        await db_session.commit()
+
+        await _delete_user(_task_mock(), user.id)
+
+        assert await db_session.scalar(select(Yarn).where(Yarn.owner_id == user.id)) is None
+
+    async def test_deletes_looms(self, db_session, mock_db, mock_storage, mock_emails):
+        user = await self._pending_user(db_session)
+        db_session.add(Loom(owner_id=user.id, loom_type="floor", manufacturer="Acme", model_name="L"))
+        await db_session.commit()
+
+        await _delete_user(_task_mock(), user.id)
+
+        assert await db_session.scalar(select(Loom).where(Loom.owner_id == user.id)) is None
+
+    async def test_notifies_admins_on_complete(self, db_session, mock_db, mock_storage):
+        admin = User(
+            email="task-notify-admin@test.com",
+            display_name="Task Admin",
+            oidc_sub=f"task-admin-{uuid.uuid4().hex}",
+            is_admin=True,
+        )
+        db_session.add(admin)
+        await db_session.commit()
+
+        user = await self._pending_user(db_session)
+
+        with (
+            patch("app.services.email.send_deletion_completed_admin", new_callable=AsyncMock) as mock_email,
+            patch("app.services.email.send_deletion_stalled_superuser", new_callable=AsyncMock),
+        ):
+            await _delete_user(_task_mock(), user.id)
+
+        mock_email.assert_called_once()
+        assert admin.email in mock_email.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# TestDeleteUserSkipPaths
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteUserSkipPaths:
+    async def test_skips_not_found(self, db_session, mock_db, mock_storage, mock_emails):
+        await _delete_user(_task_mock(), uuid.uuid4())
+
+    async def test_skips_already_complete(self, db_session, mock_db, mock_storage, mock_emails):
+        user = User(
+            email=f"done-{uuid.uuid4().hex[:6]}@test.com",
+            display_name="Done",
+            oidc_sub=f"done-{uuid.uuid4().hex}",
+            deletion_state="complete",
+        )
+        user.soft_delete()
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        await _delete_user(_task_mock(), user.id)
+
+        await db_session.refresh(user)
+        assert user.deletion_state == "complete"
+
+
+# ---------------------------------------------------------------------------
+# TestDeleteUserErrorPaths
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteUserErrorPaths:
+    async def _pending_user(self, db: AsyncSession) -> User:
+        user = User(
+            email=f"err-{uuid.uuid4().hex[:6]}@test.com",
+            display_name="Error User",
+            oidc_sub=f"err-sub-{uuid.uuid4().hex}",
+            deletion_state="pending",
+        )
+        user.soft_delete()
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
+        return user
+
+    async def test_soft_time_limit_sets_stalled(self, db_session, mock_db, mock_emails):
+        user = await self._pending_user(db_session)
+
+        with patch(
+            "app.tasks.deletion._purge_storage",
+            new_callable=AsyncMock,
+            side_effect=SoftTimeLimitExceeded(),
+        ):
+            with pytest.raises(SoftTimeLimitExceeded):
+                await _delete_user(_task_mock(), user.id)
+
+        await db_session.refresh(user)
+        assert user.deletion_state == "stalled"
+
+    async def test_exception_at_max_retries_sets_stalled(self, db_session, mock_db, mock_emails):
+        user = await self._pending_user(db_session)
+        task = _task_mock(retries=3, max_retries=3)
+
+        with patch(
+            "app.tasks.deletion._purge_storage",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("storage error"),
+        ):
+            await _delete_user(task, user.id)
+
+        await db_session.refresh(user)
+        assert user.deletion_state == "stalled"
+
+    async def test_exception_under_max_retries_calls_retry(self, db_session, mock_db, mock_emails):
+        user = await self._pending_user(db_session)
+        task = _task_mock(retries=0, max_retries=3)
+        task.retry = MagicMock(side_effect=RuntimeError("retry scheduled"))
+
+        with patch(
+            "app.tasks.deletion._purge_storage",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("storage error"),
+        ):
+            with pytest.raises(RuntimeError, match="retry scheduled"):
+                await _delete_user(task, user.id)
+
+        task.retry.assert_called_once()
+
+    async def test_stalled_notifies_superusers(self, db_session, mock_db):
+        superuser = User(
+            email="stall-super@test.com",
+            display_name="Stall Super",
+            oidc_sub=f"stall-super-{uuid.uuid4().hex}",
+            is_superuser=True,
+        )
+        db_session.add(superuser)
+        await db_session.commit()
+
+        user = await self._pending_user(db_session)
+
+        with (
+            patch(
+                "app.tasks.deletion._purge_storage",
+                new_callable=AsyncMock,
+                side_effect=SoftTimeLimitExceeded(),
+            ),
+            patch("app.services.email.send_deletion_completed_admin", new_callable=AsyncMock),
+            patch("app.services.email.send_deletion_stalled_superuser", new_callable=AsyncMock) as mock_stall_email,
+        ):
+            with pytest.raises(SoftTimeLimitExceeded):
+                await _delete_user(_task_mock(), user.id)
+
+        mock_stall_email.assert_called_once()
+        assert superuser.email in mock_stall_email.call_args[0][0]

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -34,7 +34,7 @@ services:
   # Backend — FastAPI application
   # Reachable only through the nginx proxy; not exposed to host.
   # Connected to both networks so nginx can reach it (public)
-  # and it can reach db (internal).
+  # and it can reach db and redis (internal).
   # Exposed: no
   # ----------------------------------------------------------
   backend:
@@ -51,6 +51,8 @@ services:
     volumes:
       - uploads:/app/uploads
     depends_on:
+      redis:
+        condition: service_healthy
       db:
         condition: service_healthy
         required: false
@@ -63,9 +65,51 @@ services:
     restart: unless-stopped
 
   # ----------------------------------------------------------
+  # Celery worker — background task processor
+  # Uses the same backend image; runs the Celery worker instead of uvicorn.
+  # ----------------------------------------------------------
+  worker:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    image: weaving_site_backend:${APP_VERSION:-dev}
+    container_name: weaving_site_worker
+    entrypoint: ["celery", "-A", "app.celery_app", "worker", "--loglevel=info", "--concurrency=2"]
+    networks:
+      - internal
+    env_file:
+      - .env.local
+    volumes:
+      - uploads:/app/uploads
+    depends_on:
+      redis:
+        condition: service_healthy
+      db:
+        condition: service_healthy
+        required: false
+    restart: unless-stopped
+
+  # ----------------------------------------------------------
+  # Redis — Celery broker and result backend
+  # ----------------------------------------------------------
+  redis:
+    image: redis:7-alpine
+    container_name: weaving_site_redis
+    networks:
+      - internal
+    ports:
+      - "127.0.0.1:6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+
+  # ----------------------------------------------------------
   # Database — PostgreSQL (local dev only)
   # Only starts when the "local-db" profile is active.
-  # Set COMPOSE_PROFILES=local-db in .env to enable.
+  # Set COMPOSE_PROFILES=local-db in .env.local to enable.
   # When POSTGRES_DSN is set (e.g. Neon), leave COMPOSE_PROFILES
   # unset — this container will not start.
   # ----------------------------------------------------------

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -46,6 +46,8 @@ services:
     volumes:
       - uploads:/app/uploads
     depends_on:
+      redis:
+        condition: service_healthy
       db:
         condition: service_healthy
         required: false
@@ -55,6 +57,42 @@ services:
       timeout: 5s
       retries: 5
       start_period: 15s
+    restart: unless-stopped
+
+  # ----------------------------------------------------------
+  # Celery worker — background task processor
+  # ----------------------------------------------------------
+  worker:
+    image: ghcr.io/weftmark/weftmark-backend:dev
+    container_name: weftmark_worker_dev
+    entrypoint: ["celery", "-A", "app.celery_app", "worker", "--loglevel=info", "--concurrency=2"]
+    networks:
+      - internal
+    env_file:
+      - .env.dev
+    volumes:
+      - uploads:/app/uploads
+    depends_on:
+      redis:
+        condition: service_healthy
+      db:
+        condition: service_healthy
+        required: false
+    restart: unless-stopped
+
+  # ----------------------------------------------------------
+  # Redis — Celery broker and result backend
+  # ----------------------------------------------------------
+  redis:
+    image: redis:7-alpine
+    container_name: weftmark_redis_dev
+    networks:
+      - internal
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
     restart: unless-stopped
 
   # ----------------------------------------------------------

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -46,6 +46,8 @@ services:
     volumes:
       - uploads:/app/uploads
     depends_on:
+      redis:
+        condition: service_healthy
       db:
         condition: service_healthy
         required: false
@@ -55,6 +57,42 @@ services:
       timeout: 5s
       retries: 5
       start_period: 15s
+    restart: unless-stopped
+
+  # ----------------------------------------------------------
+  # Celery worker — background task processor
+  # ----------------------------------------------------------
+  worker:
+    image: ghcr.io/weftmark/weftmark-backend:latest
+    container_name: weftmark_worker_prod
+    entrypoint: ["celery", "-A", "app.celery_app", "worker", "--loglevel=info", "--concurrency=2"]
+    networks:
+      - internal
+    env_file:
+      - .env.prod
+    volumes:
+      - uploads:/app/uploads
+    depends_on:
+      redis:
+        condition: service_healthy
+      db:
+        condition: service_healthy
+        required: false
+    restart: unless-stopped
+
+  # ----------------------------------------------------------
+  # Redis — Celery broker and result backend
+  # ----------------------------------------------------------
+  redis:
+    image: redis:7-alpine
+    container_name: weftmark_redis_prod
+    networks:
+      - internal
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
     restart: unless-stopped
 
   # ----------------------------------------------------------

--- a/frontend/src/api/activities.ts
+++ b/frontend/src/api/activities.ts
@@ -75,6 +75,8 @@ export interface PicksResponse {
   has_weft_colors: boolean;
 }
 
+import { getAuthToken } from "@/api/client";
+
 export class ApiError extends Error {
   constructor(
     message: string,
@@ -85,7 +87,12 @@ export class ApiError extends Error {
 }
 
 async function req<T>(url: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(url, { credentials: "include", ...init });
+  const token = await getAuthToken();
+  const headers: Record<string, string> = {
+    ...(init?.headers as Record<string, string>),
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+  const res = await fetch(url, { credentials: "include", ...init, headers });
   if (!res.ok) {
     const err = await res.json().catch(() => ({ detail: "Request failed" }));
     throw new ApiError(err.detail ?? "Request failed", res.status);

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -7,6 +7,25 @@ export function configureApiClient(getter: TokenGetter) {
   _getToken = getter;
 }
 
+export async function getAuthToken(): Promise<string | null> {
+  if (!_getToken) return null;
+  return _getToken();
+}
+
+export async function downloadAuthed(url: string, filename: string): Promise<void> {
+  const token = await getAuthToken();
+  const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
+  const res = await fetch(url, { headers, credentials: "include" });
+  if (!res.ok) throw new Error("Download failed");
+  const blob = await res.blob();
+  const objectUrl = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = objectUrl;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(objectUrl);
+}
+
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",

--- a/frontend/src/api/looms.ts
+++ b/frontend/src/api/looms.ts
@@ -128,8 +128,15 @@ export interface CloneVersionPayload {
   include_accessories?: boolean;
 }
 
+import { getAuthToken } from "@/api/client";
+
 async function req<T>(url: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(url, { credentials: "include", ...init });
+  const token = await getAuthToken();
+  const headers: Record<string, string> = {
+    ...(init?.headers as Record<string, string>),
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+  const res = await fetch(url, { credentials: "include", ...init, headers });
   if (!res.ok) {
     const err = await res.json().catch(() => ({ detail: "Request failed" }));
     throw new Error(err.detail ?? "Request failed");
@@ -181,9 +188,12 @@ export function loomPhotoUrl(id: string): string {
 export async function uploadLoomPhoto(id: string, file: File): Promise<void> {
   const form = new FormData();
   form.append("file", file);
+  const token = await getAuthToken();
+  const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
   const res = await fetch(`/api/looms/${id}/photo`, {
     method: "PUT",
     credentials: "include",
+    headers,
     body: form,
   });
   if (!res.ok) {
@@ -203,9 +213,12 @@ export function versionPhotoUrl(loomId: string, versionId: string, photoId: stri
 export async function uploadVersionPhoto(loomId: string, versionId: string, file: File): Promise<LoomVersionPhoto> {
   const form = new FormData();
   form.append("file", file);
+  const token = await getAuthToken();
+  const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
   const res = await fetch(`/api/looms/${loomId}/versions/${versionId}/photos`, {
     method: "POST",
     credentials: "include",
+    headers,
     body: form,
   });
   if (!res.ok) {
@@ -232,9 +245,12 @@ export async function uploadVersionReceipt(
   const form = new FormData();
   form.append("file", file);
   if (description) form.append("description", description);
+  const token = await getAuthToken();
+  const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
   const res = await fetch(`/api/looms/${loomId}/versions/${versionId}/receipts`, {
     method: "POST",
     credentials: "include",
+    headers,
     body: form,
   });
   if (!res.ok) {

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -21,21 +21,34 @@ export interface Project {
   updated_at: string;
 }
 
+import { getAuthToken } from "@/api/client";
+
 export interface ProjectDetail extends Project {
   wif_source_software: string | null;
   wif_source_version: string | null;
 }
 
-export async function listProjects(): Promise<Project[]> {
-  const res = await fetch("/api/projects", { credentials: "include" });
-  if (!res.ok) throw new Error("Failed to load projects");
+async function req<T>(url: string, init?: RequestInit): Promise<T> {
+  const token = await getAuthToken();
+  const headers: Record<string, string> = {
+    ...(init?.headers as Record<string, string>),
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+  const res = await fetch(url, { credentials: "include", ...init, headers });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: "Request failed" }));
+    throw new Error(err.detail ?? "Request failed");
+  }
+  if (res.status === 204) return undefined as T;
   return res.json();
 }
 
+export async function listProjects(): Promise<Project[]> {
+  return req("/api/projects");
+}
+
 export async function getProject(id: string): Promise<ProjectDetail> {
-  const res = await fetch(`/api/projects/${id}`, { credentials: "include" });
-  if (!res.ok) throw new Error("Failed to load project");
-  return res.json();
+  return req(`/api/projects/${id}`);
 }
 
 export async function uploadProject(
@@ -47,25 +60,11 @@ export async function uploadProject(
   form.append("name", name);
   form.append("wif_file", file);
   if (description) form.append("description", description);
-
-  const res = await fetch("/api/projects", {
-    method: "POST",
-    credentials: "include",
-    body: form,
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({ detail: "Upload failed" }));
-    throw new Error(err.detail ?? "Upload failed");
-  }
-  return res.json();
+  return req("/api/projects", { method: "POST", body: form });
 }
 
 export async function deleteProject(id: string): Promise<void> {
-  const res = await fetch(`/api/projects/${id}`, {
-    method: "DELETE",
-    credentials: "include",
-  });
-  if (!res.ok) throw new Error("Failed to delete project");
+  return req(`/api/projects/${id}`, { method: "DELETE" });
 }
 
 export function previewUrl(id: string): string {
@@ -73,13 +72,5 @@ export function previewUrl(id: string): string {
 }
 
 export async function generateLiftplan(id: string): Promise<ProjectDetail> {
-  const res = await fetch(`/api/projects/${id}/generate-liftplan`, {
-    method: "POST",
-    credentials: "include",
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({ detail: "Failed to generate lift plan" }));
-    throw new Error(err.detail ?? "Failed to generate lift plan");
-  }
-  return res.json();
+  return req(`/api/projects/${id}/generate-liftplan`, { method: "POST" });
 }

--- a/frontend/src/api/yarn.ts
+++ b/frontend/src/api/yarn.ts
@@ -102,8 +102,15 @@ export interface UpdateSkeinPayload {
   notes?: string | null;
 }
 
+import { getAuthToken } from "@/api/client";
+
 async function req<T>(url: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(url, { credentials: "include", ...init });
+  const token = await getAuthToken();
+  const headers: Record<string, string> = {
+    ...(init?.headers as Record<string, string>),
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+  const res = await fetch(url, { credentials: "include", ...init, headers });
   if (!res.ok) {
     const err = await res.json().catch(() => ({ detail: "Request failed" }));
     throw new Error(err.detail ?? "Request failed");
@@ -147,9 +154,12 @@ export function yarnPhotoUrl(id: string): string {
 export async function uploadYarnPhoto(id: string, file: File): Promise<void> {
   const form = new FormData();
   form.append("file", file);
+  const token = await getAuthToken();
+  const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
   const res = await fetch(`/api/yarn/${id}/photo`, {
     method: "PUT",
     credentials: "include",
+    headers,
     body: form,
   });
   if (!res.ok) {

--- a/frontend/src/components/ui/AuthedImage.tsx
+++ b/frontend/src/components/ui/AuthedImage.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import { getAuthToken } from "@/api/client";
+
+interface Props extends React.ImgHTMLAttributes<HTMLImageElement> {
+  src: string;
+}
+
+export function AuthedImage({ src, ...props }: Props) {
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let objectUrl: string | null = null;
+    let cancelled = false;
+
+    async function load() {
+      const token = await getAuthToken();
+      const headers: Record<string, string> = {};
+      if (token) headers["Authorization"] = `Bearer ${token}`;
+
+      const res = await fetch(src, { headers, credentials: "include" });
+      if (!res.ok || cancelled) return;
+
+      const blob = await res.blob();
+      if (cancelled) return;
+
+      objectUrl = URL.createObjectURL(blob);
+      setBlobUrl(objectUrl);
+    }
+
+    load().catch(() => {});
+
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [src]);
+
+  if (!blobUrl) return null;
+  return <img src={blobUrl} {...props} />;
+}

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -31,10 +31,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
-  // Wire Clerk's token getter into the API client as soon as it's available.
-  useEffect(() => {
-    configureApiClient(getToken);
-  }, [getToken]);
+  // Wire Clerk's token getter synchronously during render so it's available
+  // before any child component mounts and fires API calls.
+  configureApiClient(getToken);
 
   const fetchUser = () => {
     setIsLoading(true);

--- a/frontend/src/pages/ActivitiesPage.tsx
+++ b/frontend/src/pages/ActivitiesPage.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { listActivities, ACTIVITY_TYPE_LABELS, ACTIVITY_STATUS_LABELS, type ActivitySummary } from "@/api/activities";
 import { previewUrl } from "@/api/projects";
+import { AuthedImage } from "@/components/ui/AuthedImage";
 import { CreateActivityModal } from "@/components/activities/CreateActivityModal";
 import { AssignLoomModal } from "@/components/activities/AssignLoomModal";
 import { Button } from "@/components/ui/button";
@@ -118,7 +119,7 @@ function ActivityCard({ activity, onAssign }: {
               Close ✕
             </button>
             <p className="absolute -top-9 left-0 text-white/70 text-sm truncate max-w-xs">{activity.name}</p>
-            <img
+            <AuthedImage
               src={previewUrl(activity.project_id)}
               alt="Design preview"
               className="w-full rounded-lg shadow-2xl"

--- a/frontend/src/pages/ActivityDetailPage.tsx
+++ b/frontend/src/pages/ActivityDetailPage.tsx
@@ -9,7 +9,9 @@ import {
   type ActivitySummary, type ActivityPhoto, type PickRow,
 } from "@/api/activities";
 import { previewUrl } from "@/api/projects";
+import { getAuthToken } from "@/api/client";
 import { AssignLoomModal } from "@/components/activities/AssignLoomModal";
+import { AuthedImage } from "@/components/ui/AuthedImage";
 import { Button } from "@/components/ui/button";
 
 // ---------------------------------------------------------------------------
@@ -72,7 +74,7 @@ function DesignPreviewModal({ projectId, onClose }: { projectId: string; onClose
         >
           Close ✕
         </button>
-        <img
+        <AuthedImage
           src={previewUrl(projectId)}
           alt="WIF design preview"
           className="w-full rounded-lg shadow-2xl"
@@ -207,20 +209,20 @@ function WeavingPatternView({
 
   useEffect(() => {
     let cancelled = false;
-    fetch(`/api/projects/${projectId}/drawdown`, { credentials: "include" })
-      .then((res) => {
-        const ppr = parseInt(res.headers.get("X-Pixels-Per-Row") ?? "20", 10);
-        if (!cancelled) setPixelsPerRow(ppr);
-        return res.blob();
-      })
-      .then((blob) => {
-        if (cancelled) return;
-        if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
-        const url = URL.createObjectURL(blob);
-        objectUrlRef.current = url;
-        setImgSrc(url);
-      })
-      .catch(() => {});
+    async function load() {
+      const token = await getAuthToken();
+      const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
+      const res = await fetch(`/api/projects/${projectId}/drawdown`, { credentials: "include", headers });
+      const ppr = parseInt(res.headers.get("X-Pixels-Per-Row") ?? "20", 10);
+      if (!cancelled) setPixelsPerRow(ppr);
+      const blob = await res.blob();
+      if (cancelled) return;
+      if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+      const url = URL.createObjectURL(blob);
+      objectUrlRef.current = url;
+      setImgSrc(url);
+    }
+    load().catch(() => {});
     return () => {
       cancelled = true;
       if (objectUrlRef.current) {
@@ -366,16 +368,18 @@ function AbandonedDrawdownView({
 
   useEffect(() => {
     let cancelled = false;
-    fetch(`/api/projects/${projectId}/drawdown`, { credentials: "include" })
-      .then((res) => res.blob())
-      .then((blob) => {
-        if (cancelled) return;
-        if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
-        const url = URL.createObjectURL(blob);
-        objectUrlRef.current = url;
-        setImgSrc(url);
-      })
-      .catch(() => {});
+    async function load() {
+      const token = await getAuthToken();
+      const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
+      const res = await fetch(`/api/projects/${projectId}/drawdown`, { credentials: "include", headers });
+      const blob = await res.blob();
+      if (cancelled) return;
+      if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+      const url = URL.createObjectURL(blob);
+      objectUrlRef.current = url;
+      setImgSrc(url);
+    }
+    load().catch(() => {});
     return () => {
       cancelled = true;
       if (objectUrlRef.current) {
@@ -646,7 +650,7 @@ function PhotoGrid({
         <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2">
           {photos.map((p) => (
             <div key={p.id} className="group relative aspect-square">
-              <img
+              <AuthedImage
                 src={activityPhotoUrl(activityId, p.id)}
                 alt={p.filename}
                 className="w-full h-full object-cover rounded-md border cursor-pointer"
@@ -679,7 +683,7 @@ function PhotoGrid({
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
           onClick={() => setLightbox(null)}
         >
-          <img
+          <AuthedImage
             src={activityPhotoUrl(activityId, lightbox)}
             alt=""
             className="max-h-full max-w-full rounded-lg shadow-2xl"
@@ -769,7 +773,7 @@ function CompletedSummary({
       <div>
         <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide mb-2">Design Preview</h2>
         <div className="overflow-auto rounded-lg border bg-white p-2">
-          <img
+          <AuthedImage
             src={previewUrl(activity.project_id)}
             alt={`Design for ${activity.project_name}`}
             className="max-w-full mx-auto block"

--- a/frontend/src/pages/LoomDetailPage.tsx
+++ b/frontend/src/pages/LoomDetailPage.tsx
@@ -16,6 +16,8 @@ import { AddVersionModal } from "@/components/looms/AddVersionModal";
 import { EditLoomModal } from "@/components/looms/EditLoomModal";
 import { CloneVersionModal } from "@/components/looms/CloneVersionModal";
 import { Button } from "@/components/ui/button";
+import { AuthedImage } from "@/components/ui/AuthedImage";
+import { downloadAuthed } from "@/api/client";
 import { resizeImageToFile, formatBytes } from "@/lib/image-utils";
 
 const PHOTO_MAX_BYTES = 5 * 1024 * 1024; // 5 MB — must match backend MAX_FILE_SIZE
@@ -119,7 +121,7 @@ function ProfilePhoto({ loom, onChanged }: { loom: LoomDetail; onChanged: () => 
   return (
     <div className="flex items-start gap-4">
       {loom.has_photo ? (
-        <img
+        <AuthedImage
           src={loomPhotoUrl(loom.id)}
           alt="Loom profile"
           className="h-32 w-32 rounded-lg object-cover border"
@@ -243,7 +245,7 @@ function VersionPhotos({ loom, version, onChanged }: { loom: LoomDetail; version
       <div className="flex flex-wrap gap-2 items-start">
         {version.photos.map((p) => (
           <div key={p.id} className="flex flex-col items-center gap-1">
-            <img src={versionPhotoUrl(loom.id, version.id, p.id)} alt={p.filename} className="h-20 w-20 rounded object-cover border" />
+            <AuthedImage src={versionPhotoUrl(loom.id, version.id, p.id)} alt={p.filename} className="h-20 w-20 rounded object-cover border" />
             {confirmId !== p.id ? (
               <button
                 onClick={() => setConfirmId(p.id)}
@@ -338,12 +340,11 @@ function VersionReceipts({ loom, version, onChanged }: { loom: LoomDetail; versi
         <ul className="mb-3 space-y-2">
           {version.receipts.map((r) => (
             <li key={r.id} className="flex items-center gap-2 text-sm">
-              <a
-                href={versionReceiptUrl(loom.id, version.id, r.id)}
-                target="_blank"
-                rel="noreferrer"
-                className="underline underline-offset-2 text-muted-foreground hover:text-foreground truncate max-w-xs"
-              >{r.description || r.filename}</a>
+              <button
+                type="button"
+                onClick={() => downloadAuthed(versionReceiptUrl(loom.id, version.id, r.id), r.filename).catch(() => {})}
+                className="underline underline-offset-2 text-muted-foreground hover:text-foreground truncate max-w-xs text-left"
+              >{r.description || r.filename}</button>
               <span className="ml-auto shrink-0">
                 {confirmId !== r.id ? (
                   <button onClick={() => setConfirmId(r.id)} className="text-xs text-destructive hover:underline">

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -6,6 +6,7 @@ import { listActivities } from "@/api/activities";
 import { ActivitySummaryList } from "@/components/activities/ActivitySummaryList";
 import { CreateActivityModal } from "@/components/activities/CreateActivityModal";
 import { Button } from "@/components/ui/button";
+import { AuthedImage } from "@/components/ui/AuthedImage";
 
 export function ProjectDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -189,7 +190,7 @@ export function ProjectDetailPage() {
             <h2 className="text-base font-semibold mb-3">Design Preview</h2>
             {project.has_preview ? (
               <div className="overflow-auto rounded-lg border bg-white p-2">
-                <img
+                <AuthedImage
                   src={previewUrl(project.id)}
                   alt={`Draft preview for ${project.name}`}
                   className="max-w-full"

--- a/frontend/src/pages/YarnDetailPage.tsx
+++ b/frontend/src/pages/YarnDetailPage.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/api/yarn";
 import { CloneYarnModal } from "@/components/yarn/CloneYarnModal";
 import { Button } from "@/components/ui/button";
+import { AuthedImage } from "@/components/ui/AuthedImage";
 import { resizeImageToFile, formatBytes } from "@/lib/image-utils";
 
 const PHOTO_MAX_BYTES = 5 * 1024 * 1024;
@@ -80,7 +81,7 @@ function YarnPhoto({ yarn, onChanged }: { yarn: YarnDetail; onChanged: () => voi
   return (
     <div className="flex items-start gap-4">
       {yarn.has_photo ? (
-        <img src={yarnPhotoUrl(yarn.id)} alt="Yarn" className="h-32 w-32 rounded-lg object-cover border" />
+        <AuthedImage src={yarnPhotoUrl(yarn.id)} alt="Yarn" className="h-32 w-32 rounded-lg object-cover border" />
       ) : yarn.color_hex ? (
         <div className="h-32 w-32 rounded-lg border shrink-0" style={{ backgroundColor: yarn.color_hex }} />
       ) : (

--- a/frontend/src/pages/YarnPage.tsx
+++ b/frontend/src/pages/YarnPage.tsx
@@ -4,6 +4,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { listYarn, yarnPhotoUrl, type YarnSummary } from "@/api/yarn";
 import { AddYarnModal } from "@/components/yarn/AddYarnModal";
 import { Button } from "@/components/ui/button";
+import { AuthedImage } from "@/components/ui/AuthedImage";
 
 function YarnCard({ yarn }: { yarn: YarnSummary }) {
   const skeinLabel = yarn.skein_count === 0
@@ -18,7 +19,7 @@ function YarnCard({ yarn }: { yarn: YarnSummary }) {
       className="flex items-start gap-3 rounded-lg border p-4 hover:border-ring transition-colors"
     >
       {yarn.has_photo ? (
-        <img
+        <AuthedImage
           src={yarnPhotoUrl(yarn.id)}
           alt={`${yarn.brand} ${yarn.name}`}
           className="h-14 w-14 rounded-md object-cover border shrink-0"


### PR DESCRIPTION
## Summary

- Implements the backend for #117 (user deletion service with Celery + Redis)
- Fixes #106 and #128 (all frontend API calls were bypassing Bearer token auth)
- Adds Redis + Celery worker services to all docker-compose environments

## Changes

### Backend — User deletion service (#117)
- `User` model: `deletion_state` (pending/in_progress/complete/stalled/aborted) and `deletion_initiated_at`
- Alembic migration 0029
- `app.celery_app` — Celery instance with Redis broker/backend
- `app.tasks.deletion.run_user_deletion` — cascade purge (storage → DB in FK-safe order), stall/retry handling, superuser notification on stall
- `app.services.deletion.initiate_user_deletion` — soft-delete → pending → enqueue
- `POST /api/admin/users/:id/delete` — superuser-only, `confirm: "DELETE USER"` required, 202 accepted
- `GET /api/admin/users` — now includes users in the deletion pipeline (non-null `deletion_state`)
- Deletion email notifications: queued (admins), completed (admins), stalled (superusers)

### Infrastructure
- Redis (`redis:7-alpine`) and Celery worker services added to `docker-compose.build.yml`, `docker-compose.dev.yml`, `docker-compose.prod.yml`
- `REDIS_URL` added to `.env.example`

### Frontend — API auth bypass fix (#106, #128)
- `api/activities.ts`, `api/looms.ts`, `api/yarn.ts`, `api/projects.ts` all had private `req()` functions that bypassed `client.ts` — no Bearer token was ever sent
- Exported `getAuthToken()` and `downloadAuthed()` from `client.ts`; patched all modules
- Fixed 4 FormData upload functions (loom photo, version photos, version receipts, yarn photo)
- Fixed 2 drawdown `fetch()` calls in `ActivityDetailPage`
- Added `AuthedImage` component for authed image loading via blob URL
- Replaced all `<img src={authedUrl}>` across 6 pages with `AuthedImage`
- Replaced receipt `<a href>` with `downloadAuthed()` button
- Moved `configureApiClient()` to synchronous render body in `AuthContext`

## Pending (not in this PR)
- Admin UI for delete button and errored user state → #118
- `user.deleted` Clerk webhook handler → #118

## Test plan
- [ ] `POST /api/admin/users/:id/delete` returns 202 and enqueues task
- [ ] Celery worker picks up task; user data purged from S3 + DB
- [ ] Stalled task sends superuser notification email
- [x] Dashboard loads without 401 on looms / projects / activities
- [x] Loom profile photos, version photos, yarn photos render
- [x] Activity drawdown view renders
- [x] Photo upload (loom, yarn, activity) succeeds
- [ ] Receipt download button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)