### PR TITLE
feat: storage quota bar on dashboard (#127)

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -222,6 +222,8 @@ class UserResponse(BaseModel):
     ai_training_consent: bool
     eula_accepted_version: str | None
     current_eula_version: str
+    storage_used_bytes: int
+    storage_quota_bytes: int
 
     model_config = {"from_attributes": True}
 
@@ -232,8 +234,10 @@ async def me(
     db: AsyncSession = Depends(get_db),
 ) -> UserResponse:
     from app.routers.users import get_current_eula_version
+    from app.services.storage_quota import MAX_USER_STORAGE_BYTES, get_user_storage_used
 
     current_eula_version = await get_current_eula_version(db)
+    storage_used = await get_user_storage_used(current_user.id, db)
     return UserResponse(
         id=current_user.id,
         email=current_user.email,
@@ -247,6 +251,8 @@ async def me(
         ai_training_consent=current_user.ai_training_consent,
         eula_accepted_version=current_user.eula_accepted_version,
         current_eula_version=current_eula_version,
+        storage_used_bytes=storage_used,
+        storage_quota_bytes=MAX_USER_STORAGE_BYTES,
     )
 
 

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -15,6 +15,8 @@ export interface User {
   ai_training_consent: boolean;
   eula_accepted_version: string | null;
   current_eula_version: string;
+  storage_used_bytes: number;
+  storage_quota_bytes: number;
 }
 
 interface AuthState {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -228,6 +228,33 @@ export function DashboardPage() {
             </div>
           </div>
         </section>
+
+        {/* Storage */}
+        {user && (
+          <section>
+            <h2 className="mb-3 text-sm font-medium text-muted-foreground uppercase tracking-wide">Storage</h2>
+            <div className="rounded-lg border p-4">
+              {(() => {
+                const usedMB = user.storage_used_bytes / (1024 * 1024);
+                const quotaMB = user.storage_quota_bytes / (1024 * 1024);
+                const pct = Math.min(Math.round((user.storage_used_bytes / user.storage_quota_bytes) * 100), 100);
+                const barColor = pct >= 90 ? "bg-red-500" : pct >= 75 ? "bg-amber-500" : "bg-primary";
+                return (
+                  <>
+                    <div className="mb-2 flex justify-between text-sm">
+                      <span>{usedMB < 1 ? `${Math.round(usedMB * 1024)} KB` : `${usedMB.toFixed(1)} MB`} used</span>
+                      <span className="text-muted-foreground">{Math.round(quotaMB)} MB total</span>
+                    </div>
+                    <div className="h-2 w-full rounded-full bg-muted overflow-hidden">
+                      <div className={`h-full rounded-full transition-all ${barColor}`} style={{ width: `${pct}%` }} />
+                    </div>
+                    <p className="mt-1.5 text-xs text-muted-foreground text-right">{pct}% used</p>
+                  </>
+                );
+              })()}
+            </div>
+          </section>
+        )}
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- `GET /auth/me` now includes `storage_used_bytes` and `storage_quota_bytes` in the response
- `User` interface in `AuthContext.tsx` updated with both new fields
- Dashboard gets a **Storage** section with a color-coded progress bar: green <75%, amber 75–90%, red ≥90%
- Displays used/total in KB or MB with percentage label

Closes #127

## Test plan
- [ ] Log in and visit the dashboard — Storage section appears below Activities
- [ ] Confirm bar is green when usage is low
- [ ] Confirm `GET /auth/me` JSON includes `storage_used_bytes` and `storage_quota_bytes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)