### PR TITLE
fix: mock storage layer in tests to prevent S3 calls (#130)

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -301,3 +301,23 @@ async def superuser_client(db_session: AsyncSession, superuser_user: User) -> As
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         yield c
     app.dependency_overrides.clear()
+
+
+@pytest.fixture(autouse=True)
+def mock_storage(monkeypatch):
+    """Replace storage primitives with an in-memory dict for all tests.
+
+    Prevents any test from hitting real S3/R2 or requiring files on disk.
+    Tests that need to pre-populate storage can import and call the normal
+    storage service functions (save_wif, etc.) — they will write to this dict.
+    """
+    import app.services.storage as _storage
+
+    _store: dict[str, bytes] = {}
+
+    monkeypatch.setattr(_storage, "_put", lambda key, data: (_store.__setitem__(key, data), key)[1])
+    monkeypatch.setattr(_storage, "_get", lambda key: _store[key])
+    monkeypatch.setattr(_storage, "_delete", lambda key: _store.pop(key, None))
+    monkeypatch.setattr(_storage, "_exists", lambda key: bool(key) and key in _store)
+
+    return _store

--- a/backend/tests/routers/test_activities.py
+++ b/backend/tests/routers/test_activities.py
@@ -80,18 +80,20 @@ _LOOM_PAYLOAD = {
 
 
 async def _insert_project(db_session: AsyncSession, owner: User) -> Project:
-    """Insert a project with a real WIF stored at a temp path."""
-    import tempfile
+    """Insert a project with WIF bytes written through the (mocked) storage layer."""
+    import uuid
 
-    tmp = tempfile.NamedTemporaryFile(suffix=".wif", delete=False)
-    tmp.write(_WIF)
-    tmp.close()
+    import app.services.storage as storage
+
+    project_id = uuid.uuid4()
+    wif_key = storage.save_wif(project_id, "test.wif", _WIF)
 
     project = Project(
+        id=project_id,
         owner_id=owner.id,
         name="Test Project",
         wif_filename="test.wif",
-        wif_path=tmp.name,
+        wif_path=wif_key,
         has_treadling=True,
         has_liftplan=True,
         num_shafts=4,

--- a/backend/tests/routers/test_projects.py
+++ b/backend/tests/routers/test_projects.py
@@ -5,7 +5,6 @@ WeavingPatternView feature (issue #8).
 """
 
 import io
-import tempfile
 import uuid
 
 import pytest
@@ -264,12 +263,28 @@ class TestGetDrawdown:
         resp = await auth_client.get(f"/api/projects/{project.id}/drawdown")
         assert resp.status_code == 404
 
-    async def test_renders_and_returns_png(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
-        tmp = tempfile.NamedTemporaryFile(suffix=".wif", delete=False)
-        tmp.write(_WIF)
-        tmp.close()
+    async def _project_with_wif(self, db_session: AsyncSession, user: User) -> Project:
+        import app.services.storage as storage
 
-        project = await _insert_project(db_session, test_user, wif_path=tmp.name, weft_threads=4)
+        project_id = uuid.uuid4()
+        wif_key = storage.save_wif(project_id, "test.wif", _WIF)
+        project = Project(
+            id=project_id,
+            owner_id=user.id,
+            name="Test Project",
+            wif_filename="test.wif",
+            wif_path=wif_key,
+            has_treadling=True,
+            num_shafts=4,
+            num_treadles=4,
+            weft_threads=4,
+        )
+        db_session.add(project)
+        await db_session.commit()
+        return project
+
+    async def test_renders_and_returns_png(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        project = await self._project_with_wif(db_session, test_user)
         resp = await auth_client.get(f"/api/projects/{project.id}/drawdown")
 
         assert resp.status_code == 200
@@ -279,11 +294,7 @@ class TestGetDrawdown:
     async def test_response_includes_pixels_per_row_header(
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
     ):
-        tmp = tempfile.NamedTemporaryFile(suffix=".wif", delete=False)
-        tmp.write(_WIF)
-        tmp.close()
-
-        project = await _insert_project(db_session, test_user, wif_path=tmp.name, weft_threads=4)
+        project = await self._project_with_wif(db_session, test_user)
         resp = await auth_client.get(f"/api/projects/{project.id}/drawdown")
 
         assert resp.headers.get("X-Pixels-Per-Row") == str(rendering.DRAWDOWN_SCALE)
@@ -291,11 +302,7 @@ class TestGetDrawdown:
     async def test_response_includes_total_rows_header(
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
     ):
-        tmp = tempfile.NamedTemporaryFile(suffix=".wif", delete=False)
-        tmp.write(_WIF)
-        tmp.close()
-
-        project = await _insert_project(db_session, test_user, wif_path=tmp.name, weft_threads=4)
+        project = await self._project_with_wif(db_session, test_user)
         resp = await auth_client.get(f"/api/projects/{project.id}/drawdown")
 
         assert resp.headers.get("X-Total-Rows") == "4"
@@ -303,21 +310,13 @@ class TestGetDrawdown:
     async def test_response_has_cache_control_header(
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
     ):
-        tmp = tempfile.NamedTemporaryFile(suffix=".wif", delete=False)
-        tmp.write(_WIF)
-        tmp.close()
-
-        project = await _insert_project(db_session, test_user, wif_path=tmp.name, weft_threads=4)
+        project = await self._project_with_wif(db_session, test_user)
         resp = await auth_client.get(f"/api/projects/{project.id}/drawdown")
 
         assert resp.headers.get("Cache-Control") == "public, max-age=31536000, immutable"
 
     async def test_response_has_etag_header(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
-        tmp = tempfile.NamedTemporaryFile(suffix=".wif", delete=False)
-        tmp.write(_WIF)
-        tmp.close()
-
-        project = await _insert_project(db_session, test_user, wif_path=tmp.name, weft_threads=4)
+        project = await self._project_with_wif(db_session, test_user)
         resp = await auth_client.get(f"/api/projects/{project.id}/drawdown")
 
         assert resp.headers.get("ETag") == f'"{project.id}"'
@@ -424,12 +423,6 @@ class TestGetPreview:
 
 
 class TestGenerateLiftplan:
-    @pytest.fixture(autouse=True)
-    def _use_tmp_upload_dir(self, tmp_path, monkeypatch):
-        import app.services.storage as _storage
-
-        monkeypatch.setattr(_storage.settings, "upload_dir", str(tmp_path))
-
     async def _create_project_with_wif(
         self,
         db_session,
@@ -438,14 +431,16 @@ class TestGenerateLiftplan:
         has_treadling: bool = True,
         has_tieup: bool = True,
     ) -> Project:
-        tmp = tempfile.NamedTemporaryFile(suffix=".wif", delete=False)
-        tmp.write(_WIF)
-        tmp.close()
+        import app.services.storage as storage
+
+        project_id = uuid.uuid4()
+        wif_key = storage.save_wif(project_id, "test.wif", _WIF)
         project = Project(
+            id=project_id,
             owner_id=user.id,
             name="Liftplan Project",
             wif_filename="test.wif",
-            wif_path=tmp.name,
+            wif_path=wif_key,
             has_treadling=has_treadling,
             has_tieup=has_tieup,
             has_liftplan=False,

--- a/backend/tests/services/test_storage.py
+++ b/backend/tests/services/test_storage.py
@@ -7,10 +7,18 @@ before each test via a session-scoped monkeypatch on the upload_dir attribute.
 """
 
 import uuid
+from unittest.mock import MagicMock
 
 import pytest
 
 import app.services.storage as storage
+
+# Capture originals at import time — before the autouse mock_storage fixture can
+# replace them.  These references let us test the real S3 code paths directly.
+_real_put = storage._put
+_real_get = storage._get
+_real_delete = storage._delete
+_real_exists = storage._exists
 
 # ---------------------------------------------------------------------------
 # Fixture: redirect every storage call to tmp_path
@@ -294,3 +302,60 @@ class TestGenericReadExists:
         rel2 = storage.save_wif(pid2, "a.wif", b"project two")
         assert storage.read_wif(rel1) == b"project one"
         assert storage.read_wif(rel2) == b"project two"
+
+
+# ---------------------------------------------------------------------------
+# S3 code paths — use real function references captured before autouse patches
+# ---------------------------------------------------------------------------
+
+
+class TestS3Paths:
+    @pytest.fixture(autouse=True)
+    def _s3_env(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.get_object.return_value = {"Body": MagicMock(read=MagicMock(return_value=b"wif bytes"))}
+        monkeypatch.setattr(storage, "_s3_client", mock_client)
+        monkeypatch.setattr(storage.settings, "storage_backend", "s3")
+        monkeypatch.setattr(storage.settings, "s3_bucket_name", "test-bucket")
+        return mock_client
+
+    def test_put_calls_s3_put_object(self, _s3_env):
+        _real_put("projects/abc/original.wif", b"data")
+        _s3_env.put_object.assert_called_once_with(Bucket="test-bucket", Key="projects/abc/original.wif", Body=b"data")
+
+    def test_put_returns_key(self, _s3_env):
+        assert _real_put("some/key", b"x") == "some/key"
+
+    def test_get_calls_s3_get_object(self, _s3_env):
+        result = _real_get("projects/abc/original.wif")
+        _s3_env.get_object.assert_called_once_with(Bucket="test-bucket", Key="projects/abc/original.wif")
+        assert result == b"wif bytes"
+
+    def test_delete_calls_s3_delete_object(self, _s3_env):
+        _real_delete("projects/abc/original.wif")
+        _s3_env.delete_object.assert_called_once_with(Bucket="test-bucket", Key="projects/abc/original.wif")
+
+    def test_exists_true_when_head_succeeds(self, _s3_env):
+        _s3_env.head_object.return_value = {}
+        assert _real_exists("some/key") is True
+
+    def test_exists_false_when_client_error(self, _s3_env, monkeypatch):
+        from botocore.exceptions import ClientError
+
+        _s3_env.head_object.side_effect = ClientError({"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject")
+        assert _real_exists("some/key") is False
+
+    def test_exists_false_for_empty_key(self, _s3_env):
+        assert _real_exists("") is False
+
+    def test_exists_false_for_none(self, _s3_env):
+        assert _real_exists(None) is False
+
+    def test_s3_client_constructed_when_none(self, monkeypatch):
+        monkeypatch.setattr(storage, "_s3_client", None)
+        monkeypatch.setattr(storage.settings, "storage_backend", "s3")
+        monkeypatch.setattr(storage.settings, "s3_bucket_name", "test-bucket")
+        mock_boto3_client = MagicMock()
+        monkeypatch.setattr("boto3.client", mock_boto3_client)
+        storage._s3()
+        mock_boto3_client.assert_called_once()


### PR DESCRIPTION
## Summary
- Adds `mock_storage` autouse fixture to `conftest.py` — intercepts all `_put`/`_get`/`_delete`/`_exists` storage primitives with an in-memory dict; no test ever touches real S3/R2 again
- Updates `_insert_project` in `test_activities.py` to call `storage.save_wif()` through the mock instead of writing a raw tempfile path
- Replaces all inline `tempfile.NamedTemporaryFile` patterns in `TestGetDrawdown` and `TestGenerateLiftplan` in `test_projects.py` with the same approach
- Adds `TestS3Paths` to `test_storage.py` — captures original function references at import time (before autouse can patch them) and tests S3 branches with a mocked boto3 client to maintain coverage

## Result
- 19 previously-failing tests now pass (709 total, 0 failures)
- Coverage: 65.33% (threshold 65% ✅)

Closes #130

## Test plan
- [ ] CI full suite passes with no failures
- [ ] Coverage stays at or above 65%

🤖 Generated with [Claude Code](https://claude.com/claude-code)