### PR TITLE
feat: audit event history log (#119)

### DIFF
--- a/backend/alembic/versions/0030_audit_log.py
+++ b/backend/alembic/versions/0030_audit_log.py
@@ -1,0 +1,39 @@
+"""create audit_logs table
+
+Revision ID: 0030
+Revises: 0029
+Create Date: 2026-04-30
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSON, UUID
+
+revision = "0030"
+down_revision = "0029"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "audit_logs",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("actor_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("actor_email", sa.String(255), nullable=True),
+        sa.Column("event_type", sa.String(64), nullable=False),
+        sa.Column("target_user_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("target_email", sa.String(255), nullable=True),
+        sa.Column("details", JSON, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index("ix_audit_logs_event_type", "audit_logs", ["event_type"])
+    op.create_index("ix_audit_logs_created_at", "audit_logs", ["created_at"])
+    op.create_index("ix_audit_logs_actor_email", "audit_logs", ["actor_email"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_audit_logs_actor_email", table_name="audit_logs")
+    op.drop_index("ix_audit_logs_created_at", table_name="audit_logs")
+    op.drop_index("ix_audit_logs_event_type", table_name="audit_logs")
+    op.drop_table("audit_logs")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,4 +1,5 @@
 from app.models.activity import Activity, ActivityStep
+from app.models.audit_log import AuditLog
 from app.models.base import Base
 from app.models.eula_version import EulaVersion
 from app.models.invite import Invite
@@ -17,6 +18,7 @@ from app.models.yarn import Skein, Yarn
 
 __all__ = [
     "Base",
+    "AuditLog",
     "User",
     "UserIdentity",
     "Invite",

--- a/backend/app/models/audit_log.py
+++ b/backend/app/models/audit_log.py
@@ -1,0 +1,25 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Index, String, func
+from sqlalchemy.dialects.postgresql import JSON, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_logs"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    actor_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    actor_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    event_type: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    target_user_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    target_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    details: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
+    )
+
+    __table_args__ = (Index("ix_audit_logs_actor_email", "actor_email"),)

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import Settings, get_settings
 from app.deps import get_db, require_admin, require_superuser
 from app.models.activity import Activity, ActivityPhoto
+from app.models.audit_log import AuditLog
 from app.models.eula_version import EulaVersion
 from app.models.invite import Invite
 from app.models.loom import Loom, LoomVersion, LoomVersionPhoto
@@ -24,6 +25,7 @@ from app.models.pending_signup import PendingSignup
 from app.models.project import Project
 from app.models.user import User
 from app.models.yarn import Yarn
+from app.services.audit import write_audit_log
 from app.services.clerk import ban_clerk_user, set_user_metadata, unban_clerk_user
 from app.services.email import (
     send_account_approved_email,
@@ -505,6 +507,8 @@ async def patch_user(
     if body.is_superuser is not None:
         user.is_superuser = body.is_superuser
 
+    changed = {k: v for k, v in body.model_dump(exclude_none=True).items()}
+    await write_audit_log(db, event_type="user.role_changed", actor=admin, target=user, details=changed)
     await db.commit()
     await db.refresh(user)
 
@@ -607,6 +611,7 @@ async def ban_user(
     await set_user_metadata(user.clerk_user_id, {"status": "banned"})
     user.clerk_banned = True
     user.is_active = False
+    await write_audit_log(db, event_type="user.banned", actor=admin, target=user)
     await db.commit()
     await db.refresh(user)
 
@@ -631,7 +636,7 @@ async def ban_user(
 @router.post("/users/{user_id}/unban", status_code=200)
 async def unban_user(
     user_id: uuid.UUID,
-    _: User = Depends(require_admin),
+    admin: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ) -> AdminUserResponse:
     user = await db.scalar(select(User).where(User.id == user_id, User.deleted_at.is_(None)))
@@ -644,6 +649,7 @@ async def unban_user(
     await set_user_metadata(user.clerk_user_id, {"status": "active"})
     user.clerk_banned = False
     user.is_active = True
+    await write_audit_log(db, event_type="user.unbanned", actor=admin, target=user)
     await db.commit()
     await db.refresh(user)
 
@@ -694,6 +700,13 @@ async def delete_user(
 
     from app.services.deletion import initiate_user_deletion
 
+    await write_audit_log(
+        db,
+        event_type="user.deleted",
+        actor=requesting_user,
+        target_user_id=user.id,
+        target_email=user.email,
+    )
     await initiate_user_deletion(db, user)
     log.info("admin_delete_initiated user_id=%s by=%s", user_id, requesting_user.email)
 
@@ -886,6 +899,25 @@ async def check_services(
 # ---------------------------------------------------------------------------
 
 
+class AuditLogEntry(BaseModel):
+    id: uuid.UUID
+    actor_email: str | None
+    event_type: str
+    target_email: str | None
+    details: dict | None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class AuditLogPage(BaseModel):
+    items: list[AuditLogEntry]
+    total: int
+    page: int
+    page_size: int
+    pages: int
+
+
 class WebhookProbeResponse(BaseModel):
     status: Literal["ok", "skipped", "error"]
     latency_ms: int | None = None
@@ -900,6 +932,53 @@ async def test_webhook(
 
     result = await run_webhook_probe()
     return WebhookProbeResponse(status=result.status, latency_ms=result.latency_ms, message=result.message)
+
+
+# ---------------------------------------------------------------------------
+# Audit log
+# ---------------------------------------------------------------------------
+
+
+@router.get("/audit-log", response_model=AuditLogPage)
+async def list_audit_log(
+    _: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+    page: int = 1,
+    page_size: int = 50,
+    event_type: str | None = None,
+    q: str | None = None,
+) -> AuditLogPage:
+    from sqlalchemy import or_
+
+    stmt = select(AuditLog)
+    count_stmt = select(func.count()).select_from(AuditLog)
+
+    if event_type:
+        stmt = stmt.where(AuditLog.event_type == event_type)
+        count_stmt = count_stmt.where(AuditLog.event_type == event_type)
+    if q:
+        like = f"%{q}%"
+        filter_q = or_(AuditLog.actor_email.ilike(like), AuditLog.target_email.ilike(like))
+        stmt = stmt.where(filter_q)
+        count_stmt = count_stmt.where(filter_q)
+
+    total = await db.scalar(count_stmt) or 0
+    pages = max(1, (total + page_size - 1) // page_size)
+    offset = (page - 1) * page_size
+
+    rows = await db.scalars(stmt.order_by(AuditLog.created_at.desc()).offset(offset).limit(page_size))
+    items = [
+        AuditLogEntry(
+            id=r.id,
+            actor_email=r.actor_email,
+            event_type=r.event_type,
+            target_email=r.target_email,
+            details=r.details,
+            created_at=r.created_at,
+        )
+        for r in rows.all()
+    ]
+    return AuditLogPage(items=items, total=total, page=page, page_size=page_size, pages=pages)
 
 
 # ---------------------------------------------------------------------------
@@ -998,6 +1077,13 @@ async def elevate_to_superuser(
         await db.execute(Yarn.__table__.delete().where(Yarn.owner_id == user_id))
 
     user.is_superuser = True
+    await write_audit_log(
+        db,
+        event_type="user.elevated",
+        actor=admin,
+        target=user,
+        details={"content_deleted": has_content},
+    )
     await db.commit()
     if user.clerk_user_id:
         await set_user_metadata(user.clerk_user_id, {"is_superuser": True})
@@ -1057,6 +1143,12 @@ async def approve_pending_signup(
     )
     db.add(user)
     await db.delete(signup)
+    await write_audit_log(
+        db,
+        event_type="signup.approved",
+        actor=admin,
+        target_email=signup.email,
+    )
     await db.commit()
     await set_user_metadata(signup.clerk_user_id, {"status": "active", "is_admin": False, "is_superuser": False})
 
@@ -1081,13 +1173,14 @@ async def approve_pending_signup(
 @router.post("/pending-signups/{signup_id}/ban", status_code=204)
 async def ban_pending_signup(
     signup_id: uuid.UUID,
-    _: User = Depends(require_admin),
+    admin: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ) -> None:
     signup = await db.scalar(select(PendingSignup).where(PendingSignup.id == signup_id))
     if signup is None:
         raise HTTPException(status_code=404, detail="Pending signup not found")
     email, display_name, clerk_user_id = signup.email, signup.display_name, signup.clerk_user_id
+    await write_audit_log(db, event_type="signup.banned", actor=admin, target_email=email)
     await db.delete(signup)
     await db.commit()
     await ban_clerk_user(clerk_user_id)
@@ -1101,13 +1194,14 @@ async def ban_pending_signup(
 @router.delete("/pending-signups/{signup_id}", status_code=204)
 async def dismiss_pending_signup(
     signup_id: uuid.UUID,
-    _: User = Depends(require_admin),
+    admin: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ) -> None:
     signup = await db.scalar(select(PendingSignup).where(PendingSignup.id == signup_id))
     if signup is None:
         raise HTTPException(status_code=404, detail="Pending signup not found")
     email, display_name, clerk_user_id = signup.email, signup.display_name, signup.clerk_user_id
+    await write_audit_log(db, event_type="signup.dismissed", actor=admin, target_email=email)
     await db.delete(signup)
     await db.commit()
     await set_user_metadata(clerk_user_id, {"status": "denied"})
@@ -1165,7 +1259,7 @@ async def get_eula_admin(
 @router.post("/eula", response_model=EulaVersionResponse, status_code=201)
 async def create_eula_version(
     body: EulaCreateRequest,
-    _: User = Depends(require_superuser),
+    admin: User = Depends(require_superuser),
     db: AsyncSession = Depends(get_db),
 ) -> EulaVersionResponse:
     existing = await db.scalar(select(EulaVersion).where(EulaVersion.version == body.version))
@@ -1175,6 +1269,7 @@ async def create_eula_version(
     effective = body.effective_date or datetime.now(timezone.utc)
     row = EulaVersion(version=body.version, body_html=body.body_html, effective_date=effective)
     db.add(row)
+    await write_audit_log(db, event_type="eula.created", actor=admin, details={"version": body.version})
     await db.commit()
     await db.refresh(row)
     log.info("New EULA version created: %s (effective %s)", row.version, row.effective_date)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -36,6 +36,7 @@ from app.deps import get_current_user, get_db, require_admin
 from app.models.invite import Invite
 from app.models.pending_signup import PendingSignup
 from app.models.user import User
+from app.services.audit import write_audit_log
 from app.services.clerk import set_user_metadata
 from app.services.email import send_invite_email, send_pending_signup_notification, send_signup_received_email
 
@@ -306,6 +307,7 @@ async def create_invite(
         created_by_id=admin.id,
     )
     db.add(invite)
+    await write_audit_log(db, event_type="invite.created", actor=admin, target_email=body.email)
     await db.commit()
     await db.refresh(invite)
 
@@ -325,7 +327,7 @@ async def list_invites(
 @router.delete("/invite/{invite_id}", status_code=204)
 async def revoke_invite(
     invite_id: uuid.UUID,
-    _: User = Depends(require_admin),
+    admin: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ) -> None:
     invite = await db.scalar(select(Invite).where(Invite.id == invite_id))
@@ -334,4 +336,5 @@ async def revoke_invite(
     if invite.accepted_at is not None:
         raise HTTPException(status_code=400, detail="Invite already accepted")
     invite.revoked_at = datetime.now(timezone.utc)
+    await write_audit_log(db, event_type="invite.revoked", actor=admin, target_email=invite.email)
     await db.commit()

--- a/backend/app/services/audit.py
+++ b/backend/app/services/audit.py
@@ -1,0 +1,41 @@
+"""Audit log helpers."""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.audit_log import AuditLog
+from app.models.user import User
+
+
+async def write_audit_log(
+    db: AsyncSession,
+    *,
+    event_type: str,
+    actor: User | None = None,
+    actor_id: uuid.UUID | None = None,
+    actor_email: str | None = None,
+    target: User | None = None,
+    target_user_id: uuid.UUID | None = None,
+    target_email: str | None = None,
+    details: dict | None = None,
+) -> None:
+    """Insert an audit log entry and flush (does not commit — caller commits)."""
+    resolved_actor_id = actor.id if actor else actor_id
+    resolved_actor_email = actor.email if actor else actor_email
+    resolved_target_id = target.id if target else target_user_id
+    resolved_target_email = target.email if target else target_email
+
+    entry = AuditLog(
+        id=uuid.uuid4(),
+        actor_id=resolved_actor_id,
+        actor_email=resolved_actor_email,
+        event_type=event_type,
+        target_user_id=resolved_target_id,
+        target_email=resolved_target_email,
+        details=details,
+    )
+    db.add(entry)
+    await db.flush()

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -152,3 +152,30 @@ export interface WebhookProbeResult {
 }
 
 export const testWebhook = () => api.post<WebhookProbeResult>("/api/admin/test-webhook", {});
+
+export interface AuditLogEntry {
+  id: string;
+  actor_email: string | null;
+  event_type: string;
+  target_email: string | null;
+  details: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export interface AuditLogPage {
+  items: AuditLogEntry[];
+  total: number;
+  page: number;
+  page_size: number;
+  pages: number;
+}
+
+export const getAuditLog = (params: { page?: number; page_size?: number; event_type?: string; q?: string } = {}) => {
+  const qs = new URLSearchParams();
+  if (params.page) qs.set("page", String(params.page));
+  if (params.page_size) qs.set("page_size", String(params.page_size));
+  if (params.event_type) qs.set("event_type", params.event_type);
+  if (params.q) qs.set("q", params.q);
+  const query = qs.toString();
+  return api.get<AuditLogPage>(`/api/admin/audit-log${query ? `?${query}` : ""}`);
+};

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -25,7 +25,9 @@ import {
   getAdminServices,
   sendTestEmail,
   testWebhook,
+  getAuditLog,
   type AdminHealth,
+  type AuditLogEntry,
   type ElevateContentSummary,
   type InviteRecord,
   type PendingSignup,
@@ -36,7 +38,7 @@ import {
 import { EulaContent } from "@/components/EulaContent";
 import { formatBytes } from "@/lib/image-utils";
 
-type Tab = "users" | "invites" | "stats" | "health" | "services" | "eula";
+type Tab = "users" | "invites" | "stats" | "health" | "services" | "eula" | "audit";
 
 function formatLastActive(iso: string | null): string {
   if (!iso) return "Never";
@@ -90,7 +92,7 @@ export function AdminPage() {
 
       <main className="flex-1 p-6 max-w-4xl mx-auto w-full space-y-6">
         <div className="flex gap-2 border-b pb-2">
-          {(["users", "invites", "stats", "health", "services", "eula"] as Tab[]).map((t) => (
+          {(["users", "invites", "stats", "health", "services", "eula", "audit"] as Tab[]).map((t) => (
             <button
               key={t}
               onClick={() => setTab(t)}
@@ -111,6 +113,7 @@ export function AdminPage() {
         {tab === "health" && <HealthTab />}
         {tab === "services" && <ServicesTab />}
         {tab === "eula" && <EulaTab />}
+        {tab === "audit" && <AuditLogTab />}
       </main>
     </div>
   );
@@ -1179,5 +1182,167 @@ function EulaTab() {
         )}
       </form>
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Audit log tab
+// ---------------------------------------------------------------------------
+
+const EVENT_TYPES = [
+  "user.role_changed",
+  "user.banned",
+  "user.unbanned",
+  "user.deleted",
+  "user.elevated",
+  "signup.approved",
+  "signup.dismissed",
+  "signup.banned",
+  "invite.created",
+  "invite.revoked",
+  "eula.created",
+] as const;
+
+function eventBadgeClass(eventType: string): string {
+  if (eventType.startsWith("user.ban") || eventType === "signup.banned") return "bg-destructive/10 text-destructive";
+  if (eventType === "user.deleted") return "bg-destructive/10 text-destructive";
+  if (eventType === "user.elevated" || eventType === "signup.approved") return "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400";
+  if (eventType === "user.unbanned") return "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400";
+  return "bg-muted text-muted-foreground";
+}
+
+function formatAuditTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString(undefined, { dateStyle: "short", timeStyle: "medium" });
+}
+
+function AuditLogTab() {
+  const [page, setPage] = useState(1);
+  const [eventType, setEventType] = useState<string>("");
+  const [q, setQ] = useState<string>("");
+  const [debouncedQ, setDebouncedQ] = useState<string>("");
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQ(q), 300);
+    return () => clearTimeout(t);
+  }, [q]);
+
+  useEffect(() => { setPage(1); }, [eventType, debouncedQ]); // eslint-disable-line react-hooks/set-state-in-effect
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["audit-log", page, eventType, debouncedQ],
+    queryFn: () => getAuditLog({ page, page_size: 50, event_type: eventType || undefined, q: debouncedQ || undefined }),
+  });
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold">Audit Log</h2>
+
+      <div className="flex gap-2 flex-wrap">
+        <select
+          value={eventType}
+          onChange={(e) => setEventType(e.target.value)}
+          className="text-sm border rounded px-2 py-1.5 bg-background"
+        >
+          <option value="">All events</option>
+          {EVENT_TYPES.map((t) => (
+            <option key={t} value={t}>{t}</option>
+          ))}
+        </select>
+        <input
+          type="text"
+          placeholder="Search by email…"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          className="text-sm border rounded px-2 py-1.5 bg-background w-52"
+        />
+        {data && (
+          <span className="text-xs text-muted-foreground self-center ml-auto">
+            {data.total.toLocaleString()} event{data.total !== 1 ? "s" : ""}
+          </span>
+        )}
+      </div>
+
+      {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+      {isError && <p className="text-sm text-destructive">Failed to load audit log.</p>}
+
+      {data && data.items.length === 0 && (
+        <p className="text-sm text-muted-foreground">No events found.</p>
+      )}
+
+      {data && data.items.length > 0 && (
+        <div className="rounded-lg border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50 text-xs text-muted-foreground">
+              <tr>
+                <th className="text-left px-3 py-2">Time</th>
+                <th className="text-left px-3 py-2">Event</th>
+                <th className="text-left px-3 py-2">Actor</th>
+                <th className="text-left px-3 py-2">Target</th>
+                <th className="text-left px-3 py-2">Details</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {data.items.map((entry) => (
+                <AuditLogRow key={entry.id} entry={entry} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {data && data.pages > 1 && (
+        <div className="flex items-center gap-2 justify-center text-sm">
+          <button
+            disabled={page <= 1}
+            onClick={() => setPage((p) => p - 1)}
+            className="px-2 py-1 border rounded disabled:opacity-40"
+          >
+            ←
+          </button>
+          <span className="text-muted-foreground">Page {data.page} of {data.pages}</span>
+          <button
+            disabled={page >= data.pages}
+            onClick={() => setPage((p) => p + 1)}
+            className="px-2 py-1 border rounded disabled:opacity-40"
+          >
+            →
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AuditLogRow({ entry }: { entry: AuditLogEntry }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasDetails = entry.details && Object.keys(entry.details).length > 0;
+
+  return (
+    <>
+      <tr
+        className={`hover:bg-muted/30 ${hasDetails ? "cursor-pointer" : ""}`}
+        onClick={() => hasDetails && setExpanded((v) => !v)}
+      >
+        <td className="px-3 py-2 text-muted-foreground whitespace-nowrap">{formatAuditTime(entry.created_at)}</td>
+        <td className="px-3 py-2">
+          <span className={`inline-block text-xs font-medium px-1.5 py-0.5 rounded ${eventBadgeClass(entry.event_type)}`}>
+            {entry.event_type}
+          </span>
+        </td>
+        <td className="px-3 py-2 text-muted-foreground">{entry.actor_email ?? <span className="italic">system</span>}</td>
+        <td className="px-3 py-2 text-muted-foreground">{entry.target_email ?? "—"}</td>
+        <td className="px-3 py-2 text-muted-foreground text-xs">
+          {hasDetails ? (expanded ? "▲ hide" : "▼ show") : "—"}
+        </td>
+      </tr>
+      {expanded && hasDetails && (
+        <tr>
+          <td colSpan={5} className="px-3 pb-2 bg-muted/20">
+            <pre className="text-xs font-mono whitespace-pre-wrap">{JSON.stringify(entry.details, null, 2)}</pre>
+          </td>
+        </tr>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary

- New `AuditLog` model with migration `0030_audit_log` — stores actor email snapshot, event type, target email snapshot, JSON details, and timestamp
- `write_audit_log()` helper in `app/services/audit.py` — flushed within the caller's transaction
- All 11 admin actions instrumented: user role changes, ban/unban, delete, elevate, signup approve/dismiss/ban, invite create/revoke, EULA publish
- `GET /api/admin/audit-log` with pagination (`page`, `page_size`) and filters (`event_type`, `q` email search)
- New **audit** tab in admin console: paginated table with event type badges (color-coded by severity), actor, target, expandable JSON details, and email search

## Test plan

- [ ] Open admin console → audit tab — loads empty state cleanly
- [ ] Approve a pending signup — verify `signup.approved` entry appears with actor/target emails
- [ ] Ban a user — verify `user.banned` entry with correct actor
- [ ] Change a user's roles — verify `user.role_changed` entry with `details` showing changed fields (click row to expand)
- [ ] Create and revoke an invite — verify both events appear
- [ ] Filter by event type — verify results narrow correctly
- [ ] Search by actor email — verify results filter
- [ ] Verify migration runs cleanly on deploy (`alembic upgrade head`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)