### PR TITLE
chore: dev reset scripts and workflow documentation

### DIFF
--- a/docs/dev-reset.md
+++ b/docs/dev-reset.md
@@ -1,0 +1,206 @@
+# Dev Reset Workflow
+
+Procedures for resetting a WeftMark dev instance to a clean state.
+All scripts live in `scripts/` and accept an `--env-file` argument (default: `.env.local`).
+
+---
+
+## Prerequisites
+
+| Requirement | Notes |
+|---|---|
+| Python (project virtualenv active) | asyncpg + boto3 must be importable |
+| Docker + Compose | Required for Postgres reset |
+| Backend image built | `docker compose build backend` |
+| `APP_ENV=dev` in your env file | Scripts abort before destructive ops if not set |
+
+---
+
+## Modes
+
+Every script supports three modes:
+
+| Flag | Behaviour | APP_ENV required |
+|---|---|---|
+| `--check` | Report current state (read-only) | No |
+| `--dry-run` | Show what would be done (read-only) | No |
+| *(none)* | Execute the operation | `APP_ENV=dev` |
+
+---
+
+## Quick reference
+
+```bash
+# Check state across all three systems
+python scripts/dev_reset.py --env-file .env.local --check
+
+# Preview what a full reset would do
+python scripts/dev_reset.py --env-file .env.local --dry-run
+
+# Full interactive reset (prompts for confirmation)
+python scripts/dev_reset.py --env-file .env.local
+```
+
+---
+
+## Workflow: reset from unknown state
+
+Follow these steps when the dev instance is in an unknown or broken state.
+
+### 1 — Check current state
+
+```bash
+python scripts/dev_reset.py --env-file .env.local --check
+```
+
+This runs the `--check` mode on Clerk, S3, and Postgres and prints a summary
+of what each system contains. No changes are made.
+
+### 2 — Stop running containers
+
+```bash
+docker compose --env-file .env.local -f docker-compose.build.yml down
+```
+
+Stop before clearing to prevent new data from being written mid-reset.
+
+### 3 — Clear each system (or use the orchestrator)
+
+#### Option A — orchestrator (clears all three, requires confirmation)
+
+```bash
+python scripts/dev_reset.py --env-file .env.local
+```
+
+Prints a state summary, prompts `Type RESET to continue`, then clears Clerk →
+S3 → Postgres in that order. Aborts if Clerk fails before touching the others.
+
+#### Option B — individual scripts
+
+Clear each system separately if you only need to reset one:
+
+```bash
+# Clerk users
+python scripts/clear_clerk.py --env-file .env.local
+
+# S3 objects
+python scripts/clear_s3.py --env-file .env.local
+
+# Postgres (downgrade base → upgrade head via Docker)
+python scripts/clear_postgres.py --env-file .env.local
+```
+
+### 4 — Verify clean state
+
+```bash
+python scripts/dev_reset.py --env-file .env.local --check
+```
+
+All three systems should report empty.
+
+### 5 — Start containers
+
+```bash
+docker compose --env-file .env.local -f docker-compose.build.yml up -d backend redis
+```
+
+Start backend and redis. Add `--profile local-db` if using the local Postgres container.
+
+### 6 — Seed (once implemented — see issue #140)
+
+```bash
+python -m app.cli seed --config seed.json
+```
+
+Creates users in Clerk (email + username + password), waits for webhook confirmation,
+then applies roles. See `seed.example.json` for the config format.
+
+---
+
+## Individual script reference
+
+### `clear_clerk.py`
+
+Clears all users from the Clerk instance.
+
+```
+python scripts/clear_clerk.py --env-file .env.local [--check | --dry-run]
+```
+
+**Requires:** `CLERK_SECRET_KEY` in env file.  
+**Rate-limit:** 100ms delay between deletes.
+
+---
+
+### `clear_s3.py`
+
+Clears all objects from the configured S3 bucket.
+
+```
+python scripts/clear_s3.py --env-file .env.local [--check | --dry-run]
+```
+
+**Requires:** `STORAGE_BACKEND=s3` and S3 credentials in env file.  
+**No-op** if `STORAGE_BACKEND=local`.  
+**Batch size:** 1000 objects per S3 delete request.
+
+---
+
+### `clear_postgres.py`
+
+Resets the database by running `alembic downgrade base` then `alembic upgrade head`
+inside a one-shot backend container.
+
+```
+python scripts/clear_postgres.py --env-file .env.local [--check | --dry-run]
+  [--db-port PORT]       # host port for local DB (default: 5435 for build.yml)
+  [--compose-file FILE]  # override compose file (default: docker-compose.build.yml)
+```
+
+**Check mode** requires asyncpg and a reachable database.  
+**Run mode** requires Docker and a built backend image.
+
+#### Local DB port reference
+
+| Compose file | Host port |
+|---|---|
+| `docker-compose.build.yml` | `5435` |
+| `docker-compose.dev.yml` | `5434` |
+| Neon / managed | set `POSTGRES_DSN_DIRECT` — port flag ignored |
+
+---
+
+### `dev_reset.py`
+
+Orchestrates all three clear scripts in sequence.
+
+```
+python scripts/dev_reset.py --env-file .env.local [--check | --dry-run]
+  [--db-port PORT]
+  [--compose-file FILE]
+```
+
+Run mode prompts `Type RESET to continue` before any destructive action.  
+Aborts if Clerk clear fails, then continues even if S3 fails (Postgres reset still runs).
+
+---
+
+## Troubleshooting
+
+**`asyncpg` not found during --check**  
+Activate the project virtualenv: `conda activate weaving_site`
+
+**`STORAGE_BACKEND=local` and nothing to clear**  
+Local file storage (`UPLOAD_DIR`) is not cleared by `clear_s3.py`. Delete the volume manually:
+```bash
+docker volume rm weaving_site_uploads
+```
+
+**Postgres `alembic downgrade base` fails**  
+The backend image may be stale. Rebuild:
+```bash
+docker compose --env-file .env.local -f docker-compose.build.yml build backend
+```
+
+**Clerk delete returns 404 or 422**  
+User may have been partially deleted already. Re-run `--check` — if the list is now empty, proceed.

--- a/scripts/_lib.py
+++ b/scripts/_lib.py
@@ -1,0 +1,134 @@
+"""Shared utilities for WeftMark dev scripts."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# ANSI output
+# ---------------------------------------------------------------------------
+
+BOLD = "\033[1m"
+RED = "\033[31m"
+GREEN = "\033[32m"
+YELLOW = "\033[33m"
+CYAN = "\033[36m"
+DIM = "\033[2m"
+RESET = "\033[0m"
+
+
+def ok(msg: str) -> None:
+    print(f"{GREEN}✓{RESET} {msg}")
+
+
+def warn(msg: str) -> None:
+    print(f"{YELLOW}⚠{RESET}  {msg}")
+
+
+def fail(msg: str, exit_code: int = 1) -> None:
+    print(f"{RED}✗{RESET}  {msg}", file=sys.stderr)
+    sys.exit(exit_code)
+
+
+def info(msg: str) -> None:
+    print(f"{CYAN}→{RESET} {msg}")
+
+
+def header(msg: str) -> None:
+    print(f"\n{BOLD}{msg}{RESET}")
+
+
+def dry(msg: str) -> None:
+    print(f"{DIM}  (dry-run){RESET} {msg}")
+
+
+# ---------------------------------------------------------------------------
+# Env file loading
+# ---------------------------------------------------------------------------
+
+
+def load_env(path: str) -> dict[str, str]:
+    """Parse a .env file and return {KEY: value}, stripping quotes and comments."""
+    env: dict[str, str] = {}
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if line.startswith("export "):
+                    line = line[7:]
+                if "=" not in line:
+                    continue
+                key, _, val = line.partition("=")
+                key = key.strip()
+                val = val.strip()
+                # strip surrounding single or double quotes
+                if len(val) >= 2 and val[0] == val[-1] and val[0] in "\"'":
+                    val = val[1:-1]
+                env[key] = val
+    except FileNotFoundError:
+        fail(f"Env file not found: {path}")
+    return env
+
+
+# ---------------------------------------------------------------------------
+# Safety gate
+# ---------------------------------------------------------------------------
+
+
+def require_dev_env(env: dict[str, str]) -> None:
+    """Abort unless APP_ENV=dev. Call this before any destructive operation."""
+    app_env = env.get("APP_ENV", "")
+    if app_env != "dev":
+        fail(
+            f"APP_ENV='{app_env}' — must be 'dev' to run destructive operations.\n"
+            "  Set APP_ENV=dev in your env file, or use --check / --dry-run."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def format_bytes(n: int | float) -> str:
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if n < 1024:
+            return f"{n:.1f} {unit}"
+        n /= 1024
+    return f"{n:.1f} PB"
+
+
+# ---------------------------------------------------------------------------
+# Postgres DSN resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_postgres_dsn(env: dict[str, str], host_port: int = 5435) -> str:
+    """
+    Return a plain postgresql:// DSN suitable for asyncpg or psql.
+
+    Priority:
+    1. POSTGRES_DSN_DIRECT (Neon direct connection / explicit override)
+    2. POSTGRES_DSN (pooled connection — works for read-only checks)
+    3. Build from POSTGRES_HOST / USER / PASSWORD / DB with host_port override
+       for local Docker setups where the container port is remapped on the host.
+    """
+    dsn = env.get("POSTGRES_DSN_DIRECT") or env.get("POSTGRES_DSN") or ""
+    if dsn:
+        # strip SQLAlchemy driver prefix if present
+        for prefix in ("postgresql+asyncpg://", "postgresql+psycopg2://"):
+            if dsn.startswith(prefix):
+                dsn = "postgresql://" + dsn[len(prefix):]
+        return dsn
+
+    # Build from individual vars
+    host = env.get("POSTGRES_HOST", "localhost")
+    if host == "db":
+        host = "127.0.0.1"
+    db = env.get("POSTGRES_DB", "weaving_site")
+    user = env.get("POSTGRES_USER", "")
+    password = env.get("POSTGRES_PASSWORD", "")
+    return f"postgresql://{user}:{password}@{host}:{host_port}/{db}"

--- a/scripts/_lib.py
+++ b/scripts/_lib.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+# Force UTF-8 output on Windows terminals that default to CP1252.
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
 # ---------------------------------------------------------------------------
 # ANSI output
 # ---------------------------------------------------------------------------
@@ -19,20 +25,20 @@ RESET = "\033[0m"
 
 
 def ok(msg: str) -> None:
-    print(f"{GREEN}✓{RESET} {msg}")
+    print(f"{GREEN}ok{RESET}  {msg}")
 
 
 def warn(msg: str) -> None:
-    print(f"{YELLOW}⚠{RESET}  {msg}")
+    print(f"{YELLOW}!!{RESET}  {msg}")
 
 
 def fail(msg: str, exit_code: int = 1) -> None:
-    print(f"{RED}✗{RESET}  {msg}", file=sys.stderr)
+    print(f"{RED}ERR{RESET} {msg}", file=sys.stderr)
     sys.exit(exit_code)
 
 
 def info(msg: str) -> None:
-    print(f"{CYAN}→{RESET} {msg}")
+    print(f"{CYAN}>>{RESET} {msg}")
 
 
 def header(msg: str) -> None:
@@ -40,7 +46,7 @@ def header(msg: str) -> None:
 
 
 def dry(msg: str) -> None:
-    print(f"{DIM}  (dry-run){RESET} {msg}")
+    print(f"{DIM}  [dry-run]{RESET} {msg}")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/audit_s3_orphans.py
+++ b/scripts/audit_s3_orphans.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Compare S3 objects against all Postgres file references to find orphaned objects.
+
+File columns checked:
+  activity_photos.file_path
+  loom_version_photos.path
+  loom_version_receipts.path
+  projects.wif_path
+  projects.preview_path
+  looms.photo_path
+
+Modes:
+  --check    List orphaned S3 keys and sizes (read-only, no prompt)
+  --dry-run  Show which delete operations would run (read-only, no prompt)
+  (default)  List orphans then prompt to delete — defaults to N (requires APP_ENV=dev)
+
+Requires asyncpg and boto3 (both in the project virtualenv).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _lib import dry, fail, format_bytes, header, info, load_env, ok, require_dev_env, resolve_postgres_dsn, warn
+
+try:
+    import boto3
+    import botocore.exceptions
+except ImportError:
+    print("boto3 is required — activate the project virtualenv or: pip install boto3", file=sys.stderr)
+    sys.exit(1)
+
+# ---------------------------------------------------------------------------
+# Postgres — collect all referenced S3 keys
+# ---------------------------------------------------------------------------
+
+_QUERIES = [
+    ("activity_photos",      "SELECT file_path    FROM activity_photos WHERE file_path IS NOT NULL"),
+    ("loom_version_photos",  "SELECT path         FROM loom_version_photos WHERE path IS NOT NULL"),
+    ("loom_version_receipts","SELECT path         FROM loom_version_receipts WHERE path IS NOT NULL"),
+    ("projects.wif_path",    "SELECT wif_path     FROM projects WHERE wif_path IS NOT NULL"),
+    ("projects.preview_path","SELECT preview_path FROM projects WHERE preview_path IS NOT NULL"),
+    ("looms.photo_path",     "SELECT photo_path   FROM looms WHERE photo_path IS NOT NULL"),
+    ("yarns.photo_path",     "SELECT photo_path   FROM yarns WHERE photo_path IS NOT NULL"),
+]
+
+
+async def _fetch_referenced_keys(dsn: str) -> tuple[set[str], dict[str, int]]:
+    """Return (all_referenced_keys, {source_label: count})."""
+    try:
+        import asyncpg  # type: ignore[import]
+    except ImportError:
+        fail(
+            "asyncpg is required.\n"
+            "  Activate the project virtualenv or: pip install asyncpg"
+        )
+
+    conn = await asyncpg.connect(dsn)
+    try:
+        keys: set[str] = set()
+        counts: dict[str, int] = {}
+        for label, sql in _QUERIES:
+            rows = await conn.fetch(sql)
+            vals = {row[0] for row in rows if row[0]}
+            keys |= vals
+            counts[label] = len(vals)
+        return keys, counts
+    finally:
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# S3 — list all objects
+# ---------------------------------------------------------------------------
+
+
+def _make_s3_client(env: dict[str, str]):  # type: ignore[return]
+    return boto3.client(
+        "s3",
+        endpoint_url=env.get("S3_ENDPOINT_URL") or None,
+        aws_access_key_id=env.get("S3_ACCESS_KEY_ID") or None,
+        aws_secret_access_key=env.get("S3_SECRET_ACCESS_KEY") or None,
+        region_name=env.get("S3_REGION", "auto") or "auto",
+    )
+
+
+def _list_s3_objects(s3, bucket: str) -> dict[str, int]:
+    """Return {key: size_bytes} for all objects in the bucket."""
+    objects: dict[str, int] = {}
+    paginator = s3.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket):
+        for obj in page.get("Contents", []):
+            objects[obj["Key"]] = obj.get("Size", 0)
+    return objects
+
+
+def _delete_objects(s3, bucket: str, keys: list[str]) -> int:
+    """Delete keys in batches of 1000. Returns error count."""
+    errors = 0
+    for i in range(0, len(keys), 1000):
+        batch = keys[i : i + 1000]
+        resp = s3.delete_objects(
+            Bucket=bucket,
+            Delete={"Objects": [{"Key": k} for k in batch], "Quiet": True},
+        )
+        for err in resp.get("Errors", []):
+            warn(f"Failed to delete {err['Key']}: {err['Message']}")
+            errors += 1
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--env-file", default=".env.local", metavar="PATH",
+                        help="Path to .env file (default: .env.local)")
+    parser.add_argument("--db-port", type=int, default=5435, metavar="PORT",
+                        help="Host port for local DB (default: 5435)")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--check", action="store_true",
+                       help="List orphaned keys (read-only, no prompt)")
+    group.add_argument("--dry-run", action="store_true",
+                       help="Show delete operations that would run (read-only, no prompt)")
+    args = parser.parse_args()
+
+    env = load_env(args.env_file)
+
+    storage_backend = env.get("STORAGE_BACKEND", "local").strip()
+    if storage_backend != "s3":
+        info(f"STORAGE_BACKEND={storage_backend!r} — not S3, nothing to audit")
+        return
+
+    bucket = env.get("S3_BUCKET_NAME", "").strip()
+    if not bucket:
+        fail("S3_BUCKET_NAME not set in env file")
+
+    # --- Collect Postgres references ---
+    header("Postgres — collecting file references")
+    dsn = resolve_postgres_dsn(env, host_port=args.db_port)
+    info(f"Connecting to: {dsn.split('@')[-1]}")
+
+    try:
+        referenced_keys, counts = asyncio.run(_fetch_referenced_keys(dsn))
+    except Exception as exc:
+        fail(f"Postgres connection failed: {exc}")
+
+    for label, count in counts.items():
+        print(f"  {label}: {count} reference(s)")
+    info(f"Total unique referenced keys: {len(referenced_keys)}")
+
+    # --- Collect S3 objects ---
+    header(f"S3 — listing objects in {bucket}")
+    s3 = _make_s3_client(env)
+    try:
+        s3_objects = _list_s3_objects(s3, bucket)
+    except botocore.exceptions.ClientError as exc:
+        fail(f"S3 error: {exc}")
+
+    info(f"Total S3 objects: {len(s3_objects)}")
+
+    # --- Compare ---
+    header("Comparison")
+    s3_keys = set(s3_objects.keys())
+    orphaned_keys = sorted(s3_keys - referenced_keys)
+    referenced_present = s3_keys & referenced_keys
+    missing_from_s3 = referenced_keys - s3_keys
+
+    ok(f"Referenced and present in S3: {len(referenced_present)}")
+
+    if missing_from_s3:
+        warn(f"Referenced in Postgres but MISSING from S3: {len(missing_from_s3)}")
+        for key in sorted(missing_from_s3):
+            print(f"  {key}")
+
+    if not orphaned_keys:
+        ok("No orphaned S3 objects found")
+        return
+
+    orphaned_bytes = sum(s3_objects[k] for k in orphaned_keys)
+    print()
+    warn(f"Orphaned S3 objects (not referenced in Postgres): {len(orphaned_keys)}  ({format_bytes(orphaned_bytes)})")
+    for key in orphaned_keys:
+        size = s3_objects[key]
+        print(f"  {key}  ({format_bytes(size)})")
+
+    # --- Dry-run: show delete commands ---
+    if args.dry_run:
+        print()
+        info("Would delete:")
+        for key in orphaned_keys:
+            dry(f"s3://{bucket}/{key}  ({format_bytes(s3_objects[key])})")
+        return
+
+    # --- Check: stop here ---
+    if args.check:
+        return
+
+    # --- Default run mode: prompt to delete ---
+    require_dev_env(env)
+    print()
+    answer = input(f"Delete {len(orphaned_keys)} orphaned object(s) ({format_bytes(orphaned_bytes)})? [y/N]: ").strip().lower()
+    if answer != "y":
+        info("Skipped — no objects deleted")
+        return
+
+    info(f"Deleting {len(orphaned_keys)} orphaned object(s)…")
+    errors = _delete_objects(s3, bucket, orphaned_keys)
+    print()
+    if errors:
+        warn(f"Done with {errors} error(s)")
+    else:
+        ok(f"Deleted {len(orphaned_keys)} orphaned object(s), freed {format_bytes(orphaned_bytes)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/clear_clerk.py
+++ b/scripts/clear_clerk.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Clear all users from a Clerk instance.
+
+Modes:
+  --check    List users and count (read-only, no APP_ENV restriction)
+  --dry-run  Show which users would be deleted (read-only)
+  (default)  Delete all users — requires APP_ENV=dev
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _lib import dry, fail, header, info, load_env, ok, require_dev_env, warn
+
+CLERK_API = "https://api.clerk.com/v1"
+
+
+def _clerk_request(secret_key: str, method: str, path: str) -> object:
+    req = urllib.request.Request(
+        f"{CLERK_API}{path}",
+        method=method,
+        headers={"Authorization": f"Bearer {secret_key}"},
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")
+        fail(f"Clerk API {method} {path} → {exc.code}: {body[:200]}")
+
+
+def fetch_all_users(secret_key: str) -> list[dict]:
+    users: list[dict] = []
+    limit = 100
+    offset = 0
+    while True:
+        page = _clerk_request(secret_key, "GET", f"/users?limit={limit}&offset={offset}")
+        if not isinstance(page, list) or not page:
+            break
+        users.extend(page)
+        if len(page) < limit:
+            break
+        offset += limit
+    return users
+
+
+def _primary_email(user: dict) -> str:
+    primary_id = user.get("primary_email_address_id", "")
+    for addr in user.get("email_addresses", []):
+        if addr.get("id") == primary_id:
+            return addr.get("email_address", "—")
+    return "—"
+
+
+def _format_user(user: dict) -> str:
+    email = _primary_email(user)
+    username = user.get("username") or "—"
+    return f"{user['id']}  {email}  ({username})"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--env-file", default=".env.local", metavar="PATH", help="Path to .env file (default: .env.local)")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--check", action="store_true", help="Report user count and list (read-only)")
+    group.add_argument("--dry-run", action="store_true", help="Show what would be deleted (read-only)")
+    args = parser.parse_args()
+
+    env = load_env(args.env_file)
+    secret_key = env.get("CLERK_SECRET_KEY", "").strip()
+    if not secret_key:
+        fail("CLERK_SECRET_KEY not set in env file")
+
+    header("Clerk — users")
+    users = fetch_all_users(secret_key)
+
+    if not users:
+        ok("Clerk instance is empty — 0 users")
+        return
+
+    if args.check:
+        info(f"{len(users)} user(s) found:")
+        for u in users:
+            print(f"  {_format_user(u)}")
+        return
+
+    if args.dry_run:
+        info(f"Would delete {len(users)} user(s):")
+        for u in users:
+            dry(_format_user(u))
+        return
+
+    require_dev_env(env)
+    info(f"Deleting {len(users)} user(s)…")
+    errors = 0
+    for u in users:
+        label = _primary_email(u)
+        try:
+            _clerk_request(secret_key, "DELETE", f"/users/{u['id']}")
+            ok(f"Deleted {label}  ({u['id']})")
+        except SystemExit:
+            warn(f"Failed to delete {label}  ({u['id']})")
+            errors += 1
+        time.sleep(0.1)  # avoid Clerk rate limit
+
+    print()
+    if errors:
+        warn(f"Done with {errors} error(s) — re-run --check to verify")
+    else:
+        ok(f"All {len(users)} user(s) deleted")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/clear_clerk.py
+++ b/scripts/clear_clerk.py
@@ -27,7 +27,10 @@ def _clerk_request(secret_key: str, method: str, path: str) -> object:
     req = urllib.request.Request(
         f"{CLERK_API}{path}",
         method=method,
-        headers={"Authorization": f"Bearer {secret_key}"},
+        headers={
+            "Authorization": f"Bearer {secret_key}",
+            "User-Agent": "WeftMark-DevTools/1.0",
+        },
     )
     try:
         with urllib.request.urlopen(req) as resp:

--- a/scripts/clear_postgres.py
+++ b/scripts/clear_postgres.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Reset the Postgres database via Alembic downgrade base → upgrade head.
+
+Modes:
+  --check    Count rows per table (read-only, no APP_ENV restriction)
+  --dry-run  Show the Alembic commands that would run (read-only)
+  (default)  Run downgrade base + upgrade head — requires APP_ENV=dev
+
+Check mode requires asyncpg (already in the project virtualenv).
+Run mode requires Docker and the backend image to be built.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _lib import dry, fail, header, info, load_env, ok, require_dev_env, resolve_postgres_dsn, warn
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# ---------------------------------------------------------------------------
+# Check mode — count rows via asyncpg
+# ---------------------------------------------------------------------------
+
+
+async def _count_rows(dsn: str) -> dict[str, int]:
+    try:
+        import asyncpg  # type: ignore[import]
+    except ImportError:
+        fail(
+            "asyncpg is required for --check mode.\n"
+            "  Activate the project virtualenv or: pip install asyncpg"
+        )
+
+    conn = await asyncpg.connect(dsn)
+    try:
+        tables = await conn.fetch(
+            "SELECT tablename FROM pg_tables WHERE schemaname = 'public' ORDER BY tablename"
+        )
+        counts: dict[str, int] = {}
+        for row in tables:
+            table = row["tablename"]
+            count = await conn.fetchval(f"SELECT COUNT(*) FROM {table}")
+            counts[table] = count
+        return counts
+    finally:
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Run mode — Alembic via Docker
+# ---------------------------------------------------------------------------
+
+
+def _find_compose_file() -> Path:
+    for name in ("docker-compose.build.yml", "docker-compose.dev.yml"):
+        path = REPO_ROOT / name
+        if path.exists():
+            return path
+    fail("No docker-compose.build.yml or docker-compose.dev.yml found in repo root")
+
+
+def _run_alembic(cmd: str, env_file: str, compose_file: Path) -> None:
+    """Run an Alembic command inside a one-shot backend container."""
+    docker_cmd = [
+        "docker", "compose",
+        "--env-file", env_file,
+        "-f", str(compose_file),
+        "run", "--rm", "--no-deps", "backend",
+        "alembic", *cmd.split(),
+    ]
+    info(f"Running: {' '.join(docker_cmd)}")
+    result = subprocess.run(docker_cmd, cwd=REPO_ROOT)
+    if result.returncode != 0:
+        fail(f"alembic {cmd} failed (exit {result.returncode})")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--env-file", default=".env.local", metavar="PATH", help="Path to .env file (default: .env.local)")
+    parser.add_argument("--db-port", type=int, default=5435, metavar="PORT",
+                        help="Host port the local DB container is mapped to (default: 5435 for docker-compose.build.yml)")
+    parser.add_argument("--compose-file", metavar="FILE", help="Override compose file for run mode")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--check", action="store_true", help="Count rows per table (read-only)")
+    group.add_argument("--dry-run", action="store_true", help="Show Alembic commands that would run (read-only)")
+    args = parser.parse_args()
+
+    env = load_env(args.env_file)
+
+    header("Postgres — database")
+
+    if args.check:
+        dsn = resolve_postgres_dsn(env, host_port=args.db_port)
+        info(f"Connecting to: {dsn.split('@')[-1]}")  # hide credentials
+        try:
+            counts = asyncio.run(_count_rows(dsn))
+        except Exception as exc:
+            fail(f"Connection failed: {exc}")
+
+        total = sum(counts.values())
+        if total == 0:
+            ok("Database is empty — all tables have 0 rows")
+        else:
+            info(f"Row counts ({total} total):")
+            for table, count in sorted(counts.items()):
+                flag = "  " if count == 0 else "⚠ "
+                print(f"  {flag}{table}: {count}")
+        return
+
+    compose_file = Path(args.compose_file) if args.compose_file else _find_compose_file()
+
+    alembic_cmds = ["downgrade base", "upgrade head"]
+
+    if args.dry_run:
+        info(f"Compose file: {compose_file.name}")
+        info("Would run:")
+        for cmd in alembic_cmds:
+            dry(f"docker compose run --rm --no-deps backend alembic {cmd}")
+        return
+
+    require_dev_env(env)
+    info(f"Compose file: {compose_file.name}")
+    for cmd in alembic_cmds:
+        _run_alembic(cmd, args.env_file, compose_file)
+
+    print()
+    ok("Database reset complete (downgrade base → upgrade head)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/clear_s3.py
+++ b/scripts/clear_s3.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Clear all objects from the configured S3 bucket.
+
+Modes:
+  --check    List object count and total size (read-only, no APP_ENV restriction)
+  --dry-run  Show what would be deleted (read-only)
+  (default)  Delete all objects — requires APP_ENV=dev
+
+Requires boto3: pip install boto3  (already in backend/requirements.txt)
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _lib import dry, fail, format_bytes, header, info, load_env, ok, require_dev_env, warn
+
+try:
+    import boto3
+    import botocore.exceptions
+except ImportError:
+    print("boto3 is required — activate the project virtualenv or: pip install boto3", file=sys.stderr)
+    sys.exit(1)
+
+
+def make_s3_client(env: dict[str, str]):  # type: ignore[return]
+    endpoint = env.get("S3_ENDPOINT_URL", "").strip() or None
+    access_key = env.get("S3_ACCESS_KEY_ID", "").strip() or None
+    secret_key = env.get("S3_SECRET_ACCESS_KEY", "").strip() or None
+    region = env.get("S3_REGION", "auto").strip() or "auto"
+    return boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name=region,
+    )
+
+
+def list_all_objects(s3, bucket: str) -> list[dict]:
+    objects: list[dict] = []
+    paginator = s3.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket):
+        objects.extend(page.get("Contents", []))
+    return objects
+
+
+def delete_objects_batch(s3, bucket: str, keys: list[str]) -> int:
+    """Delete up to 1000 keys in one request. Returns number of errors."""
+    resp = s3.delete_objects(
+        Bucket=bucket,
+        Delete={"Objects": [{"Key": k} for k in keys], "Quiet": True},
+    )
+    errors = resp.get("Errors", [])
+    for err in errors:
+        warn(f"Failed to delete {err['Key']}: {err['Message']}")
+    return len(errors)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--env-file", default=".env.local", metavar="PATH", help="Path to .env file (default: .env.local)")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--check", action="store_true", help="Report object count and size (read-only)")
+    group.add_argument("--dry-run", action="store_true", help="Show what would be deleted (read-only)")
+    args = parser.parse_args()
+
+    env = load_env(args.env_file)
+
+    storage_backend = env.get("STORAGE_BACKEND", "local").strip()
+    if storage_backend != "s3":
+        info(f"STORAGE_BACKEND={storage_backend!r} — not S3, nothing to clear")
+        return
+
+    bucket = env.get("S3_BUCKET_NAME", "").strip()
+    if not bucket:
+        fail("S3_BUCKET_NAME not set in env file")
+
+    header(f"S3 — bucket: {bucket}")
+    s3 = make_s3_client(env)
+
+    try:
+        objects = list_all_objects(s3, bucket)
+    except botocore.exceptions.ClientError as exc:
+        fail(f"S3 error listing objects: {exc}")
+
+    if not objects:
+        ok("Bucket is empty — 0 objects")
+        return
+
+    total_bytes = sum(o.get("Size", 0) for o in objects)
+    summary = f"{len(objects)} object(s), {format_bytes(total_bytes)}"
+
+    if args.check:
+        info(f"Found {summary}:")
+        sample = objects[:20]
+        for o in sample:
+            print(f"  {o['Key']}  ({format_bytes(o.get('Size', 0))})")
+        if len(objects) > 20:
+            print(f"  … and {len(objects) - 20} more")
+        return
+
+    if args.dry_run:
+        info(f"Would delete {summary}:")
+        sample = objects[:20]
+        for o in sample:
+            dry(f"{o['Key']}  ({format_bytes(o.get('Size', 0))})")
+        if len(objects) > 20:
+            print(f"  … and {len(objects) - 20} more")
+        return
+
+    require_dev_env(env)
+    info(f"Deleting {summary}…")
+
+    keys = [o["Key"] for o in objects]
+    total_errors = 0
+    for i in range(0, len(keys), 1000):
+        batch = keys[i : i + 1000]
+        total_errors += delete_objects_batch(s3, bucket, batch)
+        info(f"  Deleted batch {i // 1000 + 1} ({len(batch)} keys)")
+
+    print()
+    if total_errors:
+        warn(f"Done with {total_errors} error(s) — re-run --check to verify")
+    else:
+        ok(f"All {len(objects)} object(s) deleted from {bucket}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev_reset.py
+++ b/scripts/dev_reset.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Master dev reset orchestrator — Clerk + S3 + Postgres.
+
+Modes:
+  --check    Report current state across all three systems (read-only)
+  --dry-run  Show what each clear script would do (read-only)
+  (default)  Interactively confirm, then clear all three — requires APP_ENV=dev
+
+Individual scripts can be run in isolation:
+  python scripts/clear_clerk.py    --env-file .env.local [--check | --dry-run]
+  python scripts/clear_s3.py      --env-file .env.local [--check | --dry-run]
+  python scripts/clear_postgres.py --env-file .env.local [--check | --dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _lib import BOLD, RED, RESET, fail, header, info, load_env, ok, require_dev_env, warn
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+
+
+def run_script(script: str, extra_args: list[str], env_file: str) -> bool:
+    """Run a sub-script and return True on success."""
+    cmd = [sys.executable, str(SCRIPTS_DIR / script), "--env-file", env_file, *extra_args]
+    result = subprocess.run(cmd)
+    return result.returncode == 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--env-file", default=".env.local", metavar="PATH",
+                        help="Path to .env file (default: .env.local)")
+    parser.add_argument("--db-port", type=int, default=5435, metavar="PORT",
+                        help="Host port the local DB is mapped to (default: 5435)")
+    parser.add_argument("--compose-file", metavar="FILE",
+                        help="Compose file for Postgres reset (default: auto-detect)")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--check", action="store_true",
+                       help="Report state across all systems (read-only)")
+    group.add_argument("--dry-run", action="store_true",
+                       help="Show what would be done (read-only)")
+    args = parser.parse_args()
+
+    pg_extra = ["--db-port", str(args.db_port)]
+    if args.compose_file:
+        pg_extra += ["--compose-file", args.compose_file]
+
+    # -----------------------------------------------------------------------
+    # Check / dry-run: delegate and exit
+    # -----------------------------------------------------------------------
+
+    if args.check or args.dry_run:
+        mode_flag = "--check" if args.check else "--dry-run"
+        for script, extra in [
+            ("clear_clerk.py", []),
+            ("clear_s3.py", []),
+            ("clear_postgres.py", pg_extra),
+        ]:
+            run_script(script, [mode_flag, *extra], args.env_file)
+        return
+
+    # -----------------------------------------------------------------------
+    # Run mode: safety checks + confirmation
+    # -----------------------------------------------------------------------
+
+    env = load_env(args.env_file)
+    require_dev_env(env)
+
+    # Show current state first
+    header("Current state (--check)")
+    for script, extra in [
+        ("clear_clerk.py", []),
+        ("clear_s3.py", []),
+        ("clear_postgres.py", pg_extra),
+    ]:
+        run_script(script, ["--check", *extra], args.env_file)
+
+    # Confirmation prompt
+    print(f"\n{BOLD}{RED}WARNING{RESET} — This will permanently delete all data in:")
+    print("  • Clerk (all users)")
+    print("  • S3 bucket (all objects)")
+    print("  • Postgres (all tables, then re-migrate)")
+    print()
+    confirm = input("Type RESET to continue, or anything else to abort: ").strip()
+    if confirm != "RESET":
+        info("Aborted — nothing was changed")
+        sys.exit(0)
+
+    # -----------------------------------------------------------------------
+    # Execute
+    # -----------------------------------------------------------------------
+
+    header("Clearing Clerk")
+    if not run_script("clear_clerk.py", [], args.env_file):
+        fail("Clerk clear failed — aborting before touching S3 or Postgres")
+
+    header("Clearing S3")
+    if not run_script("clear_s3.py", [], args.env_file):
+        warn("S3 clear failed — continuing to Postgres reset")
+
+    header("Resetting Postgres")
+    if not run_script("clear_postgres.py", pg_extra, args.env_file):
+        fail("Postgres reset failed")
+
+    # Verify
+    header("Verifying clean state")
+    for script, extra in [
+        ("clear_clerk.py", []),
+        ("clear_s3.py", []),
+        ("clear_postgres.py", pg_extra),
+    ]:
+        run_script(script, ["--check", *extra], args.env_file)
+
+    print()
+    ok("Reset complete — instance is in a clean state")
+    info("Next: run 'python -m app.cli seed' to populate with seed users (see issue #140)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- `scripts/_lib.py` — shared env loading, output helpers, safety checks, DSN resolution
- `scripts/clear_clerk.py` — delete all Clerk users via REST API
- `scripts/clear_s3.py` — delete all S3 bucket objects in batches of 1000
- `scripts/clear_postgres.py` — reset DB via `alembic downgrade base` + `upgrade head` in a one-shot container
- `scripts/dev_reset.py` — master orchestrator: check → confirm → clear all three
- `scripts/audit_s3_orphans.py` — compare S3 inventory against all Postgres file path columns; identify and optionally delete orphaned objects
- `docs/dev-reset.md` — full workflow documentation (unknown state → clean state → seed)

All scripts support `--check` (read-only state report), `--dry-run` (preview), and default run mode (requires `APP_ENV=dev`). `audit_s3_orphans.py` covers all file path columns: `activity_photos.file_path`, `loom_version_photos.path`, `loom_version_receipts.path`, `projects.wif_path`, `projects.preview_path`, `looms.photo_path`, `yarns.photo_path`.

See #140 for the seed command that follows a reset.

Missed PR #138 — this is a follow-up PR for the same feature work.

## Test plan

- [x] `python scripts/dev_reset.py --env-file .env.local --check` reports state across all three systems
- [x] `python scripts/dev_reset.py --env-file .env.local --dry-run` shows commands without executing
- [x] `python scripts/audit_s3_orphans.py --env-file .env.local --check` lists orphaned S3 objects
- [x] `python scripts/audit_s3_orphans.py --env-file .env.local --dry-run` shows delete operations
- [ ] `APP_ENV` set to anything other than `dev` causes run mode to abort before touching anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)