### PR TITLE
ci: add check-merge-source workflow for main branch protection

### DIFF
--- a/.github/workflows/check-merge-source.yml
+++ b/.github/workflows/check-merge-source.yml
@@ -1,0 +1,24 @@
+name: Check merge source
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check-source-branch:
+    name: Source branch must be dev or hotfix/*
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify source branch
+        env:
+          SOURCE: ${{ github.head_ref }}
+        run: |
+          if [[ "$SOURCE" == "dev" || "$SOURCE" == hotfix/* ]]; then
+            echo "ok  Source branch '$SOURCE' is allowed to merge into main."
+          else
+            echo "ERR Source branch '$SOURCE' is not allowed to merge into main."
+            echo "    Only 'dev' and 'hotfix/*' branches may target main."
+            echo "    Merge your changes into 'dev' first, then open a release PR from dev."
+            exit 1
+          fi


### PR DESCRIPTION
Closes #144

## Summary

Adds `.github/workflows/check-merge-source.yml` — a workflow that runs on every PR targeting `main` and fails if the source branch is not `dev` or `hotfix/*`.

## After merging

Add **`Check merge source / Source branch must be dev or hotfix/*`** to the required status checks in the `main` branch protection rules to enforce at merge time.

## Test plan

- [ ] This PR (hotfix/check-merge-source) passes the check once the workflow is active
- [ ] PR from `dev` to `main` — check passes
- [ ] PR from `feature/anything` to `main` — check fails with descriptive message
- [ ] Required status check added to main branch protection (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)