### PR TITLE
feat: loom type enforcement — derive tracking flags, block activities on unsupported looms

### DIFF
--- a/backend/app/models/loom.py
+++ b/backend/app/models/loom.py
@@ -8,7 +8,15 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, SoftDeleteMixin, TimestampMixin
 
-LOOM_TYPES = ("floor_loom", "table_loom", "rigid_heddle", "inkle", "other")
+LOOM_TYPES = ("floor_loom", "table_loom", "rigid_heddle", "inkle", "dobby", "other")
+
+# Only these types support activity tracking (treadle or lift).
+ACTIVITY_SUPPORTED_LOOM_TYPES = frozenset({"floor_loom", "table_loom"})
+
+
+def loom_tracking_flags(loom_type: str) -> tuple[bool, bool]:
+    """Return (supports_lift_tracking, supports_treadle_tracking) derived from loom_type."""
+    return loom_type == "table_loom", loom_type == "floor_loom"
 
 
 class Loom(Base, TimestampMixin, SoftDeleteMixin):

--- a/backend/app/routers/activities.py
+++ b/backend/app/routers/activities.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import selectinload
 
 from app.deps import get_current_user, get_db
 from app.models.activity import Activity, ActivityPhoto, ActivityStep
-from app.models.loom import Loom, LoomVersion
+from app.models.loom import ACTIVITY_SUPPORTED_LOOM_TYPES, Loom, LoomVersion
 from app.models.project import Project
 from app.models.user import User
 from app.services import storage, wif_parser
@@ -233,6 +233,12 @@ async def create_activity(
         if loom is None:
             raise HTTPException(status_code=404, detail="Loom not found")
 
+        if loom.loom_type not in ACTIVITY_SUPPORTED_LOOM_TYPES:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Loom type '{loom.loom_type}' does not support activity tracking",
+            )
+
         if body.loom_version_id:
             version_ok = await db.scalar(
                 select(LoomVersion).where(
@@ -343,6 +349,12 @@ async def assign_loom(
     )
     if loom is None:
         raise HTTPException(status_code=404, detail="Loom not found")
+
+    if loom.loom_type not in ACTIVITY_SUPPORTED_LOOM_TYPES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Loom type '{loom.loom_type}' does not support activity tracking",
+        )
 
     if body.loom_version_id:
         version_ok = await db.scalar(

--- a/backend/app/routers/looms.py
+++ b/backend/app/routers/looms.py
@@ -19,6 +19,7 @@ from app.models.loom import (
     LoomVersionAccessory,
     LoomVersionPhoto,
     LoomVersionReceipt,
+    loom_tracking_flags,
 )
 from app.models.user import User
 from app.services import storage
@@ -35,7 +36,7 @@ def _content_disposition(disposition: str, filename: str) -> str:
     return f"{disposition}; filename=\"{ascii_fallback}\"; filename*=UTF-8''{encoded}"
 
 
-LoomType = Literal["floor_loom", "table_loom", "rigid_heddle", "inkle", "other"]
+LoomType = Literal["floor_loom", "table_loom", "rigid_heddle", "inkle", "dobby", "other"]
 
 ALLOWED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/webp", "image/gif"}
 ALLOWED_RECEIPT_TYPES = {"image/jpeg", "image/png", "image/webp", "application/pdf"}
@@ -177,8 +178,6 @@ class CreateLoomRequest(BaseModel):
     purchase_date: date | None = None
     purchase_price: Decimal | None = None
     vendor: str | None = None
-    supports_lift_tracking: bool = False
-    supports_treadle_tracking: bool = False
     notes: str | None = None
     # Initial version
     effective_date: date
@@ -200,8 +199,6 @@ class UpdateLoomRequest(BaseModel):
     purchase_date: date | None = None
     purchase_price: Decimal | None = None
     vendor: str | None = None
-    supports_lift_tracking: bool | None = None
-    supports_treadle_tracking: bool | None = None
     notes: str | None = None
 
 
@@ -291,6 +288,7 @@ async def create_loom(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> LoomDetail:
+    lift, treadle = loom_tracking_flags(body.loom_type)
     loom = Loom(
         owner_id=current_user.id,
         loom_type=body.loom_type,
@@ -300,8 +298,8 @@ async def create_loom(
         purchase_date=body.purchase_date,
         purchase_price=body.purchase_price,
         vendor=body.vendor,
-        supports_lift_tracking=body.supports_lift_tracking,
-        supports_treadle_tracking=body.supports_treadle_tracking,
+        supports_lift_tracking=lift,
+        supports_treadle_tracking=treadle,
         notes=body.notes,
     )
     db.add(loom)
@@ -364,7 +362,11 @@ async def update_loom(
 ) -> LoomDetail:
     loom = await _get_owned_loom(loom_id, current_user, db)
     for field, value in body.model_dump(exclude_none=True).items():
-        setattr(loom, field, value)
+        if field == "loom_type":
+            loom.loom_type = value
+            loom.supports_lift_tracking, loom.supports_treadle_tracking = loom_tracking_flags(value)
+        else:
+            setattr(loom, field, value)
     await db.commit()
     loom = await _get_owned_loom(loom_id, current_user, db)
     return LoomDetail.from_loom(loom)

--- a/backend/tests/routers/test_activities.py
+++ b/backend/tests/routers/test_activities.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.activity import Activity
 from app.models.activity import ActivityPhoto as ActivityPhotoModel
-from app.models.loom import Loom, LoomVersion
+from app.models.loom import Loom, LoomVersion, loom_tracking_flags
 from app.models.project import Project
 from app.models.user import User
 
@@ -106,13 +106,15 @@ async def _insert_project(db_session: AsyncSession, owner: User) -> Project:
 
 
 async def _insert_loom(db_session: AsyncSession, owner: User, **kwargs) -> tuple[Loom, LoomVersion]:
+    loom_type = kwargs.get("loom_type", "floor_loom")
+    lift, treadle = loom_tracking_flags(loom_type)
     loom = Loom(
         owner_id=owner.id,
-        loom_type=kwargs.get("loom_type", "floor_loom"),
+        loom_type=loom_type,
         manufacturer=kwargs.get("manufacturer", "Ashford"),
         model_name=kwargs.get("model_name", "Table Loom 8"),
-        supports_treadle_tracking=kwargs.get("supports_treadle_tracking", True),
-        supports_lift_tracking=kwargs.get("supports_lift_tracking", True),
+        supports_treadle_tracking=treadle,
+        supports_lift_tracking=lift,
     )
     db_session.add(loom)
     await db_session.flush()
@@ -1196,3 +1198,60 @@ class TestGetPicks:
         activity = await _insert_active_activity(db_session, test_user, project, None)
         resp = await client.get(f"/api/activities/{activity.id}/picks")
         assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Unsupported loom type — activity creation and assignment
+# ---------------------------------------------------------------------------
+
+
+class TestUnsupportedLoomType:
+    async def test_unsupported_loom_type_blocks_create(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        project = await _insert_project(db_session, test_user)
+        loom, _ = await _insert_loom(db_session, test_user, loom_type="rigid_heddle")
+        resp = await auth_client.post(
+            "/api/activities",
+            json=_base_payload(str(project.id), loom_id=str(loom.id)),
+        )
+        assert resp.status_code == 422
+
+    async def test_dobby_loom_blocks_create(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        project = await _insert_project(db_session, test_user)
+        loom, _ = await _insert_loom(db_session, test_user, loom_type="dobby")
+        resp = await auth_client.post(
+            "/api/activities",
+            json=_base_payload(str(project.id), loom_id=str(loom.id)),
+        )
+        assert resp.status_code == 422
+
+    async def test_floor_loom_allowed(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        project = await _insert_project(db_session, test_user)
+        loom, _ = await _insert_loom(db_session, test_user, loom_type="floor_loom")
+        resp = await auth_client.post(
+            "/api/activities",
+            json=_base_payload(str(project.id), loom_id=str(loom.id)),
+        )
+        assert resp.status_code == 201
+
+    async def test_table_loom_allowed(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        project = await _insert_project(db_session, test_user)
+        loom, _ = await _insert_loom(db_session, test_user, loom_type="table_loom")
+        resp = await auth_client.post(
+            "/api/activities",
+            json=_base_payload(str(project.id), activity_type="lift", loom_id=str(loom.id)),
+        )
+        assert resp.status_code == 201
+
+    async def test_unsupported_loom_type_blocks_assign(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        project = await _insert_project(db_session, test_user)
+        activity = await _insert_active_activity(db_session, test_user, project, None)
+        loom, _ = await _insert_loom(db_session, test_user, loom_type="inkle")
+        resp = await auth_client.post(
+            f"/api/activities/{activity.id}/assign-loom",
+            json={"loom_id": str(loom.id)},
+        )
+        assert resp.status_code == 422

--- a/backend/tests/routers/test_looms.py
+++ b/backend/tests/routers/test_looms.py
@@ -442,3 +442,55 @@ class TestDeleteAccessory:
     async def test_unauthenticated_returns_401(self, client: AsyncClient):
         resp = await client.delete(f"/api/looms/{uuid.uuid4()}/versions/{uuid.uuid4()}/accessories/{uuid.uuid4()}")
         assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Loom tracking flags — derived from loom_type, never from client input
+# ---------------------------------------------------------------------------
+
+
+class TestLoomTrackingFlags:
+    async def test_floor_loom_sets_treadle_tracking(self, auth_client: AsyncClient):
+        resp = await auth_client.post("/api/looms", json=_LOOM_PAYLOAD)
+        body = resp.json()
+        assert body["supports_treadle_tracking"] is True
+        assert body["supports_lift_tracking"] is False
+
+    async def test_table_loom_sets_lift_tracking(self, auth_client: AsyncClient):
+        payload = {**_LOOM_PAYLOAD, "loom_type": "table_loom"}
+        resp = await auth_client.post("/api/looms", json=payload)
+        body = resp.json()
+        assert body["supports_lift_tracking"] is True
+        assert body["supports_treadle_tracking"] is False
+
+    async def test_unsupported_type_clears_both_flags(self, auth_client: AsyncClient):
+        for loom_type in ("rigid_heddle", "inkle", "dobby", "other"):
+            payload = {**_LOOM_PAYLOAD, "loom_type": loom_type}
+            resp = await auth_client.post("/api/looms", json=payload)
+            body = resp.json()
+            assert body["supports_treadle_tracking"] is False, f"{loom_type} should not set treadle"
+            assert body["supports_lift_tracking"] is False, f"{loom_type} should not set lift"
+
+    async def test_dobby_can_be_created(self, auth_client: AsyncClient):
+        payload = {**_LOOM_PAYLOAD, "loom_type": "dobby"}
+        resp = await auth_client.post("/api/looms", json=payload)
+        assert resp.status_code == 201
+        assert resp.json()["loom_type"] == "dobby"
+
+    async def test_changing_type_updates_tracking_flags(self, auth_client: AsyncClient):
+        loom = await _create_loom(auth_client)
+        assert loom["loom_type"] == "floor_loom"
+        assert loom["supports_treadle_tracking"] is True
+
+        resp = await auth_client.patch(f"/api/looms/{loom['id']}", json={"loom_type": "table_loom"})
+        body = resp.json()
+        assert body["loom_type"] == "table_loom"
+        assert body["supports_lift_tracking"] is True
+        assert body["supports_treadle_tracking"] is False
+
+    async def test_changing_to_unsupported_type_clears_flags(self, auth_client: AsyncClient):
+        loom = await _create_loom(auth_client)
+        resp = await auth_client.patch(f"/api/looms/{loom['id']}", json={"loom_type": "dobby"})
+        body = resp.json()
+        assert body["supports_treadle_tracking"] is False
+        assert body["supports_lift_tracking"] is False

--- a/frontend/src/api/looms.ts
+++ b/frontend/src/api/looms.ts
@@ -1,12 +1,16 @@
-export type LoomType = "floor_loom" | "table_loom" | "rigid_heddle" | "inkle" | "other";
+export type LoomType = "floor_loom" | "table_loom" | "rigid_heddle" | "inkle" | "dobby" | "other";
 
 export const LOOM_TYPE_LABELS: Record<LoomType, string> = {
-  floor_loom: "Floor loom",
-  table_loom: "Table loom",
-  rigid_heddle: "Rigid heddle",
+  floor_loom: "Floor Loom — treadle tracking",
+  table_loom: "Table Loom — lift tracking",
+  rigid_heddle: "Rigid Heddle",
   inkle: "Inkle",
+  dobby: "Dobby Loom",
   other: "Other",
 };
+
+/** Loom types that support activity tracking (treadle or lift). */
+export const SUPPORTED_LOOM_TYPES = new Set<LoomType>(["floor_loom", "table_loom"]);
 
 export interface LoomVersionPhoto {
   id: string;
@@ -76,8 +80,6 @@ export interface CreateLoomPayload {
   purchase_date?: string;
   purchase_price?: number;
   vendor?: string;
-  supports_lift_tracking: boolean;
-  supports_treadle_tracking: boolean;
   notes?: string;
   effective_date: string;
   num_shafts?: number;
@@ -98,8 +100,6 @@ export interface UpdateLoomPayload {
   purchase_date?: string;
   purchase_price?: number;
   vendor?: string;
-  supports_lift_tracking?: boolean;
-  supports_treadle_tracking?: boolean;
   notes?: string;
 }
 

--- a/frontend/src/components/activities/AssignLoomModal.tsx
+++ b/frontend/src/components/activities/AssignLoomModal.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { assignLoom, completeActivity, abandonActivity, ApiError, type ActivitySummary } from "@/api/activities";
-import { listLooms, getLoom } from "@/api/looms";
+import { listLooms, getLoom, SUPPORTED_LOOM_TYPES } from "@/api/looms";
 import { Button } from "@/components/ui/button";
 
 interface Props {
@@ -90,10 +90,13 @@ export function AssignLoomModal({ activityId, activeActivities, onSuccess, onClo
             <label className="mb-1 block text-sm font-medium">Loom <span className="text-destructive">*</span></label>
             <select className={f} value={loomId} onChange={(e) => handleLoomChange(e.target.value)}>
               <option value="">Select a loom…</option>
-              {looms.map((l) => (
+              {looms.filter((l) => SUPPORTED_LOOM_TYPES.has(l.loom_type)).map((l) => (
                 <option key={l.id} value={l.id}>{l.manufacturer} {l.model_name}</option>
               ))}
             </select>
+            {looms.some((l) => !SUPPORTED_LOOM_TYPES.has(l.loom_type)) && (
+              <p className="mt-1 text-xs text-muted-foreground">Looms without activity tracking support are not shown.</p>
+            )}
           </div>
 
           {loomVersions.length > 1 && (

--- a/frontend/src/components/activities/CreateActivityModal.tsx
+++ b/frontend/src/components/activities/CreateActivityModal.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { createActivity, completeActivity, abandonActivity, listActivities, ApiError, ACTIVITY_TYPE_LABELS, type ActivityType, type ActivitySummary } from "@/api/activities";
 import { listProjects } from "@/api/projects";
-import { listLooms, getLoom } from "@/api/looms";
+import { listLooms, getLoom, SUPPORTED_LOOM_TYPES } from "@/api/looms";
 import { Button } from "@/components/ui/button";
 
 interface Props {
@@ -181,10 +181,13 @@ export function CreateActivityModal({ onSuccess, onClose, defaultProjectId }: Pr
             <label className="mb-1 block text-sm font-medium">Loom <span className="text-muted-foreground font-normal">(optional)</span></label>
             <select className={f} value={loomId} onChange={(e) => handleLoomChange(e.target.value)}>
               <option value="">No loom selected</option>
-              {looms.map((l) => (
+              {looms.filter((l) => SUPPORTED_LOOM_TYPES.has(l.loom_type)).map((l) => (
                 <option key={l.id} value={l.id}>{l.manufacturer} {l.model_name}</option>
               ))}
             </select>
+            {looms.some((l) => !SUPPORTED_LOOM_TYPES.has(l.loom_type)) && (
+              <p className="mt-1 text-xs text-muted-foreground">Looms without activity tracking support are not shown.</p>
+            )}
           </div>
 
           {selectedLoom && loomVersions.length > 1 && (

--- a/frontend/src/components/looms/EditLoomModal.tsx
+++ b/frontend/src/components/looms/EditLoomModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import {
-  updateLoom, type LoomDetail, type UpdateLoomPayload, type LoomType, LOOM_TYPE_LABELS,
+  updateLoom, type LoomDetail, type UpdateLoomPayload, type LoomType, LOOM_TYPE_LABELS, SUPPORTED_LOOM_TYPES,
 } from "@/api/looms";
 import { Button } from "@/components/ui/button";
 
@@ -10,7 +10,7 @@ interface Props {
   onClose: () => void;
 }
 
-const LOOM_TYPES: LoomType[] = ["floor_loom", "table_loom", "rigid_heddle", "inkle", "other"];
+const LOOM_TYPES: LoomType[] = ["floor_loom", "table_loom", "rigid_heddle", "inkle", "dobby", "other"];
 
 export function EditLoomModal({ loom, onSuccess, onClose }: Props) {
   const [loomType, setLoomType] = useState<LoomType>(loom.loom_type);
@@ -20,11 +20,11 @@ export function EditLoomModal({ loom, onSuccess, onClose }: Props) {
   const [purchaseDate, setPurchaseDate] = useState(loom.purchase_date ?? "");
   const [purchasePrice, setPurchasePrice] = useState(loom.purchase_price ?? "");
   const [vendor, setVendor] = useState(loom.vendor ?? "");
-  const [supportsLift, setSupportsLift] = useState(loom.supports_lift_tracking);
-  const [supportsTreadle, setSupportsTreadle] = useState(loom.supports_treadle_tracking);
   const [notes, setNotes] = useState(loom.notes ?? "");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
+  const isUnsupported = !SUPPORTED_LOOM_TYPES.has(loomType);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -39,8 +39,6 @@ export function EditLoomModal({ loom, onSuccess, onClose }: Props) {
         purchase_date: purchaseDate || undefined,
         purchase_price: purchasePrice ? parseFloat(String(purchasePrice)) : undefined,
         vendor: vendor || undefined,
-        supports_lift_tracking: supportsLift,
-        supports_treadle_tracking: supportsTreadle,
         notes: notes || undefined,
       };
       const updated = await updateLoom(loom.id, payload);
@@ -70,6 +68,13 @@ export function EditLoomModal({ loom, onSuccess, onClose }: Props) {
               ))}
             </select>
           </div>
+
+          {/* Unsupported type info banner */}
+          {isUnsupported && (
+            <div className="rounded-md border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 px-3 py-2 text-xs text-amber-800 dark:text-amber-300">
+              This loom type is not currently supported for activity tracking. Activities cannot be created using this loom.
+            </div>
+          )}
 
           <div className="grid grid-cols-2 gap-3">
             <div>
@@ -137,26 +142,6 @@ export function EditLoomModal({ loom, onSuccess, onClose }: Props) {
               />
             </div>
           </fieldset>
-
-          <div className="space-y-2">
-            <p className="text-sm font-medium">Activity tracking</p>
-            <label className="flex items-center gap-2 text-sm">
-              <input
-                type="checkbox"
-                checked={supportsLift}
-                onChange={(e) => setSupportsLift(e.target.checked)}
-              />
-              Supports lift tracking
-            </label>
-            <label className="flex items-center gap-2 text-sm">
-              <input
-                type="checkbox"
-                checked={supportsTreadle}
-                onChange={(e) => setSupportsTreadle(e.target.checked)}
-              />
-              Supports treadle tracking
-            </label>
-          </div>
 
           <div>
             <label className="mb-1 block text-sm font-medium">Notes</label>

--- a/frontend/src/components/looms/NewLoomModal.tsx
+++ b/frontend/src/components/looms/NewLoomModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { createLoom, type CreateLoomPayload, type LoomType, LOOM_TYPE_LABELS } from "@/api/looms";
+import { createLoom, type CreateLoomPayload, type LoomType, LOOM_TYPE_LABELS, SUPPORTED_LOOM_TYPES } from "@/api/looms";
 import { Button } from "@/components/ui/button";
 
 interface Props {
@@ -9,10 +9,10 @@ interface Props {
 
 const today = () => new Date(Date.now() - new Date().getTimezoneOffset() * 60000).toISOString().slice(0, 10);
 
-const LOOM_TYPES: LoomType[] = ["floor_loom", "table_loom", "rigid_heddle", "inkle", "other"];
+const LOOM_TYPES: LoomType[] = ["floor_loom", "table_loom", "rigid_heddle", "inkle", "dobby", "other"];
 
-function showsShafts(t: LoomType) { return t === "floor_loom" || t === "table_loom" || t === "other"; }
-function showsTreadles(t: LoomType) { return t === "floor_loom" || t === "other"; }
+function showsShafts(t: LoomType) { return t === "floor_loom" || t === "table_loom" || t === "dobby" || t === "other"; }
+function showsTreadles(t: LoomType) { return t === "floor_loom"; }
 function showsHeddles(t: LoomType) { return t === "rigid_heddle" || t === "other"; }
 
 export function NewLoomModal({ onSuccess, onClose }: Props) {
@@ -21,7 +21,8 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
   const [modelName, setModelName] = useState("");
   const [serialNumber, setSerialNumber] = useState("");
   const [numShafts, setNumShafts] = useState("4");
-  const [numTreadles, setNumTreadles] = useState("4");
+  const [numTreadles, setNumTreadles] = useState("6"); // default: 4 shafts + 2
+  const [treadlesManuallySet, setTreadlesManuallySet] = useState(false);
   const [numHeddles, setNumHeddles] = useState("");
   const [weavingWidth, setWeavingWidth] = useState("");
   const [weavingWidthUnit, setWeavingWidthUnit] = useState("cm");
@@ -29,10 +30,29 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
   const [warpWasteUnit, setWarpWasteUnit] = useState("cm");
   const [effectiveDate, setEffectiveDate] = useState(today());
   const [notes, setNotes] = useState("");
-  const [supportsLift, setSupportsLift] = useState(false);
-  const [supportsTreadle, setSupportsTreadle] = useState(false);
+  const [acknowledged, setAcknowledged] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
+  const isUnsupported = !SUPPORTED_LOOM_TYPES.has(loomType);
+
+  const handleTypeChange = (newType: LoomType) => {
+    setLoomType(newType);
+    setAcknowledged(false);
+    setTreadlesManuallySet(false);
+    if (newType === "floor_loom") {
+      const s = parseInt(numShafts, 10);
+      if (!isNaN(s)) setNumTreadles(String(s + 2));
+    }
+  };
+
+  const handleShaftsChange = (val: string) => {
+    setNumShafts(val);
+    if (loomType === "floor_loom" && !treadlesManuallySet) {
+      const s = parseInt(val, 10);
+      if (!isNaN(s)) setNumTreadles(String(s + 2));
+    }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -44,8 +64,6 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
         manufacturer,
         model_name: modelName,
         serial_number: serialNumber || undefined,
-        supports_lift_tracking: supportsLift,
-        supports_treadle_tracking: supportsTreadle,
         notes: notes || undefined,
         effective_date: effectiveDate,
         num_shafts: showsShafts(loomType) && numShafts ? parseInt(numShafts, 10) : undefined,
@@ -77,13 +95,32 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
             <select
               className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
               value={loomType}
-              onChange={(e) => setLoomType(e.target.value as LoomType)}
+              onChange={(e) => handleTypeChange(e.target.value as LoomType)}
             >
               {LOOM_TYPES.map((t) => (
                 <option key={t} value={t}>{LOOM_TYPE_LABELS[t]}</option>
               ))}
             </select>
           </div>
+
+          {/* Unsupported type warning + acknowledgement */}
+          {isUnsupported && (
+            <div className="rounded-md border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 px-3 py-3 text-sm space-y-2">
+              <p className="font-medium text-amber-900 dark:text-amber-200">Activity tracking not supported</p>
+              <p className="text-xs text-amber-800 dark:text-amber-300">
+                This loom type is not currently supported for activity tracking. You can save it for documentation
+                and it will be available if support is added later, but activities cannot be created using it.
+              </p>
+              <label className="flex items-center gap-2 text-xs text-amber-900 dark:text-amber-200 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={acknowledged}
+                  onChange={(e) => setAcknowledged(e.target.checked)}
+                />
+                I understand this loom cannot be used for activity tracking
+              </label>
+            </div>
+          )}
 
           {/* Identity */}
           <div className="grid grid-cols-2 gap-3">
@@ -142,8 +179,8 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
                     min={1}
                     className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                     value={numShafts}
-                    onChange={(e) => setNumShafts(e.target.value)}
-                    required={loomType !== "other"}
+                    onChange={(e) => handleShaftsChange(e.target.value)}
+                    required={loomType !== "other" && loomType !== "dobby"}
                   />
                 </div>
               )}
@@ -155,8 +192,8 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
                     min={0}
                     className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                     value={numTreadles}
-                    onChange={(e) => setNumTreadles(e.target.value)}
-                    required={loomType !== "other"}
+                    onChange={(e) => { setNumTreadles(e.target.value); setTreadlesManuallySet(true); }}
+                    required
                   />
                 </div>
               )}
@@ -225,27 +262,6 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
             </div>
           )}
 
-          {/* Activity tracking */}
-          <div className="space-y-2">
-            <p className="text-sm font-medium">Activity tracking</p>
-            <label className="flex items-center gap-2 text-sm">
-              <input
-                type="checkbox"
-                checked={supportsLift}
-                onChange={(e) => setSupportsLift(e.target.checked)}
-              />
-              Supports lift tracking
-            </label>
-            <label className="flex items-center gap-2 text-sm">
-              <input
-                type="checkbox"
-                checked={supportsTreadle}
-                onChange={(e) => setSupportsTreadle(e.target.checked)}
-              />
-              Supports treadle tracking
-            </label>
-          </div>
-
           <div>
             <label className="mb-1 block text-sm font-medium">Notes (optional)</label>
             <textarea
@@ -265,7 +281,7 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
             <Button type="button" variant="outline" onClick={onClose} disabled={loading}>
               Cancel
             </Button>
-            <Button type="submit" disabled={loading}>
+            <Button type="submit" disabled={loading || (isUnsupported && !acknowledged)}>
               {loading ? "Creating…" : "Create loom"}
             </Button>
           </div>

--- a/frontend/src/pages/LoomDetailPage.tsx
+++ b/frontend/src/pages/LoomDetailPage.tsx
@@ -10,7 +10,7 @@ import {
   addAccessory, deleteAccessory, updateVersion,
   type LoomDetail, type LoomVersion, type LoomVersionPhoto,
   type LoomVersionReceipt, type LoomVersionAccessory,
-  LOOM_TYPE_LABELS,
+  LOOM_TYPE_LABELS, SUPPORTED_LOOM_TYPES,
 } from "@/api/looms";
 import { AddVersionModal } from "@/components/looms/AddVersionModal";
 import { EditLoomModal } from "@/components/looms/EditLoomModal";
@@ -664,6 +664,13 @@ export function LoomDetailPage() {
       </header>
 
       <main className="flex-1 p-6 max-w-3xl mx-auto w-full space-y-8">
+        {!SUPPORTED_LOOM_TYPES.has(loom.loom_type) && (
+          <div className="rounded-md border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 px-4 py-3 text-sm text-amber-800 dark:text-amber-300">
+            <span className="font-medium">Activity tracking not supported</span> — this loom type is not currently
+            supported for activity tracking. It has been saved for documentation and will be available if support
+            is added later.
+          </div>
+        )}
         <section className="space-y-4">
           <ProfilePhoto loom={loom} onChanged={invalidate} />
           <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm sm:grid-cols-3">


### PR DESCRIPTION
## Summary

- Tracking flags (`supports_lift_tracking`, `supports_treadle_tracking`) are now derived server-side from `loom_type` — `floor_loom` = treadle, `table_loom` = lift, all others clear both flags. Users can no longer set these manually.
- Adds `dobby` loom type (unsupported for activity tracking).
- Unsupported looms (rigid_heddle, inkle, dobby, other) can be created for documentation with a required acknowledgement checkbox; they show an activity-blocking banner on their detail page and are hidden from activity loom selectors.
- Activities router raises 422 if an unsupported loom type is assigned during create or loom-assign.

## Test plan

- [ ] `TestLoomTrackingFlags` (6 tests): floor/table/unsupported type flag derivation, dobby create, type-change updates flags
- [ ] `TestUnsupportedLoomType` (5 tests): rigid_heddle/dobby/inkle block activity creation and assignment; floor/table allowed
- [ ] Full suite: 744 passed, 65.75% coverage (≥ 65% threshold)

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)