### PR TITLE
feat: add /home route as authenticated landing page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,12 +36,8 @@ function RootRoute() {
       </div>
     );
   }
-  if (!isAuthenticated) return <LandingPage />;
-  return (
-    <ProtectedRoute>
-      <DashboardPage />
-    </ProtectedRoute>
-  );
+  if (isAuthenticated) return <Navigate to="/home" replace />;
+  return <LandingPage />;
 }
 
 const queryClient = new QueryClient({
@@ -66,6 +62,14 @@ export default function App() {
                   <Route path="/about" element={<AboutPage />} />
                   <Route path="/privacy" element={<PrivacyPage />} />
                   <Route path="/" element={<RootRoute />} />
+                  <Route
+                    path="/home"
+                    element={
+                      <ProtectedRoute>
+                        <DashboardPage />
+                      </ProtectedRoute>
+                    }
+                  />
                   <Route
                     path="/projects"
                     element={

--- a/frontend/src/components/layout/ProtectedRoute.tsx
+++ b/frontend/src/components/layout/ProtectedRoute.tsx
@@ -30,7 +30,7 @@ export function ProtectedRoute({ children, requireAdmin = false }: Props) {
   }
 
   if (requireAdmin && !user?.is_admin) {
-    return <Navigate to="/" replace />;
+    return <Navigate to="/home" replace />;
   }
 
   return (

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -13,7 +13,7 @@ export function LoginPage() {
 
   useEffect(() => {
     if (!isLoading && isAuthenticated) {
-      navigate("/", { replace: true });
+      navigate("/home", { replace: true });
     }
   }, [isAuthenticated, isLoading, navigate]);
 
@@ -54,7 +54,7 @@ export function LoginPage() {
         <SignIn
           routing="hash"
           signUpUrl="/register"
-          fallbackRedirectUrl="/"
+          fallbackRedirectUrl="/home"
           appearance={{
             elements: {
               rootBox: "w-full",

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -11,7 +11,7 @@ export function RegisterPage() {
         <SignUp
           routing="hash"
           signInUrl="/login"
-          fallbackRedirectUrl="/"
+          fallbackRedirectUrl="/home"
           appearance={{
             elements: {
               rootBox: "w-full",


### PR DESCRIPTION
## Summary

- `/home` route added, rendering `DashboardPage` behind `ProtectedRoute`
- Authenticated users visiting `/` are redirected to `/home`; unauthenticated users still see `LandingPage`
- `LoginPage` and `RegisterPage` Clerk `fallbackRedirectUrl` updated to `/home`
- `ProtectedRoute` non-admin redirect updated from `/` to `/home`

## Test plan

- [ ] Sign in → lands at `/home` (not `/`)
- [ ] Navigate to `/` while authenticated → redirects to `/home`
- [ ] Navigate to `/` while unauthenticated → shows landing page
- [ ] Non-admin user accessing `/admin` → redirected to `/home`
- [ ] Unknown route → redirects to `/` → then to `/home` for authenticated users

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)