### PR TITLE
feat: /sign-out confirmation page and /unauthorized access-denied page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,8 @@ import { ActivitiesPage } from "@/pages/ActivitiesPage";
 import { ActivityDetailPage } from "@/pages/ActivityDetailPage";
 import { AdminPage } from "@/pages/AdminPage";
 import { SettingsPage } from "@/pages/SettingsPage";
+import { SignOutPage } from "@/pages/SignOutPage";
+import { UnauthorizedPage } from "@/pages/UnauthorizedPage";
 import { DevBanner } from "@/components/DevBanner";
 import { ServiceHealthBanner } from "@/components/ServiceHealthBanner";
 import { useAuth } from "@/hooks/useAuth";
@@ -48,7 +50,7 @@ const queryClient = new QueryClient({
 
 export default function App() {
   return (
-    <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY} afterSignOutUrl="/login">
+    <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY} afterSignOutUrl="/sign-out">
       <VersionGate>
         <QueryClientProvider client={queryClient}>
           <AuthProvider>
@@ -59,6 +61,8 @@ export default function App() {
                 <Routes>
                   <Route path="/login" element={<LoginPage />} />
                   <Route path="/register" element={<RegisterPage />} />
+                  <Route path="/sign-out" element={<SignOutPage />} />
+                  <Route path="/unauthorized" element={<UnauthorizedPage />} />
                   <Route path="/about" element={<AboutPage />} />
                   <Route path="/privacy" element={<PrivacyPage />} />
                   <Route path="/" element={<RootRoute />} />

--- a/frontend/src/components/layout/ProtectedRoute.tsx
+++ b/frontend/src/components/layout/ProtectedRoute.tsx
@@ -30,7 +30,7 @@ export function ProtectedRoute({ children, requireAdmin = false }: Props) {
   }
 
   if (requireAdmin && !user?.is_admin) {
-    return <Navigate to="/home" replace />;
+    return <Navigate to="/unauthorized" replace />;
   }
 
   return (

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -26,7 +26,7 @@ export function DashboardPage() {
     queryFn: listLooms,
   });
 
-  const handleLogout = () => signOut({ redirectUrl: "/login" });
+  const handleLogout = () => signOut();
 
   const activeActivities = activities.filter((a) => a.status === "active" && !!a.loom_id);
   const planningActivities = activities.filter((a) => a.status === "active" && !a.loom_id);

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -43,7 +43,7 @@ export function ProjectsPage() {
     queryClient.invalidateQueries({ queryKey: ["projects"] });
   };
 
-  const handleLogout = () => signOut({ redirectUrl: "/login" });
+  const handleLogout = () => signOut();
 
   return (
     <div className="flex min-h-screen flex-col">

--- a/frontend/src/pages/SignOutPage.tsx
+++ b/frontend/src/pages/SignOutPage.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth as useClerkAuth, useClerk } from "@clerk/clerk-react";
+
+export function SignOutPage() {
+  const { isSignedIn, isLoaded } = useClerkAuth();
+  const { signOut } = useClerk();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isLoaded) return;
+    if (isSignedIn) {
+      signOut();
+    } else {
+      const timer = setTimeout(() => navigate("/", { replace: true }), 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [isLoaded, isSignedIn, signOut, navigate]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background">
+      <div className="space-y-2 text-center">
+        <h1 className="text-xl font-semibold">WeftMark</h1>
+        {!isLoaded || isSignedIn ? (
+          <p className="text-sm text-muted-foreground">Signing you out…</p>
+        ) : (
+          <p className="text-sm text-muted-foreground">You have been signed out. Redirecting…</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/UnauthorizedPage.tsx
+++ b/frontend/src/pages/UnauthorizedPage.tsx
@@ -1,0 +1,23 @@
+import { Link } from "react-router-dom";
+import { useAuth } from "@/hooks/useAuth";
+
+export function UnauthorizedPage() {
+  const { isAuthenticated } = useAuth();
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background">
+      <div className="max-w-sm space-y-4 px-4 text-center">
+        <h1 className="text-2xl font-semibold">Access denied</h1>
+        <p className="text-sm text-muted-foreground">
+          You don't have permission to view this page.
+        </p>
+        <Link
+          to={isAuthenticated ? "/home" : "/login"}
+          className="inline-block text-sm underline underline-offset-2 text-muted-foreground hover:text-foreground"
+        >
+          {isAuthenticated ? "Back to home" : "Sign in"}
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **`/sign-out`** — triggers Clerk sign-out on mount, shows "Signing you out…" while in progress and "You have been signed out. Redirecting…" on completion, then auto-navigates to `/` after 2 s. `ClerkProvider afterSignOutUrl` updated to `/sign-out` so all sign-out paths (DashboardPage, AdminPage, etc.) pass through the confirmation.
- **`/unauthorized`** — clean access-denied message with a contextual back link (→ `/home` if authenticated, → `/login` if not).
- `ProtectedRoute` non-admin block redirects to `/unauthorized` instead of `/home`.
- Removed hardcoded `redirectUrl: "/login"` from `DashboardPage` and `ProjectsPage` — ClerkProvider default now applies.

## Test plan

- [ ] Sign out from dashboard → lands on `/sign-out` confirmation, redirects to `/` after 2 s
- [ ] Navigate to `/sign-out` while already signed out → shows confirmation immediately, then redirects
- [ ] Non-admin user accessing `/admin` → redirected to `/unauthorized` with "Back to home" link
- [ ] Unauthenticated user visiting `/unauthorized` → shows "Sign in" link

> **Note:** Clerk dashboard "After sign-out URL" should be updated to `/sign-out` on each environment when validated. See also: after-sign-in URL still needs updating to `/home` (deferred from #101).

Closes #102
Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)