### PR TITLE
feat: allow users to re-download original WIF file

### DIFF
--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -213,6 +213,29 @@ async def get_drawdown(
 
 
 # ---------------------------------------------------------------------------
+# WIF download
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{project_id}/wif")
+async def download_wif(
+    project_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    project = await _get_owned_project(project_id, current_user, db)
+    if not project.wif_path or not storage.file_exists(project.wif_path):
+        raise HTTPException(status_code=404, detail="WIF file not available for this project")
+    wif_bytes = storage.read_file(project.wif_path)
+    filename = project.wif_filename or "project.wif"
+    return Response(
+        content=wif_bytes,
+        media_type="application/octet-stream",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+# ---------------------------------------------------------------------------
 # Delete (soft)
 # ---------------------------------------------------------------------------
 

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -74,3 +74,17 @@ export function previewUrl(id: string): string {
 export async function generateLiftplan(id: string): Promise<ProjectDetail> {
   return req(`/api/projects/${id}/generate-liftplan`, { method: "POST" });
 }
+
+export async function downloadWif(id: string, filename: string): Promise<void> {
+  const token = await getAuthToken();
+  const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
+  const res = await fetch(`/api/projects/${id}/wif`, { credentials: "include", headers });
+  if (!res.ok) throw new Error("WIF file not available");
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getProject, deleteProject, generateLiftplan, previewUrl } from "@/api/projects";
+import { getProject, deleteProject, generateLiftplan, previewUrl, downloadWif } from "@/api/projects";
 import { listActivities } from "@/api/activities";
 import { ActivitySummaryList } from "@/components/activities/ActivitySummaryList";
 import { CreateActivityModal } from "@/components/activities/CreateActivityModal";
@@ -15,6 +15,8 @@ export function ProjectDetailPage() {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [showDangerZone, setShowDangerZone] = useState(false);
   const [showCreateActivity, setShowCreateActivity] = useState(false);
+  const [downloading, setDownloading] = useState(false);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
 
   const { data: project, isLoading, error } = useQuery({
     queryKey: ["project", id],
@@ -96,7 +98,30 @@ export function ProjectDetailPage() {
               <h2 className="text-base font-semibold">Design Info</h2>
               <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
                 <dt className="text-muted-foreground">File</dt>
-                <dd>{project.wif_filename}</dd>
+                <dd className="flex items-center gap-2">
+                  <span>{project.wif_filename}</span>
+                  <button
+                    type="button"
+                    className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground disabled:opacity-50"
+                    disabled={downloading}
+                    onClick={async () => {
+                      setDownloadError(null);
+                      setDownloading(true);
+                      try {
+                        await downloadWif(project.id, project.wif_filename);
+                      } catch {
+                        setDownloadError("Download failed");
+                      } finally {
+                        setDownloading(false);
+                      }
+                    }}
+                  >
+                    {downloading ? "Downloading…" : "Download"}
+                  </button>
+                </dd>
+                {downloadError && (
+                  <dd className="col-span-2 text-xs text-destructive">{downloadError}</dd>
+                )}
                 <dt className="text-muted-foreground">Shafts</dt>
                 <dd>{project.num_shafts ?? "—"}</dd>
                 <dt className="text-muted-foreground">Treadles</dt>


### PR DESCRIPTION
## Summary

- New `GET /api/projects/{id}/wif` endpoint serves the stored WIF bytes with the original filename as a download attachment. Returns 404 if the file is not present in storage.
- Frontend `downloadWif()` fetches with auth, creates a blob URL, and triggers a browser download.
- "Download" link added inline next to the filename in the Design Info section on the project detail page.
- Projects where the file is not in storage show an inline error rather than breaking the page.

## Test plan

- [ ] Click "Download" on a project → browser downloads the WIF with the original filename
- [ ] Link is disabled while download is in progress ("Downloading…")
- [ ] 404 from backend shows inline error message

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)