### PR TITLE
fix: reduce max activity photos from 20 to 10 (#159)

### DIFF
--- a/backend/app/routers/activities.py
+++ b/backend/app/routers/activities.py
@@ -20,7 +20,7 @@ from app.services.images import resize_to_jpeg
 from app.services.storage_quota import check_storage_quota
 
 ALLOWED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/webp", "image/heic", "image/heif"}
-MAX_ACTIVITY_PHOTOS = 20
+MAX_ACTIVITY_PHOTOS = 10
 MAX_PHOTO_SIZE = 25 * 1024 * 1024  # 25 MB raw (resized output is much smaller)
 _ACTIVITY_RESIZE_MAX_PX = 2048
 

--- a/frontend/src/pages/ActivityDetailPage.tsx
+++ b/frontend/src/pages/ActivityDetailPage.tsx
@@ -596,7 +596,7 @@ function PhotoGrid({
     setUploading(true);
     try {
       for (const file of Array.from(files)) {
-        if (photos.length >= 20) { setError("Maximum 20 photos reached."); break; }
+        if (photos.length >= 10) { setError("Maximum 10 photos reached."); break; }
         const photo = await uploadActivityPhoto(activityId, file);
         onUploaded(photo);
       }
@@ -616,8 +616,8 @@ function PhotoGrid({
   return (
     <div>
       <div className="flex items-center justify-between mb-3">
-        <p className="text-sm font-medium">Photos <span className="text-muted-foreground font-normal">({photos.length}/20)</span></p>
-        {photos.length < 20 && (
+        <p className="text-sm font-medium">Photos <span className="text-muted-foreground font-normal">({photos.length}/10)</span></p>
+        {photos.length < 10 && (
           <button
             type="button"
             onClick={() => inputRef.current?.click()}
@@ -666,7 +666,7 @@ function PhotoGrid({
               </button>
             </div>
           ))}
-          {photos.length < 20 && (
+          {photos.length < 10 && (
             <button
               type="button"
               onClick={() => inputRef.current?.click()}
@@ -1310,7 +1310,7 @@ export function ActivityDetailPage() {
         {/* Collapsible sections */}
         <div className="mx-auto max-w-2xl px-8 pb-10 space-y-0 border-t">
           {!isCompleted && (
-            <CollapsibleSection title={`Photos (${activity.photos.length}/20)`} defaultOpen={isAbandoned}>
+            <CollapsibleSection title={`Photos (${activity.photos.length}/10)`} defaultOpen={isAbandoned}>
               <PhotoGrid
                 activityId={activity.id}
                 photos={activity.photos}


### PR DESCRIPTION
## Summary

- `MAX_ACTIVITY_PHOTOS` constant in `backend/app/routers/activities.py` changed from 20 → 10
- All four frontend references in `ActivityDetailPage.tsx` updated: guard check, error message, counter display, and upload button visibility

## Test plan

- [ ] Uploading photos up to 10 works normally
- [ ] Attempting an 11th photo shows "Maximum 10 photos reached."
- [ ] Photo counter displays as `(n/10)` throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)