### PR TITLE
ci: add [skip actions] to bot commit messages

### DIFF
--- a/.github/workflows/ci-dev-push.yml
+++ b/.github/workflows/ci-dev-push.yml
@@ -75,7 +75,7 @@ jobs:
           git config user.email "weftmark-bot[bot]@users.noreply.github.com"
           git add sbom/sbom-backend.json sbom/licenses-backend.json
           if ! git diff --staged --quiet; then
-            git commit -m "chore: update backend SBOM and license manifest"
+            git commit -m "chore: update backend SBOM and license manifest [skip actions]"
             git pull --rebase origin dev
             git push origin dev
           fi
@@ -137,7 +137,7 @@ jobs:
           git config user.email "weftmark-bot[bot]@users.noreply.github.com"
           git add sbom/sbom-frontend.json sbom/licenses-frontend.json
           if ! git diff --staged --quiet; then
-            git commit -m "chore: update frontend SBOM and license manifest"
+            git commit -m "chore: update frontend SBOM and license manifest [skip actions]"
             git pull --rebase origin dev
             git push origin dev
           fi
@@ -237,7 +237,7 @@ jobs:
       - name: Commit version files
         run: |
           git add VERSION frontend/package.json
-          git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }}"
+          git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }} [skip actions]"
 
       - name: Push version commit
         run: |


### PR DESCRIPTION
Adds `[skip actions]` to all three bot commit messages in `ci-dev-push.yml` (SBOM backend, SBOM frontend, version bump). GitHub natively suppresses workflow triggers for these pushes so no run is created and nothing appears in history.

Follow-up to #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)