### PR TITLE
feat: CLI seed command for fresh-instance bootstrap (#140)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@
 .env.*.local
 # .env.example and .env.*.example are intentionally tracked
 
+# Seed config (contains credentials — seed.example.json is tracked)
+backend/seed.json
+
 
 # ------------------------------------------------------------
 # Python / FastAPI Backend

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -1,0 +1,355 @@
+"""CLI entry point — invoked as `python -m app.cli <command>`.
+
+Usage:
+    python -m app.cli seed [--config seed.json] [--poll-timeout 30]
+    docker compose exec backend python -m app.cli seed
+    docker compose run --rm backend python -m app.cli seed
+"""
+
+import argparse
+import asyncio
+import json
+import shutil
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+import httpx
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.config import get_settings
+from app.models.user import User
+from app.services.clerk import set_user_metadata
+
+_BACKEND_DIR = Path(__file__).parent.parent
+_ALEMBIC_INI = _BACKEND_DIR / "alembic.ini"
+
+_BASE = "https://api.clerk.com/v1"
+
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+
+def _ok(msg: str) -> None:
+    print(f"  ✓ {msg}")
+
+
+def _err(msg: str) -> None:
+    print(f"  ✗ {msg}", file=sys.stderr)
+
+
+def _section(msg: str) -> None:
+    print(f"\n{msg}")
+
+
+# ---------------------------------------------------------------------------
+# Clerk helpers (CLI-only)
+# ---------------------------------------------------------------------------
+
+
+async def _clerk_list_users(secret_key: str, limit: int = 2) -> list[dict]:
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        r = await client.get(
+            f"{_BASE}/users",
+            headers={"Authorization": f"Bearer {secret_key}"},
+            params={"limit": limit},
+        )
+        r.raise_for_status()
+        return r.json()
+
+
+async def _clerk_create_user(secret_key: str, email: str, username: str, password: str, display_name: str) -> dict:
+    first, *rest = display_name.split(" ", 1)
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        r = await client.post(
+            f"{_BASE}/users",
+            headers={"Authorization": f"Bearer {secret_key}"},
+            json={
+                "email_address": [email],
+                "username": username,
+                "password": password,
+                "first_name": first,
+                "last_name": rest[0] if rest else "",
+            },
+        )
+        r.raise_for_status()
+        return r.json()
+
+
+# ---------------------------------------------------------------------------
+# Alembic reset
+# ---------------------------------------------------------------------------
+
+
+def _alembic_reset() -> None:
+    from alembic.config import Config
+
+    from alembic import command as alembic_command
+
+    cfg = Config(str(_ALEMBIC_INI))
+    alembic_command.downgrade(cfg, "base")
+    alembic_command.upgrade(cfg, "head")
+
+
+# ---------------------------------------------------------------------------
+# Storage clear
+# ---------------------------------------------------------------------------
+
+
+def _clear_storage(settings: Any) -> None:
+    if settings.storage_backend == "s3":
+        _clear_s3(settings)
+    else:
+        _clear_local(settings)
+
+
+def _clear_local(settings: Any) -> None:
+    upload_dir = Path(settings.upload_dir)
+    if upload_dir.exists():
+        shutil.rmtree(upload_dir)
+    upload_dir.mkdir(parents=True, exist_ok=True)
+    _ok(f"Local upload directory cleared ({upload_dir})")
+
+
+def _clear_s3(settings: Any) -> None:
+    import boto3
+
+    client = boto3.client(
+        "s3",
+        endpoint_url=settings.s3_endpoint_url or None,
+        aws_access_key_id=settings.s3_access_key_id,
+        aws_secret_access_key=settings.s3_secret_access_key,
+        region_name=settings.s3_region or "auto",
+    )
+    bucket = settings.s3_bucket_name
+    paginator = client.get_paginator("list_objects_v2")
+    total = 0
+    for page in paginator.paginate(Bucket=bucket):
+        objects = page.get("Contents", [])
+        if objects:
+            client.delete_objects(
+                Bucket=bucket,
+                Delete={"Objects": [{"Key": o["Key"]} for o in objects]},
+            )
+            total += len(objects)
+    _ok(f"S3 bucket '{bucket}' cleared ({total} objects deleted)")
+
+
+# ---------------------------------------------------------------------------
+# DB polling
+# ---------------------------------------------------------------------------
+
+
+async def _poll_db_for_user(
+    session_factory: async_sessionmaker,
+    clerk_user_id: str,
+    timeout: int,
+) -> User:
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    while True:
+        async with session_factory() as session:
+            user = await session.scalar(select(User).where(User.clerk_user_id == clerk_user_id))
+            if user:
+                return user
+        if loop.time() >= deadline:
+            raise TimeoutError(
+                f"clerk_user_id={clerk_user_id} not found in DB after {timeout}s — "
+                "is the webhook configured and reachable?"
+            )
+        await asyncio.sleep(1)
+
+
+# ---------------------------------------------------------------------------
+# seed command
+# ---------------------------------------------------------------------------
+
+
+async def cmd_seed(config_path: str, poll_timeout: int) -> None:
+    settings = get_settings()
+
+    # ── Prechecks ──────────────────────────────────────────────────────────
+    _section("Prechecks")
+
+    if settings.app_env != "dev":
+        _err(f"APP_ENV must be 'dev', got '{settings.app_env}'")
+        sys.exit(1)
+    _ok(f"APP_ENV = {settings.app_env}")
+
+    if not settings.seed_enabled:
+        _err("SEED_ENABLED is not set to true")
+        sys.exit(1)
+    _ok("SEED_ENABLED = true")
+
+    if not settings.clerk_secret_key:
+        _err("CLERK_SECRET_KEY is not set")
+        sys.exit(1)
+
+    try:
+        existing_clerk = await _clerk_list_users(settings.clerk_secret_key)
+    except Exception as exc:
+        _err(f"Clerk API unreachable: {exc}")
+        sys.exit(1)
+    if existing_clerk:
+        _err("Clerk already has users — aborting (use a clean Clerk instance)")
+        sys.exit(1)
+    _ok("Clerk has 0 users")
+
+    engine = create_async_engine(settings.database_url, echo=False)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with session_factory() as session:
+            count = await session.scalar(select(func.count()).select_from(User))
+    except Exception as exc:
+        _err(f"DB unreachable: {exc}")
+        await engine.dispose()
+        sys.exit(1)
+    if count:
+        _err(f"DB users table has {count} existing rows — aborting")
+        await engine.dispose()
+        sys.exit(1)
+    _ok("DB users table has 0 rows")
+
+    # ── Load config ────────────────────────────────────────────────────────
+    config_file = Path(config_path)
+    if not config_file.exists():
+        _err(f"Seed config not found: {config_file.resolve()}")
+        await engine.dispose()
+        sys.exit(1)
+    try:
+        seed = json.loads(config_file.read_text())
+    except Exception as exc:
+        _err(f"Failed to parse seed config: {exc}")
+        await engine.dispose()
+        sys.exit(1)
+
+    users_cfg: list[dict] = seed.get("users", [])
+    if not users_cfg:
+        _err("No users defined in seed config")
+        await engine.dispose()
+        sys.exit(1)
+
+    # ── Reset ──────────────────────────────────────────────────────────────
+    _section("Reset")
+
+    await engine.dispose()
+
+    try:
+        _alembic_reset()
+        _ok("Alembic downgrade base → upgrade head complete")
+    except Exception as exc:
+        _err(f"Alembic reset failed: {exc}")
+        sys.exit(1)
+
+    try:
+        _clear_storage(settings)
+    except Exception as exc:
+        _err(f"Storage clear failed: {exc}")
+        sys.exit(1)
+
+    engine = create_async_engine(settings.database_url, echo=False)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    # ── Seed users ─────────────────────────────────────────────────────────
+    _section("Users")
+
+    generated_passwords: list[tuple[str, str]] = []
+
+    for cfg in users_cfg:
+        email: str = cfg["email"]
+        username: str = cfg["username"]
+        display_name: str = cfg.get("display_name", username)
+        role: str = cfg.get("role", "user")
+        password: str | None = cfg.get("password")
+
+        auto_password = password is None
+        if auto_password:
+            password = uuid.uuid4().hex
+
+        try:
+            clerk_user = await _clerk_create_user(settings.clerk_secret_key, email, username, password, display_name)
+            clerk_user_id: str = clerk_user["id"]
+            _ok(f"{email} created in Clerk (clerk_user_id={clerk_user_id})")
+        except httpx.HTTPStatusError as exc:
+            _err(f"{email} — Clerk creation failed: {exc.response.text}")
+            await engine.dispose()
+            sys.exit(1)
+        except Exception as exc:
+            _err(f"{email} — Clerk creation failed: {exc}")
+            await engine.dispose()
+            sys.exit(1)
+
+        try:
+            db_user = await _poll_db_for_user(session_factory, clerk_user_id, poll_timeout)
+            _ok(f"{email} confirmed in DB (id={db_user.id})")
+        except TimeoutError as exc:
+            _err(str(exc))
+            await engine.dispose()
+            sys.exit(1)
+
+        is_admin = role in ("admin", "superuser")
+        is_superuser = role == "superuser"
+
+        async with session_factory() as session:
+            user = await session.get(User, db_user.id)
+            user.is_admin = is_admin
+            user.is_superuser = is_superuser
+            await session.commit()
+
+        await set_user_metadata(
+            clerk_user_id,
+            {
+                "is_admin": is_admin,
+                "is_superuser": is_superuser,
+            },
+        )
+        _ok(f"{email} role '{role}' applied")
+
+        if auto_password:
+            generated_passwords.append((email, password))
+
+    await engine.dispose()
+
+    # ── Summary ────────────────────────────────────────────────────────────
+    if generated_passwords:
+        _section("Generated passwords")
+        for addr, pw in generated_passwords:
+            print(f"  {addr}: {pw}")
+
+    print(f"\nSeed complete — {len(users_cfg)} user(s) created.")
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="python -m app.cli")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    seed_p = sub.add_parser("seed", help="Bootstrap a fresh WeftMark instance")
+    seed_p.add_argument(
+        "--config",
+        default="seed.json",
+        help="Path to seed config JSON (default: seed.json)",
+    )
+    seed_p.add_argument(
+        "--poll-timeout",
+        type=int,
+        default=30,
+        metavar="SECONDS",
+        help="How long to wait for the webhook to confirm each user in DB (default: 30)",
+    )
+
+    args = parser.parse_args()
+    if args.command == "seed":
+        asyncio.run(cmd_seed(args.config, args.poll_timeout))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -12,6 +12,7 @@ class Settings(BaseSettings):
     # Application
     app_secret_key: str = "change-me-in-production"
     app_env: str = "dev"
+    seed_enabled: bool = False
     debug: bool = False
     log_level: str = "INFO"
     cors_origins: str = "http://localhost:3000"

--- a/backend/seed.example.json
+++ b/backend/seed.example.json
@@ -1,0 +1,25 @@
+{
+  "users": [
+    {
+      "email": "superuser@example.com",
+      "username": "superuser",
+      "password": "change-me-123",
+      "display_name": "Super User",
+      "role": "superuser"
+    },
+    {
+      "email": "admin@example.com",
+      "username": "admin1",
+      "password": null,
+      "display_name": "Admin One",
+      "role": "admin"
+    },
+    {
+      "email": "user@example.com",
+      "username": "user1",
+      "password": null,
+      "display_name": "Regular User",
+      "role": "user"
+    }
+  ]
+}

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1,0 +1,274 @@
+"""Tests for the CLI seed command (app.cli)."""
+
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.cli import _clear_local, _poll_db_for_user, cmd_seed
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_settings(**overrides):
+    s = MagicMock()
+    s.app_env = "dev"
+    s.seed_enabled = True
+    s.clerk_secret_key = "sk_test_abcdefghij"
+    s.database_url = "postgresql+asyncpg://user:pass@localhost/test"
+    s.storage_backend = "local"
+    s.upload_dir = "/tmp/test_uploads"
+    for k, v in overrides.items():
+        setattr(s, k, v)
+    return s
+
+
+def _make_session_factory(scalar_return=0):
+    session = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    session.scalar = AsyncMock(return_value=scalar_return)
+    session.commit = AsyncMock()
+    factory = MagicMock(return_value=session)
+    return factory, session
+
+
+def _make_engine():
+    engine = MagicMock()
+    engine.dispose = AsyncMock()
+    return engine
+
+
+# ---------------------------------------------------------------------------
+# Precheck: app_env
+# ---------------------------------------------------------------------------
+
+
+async def test_seed_aborts_when_not_dev(tmp_path):
+    settings = _make_settings(app_env="prod")
+    with patch("app.cli.get_settings", return_value=settings):
+        with pytest.raises(SystemExit) as exc_info:
+            await cmd_seed(str(tmp_path / "seed.json"), 5)
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Precheck: seed_enabled
+# ---------------------------------------------------------------------------
+
+
+async def test_seed_aborts_when_seed_disabled(tmp_path):
+    settings = _make_settings(seed_enabled=False)
+    with patch("app.cli.get_settings", return_value=settings):
+        with pytest.raises(SystemExit) as exc_info:
+            await cmd_seed(str(tmp_path / "seed.json"), 5)
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Precheck: clerk_secret_key
+# ---------------------------------------------------------------------------
+
+
+async def test_seed_aborts_when_no_clerk_key(tmp_path):
+    settings = _make_settings(clerk_secret_key="")
+    with patch("app.cli.get_settings", return_value=settings):
+        with pytest.raises(SystemExit) as exc_info:
+            await cmd_seed(str(tmp_path / "seed.json"), 5)
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Precheck: Clerk already has users
+# ---------------------------------------------------------------------------
+
+
+async def test_seed_aborts_when_clerk_has_users(tmp_path):
+    settings = _make_settings()
+    with (
+        patch("app.cli.get_settings", return_value=settings),
+        patch("app.cli._clerk_list_users", AsyncMock(return_value=[{"id": "user_abc"}])),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            await cmd_seed(str(tmp_path / "seed.json"), 5)
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Precheck: Clerk API unreachable
+# ---------------------------------------------------------------------------
+
+
+async def test_seed_aborts_when_clerk_unreachable(tmp_path):
+    settings = _make_settings()
+    with (
+        patch("app.cli.get_settings", return_value=settings),
+        patch("app.cli._clerk_list_users", AsyncMock(side_effect=Exception("connection refused"))),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            await cmd_seed(str(tmp_path / "seed.json"), 5)
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Precheck: DB unreachable
+# ---------------------------------------------------------------------------
+
+
+async def test_seed_aborts_when_db_unreachable(tmp_path):
+    settings = _make_settings()
+    session = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    session.scalar = AsyncMock(side_effect=Exception("db down"))
+    factory = MagicMock(return_value=session)
+
+    with (
+        patch("app.cli.get_settings", return_value=settings),
+        patch("app.cli._clerk_list_users", AsyncMock(return_value=[])),
+        patch("app.cli.create_async_engine", return_value=_make_engine()),
+        patch("app.cli.async_sessionmaker", return_value=factory),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            await cmd_seed(str(tmp_path / "seed.json"), 5)
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Precheck: DB already has rows
+# ---------------------------------------------------------------------------
+
+
+async def test_seed_aborts_when_db_has_rows(tmp_path):
+    settings = _make_settings()
+    factory, _ = _make_session_factory(scalar_return=3)
+
+    with (
+        patch("app.cli.get_settings", return_value=settings),
+        patch("app.cli._clerk_list_users", AsyncMock(return_value=[])),
+        patch("app.cli.create_async_engine", return_value=_make_engine()),
+        patch("app.cli.async_sessionmaker", return_value=factory),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            await cmd_seed(str(tmp_path / "seed.json"), 5)
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Precheck: seed config missing
+# ---------------------------------------------------------------------------
+
+
+async def test_seed_aborts_when_config_missing(tmp_path):
+    settings = _make_settings()
+    factory, _ = _make_session_factory(scalar_return=0)
+
+    with (
+        patch("app.cli.get_settings", return_value=settings),
+        patch("app.cli._clerk_list_users", AsyncMock(return_value=[])),
+        patch("app.cli.create_async_engine", return_value=_make_engine()),
+        patch("app.cli.async_sessionmaker", return_value=factory),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            await cmd_seed(str(tmp_path / "nonexistent.json"), 5)
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Precheck: seed config has no users
+# ---------------------------------------------------------------------------
+
+
+async def test_seed_aborts_when_no_users_in_config(tmp_path):
+    settings = _make_settings()
+    factory, _ = _make_session_factory(scalar_return=0)
+    config = tmp_path / "seed.json"
+    config.write_text(json.dumps({"users": []}))
+
+    with (
+        patch("app.cli.get_settings", return_value=settings),
+        patch("app.cli._clerk_list_users", AsyncMock(return_value=[])),
+        patch("app.cli.create_async_engine", return_value=_make_engine()),
+        patch("app.cli.async_sessionmaker", return_value=factory),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            await cmd_seed(str(config), 5)
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# _poll_db_for_user — success
+# ---------------------------------------------------------------------------
+
+
+async def test_poll_db_returns_user_when_found():
+    user_id = str(uuid.uuid4())
+    mock_user = MagicMock()
+    mock_user.clerk_user_id = user_id
+
+    session = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    session.scalar = AsyncMock(return_value=mock_user)
+    factory = MagicMock(return_value=session)
+
+    result = await _poll_db_for_user(factory, user_id, timeout=5)
+
+    assert result is mock_user
+
+
+# ---------------------------------------------------------------------------
+# _poll_db_for_user — timeout
+# ---------------------------------------------------------------------------
+
+
+async def test_poll_db_raises_timeout_when_user_never_arrives():
+    session = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    session.scalar = AsyncMock(return_value=None)
+    factory = MagicMock(return_value=session)
+
+    with pytest.raises(TimeoutError):
+        await _poll_db_for_user(factory, "user_missing", timeout=0)
+
+
+# ---------------------------------------------------------------------------
+# _clear_local — clears existing files
+# ---------------------------------------------------------------------------
+
+
+def test_clear_local_removes_existing_files(tmp_path):
+    upload_dir = tmp_path / "uploads"
+    upload_dir.mkdir()
+    (upload_dir / "image.jpg").write_bytes(b"fake-image")
+    (upload_dir / "data.wif").write_bytes(b"fake-wif")
+
+    settings = MagicMock()
+    settings.upload_dir = str(upload_dir)
+
+    _clear_local(settings)
+
+    assert upload_dir.exists()
+    assert list(upload_dir.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# _clear_local — creates directory when it doesn't exist
+# ---------------------------------------------------------------------------
+
+
+def test_clear_local_creates_missing_directory(tmp_path):
+    upload_dir = tmp_path / "new_uploads"
+    assert not upload_dir.exists()
+
+    settings = MagicMock()
+    settings.upload_dir = str(upload_dir)
+
+    _clear_local(settings)
+
+    assert upload_dir.exists()
+    assert upload_dir.is_dir()


### PR DESCRIPTION
## Summary

Adds `python -m app.cli seed` — a CLI command for bootstrapping a fresh WeftMark instance or resetting a dev environment to a known state.

## Usage

```bash
# Copy and fill in the example config
cp backend/seed.example.json backend/seed.json

# Run (requires APP_ENV=dev and SEED_ENABLED=true)
docker compose exec backend python -m app.cli seed
docker compose exec backend python -m app.cli seed --config /path/to/seed.json
docker compose run --rm backend python -m app.cli seed
```

## What it does

**Prechecks (strict order — abort on first failure):**
1. `APP_ENV` must equal `"dev"`
2. `SEED_ENABLED` must equal `"true"`
3. Clerk API: must have 0 existing users
4. DB: `users` table must have 0 rows

**Reset:**
- `alembic downgrade base` → `alembic upgrade head`
- Clears local upload directory or S3 bucket (all objects)

**Seed:**
- Creates each user in Clerk with email, username, password, and display name (split into first/last)
- Polls DB for up to 30s (configurable via `--poll-timeout`) waiting for webhook to confirm the user
- Applies `is_admin` / `is_superuser` to DB and syncs to Clerk public metadata
- `password: null` in config → auto-generates a UUID hex password, printed in summary at the end

## New files

- `backend/app/cli.py` — CLI module
- `backend/seed.example.json` — example config (committed)
- `backend/seed.json` — gitignored (contains credentials)

## Config changes

- `backend/app/config.py` — adds `seed_enabled: bool = False` (`SEED_ENABLED` env var)
- `.gitignore` — adds `backend/seed.json`

## Test plan

- [ ] Run without `APP_ENV=dev` → aborts with clear error
- [ ] Run without `SEED_ENABLED=true` → aborts with clear error
- [ ] Run against Clerk with existing users → aborts
- [ ] Run against DB with existing rows → aborts
- [ ] Happy path: all users created, roles applied, auto-passwords printed
- [ ] Webhook timeout: run against an instance without webhook → aborts after poll-timeout with clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)