### PR TITLE
fix: bulk QA and usability improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ APP_SECRET_KEY=
 # Values: "dev" (local development) | "production" (deployed environment)
 APP_ENV=dev
 
+# Allow the CLI seed command to run — set to "true" in dev only, never in production
+SEED_ENABLED=false
+
 # Docker Compose profiles to activate.
 # Set to "local-db" to start a local PostgreSQL container (no managed DB).
 # Leave blank when using a managed database (e.g. Neon) — the db container will not start.
@@ -81,6 +84,11 @@ CLERK_SECRET_KEY=
 # Subscribe to: user.created, user.deleted
 # Looks like: whsec_...
 CLERK_WEBHOOK_SECRET=
+
+# Public base URL used to register the Clerk webhook endpoint with Svix.
+# Must be reachable by Clerk (i.e. a public HTTPS URL, not localhost).
+# Example: https://api.example.com
+WEBHOOK_BASE_URL=
 
 
 # ------------------------------------------------------------

--- a/backend/app/services/clerk_webhook_probe.py
+++ b/backend/app/services/clerk_webhook_probe.py
@@ -74,13 +74,11 @@ async def run_webhook_probe() -> WebhookProbeResult:
     """Run the webhook round-trip probe and return the result."""
     settings = get_settings()
 
-    if not settings.webhook_base_url:
-        return WebhookProbeResult("skipped", message="WEBHOOK_BASE_URL not configured — skipping probe")
-
     if not settings.clerk_webhook_secret:
         return WebhookProbeResult("error", message="CLERK_WEBHOOK_SECRET not configured")
 
-    webhook_url = settings.webhook_base_url.rstrip("/") + "/auth/clerk/webhook"
+    base = (settings.webhook_base_url or settings.api_url).rstrip("/")
+    webhook_url = base + "/auth/clerk/webhook"
     timeout = settings.clerk_webhook_probe_timeout_s
 
     global _pending_event
@@ -96,10 +94,11 @@ async def run_webhook_probe() -> WebhookProbeResult:
 
         msg_id = f"msg_{uuid.uuid4().hex}"
         ts = datetime.now(timezone.utc)
-        payload = json.dumps({"type": "webhook.test", "data": {"probe_id": msg_id}}).encode()
+        payload_str = json.dumps({"type": "webhook.test", "data": {"probe_id": msg_id}})
+        payload_bytes = payload_str.encode()
 
         wh = Webhook(settings.clerk_webhook_secret)
-        signature = wh.sign(msg_id, ts, payload)
+        signature = wh.sign(msg_id, ts, payload_str)
 
         headers = {
             "Content-Type": "application/json",
@@ -111,7 +110,7 @@ async def run_webhook_probe() -> WebhookProbeResult:
         start = time.monotonic()
         try:
             async with httpx.AsyncClient(timeout=5.0) as client:
-                r = await client.post(webhook_url, content=payload, headers=headers)
+                r = await client.post(webhook_url, content=payload_bytes, headers=headers)
             if r.status_code not in (200, 202, 204):
                 return WebhookProbeResult("error", message=f"Webhook endpoint returned HTTP {r.status_code}")
         except httpx.TimeoutException:

--- a/frontend/src/components/ServiceHealthBanner.tsx
+++ b/frontend/src/components/ServiceHealthBanner.tsx
@@ -9,11 +9,15 @@ export function ServiceHealthBanner() {
   const [readiness, setReadiness] = useState<ReadinessResponse | null>(null);
 
   useEffect(() => {
-    getHealthReady()
-      .then(setReadiness)
-      .catch(() => {
-        setReadiness({ status: "error", services: [{ name: "backend", ok: false, critical: true, message: "unreachable", detail: "" }] });
-      });
+    const check = () =>
+      getHealthReady()
+        .then(setReadiness)
+        .catch(() => {
+          setReadiness({ status: "error", services: [{ name: "backend", ok: false, critical: true, message: "unreachable", detail: "" }] });
+        });
+    check();
+    const id = setInterval(check, 60_000);
+    return () => clearInterval(id);
   }, []);
 
   if (!readiness || readiness.status === "ok") return null;

--- a/frontend/src/components/admin/UserDetailModal.tsx
+++ b/frontend/src/components/admin/UserDetailModal.tsx
@@ -27,7 +27,7 @@ interface Props {
 }
 
 type Confirm =
-  | "deactivate" | "ban" | "delete" | "elevate" | "elevate-force"
+  | "deactivate" | "ban" | "delete" | "grant-admin" | "elevate" | "elevate-force"
   | "dismiss-signup" | "ban-signup"
   | null;
 
@@ -64,8 +64,8 @@ function ConfirmInline({
   busy: boolean;
 }) {
   return (
-    <div className="flex flex-wrap items-center gap-2 rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2">
-      <span className="flex-1 text-sm">{message}</span>
+    <div className="flex w-full items-center gap-2 rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2">
+      <span className="shrink text-sm">{message}</span>
       <Button
         type="button"
         size="sm"
@@ -75,7 +75,7 @@ function ConfirmInline({
       >
         {confirmLabel}
       </Button>
-      <Button type="button" size="sm" variant="outline" onClick={onCancel}>
+      <Button type="button" size="sm" variant="outline" className="ml-auto" onClick={onCancel}>
         Cancel
       </Button>
     </div>
@@ -320,83 +320,43 @@ export function UserDetailModal({ target, onClose }: Props) {
 
           {/* Actions */}
           {!u.deletion_state && !u.is_superuser && (
-            <div className="border-t pt-4 space-y-2">
+            <div className="border-t pt-4 space-y-4">
               <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
                 Actions
               </p>
 
-              {/* Deactivate / reactivate */}
-              {!u.clerk_errored && !u.clerk_banned && (
-                confirming === "deactivate" ? (
-                  <ConfirmInline
-                    message={`${u.is_active ? "Deactivate" : "Reactivate"} ${u.display_name}?`}
-                    confirmLabel={u.is_active ? "Deactivate" : "Reactivate"}
-                    onConfirm={() => patch.mutate({ is_active: !u.is_active })}
-                    onCancel={() => setConfirming(null)}
-                    busy={busy}
-                  />
-                ) : (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    disabled={busy || (u.is_active && u.is_admin)}
-                    title={
-                      u.is_active && u.is_admin
-                        ? "Remove admin rights before deactivating"
-                        : undefined
-                    }
-                    onClick={() => setConfirming("deactivate")}
-                  >
-                    {u.is_active ? "Deactivate" : "Reactivate"}
-                  </Button>
-                )
-              )}
+              {/* ── Role (superuser only) ───────────────────────────── */}
+              {currentUser?.is_superuser && !u.clerk_errored && (
+                <div className="inline-flex flex-col gap-2">
+                  <p className="text-xs text-muted-foreground">Role</p>
 
-              {/* Ban / unban */}
-              {!u.clerk_errored && (
-                u.clerk_banned ? (
-                  <Button size="sm" variant="outline" disabled={busy} onClick={() => unban.mutate()}>
-                    Unban
-                  </Button>
-                ) : confirming === "ban" ? (
-                  <ConfirmInline
-                    message={`Ban ${u.display_name}?`}
-                    destructive
-                    confirmLabel="Ban"
-                    onConfirm={() => ban.mutate()}
-                    onCancel={() => setConfirming(null)}
-                    busy={busy}
-                  />
-                ) : (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    disabled={busy || u.is_admin}
-                    title={u.is_admin ? "Remove admin rights before banning" : undefined}
-                    onClick={() => setConfirming("ban")}
-                  >
-                    Ban
-                  </Button>
-                )
-              )}
-
-              {/* Superuser-only actions */}
-              {currentUser?.is_superuser && (
-                <>
                   {/* Grant / revoke admin */}
-                  {!u.clerk_errored && confirming !== "delete" && (
+                  {confirming === "grant-admin" ? (
+                    <ConfirmInline
+                      message={
+                        u.is_admin
+                          ? `Remove admin rights from ${u.display_name}?`
+                          : `Grant admin rights to ${u.display_name}?`
+                      }
+                      confirmLabel={u.is_admin ? "Remove admin" : "Grant admin"}
+                      onConfirm={() => patch.mutate({ is_admin: !u.is_admin })}
+                      onCancel={() => setConfirming(null)}
+                      busy={busy}
+                    />
+                  ) : (
                     <Button
                       size="sm"
-                      variant="outline"
+                      variant={u.is_admin ? "outline" : "default"}
+                      className={u.is_admin ? "border-amber-400 text-amber-700 hover:bg-amber-50 hover:text-amber-800" : ""}
                       disabled={busy || u.clerk_banned}
-                      onClick={() => patch.mutate({ is_admin: !u.is_admin })}
+                      onClick={() => setConfirming("grant-admin")}
                     >
                       {u.is_admin ? "Remove admin" : "Grant admin"}
                     </Button>
                   )}
 
                   {/* Elevate to superuser */}
-                  {u.is_admin && !u.clerk_errored && (
+                  {u.is_admin && (
                     confirming === "elevate" ? (
                       <ConfirmInline
                         message={`Make ${u.display_name} a superuser?`}
@@ -427,7 +387,7 @@ export function UserDetailModal({ target, onClose }: Props) {
                     ) : (
                       <Button
                         size="sm"
-                        variant="outline"
+                        variant="default"
                         disabled={busy || u.clerk_banned}
                         onClick={() => setConfirming("elevate")}
                       >
@@ -435,14 +395,65 @@ export function UserDetailModal({ target, onClose }: Props) {
                       </Button>
                     )
                   )}
+                </div>
+              )}
 
-                  {/* Delete */}
-                  {confirming === "delete" ? (
+              {/* ── Account management ──────────────────────────────── */}
+              {!u.clerk_errored && (
+                <div className="inline-flex flex-col gap-2">
+                  {currentUser?.is_superuser && (
+                    <p className="text-xs text-muted-foreground">Account</p>
+                  )}
+
+                  {/* Deactivate / reactivate */}
+                  {!u.clerk_banned && (
+                    confirming === "deactivate" ? (
+                      <ConfirmInline
+                        message={`${u.is_active ? "Deactivate" : "Reactivate"} ${u.display_name}?`}
+                        confirmLabel={u.is_active ? "Deactivate" : "Reactivate"}
+                        onConfirm={() => patch.mutate({ is_active: !u.is_active })}
+                        onCancel={() => setConfirming(null)}
+                        busy={busy}
+                      />
+                    ) : (
+                      <Button
+                        size="sm"
+                        variant={u.is_active ? "outline" : "default"}
+                        className={
+                          u.is_active
+                            ? "border-amber-400 text-amber-700 hover:bg-amber-50 hover:text-amber-800"
+                            : "bg-green-600 hover:bg-green-700"
+                        }
+                        disabled={busy || (u.is_active && u.is_admin)}
+                        title={
+                          u.is_active && u.is_admin
+                            ? "Remove admin rights before deactivating"
+                            : undefined
+                        }
+                        onClick={() => setConfirming("deactivate")}
+                      >
+                        {u.is_active ? "Deactivate" : "Reactivate"}
+                      </Button>
+                    )
+                  )}
+
+                  {/* Ban / unban */}
+                  {u.clerk_banned ? (
+                    <Button
+                      size="sm"
+                      variant="default"
+                      className="bg-green-600 hover:bg-green-700"
+                      disabled={busy}
+                      onClick={() => unban.mutate()}
+                    >
+                      Unban
+                    </Button>
+                  ) : confirming === "ban" ? (
                     <ConfirmInline
-                      message={`Delete ${u.display_name}? All data and S3 storage will be permanently removed.`}
+                      message={`Ban ${u.display_name}?`}
                       destructive
-                      confirmLabel="Delete"
-                      onConfirm={() => del.mutate()}
+                      confirmLabel="Ban"
+                      onConfirm={() => ban.mutate()}
                       onCancel={() => setConfirming(null)}
                       busy={busy}
                     />
@@ -450,13 +461,38 @@ export function UserDetailModal({ target, onClose }: Props) {
                     <Button
                       size="sm"
                       variant="destructive"
-                      disabled={busy}
-                      onClick={() => setConfirming("delete")}
+                      disabled={busy || u.is_admin}
+                      title={u.is_admin ? "Remove admin rights before banning" : undefined}
+                      onClick={() => setConfirming("ban")}
                     >
-                      Delete user
+                      Ban
                     </Button>
                   )}
-                </>
+
+                  {/* Delete (superuser only) */}
+                  {currentUser?.is_superuser && (
+                    confirming === "delete" ? (
+                      <ConfirmInline
+                        message={`Delete ${u.display_name}? All data and S3 storage will be permanently removed.`}
+                        destructive
+                        confirmLabel="Delete"
+                        onConfirm={() => del.mutate()}
+                        onCancel={() => setConfirming(null)}
+                        busy={busy}
+                      />
+                    ) : (
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        className=""
+                        disabled={busy}
+                        onClick={() => setConfirming("delete")}
+                      >
+                        Delete user
+                      </Button>
+                    )
+                  )}
+                </div>
               )}
             </div>
           )}

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -32,6 +32,7 @@ import {
   type ServicePermCheck,
   type WebhookProbeResult,
 } from "@/api/admin";
+import { getHealthReady, type ReadinessResponse } from "@/api/health";
 import { EulaContent } from "@/components/EulaContent";
 import { formatBytes } from "@/lib/image-utils";
 
@@ -991,6 +992,35 @@ function WebhookHealthCard() {
   );
 }
 
+function ReadinessCard({ readiness }: { readiness: ReadinessResponse }) {
+  const statusColor =
+    readiness.status === "ok" ? "text-green-600 dark:text-green-400" :
+    readiness.status === "error" ? "text-destructive" :
+    readiness.status === "starting" ? "text-muted-foreground" :
+    "text-amber-600 dark:text-amber-400";
+
+  return (
+    <div className="border rounded-lg overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-3 bg-muted/10 border-b">
+        <span className="text-sm font-medium">App Readiness</span>
+        <span className={`text-xs font-semibold uppercase ${statusColor}`}>{readiness.status}</span>
+      </div>
+      <div className="divide-y">
+        {readiness.services.map((s) => (
+          <div key={s.name} className="flex items-center gap-3 px-4 py-2.5">
+            <StatusDot status={s.ok ? "ok" : "error"} />
+            <span className="text-sm w-36 shrink-0">{s.name}</span>
+            <span className={`text-xs flex-1 ${s.ok ? "text-muted-foreground" : "text-destructive"}`}>
+              {s.message || (s.ok ? "ok" : "failed")}
+            </span>
+            {!s.critical && <span className="text-xs text-muted-foreground">non-critical</span>}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function ServicesTab() {
   const { user: currentUser } = useAuth();
   const { data, isLoading, isFetching, refetch, dataUpdatedAt } = useQuery({
@@ -998,6 +1028,13 @@ function ServicesTab() {
     queryFn: getAdminServices,
     staleTime: 0,
     refetchOnMount: true,
+  });
+
+  const { data: readiness } = useQuery({
+    queryKey: ["health", "ready"],
+    queryFn: getHealthReady,
+    staleTime: 30_000,
+    refetchInterval: 60_000,
   });
 
   const [testResult, setTestResult] = useState<{ ok: boolean; msg: string } | null>(null);
@@ -1029,6 +1066,8 @@ function ServicesTab() {
           ))}
         </div>
       )}
+
+      {readiness && <ReadinessCard readiness={readiness} />}
 
       <WebhookHealthCard />
 


### PR DESCRIPTION
## Summary

Bulk QA pass covering usability and correctness fixes across several areas. Going forward, PRs will be scoped to single topics — this one cleans up accumulated changes.

- **Admin user modal**: Restructured action buttons into Role/Account groups; added confirmation banners for grant/remove admin; severity-coloured buttons; equal-width stacking via `inline-flex flex-col`; cancel pushed far-right (`ml-auto`) to require deliberate cursor movement
- **Webhook probe**: Fixed `bytes` vs `str` bug in `Webhook.sign()` (svix 1.92.2 expects `str`); `WEBHOOK_BASE_URL` is now an override — falls back to `api_url` when unset
- **ServiceHealthBanner**: Polls every 60s so banner clears when service recovers (was fetch-once-on-mount)
- **Admin Services tab**: Added `ReadinessCard` showing live `/health/ready` state with per-service rows
- **`.env.example`**: Added `SEED_ENABLED=false` and `WEBHOOK_BASE_URL=` entries

Closes #157. References #166 (follow-up: `/health/status` operational endpoint).

## Test plan

- [ ] Admin modal: verify Role/Account grouping, all confirmation banners, button colors
- [ ] Webhook probe: verify probe succeeds with and without `WEBHOOK_BASE_URL` set
- [ ] ServiceHealthBanner: verify banner clears within 60s after webhook recovers
- [ ] Services tab: verify readiness card renders with per-service status rows
- [ ] `.env.example`: confirm all new vars documented correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)