### PR TITLE
fix: align .env.example with all active vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,9 @@ COMPOSE_PROFILES=
 # Set to "true" in development only — enables debug output and auto-reload
 DEBUG=false
 
+# Allow the CLI seed command to run (set to "true" only on a fresh local instance)
+SEED_ENABLED=false
+
 # Log level for the backend: DEBUG, INFO, WARNING, ERROR (default: INFO)
 # Output is always structured JSON for observability platform ingestion.
 LOG_LEVEL=INFO
@@ -81,6 +84,12 @@ CLERK_SECRET_KEY=
 # Subscribe to: user.created, user.deleted
 # Looks like: whsec_...
 CLERK_WEBHOOK_SECRET=
+
+# Override base URL for webhook delivery (optional — falls back to API_URL when blank)
+# Set when the public webhook URL differs from API_URL (e.g. behind an ngrok tunnel).
+# Probe appends /auth/clerk/webhook automatically.
+# Example: WEBHOOK_BASE_URL=https://your-tunnel.ngrok-free.app
+WEBHOOK_BASE_URL=
 
 
 # ------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `SEED_ENABLED=false` to the Application section (CLI seed bootstrap guard)
- Adds `WEBHOOK_BASE_URL=` to the Clerk section with full usage comment (optional override; probe falls back to `API_URL` when blank)

Both vars are already in use across all local env files — this brings `.env.example` in sync so anyone bootstrapping from it gets the complete variable set.

## Test plan

- [ ] Confirm `.env.example` matches the full variable set in `.env`, `.env.dev`, `.env.prod`, `.env.local`

🤖 Generated with [Claude Code](https://claude.com/claude-code)