### PR TITLE
feat: add /health/detailed live endpoint with 30s background refresh

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,12 +22,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     global start_time
     start_time = datetime.now(timezone.utc)
 
-    from app.routers.health import run_startup_probes, set_readiness
+    from app.routers.health import run_startup_probes, set_readiness, start_detailed_refresh, stop_detailed_refresh
 
     readiness = await run_startup_probes()
     set_readiness(readiness)
+    start_detailed_refresh()
 
     yield
+
+    stop_detailed_refresh()
 
 
 app = FastAPI(

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import logging
+from datetime import datetime, timezone
 from typing import Literal
 
 from fastapi import APIRouter
@@ -10,6 +12,9 @@ from pydantic import BaseModel
 from app.version import VERSION
 
 router = APIRouter(tags=["health"])
+log = logging.getLogger(__name__)
+
+DETAILED_REFRESH_INTERVAL_S = 30
 
 
 class ReadinessService(BaseModel):
@@ -23,9 +28,12 @@ class ReadinessService(BaseModel):
 class ReadinessResponse(BaseModel):
     status: Literal["ok", "degraded", "error"]
     services: list[ReadinessService]
+    checked_at: str | None = None
 
 
-_readiness_cache: ReadinessResponse | None = None
+_readiness_cache: ReadinessResponse | None = None  # startup snapshot, never refreshed
+_detailed_cache: ReadinessResponse | None = None  # live, refreshed every 30 s
+_detailed_task: asyncio.Task | None = None
 
 
 def set_readiness(result: ReadinessResponse) -> None:
@@ -46,30 +54,30 @@ async def readiness() -> JSONResponse:
     return JSONResponse(_readiness_cache.model_dump(), status_code=status_code)
 
 
-async def run_startup_probes() -> ReadinessResponse:
-    """Run service probes concurrently and return a ReadinessResponse.
+@router.get("/health/detailed")
+async def health_detailed() -> JSONResponse:
+    """Live service health — refreshed every 30 s by a background task.
 
-    Covers PostgreSQL, S3, Clerk API, and SMTP — services that gate startup.
-    Webhook round-trip health is checked separately via the admin Services tab.
+    Covers PostgreSQL, S3, Clerk API, SMTP, and the Clerk webhook round-trip.
+    Returns the same shape as /health/ready with an added checked_at timestamp.
     """
-    from app.database import AsyncSessionLocal
-    from app.routers.admin import _probe_clerk, _probe_postgres, _probe_s3, _probe_smtp
-
-    try:
-        async with AsyncSessionLocal() as db:
-            results = await asyncio.gather(
-                _probe_postgres(db),
-                _probe_s3(),
-                _probe_clerk(),
-                _probe_smtp(),
-                return_exceptions=True,
-            )
-    except Exception as exc:
-        return ReadinessResponse(
-            status="error",
-            services=[ReadinessService(name="postgres", ok=False, critical=True, message=str(exc)[:120])],
+    if _detailed_cache is None:
+        return JSONResponse(
+            {"status": "starting", "services": [], "checked_at": None}, status_code=503
         )
+    return JSONResponse(_detailed_cache.model_dump())
 
+
+# ---------------------------------------------------------------------------
+# Shared probe result processing
+# ---------------------------------------------------------------------------
+
+
+def _build_readiness_from_results(
+    results: list,
+    webhook_result,
+    checked_at: str,
+) -> ReadinessResponse:
     critical_names = {"PostgreSQL", "Clerk"}
     services: list[ReadinessService] = []
     has_hard_failure = False
@@ -99,6 +107,19 @@ async def run_startup_probes() -> ReadinessResponse:
             else:
                 has_soft_failure = True
 
+    if webhook_result is not None:
+        webhook_ok = webhook_result.status in ("ok", "skipped")
+        services.append(
+            ReadinessService(
+                name="Clerk Webhook",
+                ok=webhook_ok,
+                critical=False,
+                message=webhook_result.message,
+            )
+        )
+        if not webhook_ok:
+            has_soft_failure = True
+
     if has_hard_failure:
         status: Literal["ok", "degraded", "error"] = "error"
     elif has_soft_failure:
@@ -106,4 +127,97 @@ async def run_startup_probes() -> ReadinessResponse:
     else:
         status = "ok"
 
-    return ReadinessResponse(status=status, services=services)
+    return ReadinessResponse(status=status, services=services, checked_at=checked_at)
+
+
+# ---------------------------------------------------------------------------
+# Startup probes (called once at boot, no webhook)
+# ---------------------------------------------------------------------------
+
+
+async def run_startup_probes() -> ReadinessResponse:
+    """Run service probes concurrently and return a ReadinessResponse.
+
+    Covers PostgreSQL, S3, Clerk API, and SMTP — services that gate startup.
+    Webhook round-trip health is checked separately via /health/detailed.
+    """
+    from app.database import AsyncSessionLocal
+    from app.routers.admin import _probe_clerk, _probe_postgres, _probe_s3, _probe_smtp
+
+    try:
+        async with AsyncSessionLocal() as db:
+            results = await asyncio.gather(
+                _probe_postgres(db),
+                _probe_s3(),
+                _probe_clerk(),
+                _probe_smtp(),
+                return_exceptions=True,
+            )
+    except Exception as exc:
+        return ReadinessResponse(
+            status="error",
+            services=[ReadinessService(name="postgres", ok=False, critical=True, message=str(exc)[:120])],
+        )
+
+    return _build_readiness_from_results(
+        results, webhook_result=None, checked_at=datetime.now(timezone.utc).isoformat()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Detailed live probes (called on background schedule, includes webhook)
+# ---------------------------------------------------------------------------
+
+
+async def _run_detailed_probes() -> ReadinessResponse:
+    """Run all 5 probes and return a ReadinessResponse with a fresh checked_at."""
+    from app.database import AsyncSessionLocal
+    from app.routers.admin import _probe_clerk, _probe_postgres, _probe_s3, _probe_smtp
+    from app.services.clerk_webhook_probe import run_webhook_probe
+
+    try:
+        async with AsyncSessionLocal() as db:
+            results, webhook_result = await asyncio.gather(
+                asyncio.gather(
+                    _probe_postgres(db),
+                    _probe_s3(),
+                    _probe_clerk(),
+                    _probe_smtp(),
+                    return_exceptions=True,
+                ),
+                run_webhook_probe(),
+            )
+    except Exception as exc:
+        return ReadinessResponse(
+            status="error",
+            services=[ReadinessService(name="postgres", ok=False, critical=True, message=str(exc)[:120])],
+            checked_at=datetime.now(timezone.utc).isoformat(),
+        )
+
+    return _build_readiness_from_results(
+        results, webhook_result, checked_at=datetime.now(timezone.utc).isoformat()
+    )
+
+
+async def _detailed_refresh_loop() -> None:
+    global _detailed_cache
+    while True:
+        try:
+            _detailed_cache = await _run_detailed_probes()
+        except Exception:
+            log.exception("Unexpected error in detailed health refresh loop")
+        await asyncio.sleep(DETAILED_REFRESH_INTERVAL_S)
+
+
+def start_detailed_refresh() -> None:
+    """Create the background refresh task. Call from lifespan after startup."""
+    global _detailed_task
+    _detailed_task = asyncio.create_task(_detailed_refresh_loop())
+
+
+def stop_detailed_refresh() -> None:
+    """Cancel the background refresh task. Call from lifespan cleanup."""
+    global _detailed_task
+    if _detailed_task is not None:
+        _detailed_task.cancel()
+        _detailed_task = None

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -62,9 +62,7 @@ async def health_detailed() -> JSONResponse:
     Returns the same shape as /health/ready with an added checked_at timestamp.
     """
     if _detailed_cache is None:
-        return JSONResponse(
-            {"status": "starting", "services": [], "checked_at": None}, status_code=503
-        )
+        return JSONResponse({"status": "starting", "services": [], "checked_at": None}, status_code=503)
     return JSONResponse(_detailed_cache.model_dump())
 
 
@@ -194,9 +192,7 @@ async def _run_detailed_probes() -> ReadinessResponse:
             checked_at=datetime.now(timezone.utc).isoformat(),
         )
 
-    return _build_readiness_from_results(
-        results, webhook_result, checked_at=datetime.now(timezone.utc).isoformat()
-    )
+    return _build_readiness_from_results(results, webhook_result, checked_at=datetime.now(timezone.utc).isoformat())
 
 
 async def _detailed_refresh_loop() -> None:

--- a/backend/tests/routers/test_health.py
+++ b/backend/tests/routers/test_health.py
@@ -1,6 +1,27 @@
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
 from httpx import AsyncClient
 
+import app.routers.health as health_module
+from app.routers.health import ReadinessResponse, ReadinessService, _build_readiness_from_results
 from app.version import VERSION
+
+
+@pytest.fixture(autouse=True)
+def reset_health_state():
+    """Restore module-level caches and task between tests."""
+    original_detailed = health_module._detailed_cache
+    original_readiness = health_module._readiness_cache
+    original_task = health_module._detailed_task
+    yield
+    # Cancel any task created during the test before restoring
+    if health_module._detailed_task is not None and health_module._detailed_task is not original_task:
+        health_module._detailed_task.cancel()
+    health_module._detailed_cache = original_detailed
+    health_module._readiness_cache = original_readiness
+    health_module._detailed_task = original_task
 
 
 class TestHealth:
@@ -21,3 +42,192 @@ class TestHealth:
         body = resp.json()
         assert "status" in body
         assert "version" in body
+
+
+class TestHealthReady:
+    async def test_returns_503_when_cache_empty(self, client: AsyncClient):
+        health_module._readiness_cache = None
+        resp = await client.get("/health/ready")
+        assert resp.status_code == 503
+        assert resp.json()["status"] == "starting"
+
+    async def test_returns_200_when_ok(self, client: AsyncClient):
+        health_module._readiness_cache = ReadinessResponse(status="ok", services=[])
+        resp = await client.get("/health/ready")
+        assert resp.status_code == 200
+
+    async def test_returns_503_when_error(self, client: AsyncClient):
+        health_module._readiness_cache = ReadinessResponse(
+            status="error",
+            services=[ReadinessService(name="postgres", ok=False, critical=True)],
+        )
+        resp = await client.get("/health/ready")
+        assert resp.status_code == 503
+
+    async def test_returns_200_when_degraded(self, client: AsyncClient):
+        health_module._readiness_cache = ReadinessResponse(
+            status="degraded",
+            services=[ReadinessService(name="SMTP", ok=False, critical=False)],
+        )
+        resp = await client.get("/health/ready")
+        assert resp.status_code == 200
+
+
+class TestHealthDetailed:
+    async def test_returns_503_when_cache_empty(self, client: AsyncClient):
+        health_module._detailed_cache = None
+        resp = await client.get("/health/detailed")
+        assert resp.status_code == 503
+        assert resp.json()["status"] == "starting"
+
+    async def test_returns_200_when_cache_populated(self, client: AsyncClient):
+        health_module._detailed_cache = ReadinessResponse(
+            status="ok",
+            services=[ReadinessService(name="PostgreSQL", ok=True, critical=True)],
+            checked_at="2026-01-01T00:00:00+00:00",
+        )
+        resp = await client.get("/health/detailed")
+        assert resp.status_code == 200
+
+    async def test_returns_cached_status(self, client: AsyncClient):
+        health_module._detailed_cache = ReadinessResponse(
+            status="degraded",
+            services=[ReadinessService(name="Clerk Webhook", ok=False, critical=False, message="timeout")],
+            checked_at="2026-01-01T00:00:00+00:00",
+        )
+        body = (await client.get("/health/detailed")).json()
+        assert body["status"] == "degraded"
+        assert body["checked_at"] == "2026-01-01T00:00:00+00:00"
+
+    async def test_response_includes_services(self, client: AsyncClient):
+        health_module._detailed_cache = ReadinessResponse(
+            status="ok",
+            services=[
+                ReadinessService(name="PostgreSQL", ok=True, critical=True),
+                ReadinessService(name="Clerk Webhook", ok=True, critical=False),
+            ],
+            checked_at="2026-01-01T00:00:00+00:00",
+        )
+        body = (await client.get("/health/detailed")).json()
+        names = [s["name"] for s in body["services"]]
+        assert "PostgreSQL" in names
+        assert "Clerk Webhook" in names
+
+    async def test_detailed_returns_200_even_when_degraded(self, client: AsyncClient):
+        health_module._detailed_cache = ReadinessResponse(status="degraded", services=[])
+        resp = await client.get("/health/detailed")
+        assert resp.status_code == 200
+
+    async def test_detailed_returns_200_even_when_error(self, client: AsyncClient):
+        health_module._detailed_cache = ReadinessResponse(
+            status="error",
+            services=[ReadinessService(name="PostgreSQL", ok=False, critical=True)],
+        )
+        resp = await client.get("/health/detailed")
+        assert resp.status_code == 200
+
+
+class TestDetailedRefreshLifecycle:
+    async def test_start_creates_task(self, monkeypatch):
+        async def idle():
+            pass
+
+        monkeypatch.setattr(health_module, "_detailed_refresh_loop", idle)
+        health_module._detailed_task = None
+        health_module.start_detailed_refresh()
+        assert health_module._detailed_task is not None
+
+    async def test_stop_cancels_task(self):
+        health_module._detailed_task = asyncio.create_task(asyncio.sleep(100))
+        health_module.stop_detailed_refresh()
+        assert health_module._detailed_task is None
+
+    async def test_stop_noop_when_no_task(self):
+        health_module._detailed_task = None
+        health_module.stop_detailed_refresh()
+        assert health_module._detailed_task is None
+
+
+class TestBuildReadinessFromResults:
+    def _make_service_result(self, service: str, status: str = "ok", checks=None):
+        r = MagicMock()
+        r.service = service
+        r.status = status
+        r.message = f"{service} {status}"
+        r.checks = checks or []
+        return r
+
+    def test_all_ok_returns_ok(self):
+        results = [self._make_service_result("PostgreSQL"), self._make_service_result("S3")]
+        result = _build_readiness_from_results(results, webhook_result=None, checked_at="2026-01-01T00:00:00+00:00")
+        assert result.status == "ok"
+
+    def test_critical_failure_returns_error(self):
+        results = [self._make_service_result("PostgreSQL", status="error")]
+        result = _build_readiness_from_results(results, webhook_result=None, checked_at="2026-01-01T00:00:00+00:00")
+        assert result.status == "error"
+
+    def test_non_critical_failure_returns_degraded(self):
+        results = [
+            self._make_service_result("PostgreSQL"),
+            self._make_service_result("SMTP", status="error"),
+        ]
+        result = _build_readiness_from_results(results, webhook_result=None, checked_at="2026-01-01T00:00:00+00:00")
+        assert result.status == "degraded"
+
+    def test_exception_in_results_counts_as_hard_failure(self):
+        results = [RuntimeError("db exploded")]
+        result = _build_readiness_from_results(results, webhook_result=None, checked_at="2026-01-01T00:00:00+00:00")
+        assert result.status == "error"
+
+    def test_webhook_ok_included_in_services(self):
+        wh = MagicMock()
+        wh.status = "ok"
+        wh.message = "232ms"
+        result = _build_readiness_from_results([], webhook_result=wh, checked_at="2026-01-01T00:00:00+00:00")
+        names = [s.name for s in result.services]
+        assert "Clerk Webhook" in names
+
+    def test_webhook_error_sets_degraded(self):
+        wh = MagicMock()
+        wh.status = "error"
+        wh.message = "timeout"
+        result = _build_readiness_from_results([], webhook_result=wh, checked_at="2026-01-01T00:00:00+00:00")
+        assert result.status == "degraded"
+
+    def test_webhook_skipped_treated_as_ok(self):
+        wh = MagicMock()
+        wh.status = "skipped"
+        wh.message = "no base url"
+        result = _build_readiness_from_results([], webhook_result=wh, checked_at="2026-01-01T00:00:00+00:00")
+        webhook_svc = next(s for s in result.services if s.name == "Clerk Webhook")
+        assert webhook_svc.ok is True
+
+    def test_none_webhook_not_included(self):
+        results = [self._make_service_result("PostgreSQL")]
+        result = _build_readiness_from_results(results, webhook_result=None, checked_at="2026-01-01T00:00:00+00:00")
+        names = [s.name for s in result.services]
+        assert "Clerk Webhook" not in names
+
+    def test_checked_at_propagated(self):
+        result = _build_readiness_from_results([], webhook_result=None, checked_at="2026-05-01T12:00:00+00:00")
+        assert result.checked_at == "2026-05-01T12:00:00+00:00"
+
+    def test_first_failed_check_message_used_as_detail(self):
+        failed_check = MagicMock()
+        failed_check.status = "error"
+        failed_check.message = "permission denied"
+        svc = self._make_service_result("S3", status="error", checks=[failed_check])
+        result = _build_readiness_from_results([svc], webhook_result=None, checked_at="2026-01-01T00:00:00+00:00")
+        s3_svc = next(s for s in result.services if s.name == "S3")
+        assert s3_svc.detail == "permission denied"
+
+    def test_services_list_populated(self):
+        results = [
+            self._make_service_result("PostgreSQL"),
+            self._make_service_result("S3"),
+            self._make_service_result("Clerk"),
+            self._make_service_result("SMTP"),
+        ]
+        result = _build_readiness_from_results(results, webhook_result=None, checked_at="2026-01-01T00:00:00+00:00")
+        assert len(result.services) == 4

--- a/frontend/src/api/health.ts
+++ b/frontend/src/api/health.ts
@@ -9,9 +9,15 @@ export interface ReadinessService {
 export interface ReadinessResponse {
   status: "ok" | "degraded" | "error" | "starting";
   services: ReadinessService[];
+  checked_at?: string | null;
 }
 
 export async function getHealthReady(): Promise<ReadinessResponse> {
   const res = await fetch("/health/ready");
+  return res.json() as Promise<ReadinessResponse>;
+}
+
+export async function getHealthDetailed(): Promise<ReadinessResponse> {
+  const res = await fetch("/health/detailed");
   return res.json() as Promise<ReadinessResponse>;
 }

--- a/frontend/src/components/ServiceHealthBanner.tsx
+++ b/frontend/src/components/ServiceHealthBanner.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { getHealthReady, type ReadinessResponse, type ReadinessService } from "@/api/health";
+import { getHealthDetailed, type ReadinessResponse, type ReadinessService } from "@/api/health";
 
 function serviceLabel(s: ReadinessService): string {
   return s.detail ? `${s.name} (${s.detail})` : s.name;
@@ -10,20 +10,20 @@ export function ServiceHealthBanner() {
 
   useEffect(() => {
     const check = () =>
-      getHealthReady()
+      getHealthDetailed()
         .then(setReadiness)
         .catch(() => {
           setReadiness({ status: "error", services: [{ name: "backend", ok: false, critical: true, message: "unreachable", detail: "" }] });
         });
     check();
-    const id = setInterval(check, 60_000);
+    const id = setInterval(check, 30_000);
     return () => clearInterval(id);
   }, []);
 
-  if (!readiness || readiness.status === "ok") return null;
+  if (!readiness || readiness.status === "ok" || readiness.status === "starting") return null;
 
   const failed = readiness.services.filter((s) => !s.ok);
-  const webhookDegraded = failed.some((s) => s.name === "Clerk Webhook");
+  const webhookFailed = failed.find((s) => s.name === "Clerk Webhook");
   const otherFailed = failed.filter((s) => s.name !== "Clerk Webhook");
 
   if (readiness.status === "error") {
@@ -37,7 +37,7 @@ export function ServiceHealthBanner() {
 
   return (
     <div className="w-full bg-amber-400 text-amber-950 text-center text-xs font-semibold py-1.5 px-4 select-none">
-      {webhookDegraded && (
+      {webhookFailed && (
         <span>
           New account registration is temporarily unavailable — existing users are unaffected.
           {otherFailed.length > 0 && "  "}

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -21,7 +21,6 @@ import {
   createEulaVersion,
   getAdminServices,
   sendTestEmail,
-  testWebhook,
   getAuditLog,
   type AdminUser,
   type AdminHealth,
@@ -30,9 +29,8 @@ import {
   type PendingSignup,
   type ServiceCheck,
   type ServicePermCheck,
-  type WebhookProbeResult,
 } from "@/api/admin";
-import { getHealthReady, type ReadinessResponse } from "@/api/health";
+import { getHealthDetailed, type ReadinessResponse, type ReadinessService } from "@/api/health";
 import { EulaContent } from "@/components/EulaContent";
 import { formatBytes } from "@/lib/image-utils";
 
@@ -895,24 +893,26 @@ function StatusDot({ status, small }: { status: "ok" | "error"; small?: boolean 
   );
 }
 
-function ServiceRow({ check }: { check: ServiceCheck }) {
+function CombinedServiceRow({ service, detail }: { service: ReadinessService; detail?: ServiceCheck }) {
   const [open, setOpen] = useState(false);
-  const metaEntries = Object.entries(check.meta ?? {});
-  const hasContent = metaEntries.length > 0 || check.checks.length > 0;
+  const metaEntries = Object.entries(detail?.meta ?? {});
+  const hasDetail = detail && (metaEntries.length > 0 || detail.checks.length > 0);
+
   return (
     <div className="bg-background">
       <button
-        className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/40 text-left"
-        onClick={() => setOpen((o) => !o)}
+        className={`w-full flex items-center gap-3 px-4 py-3 text-left ${hasDetail ? "hover:bg-muted/40 cursor-pointer" : "cursor-default"}`}
+        onClick={hasDetail ? () => setOpen((o) => !o) : undefined}
       >
-        <StatusDot status={check.status} />
-        <span className="text-sm font-medium w-32 shrink-0">{check.service}</span>
-        <span className={`text-sm flex-1 ${check.status === "error" ? "text-destructive" : "text-muted-foreground"}`}>
-          {check.message}
+        <StatusDot status={service.ok ? "ok" : "error"} />
+        <span className="text-sm font-medium w-32 shrink-0">{service.name}</span>
+        <span className={`text-sm flex-1 ${!service.ok ? "text-destructive" : "text-muted-foreground"}`}>
+          {service.message || (service.ok ? "ok" : "failed")}
         </span>
-        <span className="text-xs text-muted-foreground">{open ? "▲" : "▼"}</span>
+        {!service.critical && <span className="text-xs text-muted-foreground">non-critical</span>}
+        {hasDetail && <span className="text-xs text-muted-foreground">{open ? "▲" : "▼"}</span>}
       </button>
-      {open && hasContent && (
+      {open && hasDetail && (
         <div className="border-t">
           {metaEntries.length > 0 && (
             <div className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-1 pl-10 pr-4 py-2.5 bg-muted/10 border-b">
@@ -924,9 +924,9 @@ function ServiceRow({ check }: { check: ServiceCheck }) {
               ))}
             </div>
           )}
-          {check.checks.length > 0 && (
+          {detail!.checks.length > 0 && (
             <div className="divide-y">
-              {check.checks.map((c: ServicePermCheck) => (
+              {detail!.checks.map((c: ServicePermCheck) => (
                 <div key={c.name} className="flex items-center gap-3 pl-10 pr-4 py-2 bg-muted/20">
                   <StatusDot status={c.status} small />
                   <span className="text-xs text-muted-foreground w-32 shrink-0">{c.name}</span>
@@ -943,99 +943,33 @@ function ServiceRow({ check }: { check: ServiceCheck }) {
   );
 }
 
-function WebhookHealthCard() {
-  const [result, setResult] = useState<WebhookProbeResult | null>(null);
-  const [lastChecked, setLastChecked] = useState<Date | null>(null);
-
-  const probe = useMutation({
-    mutationFn: testWebhook,
-    onSettled: (data) => {
-      if (data) { setResult(data); setLastChecked(new Date()); }
-    },
-  });
-
-  // Auto-test on mount and every 60s while this tab is open.
-  useEffect(() => {
-    probe.mutate();
-    const id = setInterval(() => probe.mutate(), 60_000);
-    return () => clearInterval(id);
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const statusColor =
-    !result || probe.isPending ? "text-muted-foreground" :
-    result.status === "ok" ? "text-green-600 dark:text-green-400" :
-    result.status === "skipped" ? "text-muted-foreground" :
-    "text-destructive";
-
-  const statusLabel =
-    probe.isPending ? "Testing…" :
-    !result ? "Not yet tested" :
-    result.status === "ok" ? `OK — ${result.latency_ms}ms` :
-    result.status === "skipped" ? "Skipped (WEBHOOK_BASE_URL not configured)" :
-    `Failed — ${result.message}`;
-
-  return (
-    <div className="border rounded-lg p-4 flex items-center justify-between gap-4">
-      <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium">Webhook Health</p>
-        <p className={`text-xs mt-0.5 ${statusColor}`}>{statusLabel}</p>
-        {lastChecked && (
-          <p className="text-xs text-muted-foreground mt-0.5">
-            Last tested {lastChecked.toLocaleTimeString()} · auto-refreshes every 60s
-          </p>
-        )}
-      </div>
-      <Button size="sm" variant="outline" disabled={probe.isPending} onClick={() => probe.mutate()}>
-        {probe.isPending ? "Testing…" : "Test Now"}
-      </Button>
-    </div>
-  );
-}
-
-function ReadinessCard({ readiness }: { readiness: ReadinessResponse }) {
-  const statusColor =
-    readiness.status === "ok" ? "text-green-600 dark:text-green-400" :
-    readiness.status === "error" ? "text-destructive" :
-    readiness.status === "starting" ? "text-muted-foreground" :
-    "text-amber-600 dark:text-amber-400";
-
-  return (
-    <div className="border rounded-lg overflow-hidden">
-      <div className="flex items-center justify-between px-4 py-3 bg-muted/10 border-b">
-        <span className="text-sm font-medium">App Readiness</span>
-        <span className={`text-xs font-semibold uppercase ${statusColor}`}>{readiness.status}</span>
-      </div>
-      <div className="divide-y">
-        {readiness.services.map((s) => (
-          <div key={s.name} className="flex items-center gap-3 px-4 py-2.5">
-            <StatusDot status={s.ok ? "ok" : "error"} />
-            <span className="text-sm w-36 shrink-0">{s.name}</span>
-            <span className={`text-xs flex-1 ${s.ok ? "text-muted-foreground" : "text-destructive"}`}>
-              {s.message || (s.ok ? "ok" : "failed")}
-            </span>
-            {!s.critical && <span className="text-xs text-muted-foreground">non-critical</span>}
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
 function ServicesTab() {
   const { user: currentUser } = useAuth();
-  const { data, isLoading, isFetching, refetch, dataUpdatedAt } = useQuery({
+
+  // Live status from /health/detailed — auto-refreshes every 30s
+  const [detailed, setDetailed] = useState<ReadinessResponse | null>(null);
+  const [detailedAt, setDetailedAt] = useState<Date | null>(null);
+
+  useEffect(() => {
+    const poll = () =>
+      getHealthDetailed()
+        .then((d) => { setDetailed(d); setDetailedAt(new Date()); })
+        .catch(() => {});
+    poll();
+    const id = setInterval(poll, 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  // Detailed diagnostics — on demand only
+  const { data: diagnostics, isFetching: diagFetching, refetch: runDiag, dataUpdatedAt: diagAt } = useQuery({
     queryKey: ["admin", "services"],
     queryFn: getAdminServices,
-    staleTime: 0,
-    refetchOnMount: true,
+    staleTime: Infinity,
+    enabled: false,
   });
 
-  const { data: readiness } = useQuery({
-    queryKey: ["health", "ready"],
-    queryFn: getHealthReady,
-    staleTime: 30_000,
-    refetchInterval: 60_000,
-  });
+  const diagTime = diagAt ? new Date(diagAt).toLocaleTimeString() : null;
+  const getDetail = (name: string) => diagnostics?.find((d) => d.service === name);
 
   const [testResult, setTestResult] = useState<{ ok: boolean; msg: string } | null>(null);
   const testEmail = useMutation({
@@ -1044,32 +978,31 @@ function ServicesTab() {
     onError: (e: Error) => setTestResult({ ok: false, msg: e.message }),
   });
 
-  const lastChecked = dataUpdatedAt ? new Date(dataUpdatedAt).toLocaleTimeString() : null;
-
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <p className="text-xs text-muted-foreground">
-          {lastChecked ? `Last checked ${lastChecked}` : "Checking…"}
-        </p>
-        <Button size="sm" variant="outline" disabled={isFetching} onClick={() => refetch()}>
-          {isFetching ? "Checking…" : "Refresh"}
+        <div className="flex items-center gap-2">
+          <span className="inline-block w-2 h-2 rounded-full bg-green-500 animate-pulse" />
+          <span className="text-xs text-muted-foreground">
+            {detailedAt
+              ? `Updated ${detailedAt.toLocaleTimeString()} · auto-refreshes every 30s`
+              : "Loading…"}
+          </span>
+        </div>
+        <Button size="sm" variant="outline" disabled={diagFetching} onClick={() => runDiag()}>
+          {diagFetching ? "Running…" : diagTime ? `Diagnostics: ${diagTime}` : "Run diagnostics"}
         </Button>
       </div>
 
-      {isLoading ? (
+      {!detailed || detailed.status === "starting" ? (
         <p className="text-sm text-muted-foreground">Checking services…</p>
       ) : (
         <div className="border rounded-lg divide-y overflow-hidden">
-          {(data ?? []).map((check) => (
-            <ServiceRow key={check.service} check={check} />
+          {detailed.services.map((svc) => (
+            <CombinedServiceRow key={svc.name} service={svc} detail={getDetail(svc.name)} />
           ))}
         </div>
       )}
-
-      {readiness && <ReadinessCard readiness={readiness} />}
-
-      <WebhookHealthCard />
 
       <div className="border rounded-lg p-4 flex items-center justify-between gap-4">
         <div>


### PR DESCRIPTION
## Summary

- Adds `GET /health/detailed` — a public endpoint that returns service health refreshed every 30s by an asyncio background task, covering all 5 services: PostgreSQL, S3, Clerk API, SMTP, and Clerk Webhook
- Unlike `/health/ready` (startup snapshot, never refreshed), this endpoint reflects current state and will clear automatically when services recover
- Adds `checked_at` ISO timestamp to `ReadinessResponse` shape (optional field, backward-compatible)
- Background task starts in `lifespan` and is cancelled on shutdown

**Frontend changes:**
- `ServiceHealthBanner` now polls `/health/detailed` every 30s instead of fetching `/health/ready` once on mount
- Admin Services tab redesigned to use `/health/detailed` as the live status source (auto-refreshes every 30s, includes webhook as a row)
- "Run diagnostics" button triggers `/admin/services` on demand — rows become expandable with meta and per-check detail data when diagnostics have been run
- `ReadinessCard` (startup snapshot) and `WebhookHealthCard` (manual 60s probe) removed — both replaced by the unified live status view

## Test plan

_Migrated to QA issue #196._