### PR TITLE
docs: add CLAUDE.md and clean up obsolete/sensitive docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,151 @@
+# WeftMark — Claude Code Instructions
+
+## Project overview
+
+WeftMark is a multi-user web platform for managing weaving (loom) projects. All projects are private by default. Users can self-register via Clerk but are blocked until an admin approves them.
+
+- Requirements: `docs/requirements/` (start with `docs/requirements/README.md`)
+- WIF 1.1 spec: `docs/standard/standard-wif1-1.txt`
+- Sample WIF files: `docs/samples/`
+
+## Tech stack
+
+| Layer | Choice |
+|---|---|
+| Frontend | React + Vite + TypeScript + Tailwind CSS + shadcn/ui + TanStack Query + React Router |
+| Backend | FastAPI (Python) + SQLAlchemy + Alembic |
+| Database | PostgreSQL (Neon managed in prod, local container in dev) |
+| Task queue | Celery + Redis |
+| Auth | Clerk (OIDC). Backend reads `Authorization: Bearer` header — NOT cookies. |
+| Deployment | Docker + Docker Compose, monorepo |
+
+## Auth
+
+Backend reads `Authorization: Bearer` header. All API modules must use `client.ts`'s `configureApiClient(getToken)` path; never raw `fetch()` without a Bearer header.
+
+Binary/image endpoints (photos, drawdown, preview) use the `AuthedImage` component (fetch → blob URL) — `<img src>` can't carry Bearer headers. File downloads use `downloadAuthed()`.
+
+## Infrastructure
+
+- **Domain/DNS/SSL:** Cloudflare (registrar + proxy). Origin CA cert with Full (strict) mode. No Certbot needed.
+- **Object storage:** Cloudflare R2 (S3-compatible; use `STORAGE_BACKEND=s3` / boto3; zero egress fees)
+- **Reverse proxy:** nginx with CrowdSec bouncer → containers
+- **Database:** PostgreSQL. Production uses a managed DSN — set `POSTGRES_DSN` in `.env`; individual `POSTGRES_*` vars are ignored when DSN is set. Dev uses a local Postgres container.
+- **Container registry:** `ghcr.io/weftmark/weftmark-backend` and `ghcr.io/weftmark/weftmark-frontend`
+- **Source:** `https://github.com/weftmark/weftmark` (org: `weftmark`, owner: `gx1400`)
+- **Email:** `admin@weftmark.com` / `feedback@weftmark.com` for SMTP config
+
+## Git workflow
+
+Three tiers: `main` (production-ready), `dev` (integration), working branches (`feature/*`, `fix/*`).
+
+### Normal path (feature or fix)
+
+- Branch from `dev`: `git checkout dev && git checkout -b feature/<name>` or `fix/<name>`
+- PR targets `dev` — always pass `--base dev` to `gh pr create`
+- Never commit directly to `main` or `dev`
+
+### Hotfix path
+
+- `hotfix/*` branches from `main` and targets `main` directly
+- `check-merge-source.yml` enforces that only `dev` and `hotfix/*` may open PRs to `main`
+- After merging to `main`, backport the fix to `dev` as a follow-up PR
+
+**Merge gate — feature/fix → dev:** unit tests written, pytest passes, tsc clean, golden path verified in browser, no regressions.
+
+**Merge gate — dev → main:** all feature gates plus full smoke-test (auth login, core CRUD, activities), pytest passes, no known open bugs.
+
+**When to suggest a commit:** After each feature passes end-to-end testing and pytest. Don't commit speculatively mid-feature.
+
+## CI/CD
+
+| Workflow | Trigger | What it does |
+| --- | --- | --- |
+| `ci-feature.yml` | push to `feature/*`, `fix/*` | lint + typecheck (fast feedback) |
+| `ci-hotfix.yml` | push to `hotfix/*` | full suite (lint, typecheck, pytest, migration, dep audit, docker build) |
+| `ci-dev-pr.yml` | PR to `dev` | full suite — this is the gate; tests don't re-run after merge |
+| `ci-dev-push.yml` | push to `dev` | SBOM update + semver version bump (bot commits, skipped if actor is bot) |
+| `ci-main-pr.yml` | PR to `main` | lint, typecheck, dep audit, docker build; **no file writes allowed** |
+| `ci-main-push.yml` | push to `main` | promote version tag, SBOM artifacts, publish versioned + `:latest` images |
+| `check-merge-source.yml` | PR to `main` | enforces source must be `dev` or `hotfix/*` |
+| `publish-dev.yml` | manual dispatch | publishes `:dev` + `:{version}-dev` images to ghcr.io |
+
+After every push, check CI status proactively: `gh run list --repo weftmark/weftmark --limit 3`. If failed, pull logs with `gh run view <id> --log-failed` and surface errors immediately.
+
+Bot actor: `weftmark-bot[bot]`. Post-merge jobs use `if: github.actor != 'weftmark-bot[bot]'` to prevent infinite re-triggering. Bot commits use `[skip actions]` in the message.
+
+Append `[skip ci]` to commit messages for documentation-only changes (`.md` files, comments) to avoid unnecessary CI runs.
+
+## Development rules
+
+### Pull before starting work
+
+Always `git pull origin <branch>` at the start of every session. The CI bot commits version bumps directly to branches — skip this and pushes will conflict on `VERSION` / `frontend/package.json`.
+
+### Rebuild both services together
+
+Always rebuild frontend AND backend together. Never rebuild just one.
+
+```bash
+docker compose -f docker-compose.build.yml --env-file .env.local stop frontend backend worker
+docker compose -f docker-compose.build.yml --env-file .env.local build frontend backend
+docker compose -f docker-compose.build.yml --env-file .env.local up -d frontend backend worker
+```
+
+The running `frontend-1` container is nginx-only — no `node`, `npm`, or build tools inside it. Never run `docker compose exec frontend npm ...`.
+
+### Test-first development
+
+Before implementing any new feature: write tests first, run them (confirm fail), implement until they pass. Commit feature + tests together.
+
+- Backend tests: `backend/tests/` mirroring `app/` structure (e.g. `app/services/foo.py` → `tests/services/test_foo.py`)
+- After each feature, update `docs/testing.md` (coverage %, gap table, history row)
+
+### Environment files on package install
+
+When any package is installed (pip, npm, conda), regenerate in the same commit:
+- `environment.yml` — `conda run -n weaving_site conda env export --no-builds > environment.yml`
+- `.nvmrc` — `node --version` (only when Node version changes)
+
+### Single bash commands
+
+Issue each command as a separate tool call — never chain with `&&` or `;`. Allows per-command session approval.
+
+## PR workflow
+
+1. Claude implements the feature and opens the PR (`gh pr create --base dev`)
+2. The developer reviews on GitHub and works through the test plan
+3. The developer merges
+
+Claude's role ends at opening the PR. Never run `gh pr merge`.
+
+### PR scope
+
+One PR = one topic (one feature, one fix, one refactor). If a fix is discovered incidentally, note it and handle it in a separate PR.
+
+## Collaboration style
+
+- Ask questions one at a time — single most important question, wait for the answer
+- Give clear recommendations with reasoning, not balanced option lists
+- Deferred/phase 2 features go in `docs/requirements/phase2.md`
+
+## Allowed bash patterns (add to .claude/settings.json if permission prompts become disruptive)
+
+```
+Bash(docker compose *)
+Bash(docker cp *)
+Bash(conda run *)
+Bash(git add *)
+Bash(git commit *)
+Bash(git push *)
+Bash(git pull *)
+Bash(git fetch *)
+Bash(git checkout *)
+Bash(git stash *)
+Bash(npx tsc *)
+Bash(npm run *)
+Bash(gh run *)
+Bash(gh pr *)
+Bash(curl -s http://localhost:*)
+Bash(python -c ' *)
+```

--- a/docs/deployment/hosting-decisions.md
+++ b/docs/deployment/hosting-decisions.md
@@ -31,7 +31,7 @@
 - Free allocation eliminates VM cost
 - Komodo manages container lifecycle and pulls images from ghcr.io on deploy
 
-**Instance sizing:** Minimum 2 vCPU / 4 GB RAM once Authentik is removed (see §6 Clerk migration). Current dev stack with Authentik still present needs 8 GB. See [Proxmox VM sizing note in infrastructure memory](../../.claude/memory/infrastructure.md).
+**Instance sizing:** Minimum 2 vCPU / 4 GB RAM.
 
 **Estimated cost:** $0/mo.
 
@@ -93,15 +93,15 @@
 **Rationale:**
 
 - Free for public images, generous storage on free org tier
-- Komodo pulls from ghcr.io on deploy — needs a registry reachable from the production VM; local Gitea at `10.10.10.90` is not reachable from the data centre
+- Komodo pulls from ghcr.io on deploy — needs a registry reachable from the production VM
 - Keeps the `weftmark` namespace clean and separate from personal GitHub activity
 
 **Image names:**
 
-- `ghcr.io/weftmark/weaving_site_backend:<version>`
-- `ghcr.io/weftmark/weaving_site_frontend:<version>`
+- `ghcr.io/weftmark/weftmark-backend:<version>`
+- `ghcr.io/weftmark/weftmark-frontend:<version>`
 
-**Note:** Code is NOT mirrored to GitHub — Gitea remains the source of truth. ghcr.io is used as the registry only. The CD pipeline (Gitea Actions → build → push → Komodo pull) is a pending milestone task.
+**Source:** `https://github.com/weftmark/weftmark` (org: `weftmark`). GitHub Actions CI/CD builds and pushes images on merge to `dev` (`:dev` tag) and `main` (`:latest` + `:{version}`).
 
 **Estimated cost:** $0/mo (public packages are free).
 
@@ -109,30 +109,18 @@
 
 ## 6. Authentication — Clerk
 
-**Decision:** Clerk hosted authentication (replacing Authentik)
+**Decision:** Clerk hosted authentication (replaced Authentik)
 
-**Status:** Developer has a Clerk free-tier account. Implementation pending before public launch. **P1 — must ship before users are onboarded.**
+**Status:** Shipped.
 
 **Why Clerk over Authentik:**
 
-- Authentik requires self-hosting (~2 GB RAM overhead), manual invite provisioning, and ongoing security maintenance. Clerk is fully managed.
-- Clerk provides built-in social login (Google, Apple, email magic link), MFA, user management dashboard, and session handling out of the box.
-- Removes Authentik from the docker-compose stack, reducing the minimum VM RAM requirement from 8 GB to ~2 GB.
+- Authentik required self-hosting (~2 GB RAM overhead), manual invite provisioning, and ongoing security maintenance. Clerk is fully managed.
+- Clerk provides built-in social login, MFA, user management dashboard, and session handling out of the box.
+- Removing Authentik from the docker-compose stack reduced the minimum VM RAM requirement.
 - Free tier: unlimited MAU on development; 10,000 MAU on production (as of 2026).
 
-**Implementation checklist:**
-
-- [ ] Install `clerk-backend-sdk` (Python) and `@clerk/clerk-react` (frontend)
-- [ ] Add `CLERK_SECRET_KEY` and `CLERK_PUBLISHABLE_KEY` to `.env` and deployment secrets
-- [ ] Create Clerk application; configure allowed origins and redirect URLs for `weftmark.com`
-- [ ] Swap `get_current_user` in `app/deps.py` to verify Clerk session tokens
-- [ ] Add webhook handler (`POST /auth/clerk/webhook`) to sync user creation/deletion to the local `users` table
-- [ ] Update `User` model: rename `oidc_sub` → `clerk_user_id`; add Alembic migration
-- [ ] Replace frontend auth: remove OIDC redirect hooks, add `<ClerkProvider>` to `App.tsx`, use Clerk's `<SignIn>` component
-- [ ] Update `docker-compose.yml`: remove Authentik service; remove Authentik env vars
-- [ ] Update VM sizing note — 4 GB RAM is now sufficient without Authentik
-
-**Architectural note:** The local `users` table remains the source of truth for app-level data (projects, activities, preferences). Clerk manages identity only; the webhook keeps the two in sync. The existing `Invite` model can be retired once Clerk's invitation emails are wired (Clerk supports restricting sign-ups to invited emails only).
+**Architectural note:** The local `users` table is the source of truth for app-level data (projects, activities, preferences). Clerk manages identity only; a webhook handler at `POST /webhooks/clerk` keeps the two in sync. Backend validates Bearer tokens in the `Authorization` header — not cookies. Users can self-register via Clerk; new accounts require admin approval before access is granted.
 
 **Estimated cost:** $0/mo on free tier.
 

--- a/docs/eula.md
+++ b/docs/eula.md
@@ -42,11 +42,11 @@ WeftMark is a web application for weavers. It lets you:
 
 ## 4. Your account
 
-You sign in using a third-party identity provider (currently Google; Apple Sign In coming later). We do not store your password — authentication is handled entirely by the provider you choose.
+You sign in using a third-party identity provider. We do not store your password — authentication is handled entirely by the provider you choose.
 
 You are responsible for maintaining the security of your account. If you believe your account has been compromised, contact us immediately.
 
-WeftMark is currently invite-only. You must be invited by an existing user or the platform administrator to register.
+Access to WeftMark requires account approval. You may register and your account will be activated once approved by an administrator.
 
 ## 5. Content license
 

--- a/docs/requirements/overview.md
+++ b/docs/requirements/overview.md
@@ -30,11 +30,10 @@ A multi-user, invite-only web platform for managing weaving projects. Users can 
 
 ### Authentication
 
-- OIDC-based authentication (any OIDC-compliant provider supported via configuration)
-- Reference implementation: **Authentik** (self-hosted)
-- Invite-only registration — users cannot self-register
-- Session stored as a signed JWT in an httpOnly cookie; signed with `APP_SECRET_KEY`
-- Bootstrap rule: the first user to authenticate becomes admin with no invite required
+- Clerk hosted authentication
+- Users can self-register; new accounts require admin approval before access is granted
+- Backend validates Bearer tokens in the `Authorization` header
+- Bootstrap rule: the first user to register becomes admin with no approval required
 
 ### Frontend
 
@@ -66,9 +65,9 @@ A multi-user, invite-only web platform for managing weaving projects. Users can 
 ## API Security
 
 - All `/api/*` endpoints require authentication via `Depends(get_current_user)`
-- Authentication is enforced by validating the signed session JWT from the httpOnly cookie
+- Authentication is enforced by validating the Clerk Bearer token from the `Authorization` header
 - Admin-only endpoints additionally use `Depends(require_admin)`
-- Unauthenticated endpoints: `/health`, `/auth/login`, `/auth/callback`, `/auth/logout`
+- Unauthenticated endpoints: `/health`, `/webhooks/clerk`
 - Swagger UI (`/api/docs`) is only available when `DEBUG=true`; disabled in production
 
 ---
@@ -86,19 +85,17 @@ Two networks are defined to limit the blast radius of any compromised service:
 
 | Service | Exposed to host | Networks | Notes |
 | --- | --- | --- | --- |
-| `frontend` (nginx) | **Yes** — port 3000 | public | Single user entry point; proxies `/api/`, `/auth/`, `/health` to backend |
-| `authentik-server` | **Yes** — port 9000 | public + internal | Browser redirects directly to it for OIDC authorization; admin UI |
+| `frontend` (nginx) | **Yes** — port 3000 | public | Single user entry point; proxies `/api/` and `/health` to backend |
 | `backend` | **No** | public + internal | Reached only through nginx; on internal to access db and redis |
 | `worker` | No | internal | Background jobs only; no inbound connections needed |
 | `db` | No | internal | Never reachable from host or public network |
 | `redis` | No | internal | Never reachable from host or public network |
-| `authentik-worker` | No | internal | Background jobs for Authentik only |
 
 ### Rationale
 
 - `db` and `redis` are on `internal` only — a compromise of the frontend or nginx container cannot directly reach the data tier
 - `backend` is not port-bound to the host — all traffic must pass through nginx, which enforces routing rules
-- `authentik-server` must be host-exposed because the browser is redirected to it directly during the OIDC authorization flow; this cannot be proxied through nginx without breaking the OIDC redirect URI
+- `backend` handles auth by validating Bearer tokens inline — no separate auth service needs host exposure
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -95,7 +95,7 @@ Before implementing any new feature:
 2. **Write tests** — add to `tests/routers/` or `tests/models/` as appropriate
 3. **Run tests** — confirm they fail (they should, feature not built yet)
 4. **Implement feature** — write code until all tests pass
-5. **Commit** — feature + tests together; update coverage estimate in this file and STATUS.md
+5. **Commit** — feature + tests together; update coverage estimate in this file
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` at repo root so Claude Code automatically picks up project instructions on any clone or path
- Remove hardcoded internal IP (`10.10.10.90`) from `hosting-decisions.md`
- Update all docs that still referenced Authentik, Gitea, invite-only registration, or old image names

## Changes

**New file — `CLAUDE.md`**
Consolidates project context, git workflow, CI/CD reference, dev rules (test-first, rebuild-both, pull-before-start), and PR workflow into a file that Claude Code auto-loads.

**`docs/deployment/hosting-decisions.md`**
- §2: remove stale Authentik RAM sizing caveat
- §5: remove internal IP from rationale; update image names to `weftmark-backend`/`weftmark-frontend`; replace Gitea-as-source-of-truth note with GitHub Actions CD description
- §6: mark Clerk as shipped; remove completed implementation checklist; update architectural note to reflect Bearer auth and admin-gated self-registration

**`docs/requirements/overview.md`**
- Auth section: Authentik → Clerk, cookie JWT → Bearer token, invite-only → admin-gated self-registration
- Service exposure table: remove `authentik-server` and `authentik-worker` rows
- API security section: update auth mechanism and unauthenticated endpoint list
- Rationale: replace Authentik-specific note with Clerk Bearer token note

**`docs/eula.md`**
- Remove "currently Google; Apple Sign In coming later" (provider-specific, constraining)
- Replace "invite-only" paragraph with neutral admin-approval language

**`docs/testing.md`**
- Remove stale `STATUS.md` reference from test-first commit step

## Test plan

_All items verified at time of merge._