### PR TITLE
chore: move traefik routing to orchestration repo override pattern

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,11 +61,6 @@ IMAGE_TAG=latest
 # Prod stack: STACK_NAME=weftmark
 STACK_NAME=weftmark
 
-# Full traefik Host() routing rule for the frontend container label.
-# Dev stack:  TRAEFIK_HOST_RULE=Host(`dev.weftmark.com`)
-# Prod stack: TRAEFIK_HOST_RULE=Host(`weftmark.com`) || Host(`www.weftmark.com`)
-TRAEFIK_HOST_RULE=
-
 # Host-side port for the local PostgreSQL container (local-db profile only).
 # Change if the default conflicts with another Postgres instance on the host.
 DB_HOST_PORT=5432

--- a/CLAUDE-orchestration.md
+++ b/CLAUDE-orchestration.md
@@ -1,0 +1,127 @@
+# WeftMark Orchestration Repo — Claude Instructions
+
+This repo contains Komodo stack definitions for the WeftMark platform. It follows a
+**base + override** pattern: the app's `docker-compose.yml` is pulled from the
+[weftmark/weftmark](https://github.com/weftmark/weftmark) repo and is infrastructure-agnostic.
+This repo layers Traefik routing on top via `docker-compose.override.yml` files.
+
+---
+
+## How the override pattern works
+
+Docker Compose automatically merges `docker-compose.yml` + `docker-compose.override.yml`
+when both are present in the same directory (or when passed with `-f`). Keys in the
+override are deep-merged on top of the base — the base file is never modified.
+
+Komodo points each stack at a directory containing both files. The base compose is
+fetched from the app repo (via Komodo's Git sync or a file reference); the override
+lives here in the orchestration repo.
+
+---
+
+## Stack structure
+
+Each stack gets a directory with two files:
+
+```
+stacks/
+  prod/
+    docker-compose.override.yml   ← Traefik labels + network for prod
+    .env                          ← stack env vars (gitignored — set secrets in Komodo UI)
+  dev/
+    docker-compose.override.yml   ← Traefik labels + network for dev
+    .env
+```
+
+---
+
+## Override file anatomy
+
+Every override file follows this template. Copy and adapt for a new stack:
+
+```yaml
+services:
+  frontend:
+    networks:
+      - traefik_proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.${STACK_NAME}.rule=${TRAEFIK_HOST_RULE}"
+      - "traefik.http.routers.${STACK_NAME}.entrypoints=websecure"
+      - "traefik.http.routers.${STACK_NAME}.tls.certresolver=cloudflare"
+      - "traefik.http.services.${STACK_NAME}.loadbalancer.server.port=80"
+
+networks:
+  traefik_proxy:
+    external: true
+    name: traefik_proxy
+```
+
+**Required env vars** (set in Komodo stack environment or the stack's `.env`):
+
+| Variable | Example (prod) | Example (dev) |
+|---|---|---|
+| `STACK_NAME` | `weftmark` | `weftmark-dev` |
+| `TRAEFIK_HOST_RULE` | `Host(\`weftmark.com\`) \|\| Host(\`www.weftmark.com\`)` | `Host(\`dev.weftmark.com\`)` |
+| `IMAGE_TAG` | `latest` | `dev` |
+
+`STACK_NAME` is also used by the base compose for container names, network names, and
+volume names — keep it unique per stack so prod and dev can coexist on the same host.
+
+---
+
+## Existing stacks
+
+### prod (`stacks/prod/`)
+- **URL:** `weftmark.com`, `www.weftmark.com`
+- **Image tag:** `latest`
+- **Stack name:** `weftmark`
+- **Backend env:** managed via Komodo secrets (Neon Postgres, Cloudflare R2, Clerk live keys)
+
+### dev (`stacks/dev/`)
+- **URL:** `dev.weftmark.com`
+- **Image tag:** `dev`
+- **Stack name:** `weftmark-dev`
+- **Backend env:** managed via Komodo secrets (Neon Postgres dev branch, R2 dev bucket, Clerk test keys)
+
+---
+
+## Adding a new stack
+
+1. Create `stacks/<name>/docker-compose.override.yml` from the template above.
+2. Set `STACK_NAME` to a unique value — it prefixes all container/network/volume names.
+3. Set `TRAEFIK_HOST_RULE` to the full Traefik `Host()` expression for the domain.
+4. Add the stack in Komodo pointing at this repo + the app repo's `docker-compose.yml`.
+5. Configure secrets in the Komodo UI (never commit real `.env` files).
+
+---
+
+## Modifying Traefik routing
+
+To change a hostname, add middleware, or adjust TLS config, edit the relevant
+`docker-compose.override.yml`. All Traefik label changes take effect on the next
+`docker compose up` / Komodo redeploy — Traefik watches for label changes via the
+Docker provider and hot-reloads without downtime.
+
+Common label additions:
+
+```yaml
+# Redirect www → apex
+- "traefik.http.middlewares.www-redirect.redirectregex.regex=^https://www\\.(.+)"
+- "traefik.http.middlewares.www-redirect.redirectregex.replacement=https://$${1}"
+- "traefik.http.routers.weftmark.middlewares=www-redirect"
+
+# Rate limiting
+- "traefik.http.middlewares.ratelimit.ratelimit.average=100"
+- "traefik.http.routers.weftmark.middlewares=ratelimit"
+```
+
+---
+
+## What NOT to change here
+
+- Application config (env vars for Postgres, Clerk, Redis, S3) — those belong in the
+  Komodo stack environment or the app repo's `.env.example`.
+- The Traefik daemon config (`traefik.yml`, `dynamic.yml`, ACME storage) — those live
+  in the `traefik/` stack if one exists in this repo, or on the host directly.
+- Image build definitions — those are in the app repo's `docker-compose.build.yml`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,22 +2,15 @@ services:
 
   # ----------------------------------------------------------
   # Frontend — React application served via nginx
-  # Entry point for all user traffic; traefik routes to it via
-  # the traefik_proxy network.  Proxies /api/, /auth/, and
-  # /health to the backend over the internal public network.
+  # Proxies /api/, /auth/, and /health to the backend over the
+  # public network.  Traefik routing is added via override file
+  # in the orchestration repo (docker-compose.override.yml).
   # ----------------------------------------------------------
   frontend:
     image: ghcr.io/weftmark/weftmark-frontend:${IMAGE_TAG:-latest}
     container_name: ${STACK_NAME:-weftmark}_frontend
     networks:
-      - traefik_proxy
       - public
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.${STACK_NAME:-weftmark}.rule=${TRAEFIK_HOST_RULE}"
-      - "traefik.http.routers.${STACK_NAME:-weftmark}.entrypoints=websecure"
-      - "traefik.http.routers.${STACK_NAME:-weftmark}.tls.certresolver=cloudflare"
-      - "traefik.http.services.${STACK_NAME:-weftmark}.loadbalancer.server.port=80"
     depends_on:
       backend:
         condition: service_healthy
@@ -120,9 +113,6 @@ services:
     restart: unless-stopped
 
 networks:
-  traefik_proxy:
-    external: true
-    name: traefik_proxy
   public:
     name: ${STACK_NAME:-weftmark}_public
     driver: bridge


### PR DESCRIPTION
## Summary

- Removes Traefik labels and `traefik_proxy` network declaration from `docker-compose.yml` so the app compose is infrastructure-agnostic
- `TRAEFIK_HOST_RULE` removed from `.env.example` — it now belongs exclusively in the orchestration repo
- Adds `CLAUDE-orchestration.md`: a drop-in instruction set for the orchestration repo covering the override pattern, stack structure, required env vars, and how to add or modify stacks

Traefik wiring (`labels`, `traefik_proxy` network) moves to `docker-compose.override.yml` files managed in the Komodo orchestration repo. Docker Compose auto-merges the two files; Komodo deploys them together from a directory. The orchestration repo is version-controlled, so routing config changes are auditable.

## Test plan

_Migrated to QA issue #198._