### PR TITLE
feat: dev clean-start via Komodo Stack action

### DIFF
--- a/backend/alembic/versions/0032_seed_runs.py
+++ b/backend/alembic/versions/0032_seed_runs.py
@@ -1,0 +1,28 @@
+"""Add seed_runs table for dev clean-start tracking.
+
+Revision ID: 0032
+Revises: 0031
+Create Date: 2026-05-01
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0032"
+down_revision = "0031"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "seed_runs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("ran_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("seed_runs")

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -12,14 +12,16 @@ import json
 import shutil
 import sys
 import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 import httpx
-from sqlalchemy import func, select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from app.config import get_settings
+from app.models.seed_run import SeedRun
 from app.models.user import User
 from app.services.clerk import set_user_metadata
 
@@ -60,6 +62,24 @@ async def _clerk_list_users(secret_key: str, limit: int = 2) -> list[dict]:
         )
         r.raise_for_status()
         return r.json()
+
+
+async def _clerk_delete_all_users(secret_key: str) -> int:
+    """Delete every user from the Clerk instance. Returns count deleted."""
+    deleted = 0
+    headers = {"Authorization": f"Bearer {secret_key}"}
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        while True:
+            r = await client.get(f"{_BASE}/users", headers=headers, params={"limit": 100})
+            r.raise_for_status()
+            users = r.json()
+            if not users:
+                break
+            for user in users:
+                d = await client.delete(f"{_BASE}/users/{user['id']}", headers=headers)
+                d.raise_for_status()
+                deleted += 1
+    return deleted
 
 
 async def _clerk_create_user(secret_key: str, email: str, username: str, password: str, display_name: str) -> dict:
@@ -190,29 +210,26 @@ async def cmd_seed(config_path: str, poll_timeout: int) -> None:
         sys.exit(1)
 
     try:
-        existing_clerk = await _clerk_list_users(settings.clerk_secret_key)
+        existing_clerk = await _clerk_list_users(settings.clerk_secret_key, limit=1)
+        user_word = "user" if len(existing_clerk) == 1 else "users"
+        count_str = (
+            f"{len(existing_clerk)} existing {user_word} — will be deleted" if existing_clerk else "0 existing users"
+        )
+        _ok(f"Clerk reachable ({count_str})")
     except Exception as exc:
         _err(f"Clerk API unreachable: {exc}")
         sys.exit(1)
-    if existing_clerk:
-        _err("Clerk already has users — aborting (use a clean Clerk instance)")
-        sys.exit(1)
-    _ok("Clerk has 0 users")
 
     engine = create_async_engine(settings.database_url, echo=False)
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
     try:
         async with session_factory() as session:
-            count = await session.scalar(select(func.count()).select_from(User))
+            await session.execute(text("SELECT 1"))
     except Exception as exc:
         _err(f"DB unreachable: {exc}")
         await engine.dispose()
         sys.exit(1)
-    if count:
-        _err(f"DB users table has {count} existing rows — aborting")
-        await engine.dispose()
-        sys.exit(1)
-    _ok("DB users table has 0 rows")
+    _ok("DB reachable")
 
     # ── Load config ────────────────────────────────────────────────────────
     config_file = Path(config_path)
@@ -237,6 +254,13 @@ async def cmd_seed(config_path: str, poll_timeout: int) -> None:
     _section("Reset")
 
     await engine.dispose()
+
+    try:
+        deleted_count = await _clerk_delete_all_users(settings.clerk_secret_key)
+        _ok(f"Clerk: deleted {deleted_count} user(s)")
+    except Exception as exc:
+        _err(f"Clerk user deletion failed: {exc}")
+        sys.exit(1)
 
     try:
         _alembic_reset()
@@ -312,6 +336,11 @@ async def cmd_seed(config_path: str, poll_timeout: int) -> None:
         if auto_password:
             generated_passwords.append((email, password))
 
+    # ── Record seed run ────────────────────────────────────────────────────
+    async with session_factory() as session:
+        await session.merge(SeedRun(id=1, ran_at=datetime.now(timezone.utc)))
+        await session.commit()
+
     await engine.dispose()
 
     # ── Summary ────────────────────────────────────────────────────────────
@@ -332,7 +361,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(prog="python -m app.cli")
     sub = parser.add_subparsers(dest="command", required=True)
 
-    seed_p = sub.add_parser("seed", help="Bootstrap a fresh WeftMark instance")
+    seed_p = sub.add_parser("seed", help="Wipe and reseed a dev WeftMark instance")
     seed_p.add_argument(
         "--config",
         default="seed.json",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.config import get_settings
 from app.logging_config import configure_logging
 from app.middleware import SecurityHeadersMiddleware
-from app.routers import activities, admin, auth, health, logs, looms, projects, users, yarn
+from app.routers import activities, admin, auth, dev, health, logs, looms, projects, users, yarn
 from app.version import VERSION
 
 settings = get_settings()
@@ -53,6 +53,8 @@ app.add_middleware(
 
 app.include_router(health.router)
 app.include_router(logs.router)
+if settings.app_env == "dev":
+    app.include_router(dev.router)
 app.include_router(auth.router)
 app.include_router(users.eula_router)
 app.include_router(users.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -12,6 +12,7 @@ from app.models.loom import (
 )
 from app.models.pending_signup import PendingSignup
 from app.models.project import Project
+from app.models.seed_run import SeedRun
 from app.models.user import User
 from app.models.user_identity import UserIdentity
 from app.models.yarn import Skein, Yarn
@@ -24,6 +25,7 @@ __all__ = [
     "Invite",
     "PendingSignup",
     "Project",
+    "SeedRun",
     "Loom",
     "LoomVersion",
     "LoomVersionPhoto",

--- a/backend/app/models/seed_run.py
+++ b/backend/app/models/seed_run.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class SeedRun(Base):
+    __tablename__ = "seed_runs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    ran_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/backend/app/routers/dev.py
+++ b/backend/app/routers/dev.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.deps import get_db
+from app.models.seed_run import SeedRun
+
+router = APIRouter(prefix="/dev", tags=["dev"])
+
+
+@router.get("/status")
+async def dev_status(db: AsyncSession = Depends(get_db)) -> dict:
+    seed_run = await db.get(SeedRun, 1)
+    return {"last_seed": seed_run.ran_at.isoformat() if seed_run else None}

--- a/backend/tests/routers/test_dev.py
+++ b/backend/tests/routers/test_dev.py
@@ -1,0 +1,40 @@
+"""Tests for GET /dev/status."""
+
+from datetime import datetime, timezone
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.seed_run import SeedRun
+
+
+class TestDevStatus:
+    async def test_returns_200(self, client: AsyncClient):
+        resp = await client.get("/dev/status")
+        assert resp.status_code == 200
+
+    async def test_last_seed_is_null_when_no_run(self, client: AsyncClient):
+        resp = await client.get("/dev/status")
+        assert resp.json()["last_seed"] is None
+
+    async def test_last_seed_returned_after_seed_run(self, client: AsyncClient, db_session: AsyncSession):
+        ran_at = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+        db_session.add(SeedRun(id=1, ran_at=ran_at))
+        await db_session.commit()
+
+        resp = await client.get("/dev/status")
+        assert resp.status_code == 200
+        assert resp.json()["last_seed"] == ran_at.isoformat()
+
+    async def test_last_seed_updates_on_reseed(self, client: AsyncClient, db_session: AsyncSession):
+        first = datetime(2026, 4, 1, 0, 0, 0, tzinfo=timezone.utc)
+        second = datetime(2026, 5, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+        db_session.add(SeedRun(id=1, ran_at=first))
+        await db_session.commit()
+
+        await db_session.merge(SeedRun(id=1, ran_at=second))
+        await db_session.commit()
+
+        resp = await client.get("/dev/status")
+        assert resp.json()["last_seed"] == second.isoformat()

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -26,12 +26,13 @@ def _make_settings(**overrides):
     return s
 
 
-def _make_session_factory(scalar_return=0):
+def _make_session_factory():
     session = AsyncMock()
     session.__aenter__ = AsyncMock(return_value=session)
     session.__aexit__ = AsyncMock(return_value=False)
-    session.scalar = AsyncMock(return_value=scalar_return)
+    session.execute = AsyncMock()
     session.commit = AsyncMock()
+    session.merge = AsyncMock()
     factory = MagicMock(return_value=session)
     return factory, session
 
@@ -82,22 +83,6 @@ async def test_seed_aborts_when_no_clerk_key(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Precheck: Clerk already has users
-# ---------------------------------------------------------------------------
-
-
-async def test_seed_aborts_when_clerk_has_users(tmp_path):
-    settings = _make_settings()
-    with (
-        patch("app.cli.get_settings", return_value=settings),
-        patch("app.cli._clerk_list_users", AsyncMock(return_value=[{"id": "user_abc"}])),
-    ):
-        with pytest.raises(SystemExit) as exc_info:
-            await cmd_seed(str(tmp_path / "seed.json"), 5)
-    assert exc_info.value.code == 1
-
-
-# ---------------------------------------------------------------------------
 # Precheck: Clerk API unreachable
 # ---------------------------------------------------------------------------
 
@@ -114,6 +99,28 @@ async def test_seed_aborts_when_clerk_unreachable(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Precheck: Clerk has existing users — proceeds, does not abort
+# ---------------------------------------------------------------------------
+
+
+async def test_seed_proceeds_when_clerk_has_users(tmp_path):
+    """Existing Clerk users are no longer a reason to abort — they get deleted."""
+    settings = _make_settings()
+    factory, _ = _make_session_factory()
+
+    with (
+        patch("app.cli.get_settings", return_value=settings),
+        patch("app.cli._clerk_list_users", AsyncMock(return_value=[{"id": "user_abc"}])),
+        patch("app.cli.create_async_engine", return_value=_make_engine()),
+        patch("app.cli.async_sessionmaker", return_value=factory),
+    ):
+        # Should exit on missing config, not on Clerk having users
+        with pytest.raises(SystemExit) as exc_info:
+            await cmd_seed(str(tmp_path / "nonexistent.json"), 5)
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
 # Precheck: DB unreachable
 # ---------------------------------------------------------------------------
 
@@ -123,28 +130,8 @@ async def test_seed_aborts_when_db_unreachable(tmp_path):
     session = AsyncMock()
     session.__aenter__ = AsyncMock(return_value=session)
     session.__aexit__ = AsyncMock(return_value=False)
-    session.scalar = AsyncMock(side_effect=Exception("db down"))
+    session.execute = AsyncMock(side_effect=Exception("db down"))
     factory = MagicMock(return_value=session)
-
-    with (
-        patch("app.cli.get_settings", return_value=settings),
-        patch("app.cli._clerk_list_users", AsyncMock(return_value=[])),
-        patch("app.cli.create_async_engine", return_value=_make_engine()),
-        patch("app.cli.async_sessionmaker", return_value=factory),
-    ):
-        with pytest.raises(SystemExit) as exc_info:
-            await cmd_seed(str(tmp_path / "seed.json"), 5)
-    assert exc_info.value.code == 1
-
-
-# ---------------------------------------------------------------------------
-# Precheck: DB already has rows
-# ---------------------------------------------------------------------------
-
-
-async def test_seed_aborts_when_db_has_rows(tmp_path):
-    settings = _make_settings()
-    factory, _ = _make_session_factory(scalar_return=3)
 
     with (
         patch("app.cli.get_settings", return_value=settings),
@@ -164,7 +151,7 @@ async def test_seed_aborts_when_db_has_rows(tmp_path):
 
 async def test_seed_aborts_when_config_missing(tmp_path):
     settings = _make_settings()
-    factory, _ = _make_session_factory(scalar_return=0)
+    factory, _ = _make_session_factory()
 
     with (
         patch("app.cli.get_settings", return_value=settings),
@@ -184,13 +171,71 @@ async def test_seed_aborts_when_config_missing(tmp_path):
 
 async def test_seed_aborts_when_no_users_in_config(tmp_path):
     settings = _make_settings()
-    factory, _ = _make_session_factory(scalar_return=0)
+    factory, _ = _make_session_factory()
     config = tmp_path / "seed.json"
     config.write_text(json.dumps({"users": []}))
 
     with (
         patch("app.cli.get_settings", return_value=settings),
         patch("app.cli._clerk_list_users", AsyncMock(return_value=[])),
+        patch("app.cli.create_async_engine", return_value=_make_engine()),
+        patch("app.cli.async_sessionmaker", return_value=factory),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            await cmd_seed(str(config), 5)
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Reset: Clerk deletion is called before Alembic
+# ---------------------------------------------------------------------------
+
+
+async def test_seed_deletes_clerk_users_before_alembic(tmp_path):
+    """_clerk_delete_all_users must be called in the Reset phase."""
+    settings = _make_settings()
+    factory, session = _make_session_factory()
+    config = tmp_path / "seed.json"
+    config.write_text(json.dumps({"users": [{"email": "a@b.com", "username": "a", "role": "user"}]}))
+
+    delete_mock = AsyncMock(return_value=3)
+    mock_db_user = MagicMock()
+    mock_db_user.id = 1
+    session.scalar = AsyncMock(return_value=mock_db_user)
+    session.get = AsyncMock(return_value=MagicMock(is_admin=False, is_superuser=False))
+
+    with (
+        patch("app.cli.get_settings", return_value=settings),
+        patch("app.cli._clerk_list_users", AsyncMock(return_value=[{"id": "u1"}, {"id": "u2"}, {"id": "u3"}])),
+        patch("app.cli._clerk_delete_all_users", delete_mock),
+        patch("app.cli.create_async_engine", return_value=_make_engine()),
+        patch("app.cli.async_sessionmaker", return_value=factory),
+        patch("app.cli._alembic_reset"),
+        patch("app.cli._clear_storage"),
+        patch("app.cli._clerk_create_user", AsyncMock(return_value={"id": "user_new"})),
+        patch("app.cli._poll_db_for_user", AsyncMock(return_value=mock_db_user)),
+        patch("app.cli.set_user_metadata", AsyncMock()),
+    ):
+        await cmd_seed(str(config), 5)
+
+    delete_mock.assert_awaited_once_with(settings.clerk_secret_key)
+
+
+# ---------------------------------------------------------------------------
+# Reset: Clerk deletion failure aborts
+# ---------------------------------------------------------------------------
+
+
+async def test_seed_aborts_when_clerk_delete_fails(tmp_path):
+    settings = _make_settings()
+    factory, _ = _make_session_factory()
+    config = tmp_path / "seed.json"
+    config.write_text(json.dumps({"users": [{"email": "a@b.com", "username": "a"}]}))
+
+    with (
+        patch("app.cli.get_settings", return_value=settings),
+        patch("app.cli._clerk_list_users", AsyncMock(return_value=[])),
+        patch("app.cli._clerk_delete_all_users", AsyncMock(side_effect=Exception("clerk error"))),
         patch("app.cli.create_async_engine", return_value=_make_engine()),
         patch("app.cli.async_sessionmaker", return_value=factory),
     ):


### PR DESCRIPTION
Closes #182.

## Summary

- **CLI flipped to wipe-and-reseed** — existing Clerk users are deleted (not an abort condition); DB checked for connectivity only (`SELECT 1`)
- **`_clerk_delete_all_users()`** — new paginated deletion function; runs as the first destructive step in Reset (before Alembic) so Clerk and DB are wiped in order
- **Seed run timestamp** — upserts a `SeedRun(id=1)` record after successful seed; `GET /dev/status` exposes `{"last_seed": "<iso>"}` for the dev banner
- **Migration 0032** — creates the `seed_runs` table
- **`GET /dev/status`** — registered only when `APP_ENV=dev`; no auth required

Safety guards retained: `APP_ENV=dev` hard abort, `SEED_ENABLED=true` env var gate.

## Out of scope
- Frontend banner wiring (follow-up PR once endpoint is live in dev)
- SSO user seeding
- Issue #131 dev seed endpoint

## Test plan

_Migrated to QA issue #198._