### PR TITLE
feat: block app when no superuser exists

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.config import get_settings
 from app.logging_config import configure_logging
 from app.middleware import SecurityHeadersMiddleware
-from app.routers import activities, admin, auth, dev, health, logs, looms, projects, users, yarn
+from app.routers import activities, admin, auth, dev, health, logs, looms, projects, system, users, yarn
 from app.version import VERSION
 
 settings = get_settings()
@@ -52,6 +52,7 @@ app.add_middleware(
 )
 
 app.include_router(health.router)
+app.include_router(system.router)
 app.include_router(logs.router)
 if settings.app_env == "dev":
     app.include_router(dev.router)

--- a/backend/app/routers/system.py
+++ b/backend/app/routers/system.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.deps import get_db
+from app.models.user import User
+
+router = APIRouter(prefix="/system", tags=["system"])
+
+
+@router.get("/status")
+async def system_status(db: AsyncSession = Depends(get_db)) -> dict:
+    count = await db.scalar(select(func.count()).select_from(User).where(User.is_superuser.is_(True)))
+    return {"initialized": (count or 0) > 0}

--- a/backend/tests/routers/test_system.py
+++ b/backend/tests/routers/test_system.py
@@ -1,0 +1,35 @@
+"""Tests for GET /system/status."""
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import User
+
+
+class TestSystemStatus:
+    async def test_returns_200(self, client: AsyncClient):
+        resp = await client.get("/system/status")
+        assert resp.status_code == 200
+
+    async def test_not_initialized_when_no_superuser(self, client: AsyncClient):
+        resp = await client.get("/system/status")
+        assert resp.json() == {"initialized": False}
+
+    async def test_not_initialized_when_only_admin(self, client: AsyncClient, db_session: AsyncSession):
+        db_session.add(User(email="admin@example.com", display_name="Admin", is_admin=True, is_superuser=False))
+        await db_session.commit()
+
+        resp = await client.get("/system/status")
+        assert resp.json() == {"initialized": False}
+
+    async def test_initialized_when_superuser_exists(self, client: AsyncClient, db_session: AsyncSession):
+        db_session.add(User(email="su@example.com", display_name="Super", is_admin=True, is_superuser=True))
+        await db_session.commit()
+
+        resp = await client.get("/system/status")
+        assert resp.json() == {"initialized": True}
+
+    async def test_no_auth_required(self, client: AsyncClient):
+        resp = await client.get("/system/status")
+        assert resp.status_code != 401
+        assert resp.status_code != 403

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ import { SignOutPage } from "@/pages/SignOutPage";
 import { UnauthorizedPage } from "@/pages/UnauthorizedPage";
 import { DevBanner } from "@/components/DevBanner";
 import { ServiceHealthBanner } from "@/components/ServiceHealthBanner";
+import { SystemGate } from "@/components/SystemGate";
 import { useAuth } from "@/hooks/useAuth";
 
 const CLERK_PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string;
@@ -52,6 +53,7 @@ export default function App() {
   return (
     <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY} afterSignOutUrl="/sign-out">
       <VersionGate>
+        <SystemGate>
         <QueryClientProvider client={queryClient}>
           <AuthProvider>
             <BrowserRouter>
@@ -160,6 +162,7 @@ export default function App() {
             </BrowserRouter>
           </AuthProvider>
         </QueryClientProvider>
+        </SystemGate>
       </VersionGate>
     </ClerkProvider>
   );

--- a/frontend/src/components/SystemGate.tsx
+++ b/frontend/src/components/SystemGate.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+import { UninitializedPage } from "@/pages/UninitializedPage";
+
+type Status = "loading" | "initialized" | "uninitialized" | "unreachable";
+
+export function SystemGate({ children }: { children: React.ReactNode }) {
+  const [status, setStatus] = useState<Status>("loading");
+
+  useEffect(() => {
+    fetch("/system/status")
+      .then((res) => res.json())
+      .then((data: { initialized: boolean }) => {
+        setStatus(data.initialized ? "initialized" : "uninitialized");
+      })
+      .catch(() => setStatus("unreachable"));
+  }, []);
+
+  if (status === "loading") return null;
+  if (status === "uninitialized") return <UninitializedPage />;
+  return <>{children}</>;
+}

--- a/frontend/src/pages/UninitializedPage.tsx
+++ b/frontend/src/pages/UninitializedPage.tsx
@@ -1,0 +1,17 @@
+export function UninitializedPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background">
+      <div className="w-full max-w-sm space-y-6 px-4 text-center">
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold tracking-tight">System Not Initialized</h1>
+          <p className="text-sm text-muted-foreground">
+            No administrator account has been configured. Run the seed command on the server to initialize the system.
+          </p>
+        </div>
+        <div className="rounded-md bg-muted px-4 py-3 text-left font-mono text-xs text-muted-foreground">
+          docker compose exec backend python -m app.cli seed
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `GET /system/status` (public, no auth) returning `{"initialized": bool}` — `false` when no `is_superuser` row exists in the DB
- `SystemGate` component fetches this on app load and renders `UninitializedPage` if the system has not been seeded
- `UninitializedPage` displays the seed CLI command so an operator knows what to run
- If the endpoint is unreachable, the gate passes through (VersionGate already handles backend unavailability)

Closes #184

## Test plan

_Migrated to QA issue #195._