### PR TITLE
fix: add verification labels to custom auth pages

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -50,6 +50,7 @@ export function LoginPage() {
         <div className="space-y-2 text-center">
           <h1 className="text-2xl font-semibold tracking-tight">WeftMark</h1>
           <p className="text-sm text-muted-foreground">Sign in to continue</p>
+          <p className="text-xs text-amber-500 font-mono">WeftMark custom login page — not Clerk hosted</p>
         </div>
         <SignIn
           routing="hash"

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -7,6 +7,7 @@ export function RegisterPage() {
         <div className="space-y-2 text-center">
           <h1 className="text-2xl font-semibold tracking-tight">WeftMark</h1>
           <p className="text-sm text-muted-foreground">Create your account</p>
+          <p className="text-xs text-amber-500 font-mono">WeftMark custom register page — not Clerk hosted</p>
         </div>
         <SignUp
           routing="hash"


### PR DESCRIPTION
## Summary

Adds a small amber monospace line to `/login` and `/register` confirming the user is on the WeftMark custom page and not Clerk's hosted account portal.

This is a temporary verification aid — remove the labels once confirmed working on `dev.weftmark.com` (tracked in #189).

## Test plan

_Migrated to QA issue #195._