### PR TITLE
feat: inject Clerk publishable key at runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,7 +96,8 @@ POSTGRES_PASSWORD=
 # All three values are found under "API Keys" in your Clerk dashboard.
 # ------------------------------------------------------------
 
-# Publishable key — safe to expose in the browser (pk_test_... or pk_live_...)
+# Publishable key — injected into the frontend container at runtime (not baked into the image).
+# Local Vite dev also needs VITE_CLERK_PUBLISHABLE_KEY set to the same value (see below).
 CLERK_PUBLISHABLE_KEY=
 
 # Secret key — backend only, never expose to the browser (sk_test_... or sk_live_...)
@@ -120,6 +121,10 @@ VITE_CLERK_SIGN_IN_URL=/login
 VITE_CLERK_SIGN_UP_URL=/register
 VITE_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/home
 VITE_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL=/home
+
+# Local Vite dev only — same value as CLERK_PUBLISHABLE_KEY above.
+# The Docker container reads CLERK_PUBLISHABLE_KEY at runtime instead.
+VITE_CLERK_PUBLISHABLE_KEY=
 
 
 # ------------------------------------------------------------

--- a/.github/workflows/ci-main-push.yml
+++ b/.github/workflows/ci-main-push.yml
@@ -24,7 +24,7 @@ name: Main push
 # Required secrets:
 #   WEFTMARK_BOT_CLIENT_ID        — GitHub App client ID
 #   WEFTMARK_BOT_PRIVATE_KEY      — GitHub App private key
-#   CLERK_PUBLISHABLE_KEY_PROD    — Clerk publishable key (baked into frontend image)
+#   CLERK_PUBLISHABLE_KEY_PROD secret is no longer required — key is injected at runtime
 
 on:
   push:
@@ -217,7 +217,6 @@ jobs:
       - name: Build and push frontend image
         run: |
           docker build -f frontend/Dockerfile \
-            --build-arg VITE_CLERK_PUBLISHABLE_KEY="${{ secrets.CLERK_PUBLISHABLE_KEY_PROD }}" \
             --build-arg VITE_APP_ENV="production" \
             -t ghcr.io/weftmark/weftmark-frontend:${{ steps.version.outputs.version }} \
             -t ghcr.io/weftmark/weftmark-frontend:latest \

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -5,7 +5,7 @@ name: Publish Dev Images
 # branch this workflow is dispatched from.
 #
 # Required secrets:
-#   CLERK_PUBLISHABLE_KEY_DEV — Clerk publishable key for dev/test (baked into frontend image at build time)
+#   CLERK_PUBLISHABLE_KEY_DEV secret is no longer required — key is injected at runtime
 
 on:
   workflow_dispatch:
@@ -66,7 +66,6 @@ jobs:
       - name: Build and push frontend image
         run: |
           docker build -f frontend/Dockerfile \
-            --build-arg VITE_CLERK_PUBLISHABLE_KEY="${{ secrets.CLERK_PUBLISHABLE_KEY_DEV }}" \
             --build-arg VITE_APP_ENV="dev" \
             -t ghcr.io/weftmark/weftmark-frontend:${{ steps.version.outputs.version }}-dev \
             -t ghcr.io/weftmark/weftmark-frontend:dev \

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -11,13 +11,14 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
       args:
-        VITE_CLERK_PUBLISHABLE_KEY: ${CLERK_PUBLISHABLE_KEY:-}
         VITE_APP_ENV: ${APP_ENV:-dev}
         VITE_CLERK_SIGN_IN_URL: /login
         VITE_CLERK_SIGN_UP_URL: /register
         VITE_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL: /home
         VITE_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL: /home
     image: weaving_site_frontend:${APP_VERSION:-dev}
+    environment:
+      CLERK_PUBLISHABLE_KEY: ${CLERK_PUBLISHABLE_KEY:-}
     container_name: weaving_site_frontend
     ports:
       - "127.0.0.1:3000:80"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,16 +4,16 @@ COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
 
-# Vite bakes VITE_* vars at build time — pass them as build args
+# Vite bakes VITE_* vars at build time — pass them as build args.
+# CLERK_PUBLISHABLE_KEY is intentionally excluded here; it is injected
+# at container startup via docker-entrypoint.sh so the image is key-agnostic.
 ARG VITE_API_URL=""
-ARG VITE_CLERK_PUBLISHABLE_KEY=""
 ARG VITE_APP_ENV="dev"
 ARG VITE_CLERK_SIGN_IN_URL="/login"
 ARG VITE_CLERK_SIGN_UP_URL="/register"
 ARG VITE_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL="/home"
 ARG VITE_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL="/home"
 ENV VITE_API_URL=$VITE_API_URL
-ENV VITE_CLERK_PUBLISHABLE_KEY=$VITE_CLERK_PUBLISHABLE_KEY
 ENV VITE_APP_ENV=$VITE_APP_ENV
 ENV VITE_CLERK_SIGN_IN_URL=$VITE_CLERK_SIGN_IN_URL
 ENV VITE_CLERK_SIGN_UP_URL=$VITE_CLERK_SIGN_UP_URL
@@ -25,3 +25,6 @@ RUN npm run build
 FROM nginx:alpine
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+printf 'window.ENV = { CLERK_PUBLISHABLE_KEY: "%s" };\n' "${CLERK_PUBLISHABLE_KEY}" \
+  > /usr/share/nginx/html/env-config.js
+exec nginx -g 'daemon off;'

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>WeftMark</title>
+    <script src="/env-config.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/public/env-config.js
+++ b/frontend/public/env-config.js
@@ -1,0 +1,5 @@
+// Overwritten at container startup by docker-entrypoint.sh
+// In local dev (vite dev), VITE_CLERK_PUBLISHABLE_KEY is used as fallback
+window.ENV = {
+  CLERK_PUBLISHABLE_KEY: "",
+};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,9 +26,8 @@ import { UnauthorizedPage } from "@/pages/UnauthorizedPage";
 import { DevBanner } from "@/components/DevBanner";
 import { ServiceHealthBanner } from "@/components/ServiceHealthBanner";
 import { SystemGate } from "@/components/SystemGate";
+import { clerkPublishableKey, clerkKeyMissing } from "@/lib/env";
 import { useAuth } from "@/hooks/useAuth";
-
-const CLERK_PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string;
 
 function RootRoute() {
   const { isAuthenticated, isLoading } = useAuth();
@@ -50,8 +49,21 @@ const queryClient = new QueryClient({
 });
 
 export default function App() {
+  if (clerkKeyMissing) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <div className="w-full max-w-sm space-y-4 px-4 text-center">
+          <h1 className="text-2xl font-semibold tracking-tight">Configuration Error</h1>
+          <p className="text-sm text-muted-foreground">
+            CLERK_PUBLISHABLE_KEY is not set. Set it in the container environment and restart.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY} afterSignOutUrl="/sign-out">
+    <ClerkProvider publishableKey={clerkPublishableKey} afterSignOutUrl="/sign-out">
       <VersionGate>
         <SystemGate>
         <QueryClientProvider client={queryClient}>

--- a/frontend/src/lib/env.ts
+++ b/frontend/src/lib/env.ts
@@ -1,0 +1,12 @@
+declare global {
+  interface Window {
+    ENV?: {
+      CLERK_PUBLISHABLE_KEY?: string;
+    };
+  }
+}
+
+export const clerkPublishableKey: string =
+  window.ENV?.CLERK_PUBLISHABLE_KEY || import.meta.env.VITE_CLERK_PUBLISHABLE_KEY || "";
+
+export const clerkKeyMissing = !clerkPublishableKey;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -19,6 +19,8 @@ export default defineConfig({
       "/auth": "http://localhost:8000",
       "/api": "http://localhost:8000",
       "/health": "http://localhost:8000",
+      "/system": "http://localhost:8000",
+      "/dev": "http://localhost:8000",
     },
   },
 });


### PR DESCRIPTION
## Summary

Closes #87.

`CLERK_PUBLISHABLE_KEY` is no longer baked into the frontend image at build time. The same image now works across environments — the key is injected at container startup.

**How it works:**
1. `docker-entrypoint.sh` runs at container start, writes `CLERK_PUBLISHABLE_KEY` from the environment into `/usr/share/nginx/html/env-config.js`
2. `index.html` loads `/env-config.js` before the app bundle, populating `window.ENV`
3. `src/lib/env.ts` reads `window.ENV.CLERK_PUBLISHABLE_KEY` with fallback to `VITE_CLERK_PUBLISHABLE_KEY` for local `vite dev`
4. `public/env-config.js` (empty default) prevents a 404 in local dev

**Error handling:** If `CLERK_PUBLISHABLE_KEY` is not set, the app renders a clear "Configuration Error" page rather than crashing silently.

**Also fixed:** Added `/system` and `/dev` to the Vite dev proxy so those routes work during local development.

## Breaking change for deployments

The frontend container now requires `CLERK_PUBLISHABLE_KEY` passed as a runtime environment variable. The `CLERK_PUBLISHABLE_KEY_PROD` and `CLERK_PUBLISHABLE_KEY_DEV` GitHub secrets are no longer used in CI builds.

## Test plan

_Migrated to QA issue #195._