### PR TITLE
feat: auto-open consolidated QA issue on dev publish

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -1,8 +1,8 @@
 name: Publish Dev Images
 
-# Manual trigger only — publishes :{version}-dev and :dev tags to ghcr.io.
-# Always reads VERSION and builds from the dev branch regardless of which
-# branch this workflow is dispatched from.
+# Manual trigger only — publishes :{version}-dev and :dev tags to ghcr.io,
+# then opens a QA issue consolidating the test plans from all PRs merged
+# since the previous dev tag.
 #
 # Required secrets:
 #   CLERK_PUBLISHABLE_KEY_DEV secret is no longer required — key is injected at runtime
@@ -72,3 +72,118 @@ jobs:
             ./frontend
           docker push ghcr.io/weftmark/weftmark-frontend:${{ steps.version.outputs.version }}-dev
           docker push ghcr.io/weftmark/weftmark-frontend:dev
+
+  open-qa-issue:
+    name: Open QA issue
+    runs-on: ubuntu-latest
+    needs: [publish-backend, publish-frontend]
+    permissions:
+      issues: write
+      contents: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Read version
+        id: version
+        run: echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
+
+      - name: Build QA issue body
+        id: qa
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          REPO: ${{ github.repository }}
+        run: |
+          python3 - << 'PYEOF'
+          import subprocess, json, re, os
+
+          version = os.environ["VERSION"]
+          repo = os.environ["REPO"]
+          current_tag = f"v{version}-dev"
+
+          # All dev tags sorted oldest → newest
+          tags = subprocess.run(
+              ["git", "tag", "--list", "v*-dev", "--sort=version:refname"],
+              capture_output=True, text=True,
+          ).stdout.strip().splitlines()
+          tags = [t for t in tags if t]
+
+          prev_tag = None
+          for i, tag in enumerate(tags):
+              if tag == current_tag and i > 0:
+                  prev_tag = tags[i - 1]
+                  break
+
+          # Merge commits in range
+          if prev_tag:
+              log = subprocess.run(
+                  ["git", "log", f"{prev_tag}..HEAD", "--merges", "--pretty=format:%s"],
+                  capture_output=True, text=True,
+              ).stdout
+          else:
+              log = subprocess.run(
+                  ["git", "log", "--merges", "--pretty=format:%s", "--max-count=40"],
+                  capture_output=True, text=True,
+              ).stdout
+
+          pr_numbers = re.findall(r"#(\d+)", log)
+          seen, unique_prs = set(), []
+          for p in pr_numbers:
+              if p not in seen:
+                  seen.add(p)
+                  unique_prs.append(p)
+
+          sections = []
+          for pr_num in unique_prs:
+              result = subprocess.run(
+                  ["gh", "pr", "view", pr_num, "--json", "title,body", "--repo", repo],
+                  capture_output=True, text=True,
+              )
+              if result.returncode != 0:
+                  continue
+              pr = json.loads(result.stdout)
+              title = pr.get("title", f"PR #{pr_num}")
+              body = pr.get("body") or ""
+              m = re.search(
+                  r"## Test plan\n(.*?)(?=\n## |\Z)", body, re.DOTALL | re.IGNORECASE
+              )
+              plan = m.group(1).strip() if m else "_No test plan specified._"
+              sections.append(f"### #{pr_num} — {title}\n\n{plan}")
+
+          range_label = f"`{prev_tag}..HEAD`" if prev_tag else "_(no previous dev tag)_"
+          pr_block = "\n\n---\n\n".join(sections) if sections else "_No merged PRs found in range._"
+
+          body = f"""## Dev build v{version}
+
+**Images**
+- `ghcr.io/weftmark/weftmark-backend:{version}-dev`
+- `ghcr.io/weftmark/weftmark-frontend:{version}-dev`
+
+**Range:** {range_label}
+
+---
+
+{pr_block}
+
+---
+
+_Close this issue when all items above are validated on `dev.weftmark.com`._"""
+
+          with open("qa_issue_body.md", "w") as f:
+              f.write(body)
+          print(f"QA issue body written ({len(sections)} PR(s) included)")
+          PYEOF
+
+      - name: Create QA issue
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "QA: v${VERSION}-dev" \
+            --body-file qa_issue_body.md \
+            --label "qa"


### PR DESCRIPTION
## Summary

When `publish-dev.yml` is manually triggered, a third job (`open-qa-issue`) now runs after both images are published. It:

1. Finds the previous `v*-dev` tag to determine the range of changes
2. Walks `git log` for merge commits in that range and extracts PR numbers
3. Fetches each PR''s title and `## Test plan

_Migrated to QA issue #199._
## Dev build v0.62.0

Images
- ghcr.io/weftmark/weftmark-backend:0.62.0-dev
- ghcr.io/weftmark/weftmark-frontend:0.62.0-dev

Range: `v0.61.0-dev..HEAD`

---

### #191 — feat: inject Clerk publishable key at runtime
- [ ] Build image without baked key — confirm build succeeds
- [ ] Start container without key — confirm config error page

---

### #190 — fix: add verification labels to custom auth pages
- [ ] Amber text visible on /login and /register
...

Close this issue when all items above are validated on dev.weftmark.com.
```

PRs with no test plan section get `_No test plan specified._` as a placeholder.

## Test plan

- [ ] Trigger `publish-dev.yml` manually — confirm both images publish and QA issue opens
- [ ] Confirm issue title is `QA: v{version}-dev` and body lists PRs since previous dev tag
- [ ] Confirm `qa` label is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)