### PR TITLE
fix: proxy /system/ routes to backend in nginx

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -59,6 +59,15 @@ server {
         proxy_set_header Host $host;
     }
 
+    location /system/ {
+        limit_req zone=api burst=60 nodelay;
+        limit_req_status 429;
+        proxy_pass http://backend:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION
## Summary

- `/system/status` was missing from nginx's proxy rules and fell through to `try_files`, returning the SPA HTML instead of JSON
- `SystemGate` fetches `/system/status`, the JSON parse failed silently, caught exception set status to `"unreachable"`, and the app rendered as if initialized — bypassing the no-superuser gate entirely
- Fix: add a `location /system/` proxy block matching the pattern used by `/api/` and `/auth/`

## Test plan

- [ ] Merge and rebuild frontend container
- [ ] With empty DB (no superusers): `dev.weftmark.com` shows `UninitializedPage`
- [ ] After seeding a superuser: `dev.weftmark.com` renders normally
- [ ] `curl /system/status` returns `{"initialized": false}` on empty DB

Discovered during QA test plan execution (Issue #206, Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)