### PR TITLE
feat: invite roles + pre-registration, remove first-user bootstrap

### DIFF
--- a/backend/alembic/versions/0002_invite_role_and_preregister.py
+++ b/backend/alembic/versions/0002_invite_role_and_preregister.py
@@ -1,0 +1,34 @@
+"""Add role + user_id to invites for pre-registration support.
+
+Revision ID: a3f8c2d19e74
+Revises: 11f6119b07a0
+Create Date: 2026-05-03
+
+- invites.role: VARCHAR(20) NOT NULL DEFAULT 'user'
+- invites.user_id: UUID nullable FK → users.id (pre-created User linked to the invite)
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+revision: str = "a3f8c2d19e74"
+down_revision: str | None = "11f6119b07a0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("invites", sa.Column("role", sa.String(20), nullable=False, server_default="user"))
+    op.add_column(
+        "invites",
+        sa.Column("user_id", UUID(as_uuid=True), sa.ForeignKey("users.id"), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("invites", "user_id")
+    op.drop_column("invites", "role")

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -17,13 +17,12 @@ from pathlib import Path
 from typing import Any
 
 import httpx
-from sqlalchemy import select, text
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from app.config import get_settings
 from app.models.seed_run import SeedRun
 from app.models.user import User
-from app.services.clerk import set_user_metadata
 
 _BACKEND_DIR = Path(__file__).parent.parent
 _ALEMBIC_INI = _BACKEND_DIR / "alembic.ini"
@@ -164,21 +163,45 @@ def _clear_s3(settings: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def _poll_db_for_user(
+async def _preregister_user(
     session_factory: async_sessionmaker,
-    clerk_user_id: str,
+    email: str,
+    display_name: str,
+    role: str,
+) -> User:
+    """Insert a pre-created User record (clerk_user_id=None). The webhook attaches the ID."""
+    is_admin = role in ("admin", "superuser")
+    is_superuser = role == "superuser"
+    async with session_factory() as session:
+        user = User(
+            email=email,
+            display_name=display_name,
+            is_admin=is_admin,
+            is_superuser=is_superuser,
+            ai_training_consent=True,
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        return user
+
+
+async def _poll_for_clerk_attach(
+    session_factory: async_sessionmaker,
+    user_id: uuid.UUID,
     timeout: int,
 ) -> User:
+    """Poll until the webhook attaches a clerk_user_id to the pre-created User."""
     loop = asyncio.get_event_loop()
     deadline = loop.time() + timeout
     while True:
         async with session_factory() as session:
-            user = await session.scalar(select(User).where(User.clerk_user_id == clerk_user_id))
-            if user:
+            user = await session.get(User, user_id)
+            if user and user.clerk_user_id is not None:
                 return user
         if loop.time() >= deadline:
             raise TimeoutError(
-                f"clerk_user_id={clerk_user_id} not found in DB after {timeout}s — "
+                f"user_id={user_id} never received a clerk_user_id after {timeout}s — "
                 "is the webhook configured and reachable?"
             )
         await asyncio.sleep(1)
@@ -294,6 +317,11 @@ async def cmd_seed(config_path: str, poll_timeout: int) -> None:
         if auto_password:
             password = uuid.uuid4().hex
 
+        # 1. Pre-create the User record with the intended role.
+        pre_user = await _preregister_user(session_factory, email, display_name, role)
+        _ok(f"{email} pre-registered in DB (id={pre_user.id}, role={role})")
+
+        # 2. Create the Clerk account — the webhook will attach the clerk_user_id.
         try:
             clerk_user = await _clerk_create_user(settings.clerk_secret_key, email, username, password, display_name)
             clerk_user_id: str = clerk_user["id"]
@@ -307,31 +335,14 @@ async def cmd_seed(config_path: str, poll_timeout: int) -> None:
             await engine.dispose()
             sys.exit(1)
 
+        # 3. Poll until the webhook attaches the Clerk ID to the pre-created User.
         try:
-            db_user = await _poll_db_for_user(session_factory, clerk_user_id, poll_timeout)
-            _ok(f"{email} confirmed in DB (id={db_user.id})")
+            db_user = await _poll_for_clerk_attach(session_factory, pre_user.id, poll_timeout)
+            _ok(f"{email} confirmed in DB (clerk_user_id={db_user.clerk_user_id})")
         except TimeoutError as exc:
             _err(str(exc))
             await engine.dispose()
             sys.exit(1)
-
-        is_admin = role in ("admin", "superuser")
-        is_superuser = role == "superuser"
-
-        async with session_factory() as session:
-            user = await session.get(User, db_user.id)
-            user.is_admin = is_admin
-            user.is_superuser = is_superuser
-            await session.commit()
-
-        await set_user_metadata(
-            clerk_user_id,
-            {
-                "is_admin": is_admin,
-                "is_superuser": is_superuser,
-            },
-        )
-        _ok(f"{email} role '{role}' applied")
 
         if auto_password:
             generated_passwords.append((email, password))

--- a/backend/app/models/invite.py
+++ b/backend/app/models/invite.py
@@ -7,6 +7,8 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, TimestampMixin
 
+INVITE_ROLES = ("user", "admin", "superuser")
+
 
 class Invite(Base, TimestampMixin):
     __tablename__ = "invites"
@@ -14,12 +16,18 @@ class Invite(Base, TimestampMixin):
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     email: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
     token: Mapped[str] = mapped_column(String(512), unique=True, nullable=False, index=True)
+    role: Mapped[str] = mapped_column(String(20), nullable=False, default="user")
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     accepted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_by_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    # Pre-created User record linked to this invite; null for invites created before this feature.
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True, default=None
+    )
 
     created_by: Mapped["User"] = relationship("User", foreign_keys=[created_by_id])  # type: ignore[name-defined]
+    user: Mapped["User | None"] = relationship("User", foreign_keys=[user_id])  # type: ignore[name-defined]
 
     @property
     def is_valid(self) -> bool:

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -6,18 +6,22 @@ Routes:
   GET  /auth/me             — return current user profile
 
 Invite management (admin only):
-  POST   /auth/invite         — create invite + send email
+  POST   /auth/invite         — create invite + pre-create User record + send email
   GET    /auth/invites         — list all invites
-  DELETE /auth/invite/{id}    — revoke invite
+  DELETE /auth/invite/{id}    — revoke invite + soft-delete pre-created User
 
 User creation flow:
-  1. Admin creates an invite for an email address.
-  2. Invitee receives an email with the WeftMark sign-up URL.
-  3. Invitee signs up via Clerk (Google, email, etc.).
-  4. Clerk fires user.created webhook.
-  5. Webhook checks for a valid invite (or first-user bootstrap).
-  6. If valid: creates User record in our DB, consumes invite.
-  7. If invalid: no DB record created — user gets 401 from all API routes.
+  1. Admin creates an invite (with role) for an email address.
+  2. A User record is pre-created in the DB with clerk_user_id=None and the intended role.
+  3. Invitee receives an email with the WeftMark sign-up URL.
+  4. Invitee signs up via Clerk (Google, email, etc.).
+  5. Clerk fires user.created webhook.
+  6. Webhook finds the pre-created User by email (clerk_user_id IS NULL), attaches the
+     Clerk ID, marks it active, and consumes the invite.
+  7. If no pre-created User exists: creates a PendingSignup instead.
+
+The seed CLI follows the same pattern: it pre-creates User records with the correct
+roles before creating Clerk accounts, so the webhook just attaches.
 """
 
 import logging
@@ -28,7 +32,7 @@ from datetime import datetime, timedelta, timezone
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, EmailStr
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
@@ -112,50 +116,50 @@ async def _handle_user_created(db: AsyncSession, data: dict) -> None:
     last_name = (data.get("last_name") or "").strip()
     display_name = f"{first_name} {last_name}".strip() or email
 
-    user_count = await db.scalar(select(func.count()).select_from(User))
-    is_first_user = user_count == 0
+    # Find a pre-created User record (from an invite or the seed CLI).
+    user = await db.scalar(
+        select(User).where(User.email == email, User.clerk_user_id.is_(None), User.deleted_at.is_(None))
+    )
 
-    if not is_first_user:
-        invite = await _consume_invite(db, email)
-        if invite is None:
-            log.warning(
-                "Clerk user.created for %s (%s) — no valid invite found; skipping DB record",
-                clerk_user_id,
-                email,
+    if user is None:
+        # No pre-created record — treat as an unsolicited signup (pending review).
+        log.warning(
+            "Clerk user.created for %s (%s) — no pre-created User found; creating PendingSignup",
+            clerk_user_id,
+            email,
+        )
+        existing = await db.scalar(select(PendingSignup).where(PendingSignup.clerk_user_id == clerk_user_id))
+        if existing is None:
+            db.add(PendingSignup(clerk_user_id=clerk_user_id, email=email, display_name=display_name))
+            await db.commit()
+            await set_user_metadata(clerk_user_id, {"status": "pending_signup", "is_admin": False})
+            admin_emails = list(
+                await db.scalars(select(User.email).where(User.is_admin.is_(True), User.deleted_at.is_(None)))
             )
-            existing = await db.scalar(select(PendingSignup).where(PendingSignup.clerk_user_id == clerk_user_id))
-            if existing is None:
-                db.add(PendingSignup(clerk_user_id=clerk_user_id, email=email, display_name=display_name))
-                await db.commit()
-                await set_user_metadata(clerk_user_id, {"status": "pending_signup", "is_admin": False})
-                admin_emails = list(
-                    await db.scalars(select(User.email).where(User.is_admin.is_(True), User.deleted_at.is_(None)))
-                )
+            try:
+                await send_signup_received_email(email, display_name)
+            except Exception:
+                log.exception("Failed to send signup received email to %s", email)
+            if admin_emails:
                 try:
-                    await send_signup_received_email(email, display_name)
+                    await send_pending_signup_notification(admin_emails, display_name, email)
                 except Exception:
-                    log.exception("Failed to send signup received email to %s", email)
-                if admin_emails:
-                    try:
-                        await send_pending_signup_notification(admin_emails, display_name, email)
-                    except Exception:
-                        log.exception("Failed to send pending signup notification to admins")
-            return
+                    log.exception("Failed to send pending signup notification to admins")
+        return
 
-    user = User(
-        email=email,
-        display_name=display_name,
-        clerk_user_id=clerk_user_id,
-        is_admin=is_first_user,
-        is_superuser=is_first_user,
-        ai_training_consent=True,
-    )
-    db.add(user)
+    # Attach the Clerk ID and update the display name from Clerk's data.
+    user.clerk_user_id = clerk_user_id
+    user.display_name = display_name
     await db.commit()
+
+    # Consume the associated invite (audit trail; may already be consumed by seed CLI).
+    await _consume_invite(db, email)
+
     await set_user_metadata(
-        clerk_user_id, {"status": "active", "is_admin": is_first_user, "is_superuser": is_first_user}
+        clerk_user_id,
+        {"status": "active", "is_admin": user.is_admin, "is_superuser": user.is_superuser},
     )
-    log.info("Created User record for Clerk user %s (%s)", clerk_user_id, email)
+    log.info("Attached Clerk user %s to pre-created User for %s", clerk_user_id, email)
 
 
 async def _handle_user_updated(db: AsyncSession, data: dict) -> None:
@@ -297,12 +301,14 @@ async def me(
 
 class InviteRequest(BaseModel):
     email: EmailStr
+    role: str = "user"
     expires_days: int | None = None
 
 
 class InviteResponse(BaseModel):
     id: uuid.UUID
     email: str
+    role: str
     expires_at: datetime
     accepted_at: datetime | None
     revoked_at: datetime | None
@@ -317,13 +323,32 @@ async def create_invite(
     admin: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ) -> Invite:
+    from app.models.invite import INVITE_ROLES
+
+    if body.role not in INVITE_ROLES:
+        raise HTTPException(status_code=422, detail=f"role must be one of: {', '.join(INVITE_ROLES)}")
+
     expires_days = body.expires_days or settings.invite_expiry_days_default
+
+    # Pre-create the User record so the webhook just attaches the Clerk ID on sign-up.
+    pre_user = User(
+        email=body.email,
+        display_name=body.email,  # updated from Clerk data when the webhook fires
+        is_admin=body.role in ("admin", "superuser"),
+        is_superuser=body.role == "superuser",
+        ai_training_consent=True,
+    )
+    db.add(pre_user)
+    await db.flush()
+
     token = secrets.token_urlsafe(32)
     invite = Invite(
         email=body.email,
         token=token,
+        role=body.role,
         expires_at=datetime.now(timezone.utc) + timedelta(days=expires_days),
         created_by_id=admin.id,
+        user_id=pre_user.id,
     )
     db.add(invite)
     await write_audit_log(db, event_type="invite.created", actor=admin, target_email=body.email)
@@ -349,11 +374,20 @@ async def revoke_invite(
     admin: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ) -> None:
+    from datetime import datetime as _dt
+
     invite = await db.scalar(select(Invite).where(Invite.id == invite_id))
     if invite is None:
         raise HTTPException(status_code=404, detail="Invite not found")
     if invite.accepted_at is not None:
         raise HTTPException(status_code=400, detail="Invite already accepted")
-    invite.revoked_at = datetime.now(timezone.utc)
+    invite.revoked_at = _dt.now(timezone.utc)
+
+    # Soft-delete the pre-created User if it hasn't been claimed yet.
+    if invite.user_id is not None:
+        pre_user = await db.get(User, invite.user_id)
+        if pre_user is not None and pre_user.clerk_user_id is None:
+            pre_user.deleted_at = _dt.now(timezone.utc)
+
     await write_audit_log(db, event_type="invite.revoked", actor=admin, target_email=invite.email)
     await db.commit()

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from app.cli import _clear_local, _poll_db_for_user, cmd_seed
+from app.cli import _clear_local, _poll_for_clerk_attach, cmd_seed
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -199,10 +199,10 @@ async def test_seed_deletes_clerk_users_before_alembic(tmp_path):
     config.write_text(json.dumps({"users": [{"email": "a@b.com", "username": "a", "role": "user"}]}))
 
     delete_mock = AsyncMock(return_value=3)
-    mock_db_user = MagicMock()
-    mock_db_user.id = 1
-    session.scalar = AsyncMock(return_value=mock_db_user)
-    session.get = AsyncMock(return_value=MagicMock(is_admin=False, is_superuser=False))
+    pre_user = MagicMock()
+    pre_user.id = uuid.uuid4()
+    attached_user = MagicMock()
+    attached_user.clerk_user_id = "user_new"
 
     with (
         patch("app.cli.get_settings", return_value=settings),
@@ -212,9 +212,9 @@ async def test_seed_deletes_clerk_users_before_alembic(tmp_path):
         patch("app.cli.async_sessionmaker", return_value=factory),
         patch("app.cli._alembic_reset"),
         patch("app.cli._clear_storage"),
+        patch("app.cli._preregister_user", AsyncMock(return_value=pre_user)),
         patch("app.cli._clerk_create_user", AsyncMock(return_value={"id": "user_new"})),
-        patch("app.cli._poll_db_for_user", AsyncMock(return_value=mock_db_user)),
-        patch("app.cli.set_user_metadata", AsyncMock()),
+        patch("app.cli._poll_for_clerk_attach", AsyncMock(return_value=attached_user)),
     ):
         await cmd_seed(str(config), 5)
 
@@ -245,40 +245,44 @@ async def test_seed_aborts_when_clerk_delete_fails(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# _poll_db_for_user — success
+# _poll_for_clerk_attach — success
 # ---------------------------------------------------------------------------
 
 
-async def test_poll_db_returns_user_when_found():
-    user_id = str(uuid.uuid4())
+async def test_poll_for_clerk_attach_returns_user_when_attached():
+    user_id = uuid.uuid4()
     mock_user = MagicMock()
-    mock_user.clerk_user_id = user_id
+    mock_user.clerk_user_id = "user_abc123"
 
     session = AsyncMock()
     session.__aenter__ = AsyncMock(return_value=session)
     session.__aexit__ = AsyncMock(return_value=False)
-    session.scalar = AsyncMock(return_value=mock_user)
+    session.get = AsyncMock(return_value=mock_user)
     factory = MagicMock(return_value=session)
 
-    result = await _poll_db_for_user(factory, user_id, timeout=5)
+    result = await _poll_for_clerk_attach(factory, user_id, timeout=5)
 
     assert result is mock_user
 
 
 # ---------------------------------------------------------------------------
-# _poll_db_for_user — timeout
+# _poll_for_clerk_attach — timeout
 # ---------------------------------------------------------------------------
 
 
-async def test_poll_db_raises_timeout_when_user_never_arrives():
+async def test_poll_for_clerk_attach_raises_timeout_when_never_attached():
+    user_id = uuid.uuid4()
+    mock_user = MagicMock()
+    mock_user.clerk_user_id = None
+
     session = AsyncMock()
     session.__aenter__ = AsyncMock(return_value=session)
     session.__aexit__ = AsyncMock(return_value=False)
-    session.scalar = AsyncMock(return_value=None)
+    session.get = AsyncMock(return_value=mock_user)
     factory = MagicMock(return_value=session)
 
     with pytest.raises(TimeoutError):
-        await _poll_db_for_user(factory, "user_missing", timeout=0)
+        await _poll_for_clerk_attach(factory, user_id, timeout=0)
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -64,6 +64,7 @@ export interface AdminVersions {
 export interface InviteRecord {
   id: string;
   email: string;
+  role: string;
   expires_at: string;
   accepted_at: string | null;
   revoked_at: string | null;
@@ -97,8 +98,8 @@ export const deleteUser = (userId: string) =>
   });
 
 export const listInvites = () => api.get<InviteRecord[]>("/auth/invites");
-export const createInvite = (email: string, expires_days?: number) =>
-  api.post<InviteRecord>("/auth/invite", { email, expires_days });
+export const createInvite = (email: string, role: string = "user", expires_days?: number) =>
+  api.post<InviteRecord>("/auth/invite", { email, role, expires_days });
 export const revokeInvite = (inviteId: string) => api.delete<void>(`/auth/invite/${inviteId}`);
 
 export interface PendingSignup {


### PR DESCRIPTION
## Summary

Architectural refactor of the user creation flow. All users — including the initial superuser — now go through the same invite-backed pre-registration path.

### Changes

**Invite model (`models/invite.py` + migration `0002`)**
- Added `role` field (`user` | `admin` | `superuser`, default `user`)
- Added `user_id` FK to the pre-created User record linked to this invite

**Webhook handler (`routers/auth.py` — `_handle_user_created`)**
- Removed the `user_count == 0` first-user bootstrap special case entirely
- Now looks for a pre-created `User` by email where `clerk_user_id IS NULL`
- If found: attaches Clerk ID, updates display name from Clerk, consumes invite, sets `status: active` metadata — same path for every role
- If not found: falls through to `PendingSignup` as before (unsolicited sign-up)

**Invite creation (`POST /auth/invite`)**
- Accepts optional `role` field in request body (validates against allowed values)
- Pre-creates a `User` record with the intended role before sending the invite email
- Invite stores `user_id` FK to the pre-created record

**Invite revocation (`DELETE /auth/invite/{id}`)**
- Soft-deletes the pre-created User if it hasn't been claimed yet (`clerk_user_id IS NULL`)

**Seed CLI (`app/cli.py`)**
- Pre-creates `User` records with correct role before creating Clerk accounts
- Polls for `clerk_user_id` attachment (webhook event) instead of waiting for User creation
- All seeded users — superuser, admin, regular — flow through the same code path

**Frontend (`api/admin.ts`)**
- `InviteRecord` gains `role` field
- `createInvite()` accepts optional `role` parameter (default `"user"`)

## After merging

1. Rebuild and redeploy backend + worker
2. Run `alembic upgrade head` on the dev server — applies migration `0002`
3. Re-run Phase 4 QA seed (superuser + admin) — both should confirm cleanly

## Test plan

- [ ] `alembic upgrade head` applies migration cleanly
- [ ] `alembic downgrade base` → `upgrade head` round-trips cleanly
- [ ] Seed Phase 3 (superuser only) — gate lifts, sign-in works
- [ ] Seed Phase 4 (superuser + admin) — both users confirmed in DB with correct roles
- [ ] Seed Phase 5 (superuser + admin + user) — all three confirmed
- [ ] Admin creates invite with `role=admin` via UI — User pre-created, invite email sent
- [ ] Invitee registers via Clerk — webhook attaches, user is active with admin role
- [ ] Admin revokes invite before registration — pre-created User soft-deleted
- [ ] Self-registration (no invite) still creates PendingSignup

Resolves Phase 4 failure discovered in QA test plan (Issue #206).

🤖 Generated with [Claude Code](https://claude.com/claude-code)