### PR TITLE
feat: write dist/version.json at build time

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "postbuild": "node -e \"const fs=require('fs');const p=JSON.parse(fs.readFileSync('./package.json','utf8'));fs.writeFileSync('dist/version.json',JSON.stringify({version:p.version,built_at:new Date().toISOString()}))\"",
     "preview": "vite preview",
     "lint": "eslint src/"
   },


### PR DESCRIPTION
## Summary

- Adds a `postbuild` npm script that writes `dist/version.json` after every `npm run build`
- File contains `{version, built_at}` — served as a static file at `/version.json` by nginx
- No nginx changes needed: `try_files` in `location /` already serves static files directly

## After merging

Both backend and frontend versions are checkable without auth:
- Backend: `GET /health` → `{"status":"ok","version":"0.63.0"}`
- Frontend: `GET /version.json` → `{"version":"0.63.0","built_at":"2026-..."}`

## Test plan

- [ ] Build frontend image and verify `/version.json` is served
- [ ] `version` matches `package.json`
- [ ] `built_at` is a valid ISO timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)