### PR TITLE
feat: enforce invite role permissions and add role selector to UI

### DIFF
--- a/backend/app/models/invite.py
+++ b/backend/app/models/invite.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, TimestampMixin
 
-INVITE_ROLES = ("user", "admin", "superuser")
+INVITE_ROLES = ("user", "admin")
 
 
 class Invite(Base, TimestampMixin):

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -328,14 +328,17 @@ async def create_invite(
     if body.role not in INVITE_ROLES:
         raise HTTPException(status_code=422, detail=f"role must be one of: {', '.join(INVITE_ROLES)}")
 
+    if body.role == "admin" and not admin.is_superuser:
+        raise HTTPException(status_code=403, detail="Only superusers can invite admins")
+
     expires_days = body.expires_days or settings.invite_expiry_days_default
 
     # Pre-create the User record so the webhook just attaches the Clerk ID on sign-up.
     pre_user = User(
         email=body.email,
         display_name=body.email,  # updated from Clerk data when the webhook fires
-        is_admin=body.role in ("admin", "superuser"),
-        is_superuser=body.role == "superuser",
+        is_admin=body.role == "admin",
+        is_superuser=False,
         ai_training_consent=True,
     )
     db.add(pre_user)

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -430,7 +430,9 @@ const INVITE_HISTORY_PAGE_SIZE = 20;
 
 function InvitesTab() {
   const qc = useQueryClient();
+  const { user: currentUser } = useAuth();
   const [email, setEmail] = useState("");
+  const [role, setRole] = useState<"user" | "admin">("user");
   const [error, setError] = useState<string | null>(null);
   const [sent, setSent] = useState<string | null>(null);
   const [historyPage, setHistoryPage] = useState(0);
@@ -446,10 +448,11 @@ function InvitesTab() {
   });
 
   const send = useMutation({
-    mutationFn: (addr: string) => createInvite(addr),
-    onSuccess: (_, addr) => {
-      setSent(addr);
+    mutationFn: () => createInvite(email, role),
+    onSuccess: () => {
+      setSent(email);
       setEmail("");
+      setRole("user");
       setError(null);
       qc.invalidateQueries({ queryKey: ["admin", "invites"] });
     },
@@ -515,10 +518,20 @@ function InvitesTab() {
             placeholder="email@example.com"
             value={email}
             onChange={(e) => { setEmail(e.target.value); setSent(null); setError(null); }}
-            onKeyDown={(e) => e.key === "Enter" && email && send.mutate(email)}
+            onKeyDown={(e) => e.key === "Enter" && email && send.mutate()}
             className="flex-1 text-sm border rounded px-3 py-1.5 bg-background focus:outline-none focus:ring-1 focus:ring-ring"
           />
-          <Button size="sm" disabled={!email || send.isPending} onClick={() => send.mutate(email)}>
+          {currentUser?.is_superuser && (
+            <select
+              value={role}
+              onChange={(e) => setRole(e.target.value as "user" | "admin")}
+              className="text-sm border rounded px-2 py-1.5 bg-background focus:outline-none focus:ring-1 focus:ring-ring"
+            >
+              <option value="user">User</option>
+              <option value="admin">Admin</option>
+            </select>
+          )}
+          <Button size="sm" disabled={!email || send.isPending} onClick={() => send.mutate()}>
             Send
           </Button>
         </div>
@@ -654,7 +667,7 @@ function InviteRow({ invite, onRevoke }: { invite: InviteRecord; onRevoke?: () =
       <div className="min-w-0">
         <p className="text-sm font-medium truncate">{invite.email}</p>
         <p className="text-xs text-muted-foreground">
-          {status} · expires {new Date(invite.expires_at).toLocaleDateString()}
+          {invite.role} · {status} · expires {new Date(invite.expires_at).toLocaleDateString()}
         </p>
       </div>
       {isPending && onRevoke && (


### PR DESCRIPTION
## Summary

- Superusers can invite `user` or `admin` roles
- Admins can invite `user` role only (403 if they attempt `admin`)
- `superuser` role removed from `INVITE_ROLES` — superuser elevation happens post-registration only via the existing elevate-to-superuser endpoint
- Frontend invite form shows a role selector (User / Admin) for superusers only; admins see no selector and always send `user` invites
- Invite list rows now display the role alongside status

## Backend changes

- `INVITE_ROLES = ("user", "admin")` — removed `"superuser"`
- `POST /auth/invite` — added caller check: `role == "admin"` requires `caller.is_superuser`, returns 403 otherwise
- `pre_user.is_superuser` simplified to `False` (superuser can no longer be invited)

## Frontend changes

- `InvitesTab` — added `role` state (default `"user"`), reset on send
- Role selector (`<select>`) rendered only when `currentUser?.is_superuser`
- `InviteRow` — role shown in the subtitle line alongside status

## Test plan

- [ ] Superuser invite form shows User / Admin selector
- [ ] Admin invite form shows no selector; invite always creates a `user`
- [ ] Superuser can send `role=admin` invite — pre-created User has `is_admin=true`
- [ ] Admin sending `role=admin` via API returns 403
- [ ] `role=superuser` via API returns 422 (not in INVITE_ROLES)
- [ ] Invited admin registers via Clerk — webhook attaches, user is active admin
- [ ] Invite list shows role in each row

🤖 Generated with [Claude Code](https://claude.com/claude-code)