### PR TITLE
fix: block duplicate user creation on re-invite, return 409 for active users

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -333,15 +333,29 @@ async def create_invite(
 
     expires_days = body.expires_days or settings.invite_expiry_days_default
 
-    # Pre-create the User record so the webhook just attaches the Clerk ID on sign-up.
-    pre_user = User(
-        email=body.email,
-        display_name=body.email,  # updated from Clerk data when the webhook fires
-        is_admin=body.role == "admin",
-        is_superuser=False,
-        ai_training_consent=True,
+    # Block re-inviting an already-active user.
+    active_user = await db.scalar(
+        select(User).where(User.email == body.email, User.clerk_user_id.is_not(None), User.deleted_at.is_(None))
     )
-    db.add(pre_user)
+    if active_user is not None:
+        raise HTTPException(status_code=409, detail="A user with this email already exists")
+
+    # Reuse an existing unclaimed User record (e.g. from a prior invite) or create one.
+    pre_user = await db.scalar(
+        select(User).where(User.email == body.email, User.clerk_user_id.is_(None), User.deleted_at.is_(None))
+    )
+    if pre_user is not None:
+        pre_user.is_admin = body.role == "admin"
+        pre_user.is_superuser = False
+    else:
+        pre_user = User(
+            email=body.email,
+            display_name=body.email,  # updated from Clerk data when the webhook fires
+            is_admin=body.role == "admin",
+            is_superuser=False,
+            ai_training_consent=True,
+        )
+        db.add(pre_user)
     await db.flush()
 
     token = secrets.token_urlsafe(32)

--- a/backend/tests/routers/test_auth.py
+++ b/backend/tests/routers/test_auth.py
@@ -156,6 +156,47 @@ class TestCreateInvite:
         resp = await admin_client.post("/auth/invite", json={"email": "not-an-email"})
         assert resp.status_code == 422
 
+    async def test_superuser_can_invite_admin_role(self, superuser_client: AsyncClient):
+        resp = await superuser_client.post("/auth/invite", json={"email": "newadmin@example.com", "role": "admin"})
+        assert resp.status_code == 201
+        assert resp.json()["role"] == "admin"
+
+    async def test_admin_cannot_invite_admin_role(self, admin_client: AsyncClient):
+        resp = await admin_client.post("/auth/invite", json={"email": "newadmin@example.com", "role": "admin"})
+        assert resp.status_code == 403
+
+    async def test_active_user_email_returns_409(self, admin_client: AsyncClient, db_session: AsyncSession):
+        active = User(
+            email="active@example.com",
+            display_name="Active User",
+            clerk_user_id="clerk_active_123",
+            is_admin=False,
+            is_superuser=False,
+        )
+        db_session.add(active)
+        await db_session.commit()
+        resp = await admin_client.post("/auth/invite", json={"email": "active@example.com"})
+        assert resp.status_code == 409
+
+    async def test_reinvite_unclaimed_user_reuses_record(
+        self, admin_client: AsyncClient, db_session: AsyncSession, superuser_client: AsyncClient
+    ):
+        # First invite creates a pre-user record (user-role).
+        r1 = await admin_client.post("/auth/invite", json={"email": "reinvite@example.com"})
+        assert r1.status_code == 201
+
+        # Second invite (admin-role, sent by superuser) reuses the same User record.
+        r2 = await superuser_client.post("/auth/invite", json={"email": "reinvite@example.com", "role": "admin"})
+        assert r2.status_code == 201
+
+        users = list(
+            await db_session.scalars(
+                select(User).where(User.email == "reinvite@example.com", User.deleted_at.is_(None))
+            )
+        )
+        assert len(users) == 1
+        assert users[0].is_admin is True
+
 
 # ---------------------------------------------------------------------------
 # GET /auth/invites  (admin only)


### PR DESCRIPTION
## Summary
- `create_invite` was always inserting a new `User` record without checking if one already existed for the given email, causing a `UniqueViolationError` (500) when a superuser tried to invite an email that had already been invited/registered
- Now returns **409** if the email belongs to an already-active user (`clerk_user_id IS NOT NULL`)
- If the email has an unclaimed pre-created `User` record (e.g. from a previous invite that hasn't been accepted), the record is **reused and updated** with the new role rather than inserting a duplicate

## Test plan
- [ ] `test_superuser_can_invite_admin_role` — superuser inviting admin role returns 201
- [ ] `test_admin_cannot_invite_admin_role` — admin inviting admin role returns 403
- [ ] `test_active_user_email_returns_409` — inviting an already-registered email returns 409
- [ ] `test_reinvite_unclaimed_user_reuses_record` — re-inviting same email creates only one User record, role updated to admin

## Repro
1. Admin invites `user@example.com` (user-role) → user signs up and becomes active
2. Superuser attempts admin-role invite to the same `user@example.com`
3. Before fix: 500 Internal Server Error with `UniqueViolationError` in logs
4. After fix: 409 with `"A user with this email already exists"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)