### PR TITLE
fix: reuse soft-deleted pre-user when re-inviting after revoke

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -340,13 +340,12 @@ async def create_invite(
     if active_user is not None:
         raise HTTPException(status_code=409, detail="A user with this email already exists")
 
-    # Reuse an existing unclaimed User record (e.g. from a prior invite) or create one.
-    pre_user = await db.scalar(
-        select(User).where(User.email == body.email, User.clerk_user_id.is_(None), User.deleted_at.is_(None))
-    )
+    # Reuse an existing unclaimed User record (even if soft-deleted by a prior revoke) or create one.
+    pre_user = await db.scalar(select(User).where(User.email == body.email, User.clerk_user_id.is_(None)))
     if pre_user is not None:
         pre_user.is_admin = body.role == "admin"
         pre_user.is_superuser = False
+        pre_user.deleted_at = None
     else:
         pre_user = User(
             email=body.email,

--- a/backend/tests/routers/test_auth.py
+++ b/backend/tests/routers/test_auth.py
@@ -197,6 +197,28 @@ class TestCreateInvite:
         assert len(users) == 1
         assert users[0].is_admin is True
 
+    async def test_reinvite_after_revoke_reuses_soft_deleted_record(
+        self, superuser_client: AsyncClient, db_session: AsyncSession
+    ):
+        # Simulate a soft-deleted pre-user (invite was previously revoked).
+        soft_deleted = User(
+            email="revoked@example.com",
+            display_name="revoked@example.com",
+            clerk_user_id=None,
+            is_admin=False,
+            is_superuser=False,
+            deleted_at=datetime.now(timezone.utc),
+        )
+        db_session.add(soft_deleted)
+        await db_session.commit()
+
+        resp = await superuser_client.post("/auth/invite", json={"email": "revoked@example.com", "role": "admin"})
+        assert resp.status_code == 201
+
+        await db_session.refresh(soft_deleted)
+        assert soft_deleted.deleted_at is None
+        assert soft_deleted.is_admin is True
+
 
 # ---------------------------------------------------------------------------
 # GET /auth/invites  (admin only)


### PR DESCRIPTION
## Summary
- PR #219 fixed the case where re-inviting an email that had an *unclaimed* pre-user would cause a 500. This PR fixes the remaining case.
- When an invite is **revoked**, the pre-created `User` record is soft-deleted (`deleted_at` set). A subsequent invite to that same email passed both the active-user check and the unclaimed-user check (both required `deleted_at IS NULL`), fell through to `INSERT`, and hit the unique constraint → 500.
- Fix: drop `deleted_at IS NULL` from the pre-user lookup. A revoked pre-user is reused and **resurrected** (`deleted_at` cleared) with the new role.

## Root cause
`notderekrowland@gmail.com` had `clerk_user_id=NULL, deleted_at=<timestamp>` — invite was previously revoked, soft-deleting the pre-user. Re-inviting as admin hit the unique constraint.

## Test plan
- [ ] `test_reinvite_after_revoke_reuses_soft_deleted_record` — re-invite after revoke returns 201, record resurrected with updated role
- [ ] Existing tests for 409 on active user and reuse of unclaimed pre-user continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)