### PR TITLE
feat: db schema documentation script

### DIFF
--- a/docs/schema.json
+++ b/docs/schema.json
@@ -1,0 +1,2010 @@
+{
+  "tables": {
+    "activities": {
+      "columns": [
+        {
+          "name": "id",
+          "position": 1,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "owner_id",
+          "position": 2,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "project_id",
+          "position": 3,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "loom_id",
+          "position": 4,
+          "type": "uuid",
+          "nullable": true
+        },
+        {
+          "name": "loom_version_id",
+          "position": 5,
+          "type": "uuid",
+          "nullable": true
+        },
+        {
+          "name": "name",
+          "position": 6,
+          "type": "varchar(255)",
+          "nullable": false
+        },
+        {
+          "name": "activity_type",
+          "position": 7,
+          "type": "varchar(10)",
+          "nullable": false
+        },
+        {
+          "name": "status",
+          "position": 8,
+          "type": "varchar(20)",
+          "nullable": false
+        },
+        {
+          "name": "current_pick",
+          "position": 9,
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "total_picks",
+          "position": 10,
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "finished_length_per_item",
+          "position": 11,
+          "type": "numeric(8,1)",
+          "nullable": true
+        },
+        {
+          "name": "num_items",
+          "position": 12,
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "waste_between_items",
+          "position": 13,
+          "type": "numeric(8,1)",
+          "nullable": true
+        },
+        {
+          "name": "warp_waste_allowance",
+          "position": 14,
+          "type": "numeric(8,1)",
+          "nullable": true
+        },
+        {
+          "name": "length_unit",
+          "position": 15,
+          "type": "varchar(5)",
+          "nullable": false
+        },
+        {
+          "name": "completed_at",
+          "position": 16,
+          "type": "timestamp with time zone",
+          "nullable": true
+        },
+        {
+          "name": "abandoned_at",
+          "position": 17,
+          "type": "timestamp with time zone",
+          "nullable": true
+        },
+        {
+          "name": "notes",
+          "position": 18,
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created_at",
+          "position": 19,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        },
+        {
+          "name": "updated_at",
+          "position": 20,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        },
+        {
+          "name": "deleted_at",
+          "position": 21,
+          "type": "timestamp with time zone",
+          "nullable": true
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": [
+        {
+          "column": "loom_id",
+          "references_table": "looms",
+          "references_column": "id",
+          "constraint": "activities_loom_id_fkey"
+        },
+        {
+          "column": "loom_version_id",
+          "references_table": "loom_versions",
+          "references_column": "id",
+          "constraint": "activities_loom_version_id_fkey"
+        },
+        {
+          "column": "owner_id",
+          "references_table": "users",
+          "references_column": "id",
+          "constraint": "activities_owner_id_fkey"
+        },
+        {
+          "column": "project_id",
+          "references_table": "projects",
+          "references_column": "id",
+          "constraint": "activities_project_id_fkey"
+        }
+      ],
+      "unique_constraints": [],
+      "indexes": [
+        {
+          "name": "activities_pkey",
+          "columns": [
+            "id"
+          ],
+          "unique": true,
+          "primary": true
+        },
+        {
+          "name": "ix_activities_owner_id",
+          "columns": [
+            "owner_id"
+          ],
+          "unique": false,
+          "primary": false
+        },
+        {
+          "name": "ix_activities_project_id",
+          "columns": [
+            "project_id"
+          ],
+          "unique": false,
+          "primary": false
+        }
+      ],
+      "check_constraints": []
+    },
+    "activity_photos": {
+      "columns": [
+        {
+          "name": "id",
+          "position": 1,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "activity_id",
+          "position": 2,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "file_path",
+          "position": 3,
+          "type": "varchar(500)",
+          "nullable": false
+        },
+        {
+          "name": "filename",
+          "position": 4,
+          "type": "varchar(255)",
+          "nullable": false
+        },
+        {
+          "name": "file_size_bytes",
+          "position": 5,
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "display_order",
+          "position": 6,
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "created_at",
+          "position": 7,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        },
+        {
+          "name": "updated_at",
+          "position": 8,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": [
+        {
+          "column": "activity_id",
+          "references_table": "activities",
+          "references_column": "id",
+          "constraint": "activity_photos_activity_id_fkey"
+        }
+      ],
+      "unique_constraints": [],
+      "indexes": [
+        {
+          "name": "activity_photos_pkey",
+          "columns": [
+            "id"
+          ],
+          "unique": true,
+          "primary": true
+        },
+        {
+          "name": "ix_activity_photos_activity_id",
+          "columns": [
+            "activity_id"
+          ],
+          "unique": false,
+          "primary": false
+        }
+      ],
+      "check_constraints": []
+    },
+    "activity_steps": {
+      "columns": [
+        {
+          "name": "id",
+          "position": 1,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "activity_id",
+          "position": 2,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "event_type",
+          "position": 3,
+          "type": "varchar(10)",
+          "nullable": false
+        },
+        {
+          "name": "from_pick",
+          "position": 4,
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "to_pick",
+          "position": 5,
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "created_at",
+          "position": 6,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        },
+        {
+          "name": "updated_at",
+          "position": 7,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": [
+        {
+          "column": "activity_id",
+          "references_table": "activities",
+          "references_column": "id",
+          "constraint": "activity_steps_activity_id_fkey"
+        }
+      ],
+      "unique_constraints": [],
+      "indexes": [
+        {
+          "name": "activity_steps_pkey",
+          "columns": [
+            "id"
+          ],
+          "unique": true,
+          "primary": true
+        },
+        {
+          "name": "ix_activity_steps_activity_id",
+          "columns": [
+            "activity_id"
+          ],
+          "unique": false,
+          "primary": false
+        }
+      ],
+      "check_constraints": []
+    },
+    "alembic_version": {
+      "columns": [
+        {
+          "name": "version_num",
+          "position": 1,
+          "type": "varchar(32)",
+          "nullable": false
+        }
+      ],
+      "primary_key": [
+        "version_num"
+      ],
+      "foreign_keys": [],
+      "unique_constraints": [],
+      "indexes": [
+        {
+          "name": "alembic_version_pkc",
+          "columns": [
+            "version_num"
+          ],
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "check_constraints": []
+    },
+    "audit_logs": {
+      "columns": [
+        {
+          "name": "id",
+          "position": 1,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "actor_id",
+          "position": 2,
+          "type": "uuid",
+          "nullable": true
+        },
+        {
+          "name": "actor_email",
+          "position": 3,
+          "type": "varchar(255)",
+          "nullable": true
+        },
+        {
+          "name": "event_type",
+          "position": 4,
+          "type": "varchar(64)",
+          "nullable": false
+        },
+        {
+          "name": "target_user_id",
+          "position": 5,
+          "type": "uuid",
+          "nullable": true
+        },
+        {
+          "name": "target_email",
+          "position": 6,
+          "type": "varchar(255)",
+          "nullable": true
+        },
+        {
+          "name": "details",
+          "position": 7,
+          "type": "json",
+          "nullable": true
+        },
+        {
+          "name": "created_at",
+          "position": 8,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": [],
+      "unique_constraints": [],
+      "indexes": [
+        {
+          "name": "audit_logs_pkey",
+          "columns": [
+            "id"
+          ],
+          "unique": true,
+          "primary": true
+        },
+        {
+          "name": "ix_audit_logs_actor_email",
+          "columns": [
+            "actor_email"
+          ],
+          "unique": false,
+          "primary": false
+        },
+        {
+          "name": "ix_audit_logs_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "unique": false,
+          "primary": false
+        },
+        {
+          "name": "ix_audit_logs_event_type",
+          "columns": [
+            "event_type"
+          ],
+          "unique": false,
+          "primary": false
+        }
+      ],
+      "check_constraints": []
+    },
+    "eula_versions": {
+      "columns": [
+        {
+          "name": "id",
+          "position": 1,
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('eula_versions_id_seq'::regclass)"
+        },
+        {
+          "name": "version",
+          "position": 2,
+          "type": "varchar(20)",
+          "nullable": false
+        },
+        {
+          "name": "body_html",
+          "position": 3,
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "effective_date",
+          "position": 4,
+          "type": "timestamp with time zone",
+          "nullable": false
+        },
+        {
+          "name": "created_at",
+          "position": 5,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": [],
+      "unique_constraints": [
+        {
+          "constraint": "eula_versions_version_key",
+          "columns": [
+            "version"
+          ]
+        }
+      ],
+      "indexes": [
+        {
+          "name": "eula_versions_pkey",
+          "columns": [
+            "id"
+          ],
+          "unique": true,
+          "primary": true
+        },
+        {
+          "name": "eula_versions_version_key",
+          "columns": [
+            "version"
+          ],
+          "unique": true,
+          "primary": false
+        }
+      ],
+      "check_constraints": []
+    },
+    "invites": {
+      "columns": [
+        {
+          "name": "id",
+          "position": 1,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "email",
+          "position": 2,
+          "type": "varchar(255)",
+          "nullable": false
+        },
+        {
+          "name": "token",
+          "position": 3,
+          "type": "varchar(512)",
+          "nullable": false
+        },
+        {
+          "name": "expires_at",
+          "position": 4,
+          "type": "timestamp with time zone",
+          "nullable": false
+        },
+        {
+          "name": "accepted_at",
+          "position": 5,
+          "type": "timestamp with time zone",
+          "nullable": true
+        },
+        {
+          "name": "revoked_at",
+          "position": 6,
+          "type": "timestamp with time zone",
+          "nullable": true
+        },
+        {
+          "name": "created_by_id",
+          "position": 7,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "created_at",
+          "position": 8,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        },
+        {
+          "name": "updated_at",
+          "position": 9,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        },
+        {
+          "name": "role",
+          "position": 10,
+          "type": "varchar(20)",
+          "nullable": false,
+          "default": "'user'::character varying"
+        },
+        {
+          "name": "user_id",
+          "position": 11,
+          "type": "uuid",
+          "nullable": true
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": [
+        {
+          "column": "created_by_id",
+          "references_table": "users",
+          "references_column": "id",
+          "constraint": "invites_created_by_id_fkey"
+        },
+        {
+          "column": "user_id",
+          "references_table": "users",
+          "references_column": "id",
+          "constraint": "invites_user_id_fkey"
+        }
+      ],
+      "unique_constraints": [],
+      "indexes": [
+        {
+          "name": "invites_pkey",
+          "columns": [
+            "id"
+          ],
+          "unique": true,
+          "primary": true
+        },
+        {
+          "name": "ix_invites_email",
+          "columns": [
+            "email"
+          ],
+          "unique": false,
+          "primary": false
+        },
+        {
+          "name": "ix_invites_token",
+          "columns": [
+            "token"
+          ],
+          "unique": true,
+          "primary": false
+        }
+      ],
+      "check_constraints": []
+    },
+    "loom_version_accessories": {
+      "columns": [
+        {
+          "name": "id",
+          "position": 1,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "loom_version_id",
+          "position": 2,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "name",
+          "position": 3,
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "created_at",
+          "position": 4,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        },
+        {
+          "name": "updated_at",
+          "position": 5,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": [
+        {
+          "column": "loom_version_id",
+          "references_table": "loom_versions",
+          "references_column": "id",
+          "constraint": "loom_version_accessories_loom_version_id_fkey"
+        }
+      ],
+      "unique_constraints": [],
+      "indexes": [
+        {
+          "name": "ix_loom_version_accessories_loom_version_id",
+          "columns": [
+            "loom_version_id"
+          ],
+          "unique": false,
+          "primary": false
+        },
+        {
+          "name": "loom_version_accessories_pkey",
+          "columns": [
+            "id"
+          ],
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "check_constraints": []
+    },
+    "loom_version_photos": {
+      "columns": [
+        {
+          "name": "id",
+          "position": 1,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "loom_version_id",
+          "position": 2,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "filename",
+          "position": 3,
+          "type": "varchar(255)",
+          "nullable": false
+        },
+        {
+          "name": "path",
+          "position": 4,
+          "type": "varchar(500)",
+          "nullable": false
+        },
+        {
+          "name": "file_size_bytes",
+          "position": 5,
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "display_order",
+          "position": 6,
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "created_at",
+          "position": 7,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        },
+        {
+          "name": "updated_at",
+          "position": 8,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": [
+        {
+          "column": "loom_version_id",
+          "references_table": "loom_versions",
+          "references_column": "id",
+          "constraint": "loom_version_photos_loom_version_id_fkey"
+        }
+      ],
+      "unique_constraints": [],
+      "indexes": [
+        {
+          "name": "ix_loom_version_photos_loom_version_id",
+          "columns": [
+            "loom_version_id"
+          ],
+          "unique": false,
+          "primary": false
+        },
+        {
+          "name": "loom_version_photos_pkey",
+          "columns": [
+            "id"
+          ],
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "check_constraints": []
+    },
+    "loom_version_receipts": {
+      "columns": [
+        {
+          "name": "id",
+          "position": 1,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "loom_version_id",
+          "position": 2,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "filename",
+          "position": 3,
+          "type": "varchar(255)",
+          "nullable": false
+        },
+        {
+          "name": "path",
+          "position": 4,
+          "type": "varchar(500)",
+          "nullable": false
+        },
+        {
+          "name": "description",
+          "position": 5,
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created_at",
+          "position": 6,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        },
+        {
+          "name": "updated_at",
+          "position": 7,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": [
+        {
+          "column": "loom_version_id",
+          "references_table": "loom_versions",
+          "references_column": "id",
+          "constraint": "loom_version_receipts_loom_version_id_fkey"
+        }
+      ],
+      "unique_constraints": [],
+      "indexes": [
+        {
+          "name": "ix_loom_version_receipts_loom_version_id",
+          "columns": [
+            "loom_version_id"
+          ],
+          "unique": false,
+          "primary": false
+        },
+        {
+          "name": "loom_version_receipts_pkey",
+          "columns": [
+            "id"
+          ],
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "check_constraints": []
+    },
+    "loom_versions": {
+      "columns": [
+        {
+          "name": "id",
+          "position": 1,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "loom_id",
+          "position": 2,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "version_number",
+          "position": 3,
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "name",
+          "position": 4,
+          "type": "varchar(255)",
+          "nullable": true
+        },
+        {
+          "name": "effective_date",
+          "position": 5,
+          "type": "date",
+          "nullable": false
+        },
+        {
+          "name": "description",
+          "position": 6,
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "num_shafts",
+          "position": 7,
+          "type": "integer",
+          "nullable": true
+        },
+        {
+          "name": "num_treadles",
+          "position": 8,
+          "type": "integer",
+          "nullable": true
+        },
+        {
+          "name": "num_heddles",
+          "position": 9,
+          "type": "integer",
+          "nullable": true
+        },
+        {
+          "name": "weaving_width",
+          "position": 10,
+          "type": "numeric(6,1)",
+          "nullable": true
+        },
+        {
+          "name": "weaving_width_unit",
+          "position": 11,
+          "type": "varchar(5)",
+          "nullable": false
+        },
+        {
+          "name": "warp_waste_allowance",
+          "position": 12,
+          "type": "numeric(6,1)",
+          "nullable": true
+        },
+        {
+          "name": "warp_waste_unit",
+          "position": 13,
+          "type": "varchar(5)",
+          "nullable": false
+        },
+        {
+          "name": "created_at",
+          "position": 14,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        },
+        {
+          "name": "updated_at",
+          "position": 15,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": [
+        {
+          "column": "loom_id",
+          "references_table": "looms",
+          "references_column": "id",
+          "constraint": "loom_versions_loom_id_fkey"
+        }
+      ],
+      "unique_constraints": [],
+      "indexes": [
+        {
+          "name": "ix_loom_versions_loom_id",
+          "columns": [
+            "loom_id"
+          ],
+          "unique": false,
+          "primary": false
+        },
+        {
+          "name": "loom_versions_pkey",
+          "columns": [
+            "id"
+          ],
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "check_constraints": []
+    },
+    "looms": {
+      "columns": [
+        {
+          "name": "id",
+          "position": 1,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "owner_id",
+          "position": 2,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "loom_type",
+          "position": 3,
+          "type": "varchar(30)",
+          "nullable": false
+        },
+        {
+          "name": "manufacturer",
+          "position": 4,
+          "type": "varchar(255)",
+          "nullable": false
+        },
+        {
+          "name": "model_name",
+          "position": 5,
+          "type": "varchar(255)",
+          "nullable": false
+        },
+        {
+          "name": "serial_number",
+          "position": 6,
+          "type": "varchar(100)",
+          "nullable": true
+        },
+        {
+          "name": "purchase_date",
+          "position": 7,
+          "type": "date",
+          "nullable": true
+        },
+        {
+          "name": "purchase_price",
+          "position": 8,
+          "type": "numeric(10,2)",
+          "nullable": true
+        },
+        {
+          "name": "vendor",
+          "position": 9,
+          "type": "varchar(255)",
+          "nullable": true
+        },
+        {
+          "name": "photo_path",
+          "position": 10,
+          "type": "varchar(500)",
+          "nullable": true
+        },
+        {
+          "name": "supports_lift_tracking",
+          "position": 11,
+          "type": "boolean",
+          "nullable": false
+        },
+        {
+          "name": "supports_treadle_tracking",
+          "position": 12,
+          "type": "boolean",
+          "nullable": false
+        },
+        {
+          "name": "notes",
+          "position": 13,
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created_at",
+          "position": 14,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        },
+        {
+          "name": "updated_at",
+          "position": 15,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        },
+        {
+          "name": "deleted_at",
+          "position": 16,
+          "type": "timestamp with time zone",
+          "nullable": true
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": [
+        {
+          "column": "owner_id",
+          "references_table": "users",
+          "references_column": "id",
+          "constraint": "looms_owner_id_fkey"
+        }
+      ],
+      "unique_constraints": [],
+      "indexes": [
+        {
+          "name": "ix_looms_owner_id",
+          "columns": [
+            "owner_id"
+          ],
+          "unique": false,
+          "primary": false
+        },
+        {
+          "name": "looms_pkey",
+          "columns": [
+            "id"
+          ],
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "check_constraints": []
+    },
+    "pending_signups": {
+      "columns": [
+        {
+          "name": "id",
+          "position": 1,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "clerk_user_id",
+          "position": 2,
+          "type": "varchar(64)",
+          "nullable": false
+        },
+        {
+          "name": "email",
+          "position": 3,
+          "type": "varchar(255)",
+          "nullable": false
+        },
+        {
+          "name": "display_name",
+          "position": 4,
+          "type": "varchar(255)",
+          "nullable": false
+        },
+        {
+          "name": "created_at",
+          "position": 5,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        },
+        {
+          "name": "updated_at",
+          "position": 6,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": [],
+      "unique_constraints": [],
+      "indexes": [
+        {
+          "name": "ix_pending_signups_clerk_user_id",
+          "columns": [
+            "clerk_user_id"
+          ],
+          "unique": true,
+          "primary": false
+        },
+        {
+          "name": "pending_signups_pkey",
+          "columns": [
+            "id"
+          ],
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "check_constraints": []
+    },
+    "projects": {
+      "columns": [
+        {
+          "name": "id",
+          "position": 1,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "owner_id",
+          "position": 2,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "name",
+          "position": 3,
+          "type": "varchar(255)",
+          "nullable": false
+        },
+        {
+          "name": "description",
+          "position": 4,
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "wif_filename",
+          "position": 5,
+          "type": "varchar(512)",
+          "nullable": false
+        },
+        {
+          "name": "wif_path",
+          "position": 6,
+          "type": "varchar(512)",
+          "nullable": false
+        },
+        {
+          "name": "num_shafts",
+          "position": 7,
+          "type": "integer",
+          "nullable": true
+        },
+        {
+          "name": "num_treadles",
+          "position": 8,
+          "type": "integer",
+          "nullable": true
+        },
+        {
+          "name": "warp_threads",
+          "position": 9,
+          "type": "integer",
+          "nullable": true
+        },
+        {
+          "name": "weft_threads",
+          "position": 10,
+          "type": "integer",
+          "nullable": true
+        },
+        {
+          "name": "has_threading",
+          "position": 11,
+          "type": "boolean",
+          "nullable": false
+        },
+        {
+          "name": "has_tieup",
+          "position": 12,
+          "type": "boolean",
+          "nullable": false
+        },
+        {
+          "name": "has_treadling",
+          "position": 13,
+          "type": "boolean",
+          "nullable": false
+        },
+        {
+          "name": "has_liftplan",
+          "position": 14,
+          "type": "boolean",
+          "nullable": false
+        },
+        {
+          "name": "has_color_palette",
+          "position": 15,
+          "type": "boolean",
+          "nullable": false
+        },
+        {
+          "name": "liftplan_generated",
+          "position": 16,
+          "type": "boolean",
+          "nullable": false
+        },
+        {
+          "name": "lint_warnings",
+          "position": 17,
+          "type": "jsonb",
+          "nullable": false
+        },
+        {
+          "name": "lint_errors",
+          "position": 18,
+          "type": "jsonb",
+          "nullable": false
+        },
+        {
+          "name": "wif_source_software",
+          "position": 19,
+          "type": "varchar(255)",
+          "nullable": true
+        },
+        {
+          "name": "wif_source_version",
+          "position": 20,
+          "type": "varchar(100)",
+          "nullable": true
+        },
+        {
+          "name": "preview_path",
+          "position": 21,
+          "type": "varchar(512)",
+          "nullable": true
+        },
+        {
+          "name": "is_shared",
+          "position": 22,
+          "type": "boolean",
+          "nullable": false
+        },
+        {
+          "name": "share_slug",
+          "position": 23,
+          "type": "varchar(64)",
+          "nullable": true
+        },
+        {
+          "name": "created_at",
+          "position": 24,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        },
+        {
+          "name": "updated_at",
+          "position": 25,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        },
+        {
+          "name": "deleted_at",
+          "position": 26,
+          "type": "timestamp with time zone",
+          "nullable": true
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": [
+        {
+          "column": "owner_id",
+          "references_table": "users",
+          "references_column": "id",
+          "constraint": "projects_owner_id_fkey"
+        }
+      ],
+      "unique_constraints": [
+        {
+          "constraint": "projects_share_slug_key",
+          "columns": [
+            "share_slug"
+          ]
+        }
+      ],
+      "indexes": [
+        {
+          "name": "ix_projects_owner_id",
+          "columns": [
+            "owner_id"
+          ],
+          "unique": false,
+          "primary": false
+        },
+        {
+          "name": "projects_pkey",
+          "columns": [
+            "id"
+          ],
+          "unique": true,
+          "primary": true
+        },
+        {
+          "name": "projects_share_slug_key",
+          "columns": [
+            "share_slug"
+          ],
+          "unique": true,
+          "primary": false
+        }
+      ],
+      "check_constraints": []
+    },
+    "seed_runs": {
+      "columns": [
+        {
+          "name": "id",
+          "position": 1,
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('seed_runs_id_seq'::regclass)"
+        },
+        {
+          "name": "ran_at",
+          "position": 2,
+          "type": "timestamp with time zone",
+          "nullable": false
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": [],
+      "unique_constraints": [],
+      "indexes": [
+        {
+          "name": "seed_runs_pkey",
+          "columns": [
+            "id"
+          ],
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "check_constraints": []
+    },
+    "skeins": {
+      "columns": [
+        {
+          "name": "id",
+          "position": 1,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "yarn_id",
+          "position": 2,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "status",
+          "position": 3,
+          "type": "varchar(20)",
+          "nullable": false
+        },
+        {
+          "name": "current_yardage",
+          "position": 4,
+          "type": "numeric(10,1)",
+          "nullable": true
+        },
+        {
+          "name": "current_weight_oz",
+          "position": 5,
+          "type": "numeric(8,2)",
+          "nullable": true
+        },
+        {
+          "name": "current_weight_g",
+          "position": 6,
+          "type": "numeric(8,2)",
+          "nullable": true
+        },
+        {
+          "name": "notes",
+          "position": 7,
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created_at",
+          "position": 8,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        },
+        {
+          "name": "updated_at",
+          "position": 9,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": [
+        {
+          "column": "yarn_id",
+          "references_table": "yarns",
+          "references_column": "id",
+          "constraint": "skeins_yarn_id_fkey"
+        }
+      ],
+      "unique_constraints": [],
+      "indexes": [
+        {
+          "name": "ix_skeins_yarn_id",
+          "columns": [
+            "yarn_id"
+          ],
+          "unique": false,
+          "primary": false
+        },
+        {
+          "name": "skeins_pkey",
+          "columns": [
+            "id"
+          ],
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "check_constraints": []
+    },
+    "user_identities": {
+      "columns": [
+        {
+          "name": "id",
+          "position": 1,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "position": 2,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "provider",
+          "position": 3,
+          "type": "varchar(64)",
+          "nullable": false
+        },
+        {
+          "name": "provider_sub",
+          "position": 4,
+          "type": "varchar(256)",
+          "nullable": false
+        },
+        {
+          "name": "email",
+          "position": 5,
+          "type": "varchar(256)",
+          "nullable": true
+        },
+        {
+          "name": "created_at",
+          "position": 6,
+          "type": "timestamp with time zone",
+          "nullable": false
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": [
+        {
+          "column": "user_id",
+          "references_table": "users",
+          "references_column": "id",
+          "constraint": "user_identities_user_id_fkey"
+        }
+      ],
+      "unique_constraints": [
+        {
+          "constraint": "uq_user_identities_provider_sub",
+          "columns": [
+            "provider",
+            "provider_sub"
+          ]
+        }
+      ],
+      "indexes": [
+        {
+          "name": "ix_user_identities_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "unique": false,
+          "primary": false
+        },
+        {
+          "name": "uq_user_identities_provider_sub",
+          "columns": [
+            "provider",
+            "provider_sub"
+          ],
+          "unique": true,
+          "primary": false
+        },
+        {
+          "name": "user_identities_pkey",
+          "columns": [
+            "id"
+          ],
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "check_constraints": []
+    },
+    "users": {
+      "columns": [
+        {
+          "name": "id",
+          "position": 1,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "email",
+          "position": 2,
+          "type": "varchar(255)",
+          "nullable": false
+        },
+        {
+          "name": "display_name",
+          "position": 3,
+          "type": "varchar(255)",
+          "nullable": false
+        },
+        {
+          "name": "oidc_sub",
+          "position": 4,
+          "type": "varchar(512)",
+          "nullable": true
+        },
+        {
+          "name": "clerk_user_id",
+          "position": 5,
+          "type": "varchar(64)",
+          "nullable": true
+        },
+        {
+          "name": "is_admin",
+          "position": 6,
+          "type": "boolean",
+          "nullable": false
+        },
+        {
+          "name": "is_superuser",
+          "position": 7,
+          "type": "boolean",
+          "nullable": false
+        },
+        {
+          "name": "is_active",
+          "position": 8,
+          "type": "boolean",
+          "nullable": false
+        },
+        {
+          "name": "theme",
+          "position": 9,
+          "type": "varchar(20)",
+          "nullable": false
+        },
+        {
+          "name": "activity_theme",
+          "position": 10,
+          "type": "varchar(50)",
+          "nullable": true
+        },
+        {
+          "name": "idle_timeout_minutes",
+          "position": 11,
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "measurement_system",
+          "position": 12,
+          "type": "varchar(10)",
+          "nullable": false
+        },
+        {
+          "name": "ai_training_consent",
+          "position": 13,
+          "type": "boolean",
+          "nullable": false
+        },
+        {
+          "name": "eula_accepted_version",
+          "position": 14,
+          "type": "varchar(20)",
+          "nullable": true
+        },
+        {
+          "name": "eula_accepted_at",
+          "position": 15,
+          "type": "timestamp with time zone",
+          "nullable": true
+        },
+        {
+          "name": "last_active_at",
+          "position": 16,
+          "type": "timestamp with time zone",
+          "nullable": true
+        },
+        {
+          "name": "approved_by_name",
+          "position": 17,
+          "type": "varchar(255)",
+          "nullable": true
+        },
+        {
+          "name": "approved_by_email",
+          "position": 18,
+          "type": "varchar(255)",
+          "nullable": true
+        },
+        {
+          "name": "clerk_banned",
+          "position": 19,
+          "type": "boolean",
+          "nullable": false
+        },
+        {
+          "name": "deletion_state",
+          "position": 20,
+          "type": "varchar(20)",
+          "nullable": true
+        },
+        {
+          "name": "deletion_initiated_at",
+          "position": 21,
+          "type": "timestamp with time zone",
+          "nullable": true
+        },
+        {
+          "name": "clerk_errored",
+          "position": 22,
+          "type": "boolean",
+          "nullable": false
+        },
+        {
+          "name": "created_at",
+          "position": 23,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        },
+        {
+          "name": "updated_at",
+          "position": 24,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        },
+        {
+          "name": "deleted_at",
+          "position": 25,
+          "type": "timestamp with time zone",
+          "nullable": true
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": [],
+      "unique_constraints": [],
+      "indexes": [
+        {
+          "name": "ix_users_clerk_user_id",
+          "columns": [
+            "clerk_user_id"
+          ],
+          "unique": true,
+          "primary": false
+        },
+        {
+          "name": "ix_users_email",
+          "columns": [
+            "email"
+          ],
+          "unique": true,
+          "primary": false
+        },
+        {
+          "name": "ix_users_oidc_sub",
+          "columns": [
+            "oidc_sub"
+          ],
+          "unique": true,
+          "primary": false
+        },
+        {
+          "name": "users_pkey",
+          "columns": [
+            "id"
+          ],
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "check_constraints": []
+    },
+    "yarns": {
+      "columns": [
+        {
+          "name": "id",
+          "position": 1,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "owner_id",
+          "position": 2,
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "brand",
+          "position": 3,
+          "type": "varchar(255)",
+          "nullable": false
+        },
+        {
+          "name": "name",
+          "position": 4,
+          "type": "varchar(255)",
+          "nullable": false
+        },
+        {
+          "name": "weight_notation",
+          "position": 5,
+          "type": "varchar(20)",
+          "nullable": true
+        },
+        {
+          "name": "weight_category",
+          "position": 6,
+          "type": "varchar(30)",
+          "nullable": true
+        },
+        {
+          "name": "fiber_content",
+          "position": 7,
+          "type": "varchar(255)",
+          "nullable": true
+        },
+        {
+          "name": "color_name",
+          "position": 8,
+          "type": "varchar(255)",
+          "nullable": true
+        },
+        {
+          "name": "color_hex",
+          "position": 9,
+          "type": "varchar(7)",
+          "nullable": true
+        },
+        {
+          "name": "unit_weight_oz",
+          "position": 10,
+          "type": "numeric(8,2)",
+          "nullable": true
+        },
+        {
+          "name": "unit_weight_g",
+          "position": 11,
+          "type": "numeric(8,2)",
+          "nullable": true
+        },
+        {
+          "name": "unit_yardage",
+          "position": 12,
+          "type": "numeric(10,1)",
+          "nullable": true
+        },
+        {
+          "name": "yards_per_pound",
+          "position": 13,
+          "type": "numeric(10,1)",
+          "nullable": true
+        },
+        {
+          "name": "sett_min",
+          "position": 14,
+          "type": "integer",
+          "nullable": true
+        },
+        {
+          "name": "sett_max",
+          "position": 15,
+          "type": "integer",
+          "nullable": true
+        },
+        {
+          "name": "purchase_source",
+          "position": 16,
+          "type": "varchar(255)",
+          "nullable": true
+        },
+        {
+          "name": "purchase_price",
+          "position": 17,
+          "type": "numeric(10,2)",
+          "nullable": true
+        },
+        {
+          "name": "purchase_date",
+          "position": 18,
+          "type": "date",
+          "nullable": true
+        },
+        {
+          "name": "notes",
+          "position": 19,
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "photo_path",
+          "position": 20,
+          "type": "varchar(500)",
+          "nullable": true
+        },
+        {
+          "name": "created_at",
+          "position": 21,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        },
+        {
+          "name": "updated_at",
+          "position": 22,
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        },
+        {
+          "name": "deleted_at",
+          "position": 23,
+          "type": "timestamp with time zone",
+          "nullable": true
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": [
+        {
+          "column": "owner_id",
+          "references_table": "users",
+          "references_column": "id",
+          "constraint": "yarns_owner_id_fkey"
+        }
+      ],
+      "unique_constraints": [],
+      "indexes": [
+        {
+          "name": "ix_yarns_owner_id",
+          "columns": [
+            "owner_id"
+          ],
+          "unique": false,
+          "primary": false
+        },
+        {
+          "name": "yarns_pkey",
+          "columns": [
+            "id"
+          ],
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "check_constraints": []
+    }
+  },
+  "enums": {}
+}

--- a/docs/schema.mermaid
+++ b/docs/schema.mermaid
@@ -1,0 +1,266 @@
+erDiagram
+    activities {
+        uuid id "PK"
+        uuid owner_id "FK"
+        uuid project_id "FK"
+        uuid loom_id "FK"
+        uuid loom_version_id "FK"
+        varchar name
+        varchar activity_type
+        varchar status
+        int current_pick
+        int total_picks
+        numeric finished_length_per_item
+        int num_items
+        numeric waste_between_items
+        numeric warp_waste_allowance
+        varchar length_unit
+        timestamptz completed_at
+        timestamptz abandoned_at
+        text notes
+        timestamptz created_at
+        timestamptz updated_at
+        timestamptz deleted_at
+    }
+    activity_photos {
+        uuid id "PK"
+        uuid activity_id "FK"
+        varchar file_path
+        varchar filename
+        int file_size_bytes
+        int display_order
+        timestamptz created_at
+        timestamptz updated_at
+    }
+    activity_steps {
+        uuid id "PK"
+        uuid activity_id "FK"
+        varchar event_type
+        int from_pick
+        int to_pick
+        timestamptz created_at
+        timestamptz updated_at
+    }
+    alembic_version {
+        varchar version_num "PK"
+    }
+    audit_logs {
+        uuid id "PK"
+        uuid actor_id
+        varchar actor_email
+        varchar event_type
+        uuid target_user_id
+        varchar target_email
+        json details
+        timestamptz created_at
+    }
+    eula_versions {
+        int id "PK"
+        varchar version
+        text body_html
+        timestamptz effective_date
+        timestamptz created_at
+    }
+    invites {
+        uuid id "PK"
+        varchar email
+        varchar token
+        timestamptz expires_at
+        timestamptz accepted_at
+        timestamptz revoked_at
+        uuid created_by_id "FK"
+        timestamptz created_at
+        timestamptz updated_at
+        varchar role
+        uuid user_id "FK"
+    }
+    loom_version_accessories {
+        uuid id "PK"
+        uuid loom_version_id "FK"
+        text name
+        timestamptz created_at
+        timestamptz updated_at
+    }
+    loom_version_photos {
+        uuid id "PK"
+        uuid loom_version_id "FK"
+        varchar filename
+        varchar path
+        int file_size_bytes
+        int display_order
+        timestamptz created_at
+        timestamptz updated_at
+    }
+    loom_version_receipts {
+        uuid id "PK"
+        uuid loom_version_id "FK"
+        varchar filename
+        varchar path
+        text description
+        timestamptz created_at
+        timestamptz updated_at
+    }
+    loom_versions {
+        uuid id "PK"
+        uuid loom_id "FK"
+        int version_number
+        varchar name
+        date effective_date
+        text description
+        int num_shafts
+        int num_treadles
+        int num_heddles
+        numeric weaving_width
+        varchar weaving_width_unit
+        numeric warp_waste_allowance
+        varchar warp_waste_unit
+        timestamptz created_at
+        timestamptz updated_at
+    }
+    looms {
+        uuid id "PK"
+        uuid owner_id "FK"
+        varchar loom_type
+        varchar manufacturer
+        varchar model_name
+        varchar serial_number
+        date purchase_date
+        numeric purchase_price
+        varchar vendor
+        varchar photo_path
+        boolean supports_lift_tracking
+        boolean supports_treadle_tracking
+        text notes
+        timestamptz created_at
+        timestamptz updated_at
+        timestamptz deleted_at
+    }
+    pending_signups {
+        uuid id "PK"
+        varchar clerk_user_id
+        varchar email
+        varchar display_name
+        timestamptz created_at
+        timestamptz updated_at
+    }
+    projects {
+        uuid id "PK"
+        uuid owner_id "FK"
+        varchar name
+        text description
+        varchar wif_filename
+        varchar wif_path
+        int num_shafts
+        int num_treadles
+        int warp_threads
+        int weft_threads
+        boolean has_threading
+        boolean has_tieup
+        boolean has_treadling
+        boolean has_liftplan
+        boolean has_color_palette
+        boolean liftplan_generated
+        jsonb lint_warnings
+        jsonb lint_errors
+        varchar wif_source_software
+        varchar wif_source_version
+        varchar preview_path
+        boolean is_shared
+        varchar share_slug
+        timestamptz created_at
+        timestamptz updated_at
+        timestamptz deleted_at
+    }
+    seed_runs {
+        int id "PK"
+        timestamptz ran_at
+    }
+    skeins {
+        uuid id "PK"
+        uuid yarn_id "FK"
+        varchar status
+        numeric current_yardage
+        numeric current_weight_oz
+        numeric current_weight_g
+        text notes
+        timestamptz created_at
+        timestamptz updated_at
+    }
+    user_identities {
+        uuid id "PK"
+        uuid user_id "FK"
+        varchar provider
+        varchar provider_sub
+        varchar email
+        timestamptz created_at
+    }
+    users {
+        uuid id "PK"
+        varchar email
+        varchar display_name
+        varchar oidc_sub
+        varchar clerk_user_id
+        boolean is_admin
+        boolean is_superuser
+        boolean is_active
+        varchar theme
+        varchar activity_theme
+        int idle_timeout_minutes
+        varchar measurement_system
+        boolean ai_training_consent
+        varchar eula_accepted_version
+        timestamptz eula_accepted_at
+        timestamptz last_active_at
+        varchar approved_by_name
+        varchar approved_by_email
+        boolean clerk_banned
+        varchar deletion_state
+        timestamptz deletion_initiated_at
+        boolean clerk_errored
+        timestamptz created_at
+        timestamptz updated_at
+        timestamptz deleted_at
+    }
+    yarns {
+        uuid id "PK"
+        uuid owner_id "FK"
+        varchar brand
+        varchar name
+        varchar weight_notation
+        varchar weight_category
+        varchar fiber_content
+        varchar color_name
+        varchar color_hex
+        numeric unit_weight_oz
+        numeric unit_weight_g
+        numeric unit_yardage
+        numeric yards_per_pound
+        int sett_min
+        int sett_max
+        varchar purchase_source
+        numeric purchase_price
+        date purchase_date
+        text notes
+        varchar photo_path
+        timestamptz created_at
+        timestamptz updated_at
+        timestamptz deleted_at
+    }
+
+    looms ||--o{ activities : "loom_id"
+    loom_versions ||--o{ activities : "loom_version_id"
+    users ||--o{ activities : "owner_id"
+    projects ||--o{ activities : "project_id"
+    activities ||--o{ activity_photos : "activity_id"
+    activities ||--o{ activity_steps : "activity_id"
+    users ||--o{ invites : "created_by_id"
+    users ||--o{ invites : "user_id"
+    loom_versions ||--o{ loom_version_accessories : "loom_version_id"
+    loom_versions ||--o{ loom_version_photos : "loom_version_id"
+    loom_versions ||--o{ loom_version_receipts : "loom_version_id"
+    looms ||--o{ loom_versions : "loom_id"
+    users ||--o{ looms : "owner_id"
+    users ||--o{ projects : "owner_id"
+    yarns ||--o{ skeins : "yarn_id"
+    users ||--o{ user_identities : "user_id"
+    users ||--o{ yarns : "owner_id"

--- a/scripts/db_schema.py
+++ b/scripts/db_schema.py
@@ -1,0 +1,403 @@
+"""
+Generate a JSON schema document and Mermaid ER diagram from the live PostgreSQL database.
+
+Usage:
+    python scripts/db_schema.py [--env .env.dev] [--out docs/schema]
+
+Outputs:
+    <out>.json       — full schema (tables, columns, PKs, FKs, unique, indexes)
+    <out>.mermaid    — erDiagram suitable for rendering with Mermaid
+
+Requires: psycopg2-binary  (pip install psycopg2-binary)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _lib import fail, header, info, load_env, ok, resolve_postgres_dsn
+
+try:
+    import psycopg2
+    import psycopg2.extras
+except ImportError:
+    fail("psycopg2-binary not installed — run: pip install psycopg2-binary")
+
+
+# ---------------------------------------------------------------------------
+# Query helpers
+# ---------------------------------------------------------------------------
+
+COLUMNS_SQL = """
+SELECT
+    c.table_name,
+    c.column_name,
+    c.ordinal_position,
+    c.data_type,
+    c.character_maximum_length,
+    c.numeric_precision,
+    c.numeric_scale,
+    c.is_nullable,
+    c.column_default,
+    c.is_identity
+FROM information_schema.columns c
+WHERE c.table_schema = 'public'
+ORDER BY c.table_name, c.ordinal_position
+"""
+
+PK_SQL = """
+SELECT
+    kcu.table_name,
+    kcu.column_name,
+    kcu.ordinal_position
+FROM information_schema.table_constraints tc
+JOIN information_schema.key_column_usage kcu
+    ON tc.constraint_name = kcu.constraint_name
+   AND tc.table_schema    = kcu.table_schema
+WHERE tc.constraint_type = 'PRIMARY KEY'
+  AND tc.table_schema = 'public'
+ORDER BY kcu.table_name, kcu.ordinal_position
+"""
+
+FK_SQL = """
+SELECT
+    kcu.table_name        AS from_table,
+    kcu.column_name       AS from_column,
+    ccu.table_name        AS to_table,
+    ccu.column_name       AS to_column,
+    tc.constraint_name
+FROM information_schema.table_constraints  tc
+JOIN information_schema.key_column_usage   kcu
+    ON tc.constraint_name = kcu.constraint_name
+   AND tc.table_schema    = kcu.table_schema
+JOIN information_schema.constraint_column_usage ccu
+    ON tc.constraint_name = ccu.constraint_name
+   AND tc.table_schema    = ccu.table_schema
+WHERE tc.constraint_type = 'FOREIGN KEY'
+  AND tc.table_schema = 'public'
+ORDER BY kcu.table_name, kcu.column_name
+"""
+
+UNIQUE_SQL = """
+SELECT
+    tc.constraint_name,
+    kcu.table_name,
+    kcu.column_name,
+    kcu.ordinal_position
+FROM information_schema.table_constraints tc
+JOIN information_schema.key_column_usage kcu
+    ON tc.constraint_name = kcu.constraint_name
+   AND tc.table_schema    = kcu.table_schema
+WHERE tc.constraint_type = 'UNIQUE'
+  AND tc.table_schema = 'public'
+ORDER BY kcu.table_name, tc.constraint_name, kcu.ordinal_position
+"""
+
+INDEX_SQL = """
+SELECT
+    t.relname        AS table_name,
+    i.relname        AS index_name,
+    ix.indisunique   AS is_unique,
+    ix.indisprimary  AS is_primary,
+    array_agg(a.attname ORDER BY k.ord) AS columns
+FROM pg_class t
+JOIN pg_index ix      ON ix.indrelid = t.oid
+JOIN pg_class i       ON i.oid = ix.indexrelid
+JOIN pg_namespace n   ON n.oid = t.relnamespace
+JOIN LATERAL unnest(ix.indkey) WITH ORDINALITY AS k(attnum, ord)
+    ON TRUE
+JOIN pg_attribute a   ON a.attrelid = t.oid AND a.attnum = k.attnum
+WHERE n.nspname = 'public'
+  AND t.relkind = 'r'
+GROUP BY t.relname, i.relname, ix.indisunique, ix.indisprimary
+ORDER BY t.relname, i.relname
+"""
+
+CHECK_SQL = """
+SELECT
+    tc.table_name,
+    tc.constraint_name,
+    cc.check_clause
+FROM information_schema.table_constraints tc
+JOIN information_schema.check_constraints cc
+    ON tc.constraint_name = cc.constraint_name
+   AND tc.table_schema    = cc.constraint_schema
+WHERE tc.constraint_type = 'CHECK'
+  AND tc.table_schema = 'public'
+  AND cc.check_clause NOT LIKE '%IS NOT NULL%'
+ORDER BY tc.table_name, tc.constraint_name
+"""
+
+ENUM_SQL = """
+SELECT
+    t.typname AS enum_name,
+    e.enumlabel AS enum_value,
+    e.enumsortorder AS sort_order
+FROM pg_type t
+JOIN pg_enum e ON e.enumtypid = t.oid
+JOIN pg_namespace n ON n.oid = t.typnamespace
+WHERE n.nspname = 'public'
+ORDER BY t.typname, e.enumsortorder
+"""
+
+
+# ---------------------------------------------------------------------------
+# Data collection
+# ---------------------------------------------------------------------------
+
+def collect_schema(cur: "psycopg2.cursor") -> dict:
+    def rows(sql: str) -> list[dict]:
+        cur.execute(sql)
+        return [dict(r) for r in cur.fetchall()]
+
+    # Tables
+    tables: dict[str, dict] = {}
+
+    for row in rows(COLUMNS_SQL):
+        tbl = row["table_name"]
+        if tbl not in tables:
+            tables[tbl] = {"columns": [], "primary_key": [], "foreign_keys": [],
+                           "unique_constraints": [], "indexes": [], "check_constraints": []}
+        col: dict = {
+            "name": row["column_name"],
+            "position": row["ordinal_position"],
+            "type": _format_type(row),
+            "nullable": row["is_nullable"] == "YES",
+        }
+        if row["column_default"] is not None:
+            col["default"] = row["column_default"]
+        if row["is_identity"] == "YES":
+            col["identity"] = True
+        tables[tbl]["columns"].append(col)
+
+    # Primary keys
+    pk_map: dict[str, list[str]] = {}
+    for row in rows(PK_SQL):
+        pk_map.setdefault(row["table_name"], []).append(row["column_name"])
+    for tbl, cols in pk_map.items():
+        if tbl in tables:
+            tables[tbl]["primary_key"] = cols
+
+    # Foreign keys
+    for row in rows(FK_SQL):
+        tbl = row["from_table"]
+        if tbl in tables:
+            tables[tbl]["foreign_keys"].append({
+                "column": row["from_column"],
+                "references_table": row["to_table"],
+                "references_column": row["to_column"],
+                "constraint": row["constraint_name"],
+            })
+
+    # Unique constraints
+    unique_groups: dict[tuple, list[str]] = {}
+    for row in rows(UNIQUE_SQL):
+        key = (row["table_name"], row["constraint_name"])
+        unique_groups.setdefault(key, []).append(row["column_name"])
+    for (tbl, cname), cols in unique_groups.items():
+        if tbl in tables:
+            tables[tbl]["unique_constraints"].append({
+                "constraint": cname,
+                "columns": cols,
+            })
+
+    # Indexes
+    idx_groups: dict[tuple, dict] = {}
+    for row in rows(INDEX_SQL):
+        key = (row["table_name"], row["index_name"])
+        idx_groups[key] = {
+            "name": row["index_name"],
+            "columns": list(row["columns"]),
+            "unique": row["is_unique"],
+            "primary": row["is_primary"],
+        }
+    for (tbl, _), idx in idx_groups.items():
+        if tbl in tables:
+            tables[tbl]["indexes"].append(idx)
+
+    # Check constraints
+    for row in rows(CHECK_SQL):
+        tbl = row["table_name"]
+        if tbl in tables:
+            tables[tbl]["check_constraints"].append({
+                "constraint": row["constraint_name"],
+                "clause": row["check_clause"],
+            })
+
+    # Enums
+    enums: dict[str, list[str]] = {}
+    for row in rows(ENUM_SQL):
+        enums.setdefault(row["enum_name"], []).append(row["enum_value"])
+
+    return {
+        "tables": tables,
+        "enums": enums,
+    }
+
+
+def _format_type(row: dict) -> str:
+    dtype = row["data_type"]
+    if dtype == "character varying" and row["character_maximum_length"]:
+        return f"varchar({row['character_maximum_length']})"
+    if dtype == "numeric" and row["numeric_precision"]:
+        if row["numeric_scale"]:
+            return f"numeric({row['numeric_precision']},{row['numeric_scale']})"
+        return f"numeric({row['numeric_precision']})"
+    return dtype
+
+
+# ---------------------------------------------------------------------------
+# Mermaid generation
+# ---------------------------------------------------------------------------
+
+MERMAID_TYPE_MAP = {
+    "integer": "int",
+    "bigint": "bigint",
+    "smallint": "smallint",
+    "boolean": "boolean",
+    "text": "text",
+    "uuid": "uuid",
+    "timestamp without time zone": "timestamp",
+    "timestamp with time zone": "timestamptz",
+    "date": "date",
+    "double precision": "float",
+    "real": "float",
+    "jsonb": "jsonb",
+    "json": "json",
+    "bytea": "bytea",
+}
+
+
+def _mermaid_type(pg_type: str) -> str:
+    if pg_type in MERMAID_TYPE_MAP:
+        return MERMAID_TYPE_MAP[pg_type]
+    if pg_type.startswith("character varying"):
+        return "varchar"
+    # Strip precision/length — Mermaid ATTRIBUTE_WORD rejects parentheses
+    base = re.sub(r"\(.*\)", "", pg_type).strip()
+    if base in MERMAID_TYPE_MAP:
+        return MERMAID_TYPE_MAP[base]
+    return base.replace(" ", "_")
+
+
+def _safe_ident(name: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_]", "_", name)
+
+
+def generate_mermaid(schema: dict) -> str:
+    tables = schema["tables"]
+    lines = ["erDiagram"]
+
+    # Entity definitions
+    for tbl_name, tbl in sorted(tables.items()):
+        safe = _safe_ident(tbl_name)
+        lines.append(f"    {safe} {{")
+        pk_cols = set(tbl["primary_key"])
+        fk_cols = {fk["column"] for fk in tbl["foreign_keys"]}
+        for col in tbl["columns"]:
+            cname = col["name"]
+            ctype = _mermaid_type(col["type"])
+            tags = []
+            if cname in pk_cols:
+                tags.append("PK")
+            if cname in fk_cols:
+                tags.append("FK")
+            tag_str = ", ".join(tags)
+            if tag_str:
+                lines.append(f"        {ctype} {cname} \"{tag_str}\"")
+            else:
+                lines.append(f"        {ctype} {cname}")
+        lines.append("    }")
+
+    lines.append("")
+
+    # Relationships (foreign keys)
+    seen: set[str] = set()
+    for tbl_name, tbl in sorted(tables.items()):
+        for fk in tbl["foreign_keys"]:
+            from_t = _safe_ident(tbl_name)
+            to_t = _safe_ident(fk["references_table"])
+            key = f"{from_t}_{to_t}_{fk['column']}"
+            if key in seen:
+                continue
+            seen.add(key)
+            label = fk["column"]
+            lines.append(f"    {to_t} ||--o{{ {from_t} : \"{label}\"")
+
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Document the WeftMark PostgreSQL schema")
+    parser.add_argument("--env", default=None,
+                        help="Path to .env file (default: .env.dev, then .env)")
+    parser.add_argument("--out", default="docs/schema",
+                        help="Output file prefix (default: docs/schema)")
+    args = parser.parse_args()
+
+    root = Path(__file__).parent.parent
+
+    # Resolve env file
+    if args.env:
+        env_path = Path(args.env)
+    else:
+        env_path = root / ".env.dev"
+        if not env_path.exists():
+            env_path = root / ".env"
+
+    info(f"Loading env from {env_path}")
+    env = load_env(str(env_path))
+
+    dsn = resolve_postgres_dsn(env)
+    # Mask password in log output
+    dsn_display = re.sub(r":([^:@]+)@", ":***@", dsn)
+    info(f"Connecting to {dsn_display}")
+
+    try:
+        conn = psycopg2.connect(dsn, cursor_factory=psycopg2.extras.RealDictCursor)
+    except Exception as e:
+        fail(f"Connection failed: {e}")
+
+    with conn:
+        with conn.cursor() as cur:
+            header("Collecting schema …")
+            schema = collect_schema(cur)
+
+    conn.close()
+
+    table_count = len(schema["tables"])
+    enum_count = len(schema["enums"])
+    ok(f"Found {table_count} tables, {enum_count} enums")
+
+    # Resolve output paths
+    out = Path(args.out)
+    if not out.is_absolute():
+        out = root / out
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    json_path = out.with_suffix(".json")
+    mermaid_path = out.with_suffix(".mermaid")
+
+    # Write JSON
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(schema, f, indent=2, default=str)
+    ok(f"JSON schema   → {json_path}")
+
+    # Write Mermaid
+    diagram = generate_mermaid(schema)
+    with open(mermaid_path, "w", encoding="utf-8") as f:
+        f.write(diagram)
+    ok(f"Mermaid diagram → {mermaid_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `scripts/db_schema.py` — connects to the live PostgreSQL database via `.env.dev` (falls back to `.env`) and documents the full schema
- Outputs `docs/schema.json` — tables, columns (type, nullable, default, identity), PKs, FKs, unique constraints, indexes, check constraints
- Outputs `docs/schema.mermaid` — `erDiagram` with all 19 tables and FK relationships

## Usage
```bash
python scripts/db_schema.py                         # uses .env.dev, writes docs/schema.*
python scripts/db_schema.py --env .env --out docs/db/schema
```
Requires `psycopg2-binary` (`pip install psycopg2-binary`).

## Test plan
- [x] Run `python scripts/db_schema.py` and confirm both output files are written
- [x] Open `docs/schema.mermaid` in a Mermaid renderer (e.g. mermaid.live) and confirm diagram renders without parse errors
- [x] Spot-check a table in `docs/schema.json` for accurate columns, PK, and FKs

🤖 Generated with [Claude Code](https://claude.com/claude-code)