### PR TITLE
fix: reject invite for pending-signup email, prompt admin to approve instead

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -340,6 +340,18 @@ async def create_invite(
     if active_user is not None:
         raise HTTPException(status_code=409, detail="A user with this email already exists")
 
+    # Block inviting an email that has a pending self-signup — admin should approve it instead.
+    pending_signup = await db.scalar(select(PendingSignup).where(PendingSignup.email == body.email))
+    if pending_signup is not None:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "reason": "pending_signup_exists",
+                "pending_signup_id": str(pending_signup.id),
+                "message": "This email already has a pending signup request.",
+            },
+        )
+
     # Reuse an existing unclaimed User record (even if soft-deleted by a prior revoke) or create one.
     pre_user = await db.scalar(select(User).where(User.email == body.email, User.clerk_user_id.is_(None)))
     if pre_user is not None:

--- a/backend/tests/routers/test_auth.py
+++ b/backend/tests/routers/test_auth.py
@@ -8,6 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.invite import Invite
+from app.models.pending_signup import PendingSignup
 from app.models.user import User
 
 
@@ -218,6 +219,23 @@ class TestCreateInvite:
         await db_session.refresh(soft_deleted)
         assert soft_deleted.deleted_at is None
         assert soft_deleted.is_admin is True
+
+    async def test_pending_signup_email_returns_409_with_reason(
+        self, admin_client: AsyncClient, db_session: AsyncSession
+    ):
+        signup = PendingSignup(
+            clerk_user_id="clerk_pending_test",
+            email="waiting@example.com",
+            display_name="Waiting User",
+        )
+        db_session.add(signup)
+        await db_session.commit()
+
+        resp = await admin_client.post("/auth/invite", json={"email": "waiting@example.com"})
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert detail["reason"] == "pending_signup_exists"
+        assert detail["pending_signup_id"] == str(signup.id)
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -435,6 +435,7 @@ function InvitesTab() {
   const [role, setRole] = useState<"user" | "admin">("user");
   const [error, setError] = useState<string | null>(null);
   const [sent, setSent] = useState<string | null>(null);
+  const [pendingApprove, setPendingApprove] = useState<{ id: string } | null>(null);
   const [historyPage, setHistoryPage] = useState(0);
 
   const { data: invites = [], isLoading } = useQuery({
@@ -454,9 +455,22 @@ function InvitesTab() {
       setEmail("");
       setRole("user");
       setError(null);
+      setPendingApprove(null);
       qc.invalidateQueries({ queryKey: ["admin", "invites"] });
     },
-    onError: (err: Error) => setError(err.message),
+    onError: (err: Error) => {
+      try {
+        const parsed = JSON.parse(err.message);
+        if (parsed?.detail?.reason === "pending_signup_exists") {
+          setPendingApprove({ id: parsed.detail.pending_signup_id });
+          setError("This email already has a pending signup request.");
+          return;
+        }
+        setError(parsed?.detail?.message ?? parsed?.detail ?? err.message);
+      } catch {
+        setError(err.message);
+      }
+    },
   });
 
   const removePending = (id: string) =>
@@ -517,7 +531,7 @@ function InvitesTab() {
             type="email"
             placeholder="email@example.com"
             value={email}
-            onChange={(e) => { setEmail(e.target.value); setSent(null); setError(null); }}
+            onChange={(e) => { setEmail(e.target.value); setSent(null); setError(null); setPendingApprove(null); }}
             onKeyDown={(e) => e.key === "Enter" && email && send.mutate()}
             className="flex-1 text-sm border rounded px-3 py-1.5 bg-background focus:outline-none focus:ring-1 focus:ring-ring"
           />
@@ -537,6 +551,27 @@ function InvitesTab() {
         </div>
         {sent && <p className="text-xs text-green-600">Invite sent to {sent}</p>}
         {error && <p className="text-xs text-destructive">{error}</p>}
+        {pendingApprove && (
+          <div className="flex items-center gap-2">
+            <p className="text-xs text-amber-600">This person is already waiting for approval.</p>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={approve.isPending}
+              onClick={() =>
+                approve.mutate(pendingApprove.id, {
+                  onSuccess: () => {
+                    setPendingApprove(null);
+                    setError(null);
+                    setEmail("");
+                  },
+                })
+              }
+            >
+              Approve instead
+            </Button>
+          </div>
+        )}
       </div>
 
       {isLoading ? (


### PR DESCRIPTION
## Summary

- Backend returns 409 with `reason: "pending_signup_exists"` and `pending_signup_id` when an invite is sent to an email that already has a pending self-signup
- Invite form parses the structured 409 and shows an inline **"Approve instead"** button
- Clicking the button calls the existing approve endpoint — user receives an account-approved email rather than an invite link

## Behaviour

**Before:** Inviting a self-registered email silently pre-created a duplicate user record (no `clerk_user_id`, display name set to email). Both rows appeared in the admin user table.

**After:** The invite is rejected with a clear message. Admin sees "This email already has a pending signup request." with an "Approve instead" button inline in the invite form.

## Changes

- `backend/app/routers/auth.py` — check `pending_signups` table before pre-creating invite user; raise structured 409
- `backend/tests/routers/test_auth.py` — `test_pending_signup_email_returns_409_with_reason`
- `frontend/src/pages/AdminPage.tsx` — parse structured 409 in invite form `onError`; render approve prompt

## Test plan

- [ ] Send invite to an email that has a pending signup — see error message and "Approve instead" button
- [ ] Click "Approve instead" — user is approved, approved email sent, pending signup removed from list, form clears
- [ ] Send invite to a fresh email — still works normally (201)
- [ ] Send invite to an already-active user email — still returns original "A user with this email already exists" error

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)