### PR TITLE
fix: approve pending signup attaches to pre-created user; rename button to Approve

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1138,15 +1138,27 @@ async def approve_pending_signup(
         await db.commit()
         return {"status": "already_exists"}
 
-    user = User(
-        email=signup.email,
-        display_name=signup.display_name,
-        clerk_user_id=signup.clerk_user_id,
-        is_admin=False,
-        approved_by_name=admin.display_name,
-        approved_by_email=admin.email,
+    # Attach to a pre-created User (from a prior invite) if one exists for this email.
+    pre_created = await db.scalar(
+        select(User).where(User.email == signup.email, User.clerk_user_id.is_(None), User.deleted_at.is_(None))
     )
-    db.add(user)
+    if pre_created is not None:
+        pre_created.clerk_user_id = signup.clerk_user_id
+        pre_created.display_name = signup.display_name
+        pre_created.approved_by_name = admin.display_name
+        pre_created.approved_by_email = admin.email
+        user = pre_created
+    else:
+        user = User(
+            email=signup.email,
+            display_name=signup.display_name,
+            clerk_user_id=signup.clerk_user_id,
+            is_admin=False,
+            approved_by_name=admin.display_name,
+            approved_by_email=admin.email,
+        )
+        db.add(user)
+
     await db.delete(signup)
     await write_audit_log(
         db,
@@ -1155,7 +1167,9 @@ async def approve_pending_signup(
         target_email=signup.email,
     )
     await db.commit()
-    await set_user_metadata(signup.clerk_user_id, {"status": "active", "is_admin": False, "is_superuser": False})
+    await set_user_metadata(
+        signup.clerk_user_id, {"status": "active", "is_admin": user.is_admin, "is_superuser": False}
+    )
 
     admin_emails = list(await db.scalars(select(User.email).where(User.is_admin.is_(True), User.deleted_at.is_(None))))
 

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -507,7 +507,7 @@ function InvitesTab() {
         <div className="space-y-2">
           <h2 className="text-sm font-medium">Waiting to join ({pendingSignups.length})</h2>
           <p className="text-xs text-muted-foreground">
-            These users signed up through Clerk but have no invite. Add them to the database or dismiss.
+            These users signed up through Clerk but have no invite. Approve them or dismiss.
           </p>
           <div className="divide-y border rounded-lg overflow-hidden">
             {pendingSignups.map((ps) => (
@@ -671,8 +671,8 @@ function PendingSignupRow({
           </>
         ) : (
           <>
-            <Button size="sm" disabled={isWorking} onClick={onApprove}>
-              Add user
+            <Button size="sm" disabled={isWorking} onClick={onApprove} className="bg-green-600 hover:bg-green-700 text-white">
+              Approve
             </Button>
             <Button size="sm" variant="outline" disabled={isWorking} onClick={() => setConfirming("dismiss")}>
               Dismiss


### PR DESCRIPTION
## Summary

Follow-up to #229. Two fixes discovered during QA testing:

- **Backend** — `approve_pending_signup` now checks for a pre-created User (`clerk_user_id IS NULL`) with the same email before inserting a new record. If found, attaches the Clerk ID to it instead — prevents a unique-email constraint failure when both an invite and a self-signup exist for the same address
- **Frontend** — Renames the "Add user" button to a green **Approve** button in the Waiting to Join list; updates the section description text to match

## Why the approve was broken

When an admin sent an invite to an email that already had a pending signup, a pre-created User record (no `clerk_user_id`) was left in the database alongside the PendingSignup. Clicking "Approve instead" then tried to `INSERT` a second User with the same email, hitting the unique index and returning a 500.

## Test plan

- [x] Self-register a new account (no invite) — appears in Waiting to Join
- [x] Click green **Approve** — user is approved, approved email sent, row disappears
- [ ] Send invite to an email that has a pending signup — see the 409 prompt
- [ ] Click **Approve instead** — user is approved, form clears, row disappears from Waiting to Join

🤖 Generated with [Claude Code](https://claude.com/claude-code)