### PR TITLE
feat: add short description to auto-generated QA issue titles

### DIFF
--- a/.github/scripts/build_qa_issue.py
+++ b/.github/scripts/build_qa_issue.py
@@ -49,7 +49,24 @@ for p in pr_numbers:
         seen.add(p)
         unique_prs.append(p)
 
+_PREFIX_RE = re.compile(r"^[a-z]+(?:\([^)]+\))?!?:\s*", re.IGNORECASE)
+
+
+def _title_suffix(titles: list[str]) -> str:
+    """Return ' — <first clean title>(+N more)' or '' if no titles."""
+    cleaned = [_PREFIX_RE.sub("", t).strip() for t in titles if t]
+    cleaned = [t for t in cleaned if t]
+    if not cleaned:
+        return ""
+    first = cleaned[0][:57] + "…" if len(cleaned[0]) > 60 else cleaned[0]
+    suffix = f" — {first}"
+    if len(cleaned) > 1:
+        suffix += f" (+{len(cleaned) - 1} more)"
+    return suffix
+
+
 sections = []
+pr_titles: list[str] = []
 for pr_num in unique_prs:
     result = subprocess.run(
         ["gh", "pr", "view", pr_num, "--json", "title,body", "--repo", repo],
@@ -60,6 +77,7 @@ for pr_num in unique_prs:
         continue
     pr = json.loads(result.stdout)
     title = pr.get("title", f"PR #{pr_num}")
+    pr_titles.append(title)
     body = pr.get("body") or ""
     m = re.search(r"## Test plan\n(.*?)(?=\n## |\Z)", body, re.DOTALL | re.IGNORECASE)
     plan = m.group(1).strip() if m else "_No test plan specified._"
@@ -87,4 +105,10 @@ _Close this issue when all items above are validated on `dev.weftmark.com`._"""
 with open("qa_issue_body.md", "w") as f:
     f.write(issue_body)
 
-print(f"QA issue body written ({len(sections)} PR(s) included)")
+suffix = _title_suffix(pr_titles)
+github_output = os.environ.get("GITHUB_OUTPUT")
+if github_output:
+    with open(github_output, "a") as f:
+        f.write(f"title_suffix={suffix}\n")
+
+print(f"QA issue body written ({len(sections)} PR(s) included, suffix: '{suffix}')")

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -93,6 +93,7 @@ jobs:
         run: echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
 
       - name: Build QA issue body
+        id: qa-body
         env:
           VERSION: ${{ steps.version.outputs.version }}
           REPO: ${{ github.repository }}
@@ -101,9 +102,10 @@ jobs:
       - name: Create QA issue
         env:
           VERSION: ${{ steps.version.outputs.version }}
+          TITLE_SUFFIX: ${{ steps.qa-body.outputs.title_suffix }}
         run: |
           gh issue create \
             --repo "${{ github.repository }}" \
-            --title "QA: v${VERSION}-dev" \
+            --title "QA: v${VERSION}-dev${TITLE_SUFFIX}" \
             --body-file qa_issue_body.md \
             --label "qa"


### PR DESCRIPTION
## Summary

QA issues are currently titled `QA: v0.X.Y-dev` with no indication of what changed, making it hard to distinguish them when multiple are open.

This PR appends a short description derived from the PR titles in the build range:

> `QA: v0.67.1-dev — reject invite for pending-signup email, prompt admin to approve instead`
> `QA: v0.68.0-dev — some new feature (+2 more)`

## Changes

- `build_qa_issue.py` — collects PR titles while already fetching PR data; derives a suffix by stripping conventional-commit prefixes, truncating the first title to 60 chars, and appending `(+N more)` for multiple PRs; writes to `GITHUB_OUTPUT`
- `publish-dev.yml` — adds `id: qa-body` to the build step; passes `title_suffix` output into the issue title

## Test plan

- [ ] Trigger `publish-dev.yml` manually — confirm the created QA issue title includes a description after the version
- [ ] Trigger with a single-PR build — title shows just that PR's subject
- [ ] Trigger with a multi-PR build — title shows first subject + `(+N more)`

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)