### PR TITLE
fix: remove approve-instead button; revoke pending invites on signup approval

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1159,6 +1159,18 @@ async def approve_pending_signup(
         )
         db.add(user)
 
+    # Revoke any pending invites for this email so they clear from the invite list.
+    pending_invites = await db.scalars(
+        select(Invite).where(
+            Invite.email == signup.email,
+            Invite.accepted_at.is_(None),
+            Invite.revoked_at.is_(None),
+        )
+    )
+    now = datetime.now(timezone.utc)
+    for invite in pending_invites:
+        invite.revoked_at = now
+
     await db.delete(signup)
     await write_audit_log(
         db,

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -435,7 +435,6 @@ function InvitesTab() {
   const [role, setRole] = useState<"user" | "admin">("user");
   const [error, setError] = useState<string | null>(null);
   const [sent, setSent] = useState<string | null>(null);
-  const [pendingApprove, setPendingApprove] = useState<{ id: string } | null>(null);
   const [historyPage, setHistoryPage] = useState(0);
 
   const { data: invites = [], isLoading } = useQuery({
@@ -455,15 +454,13 @@ function InvitesTab() {
       setEmail("");
       setRole("user");
       setError(null);
-      setPendingApprove(null);
       qc.invalidateQueries({ queryKey: ["admin", "invites"] });
     },
     onError: (err: Error) => {
       try {
         const parsed = JSON.parse(err.message);
         if (parsed?.detail?.reason === "pending_signup_exists") {
-          setPendingApprove({ id: parsed.detail.pending_signup_id });
-          setError("This email already has a pending signup request.");
+          setError("This email already has a pending signup request. Use the Approve button in the list above.");
           return;
         }
         setError(parsed?.detail?.message ?? parsed?.detail ?? err.message);
@@ -480,7 +477,11 @@ function InvitesTab() {
 
   const approve = useMutation({
     mutationFn: (id: string) => approvePendingSignup(id),
-    onSuccess: (_, id) => { removePending(id); qc.invalidateQueries({ queryKey: ["admin", "users"] }); },
+    onSuccess: (_, id) => {
+      removePending(id);
+      qc.invalidateQueries({ queryKey: ["admin", "users"] });
+      qc.invalidateQueries({ queryKey: ["admin", "invites"] });
+    },
   });
 
   const dismiss = useMutation({
@@ -531,7 +532,7 @@ function InvitesTab() {
             type="email"
             placeholder="email@example.com"
             value={email}
-            onChange={(e) => { setEmail(e.target.value); setSent(null); setError(null); setPendingApprove(null); }}
+            onChange={(e) => { setEmail(e.target.value); setSent(null); setError(null); }}
             onKeyDown={(e) => e.key === "Enter" && email && send.mutate()}
             className="flex-1 text-sm border rounded px-3 py-1.5 bg-background focus:outline-none focus:ring-1 focus:ring-ring"
           />
@@ -551,27 +552,6 @@ function InvitesTab() {
         </div>
         {sent && <p className="text-xs text-green-600">Invite sent to {sent}</p>}
         {error && <p className="text-xs text-destructive">{error}</p>}
-        {pendingApprove && (
-          <div className="flex items-center gap-2">
-            <p className="text-xs text-amber-600">This person is already waiting for approval.</p>
-            <Button
-              size="sm"
-              variant="outline"
-              disabled={approve.isPending}
-              onClick={() =>
-                approve.mutate(pendingApprove.id, {
-                  onSuccess: () => {
-                    setPendingApprove(null);
-                    setError(null);
-                    setEmail("");
-                  },
-                })
-              }
-            >
-              Approve instead
-            </Button>
-          </div>
-        )}
       </div>
 
       {isLoading ? (


### PR DESCRIPTION
## Summary

Two UX fixes for the pending signup approval flow discovered during QA.

### 1 — Remove the inline "Approve instead" button

The invite form's 409 error response now just shows a message directing the admin to the Waiting to Join section above. The inline button was redundant and confusing alongside the existing Approve button already visible on the page.

**Before:** Error + amber "Approve instead" button below the invite form  
**After:** Error message — "This email already has a pending signup request. Use the Approve button in the list above."

### 2 — Revoke pending invites when a signup is approved

When a pending signup is approved, any outstanding (unaccepted, unrevoked) invites for that email are now set to `revoked_at = now()`. This moves them from the Pending section to Past invites immediately after approval, without requiring a page reload.

The approve mutation also now invalidates the `["admin", "invites"]` query so the list refreshes automatically.

## Test plan

- [ ] Send invite to email with pending signup — see error, no approve button, just message pointing to list above
- [ ] Click Approve on a pending signup that also has a pending invite — invite moves to Past invites immediately
- [ ] Click Approve on a pending signup with no prior invite — behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)