### PR TITLE
fix: remove [skip actions] from bot commits — actor guard already prevents loops

### DIFF
--- a/.github/workflows/ci-dev-push.yml
+++ b/.github/workflows/ci-dev-push.yml
@@ -75,7 +75,7 @@ jobs:
           git config user.email "weftmark-bot[bot]@users.noreply.github.com"
           git add sbom/sbom-backend.json sbom/licenses-backend.json
           if ! git diff --staged --quiet; then
-            git commit -m "chore: update backend SBOM and license manifest [skip actions]"
+            git commit -m "chore: update backend SBOM and license manifest"
             git pull --rebase origin dev
             git push origin dev
           fi
@@ -136,7 +136,7 @@ jobs:
           git config user.email "weftmark-bot[bot]@users.noreply.github.com"
           git add sbom/sbom-frontend.json sbom/licenses-frontend.json
           if ! git diff --staged --quiet; then
-            git commit -m "chore: update frontend SBOM and license manifest [skip actions]"
+            git commit -m "chore: update frontend SBOM and license manifest"
             git pull --rebase origin dev
             git push origin dev
           fi
@@ -236,7 +236,7 @@ jobs:
       - name: Commit version files
         run: |
           git add VERSION frontend/package.json
-          git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }} [skip actions]"
+          git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }}"
 
       - name: Push version commit
         run: |


### PR DESCRIPTION
## Problem

`[skip actions]` in a commit message suppresses **both** `push` and `pull_request` workflows on GitHub Actions. The bot's version-bump commits (`chore: bump version to X.Y.Z [skip actions]`) are the HEAD commit of `dev` whenever a PR to `main` is opened, which silently prevented `ci-main-pr.yml` from ever running.

Discovered when PR #240 (dev → main) showed zero CI checks.

## Fix

Remove `[skip actions]` from all three bot commit messages in `ci-dev-push.yml`:
- backend SBOM commit
- frontend SBOM commit  
- version bump commit

The `if: github.actor != 'weftmark-bot[bot]'` guard on every job already prevents the infinite-loop scenario. `[skip actions]` was redundant and harmful.

## Test plan

- [ ] Merge this PR to dev
- [ ] Confirm the bot version-bump commit that follows does NOT have `[skip actions]`
- [ ] Close and reopen PR #240 (or push a trivial commit to dev) — confirm `ci-main-pr.yml` jobs appear and run