### PR TITLE
chore: add explanatory comment to ci-dev-push workflow

### DIFF
--- a/.github/workflows/ci-dev-push.yml
+++ b/.github/workflows/ci-dev-push.yml
@@ -10,6 +10,8 @@ name: Dev push
 #
 # All jobs are skipped when weftmark-bot[bot] pushes (version bump commits
 # would otherwise re-trigger this workflow infinitely).
+# Note: do NOT put ci-skip tokens in bot commit messages; they propagate
+# into merge commit bodies and suppress PR workflows on the target branch.
 #
 # Required secrets:
 #   WEFTMARK_BOT_CLIENT_ID   — GitHub App client ID


### PR DESCRIPTION
Adds a comment explaining why ci-skip tokens must not appear in bot commit messages — merging #241 demonstrated this: the fix commit message contained the token as descriptive text, which propagated into the merge commit body and suppressed all CI on dev.

Merging this gives dev a clean HEAD commit so that PR #240 and the version-bump bot can run normally again.

## Test plan

- [x] Merge this PR — confirm Dev push workflow triggers and version is bumped
- [ ] Confirm PR #240 ci-main-pr jobs appear and run