### PR TITLE
feat: add /pending route for post-signup approval waiting page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ import { AdminPage } from "@/pages/AdminPage";
 import { SettingsPage } from "@/pages/SettingsPage";
 import { SignOutPage } from "@/pages/SignOutPage";
 import { UnauthorizedPage } from "@/pages/UnauthorizedPage";
+import { PendingPage } from "@/pages/PendingPage";
 import { DevBanner } from "@/components/DevBanner";
 import { ServiceHealthBanner } from "@/components/ServiceHealthBanner";
 import { SystemGate } from "@/components/SystemGate";
@@ -63,7 +64,7 @@ export default function App() {
   }
 
   return (
-    <ClerkProvider publishableKey={clerkPublishableKey} afterSignOutUrl="/sign-out">
+    <ClerkProvider publishableKey={clerkPublishableKey} afterSignUpUrl="/pending" afterSignOutUrl="/sign-out">
       <VersionGate>
         <SystemGate>
         <QueryClientProvider client={queryClient}>
@@ -74,6 +75,7 @@ export default function App() {
               <EulaGate>
                 <Routes>
                   <Route path="/login" element={<LoginPage />} />
+                  <Route path="/pending" element={<PendingPage />} />
                   <Route path="/register" element={<RegisterPage />} />
                   <Route path="/sign-out" element={<SignOutPage />} />
                   <Route path="/unauthorized" element={<UnauthorizedPage />} />

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -17,9 +17,15 @@ export function LoginPage() {
     }
   }, [isAuthenticated, isLoading, navigate]);
 
-  // Clerk-authenticated but no DB record — show a holding page instead of looping.
-  if (clerkLoaded && isSignedIn && !isLoading && !isAuthenticated) {
-    const isDenied = clerkStatus === "denied";
+  useEffect(() => {
+    if (clerkLoaded && isSignedIn && !isLoading && !isAuthenticated && clerkStatus === "pending_signup") {
+      navigate("/pending", { replace: true });
+    }
+  }, [clerkLoaded, isSignedIn, isLoading, isAuthenticated, clerkStatus, navigate]);
+
+  // Clerk-authenticated but no DB record and not pending — show denied/holding page.
+  if (clerkLoaded && isSignedIn && !isLoading && !isAuthenticated && clerkStatus !== "pending_signup") {
+    const isDenied = clerkStatus === "denied" || clerkStatus === "banned";
     return (
       <div className="flex min-h-screen items-center justify-center bg-background">
         <div className="w-full max-w-sm space-y-4 px-4 text-center">

--- a/frontend/src/pages/PendingPage.tsx
+++ b/frontend/src/pages/PendingPage.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth as useClerkAuth, useClerk, useUser } from "@clerk/clerk-react";
+import { useAuth } from "@/hooks/useAuth";
+
+const MAX_POLLS = 10;
+const POLL_INTERVAL_MS = 3000;
+
+export function PendingPage() {
+  const { isAuthenticated, isLoading } = useAuth();
+  const { isSignedIn, isLoaded: clerkLoaded } = useClerkAuth();
+  const { user: clerkUser } = useUser();
+  const { signOut } = useClerk();
+  const navigate = useNavigate();
+
+  const [pollCount, setPollCount] = useState(0);
+  const pollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clerkStatus = clerkUser?.publicMetadata?.status as string | undefined;
+
+  useEffect(() => {
+    if (!isLoading && isAuthenticated) {
+      navigate("/home", { replace: true });
+    }
+  }, [isAuthenticated, isLoading, navigate]);
+
+  useEffect(() => {
+    if (clerkLoaded && !isSignedIn) {
+      navigate("/login", { replace: true });
+    }
+  }, [clerkLoaded, isSignedIn, navigate]);
+
+  // Poll clerkUser.reload() until the webhook fires and sets status
+  useEffect(() => {
+    if (!clerkLoaded || !isSignedIn || !clerkUser) return;
+    if (clerkStatus !== undefined) return;
+    if (pollCount >= MAX_POLLS) return;
+
+    pollTimer.current = setTimeout(async () => {
+      await clerkUser.reload();
+      setPollCount((c) => c + 1);
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      if (pollTimer.current) clearTimeout(pollTimer.current);
+    };
+  }, [clerkLoaded, isSignedIn, clerkUser, clerkStatus, pollCount]);
+
+  if (!clerkLoaded || isLoading || (clerkStatus === undefined && pollCount < MAX_POLLS)) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <div className="w-full max-w-sm space-y-4 px-4 text-center">
+          <h1 className="text-2xl font-semibold tracking-tight">WeftMark</h1>
+          <p className="text-sm text-muted-foreground">Setting up your account…</p>
+        </div>
+      </div>
+    );
+  }
+
+  const isDenied = clerkStatus === "denied" || clerkStatus === "banned";
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background">
+      <div className="w-full max-w-sm space-y-4 px-4 text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">WeftMark</h1>
+        {isDenied ? (
+          <p className="text-sm text-muted-foreground">
+            WeftMark is currently closed to new sign-ups, but your interest has been noted. We'll be in touch if that changes.
+          </p>
+        ) : (
+          <>
+            <p className="text-sm text-muted-foreground">
+              Your sign-up request has been received. You'll get an email when an admin approves your account.
+            </p>
+            <p className="text-xs text-muted-foreground">No action needed — sit tight.</p>
+          </>
+        )}
+        <button
+          onClick={() => signOut()}
+          className="text-sm underline underline-offset-2 text-muted-foreground hover:text-foreground"
+        >
+          Sign out
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a dedicated `/pending` page that self-registered users land on immediately after Clerk signup, replacing the inline message on `/login`
- Sets `afterSignUpUrl="/pending"` on `ClerkProvider` so Clerk redirects post-signup users automatically
- Polls `clerkUser.reload()` every 3s (up to 10 attempts) to handle the race between Clerk redirect and webhook firing
- Redirects existing pending users from `/login` to `/pending` when `status === "pending_signup"`
- Denied/banned users remain on `/login` with existing messaging

Closes #227

## Test plan

- [ ] Complete Clerk self-registration — confirm you land on `/pending` with "Your sign-up request has been received. You'll get an email when an admin approves your account."
- [ ] Confirm "Sign out" button on `/pending` works
- [ ] Sign in as an existing pending user and navigate to `/login` — confirm redirect to `/pending`
- [ ] Sign in as a denied user and navigate to `/login` — confirm denied message still shows on `/login` (no redirect)
- [ ] Approve a pending user via admin panel — confirm they can sign in and reach `/home` normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)