### PR TITLE
feat: Clerk ↔ DB reconciliation — detect and backfill divergence

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -9,7 +9,7 @@ from typing import Literal
 
 import httpx
 import psutil
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -1417,7 +1417,7 @@ async def get_reconcile_report(
 @router.post("/reconcile/backfill/{clerk_user_id}", response_model=BackfillResponse, status_code=201)
 async def backfill_clerk_user(
     clerk_user_id: str,
-    body: BackfillRequest,
+    body: BackfillRequest = Body(default_factory=BackfillRequest),
     admin: User = Depends(require_superuser),
     db: AsyncSession = Depends(get_db),
 ) -> BackfillResponse:

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -26,7 +26,7 @@ from app.models.project import Project
 from app.models.user import User
 from app.models.yarn import Yarn
 from app.services.audit import write_audit_log
-from app.services.clerk import ban_clerk_user, set_user_metadata, unban_clerk_user
+from app.services.clerk import ban_clerk_user, get_clerk_user, list_clerk_users, set_user_metadata, unban_clerk_user
 from app.services.email import (
     send_account_approved_email,
     send_account_denied_email,
@@ -1334,3 +1334,139 @@ async def get_versions(
         boto3=_pkg("boto3"),
         psutil=_pkg("psutil"),
     )
+
+
+# ---------------------------------------------------------------------------
+# Clerk ↔ DB reconciliation (superuser only)
+# ---------------------------------------------------------------------------
+
+
+class ReconcileClerkOnlyUser(BaseModel):
+    clerk_user_id: str
+    email: str
+    display_name: str
+
+
+class ReconcileDbOnlyUser(BaseModel):
+    user_id: str
+    email: str
+    display_name: str
+    clerk_errored: bool
+
+
+class ReconcileReport(BaseModel):
+    clerk_only: list[ReconcileClerkOnlyUser]
+    db_only: list[ReconcileDbOnlyUser]
+
+
+class BackfillRequest(BaseModel):
+    role: Literal["user", "admin"] = "user"
+
+
+class BackfillResponse(BaseModel):
+    status: str
+    user_id: str
+    email: str
+
+
+@router.get("/reconcile", response_model=ReconcileReport)
+async def get_reconcile_report(
+    _: User = Depends(require_superuser),
+    db: AsyncSession = Depends(get_db),
+) -> ReconcileReport:
+    clerk_users = await list_clerk_users()
+    clerk_ids = {u["id"] for u in clerk_users}
+
+    db_users = list(
+        await db.scalars(
+            select(User).where(
+                User.clerk_user_id.is_not(None),
+                User.deleted_at.is_(None),
+                User.deletion_state.is_(None),
+            )
+        )
+    )
+    db_clerk_ids = {u.clerk_user_id for u in db_users}
+
+    pending_ids = set(await db.scalars(select(PendingSignup.clerk_user_id)))
+
+    clerk_only = [
+        ReconcileClerkOnlyUser(
+            clerk_user_id=u["id"],
+            email=u["email"],
+            display_name=u["display_name"],
+        )
+        for u in clerk_users
+        if u["id"] not in db_clerk_ids and u["id"] not in pending_ids
+    ]
+
+    db_only = [
+        ReconcileDbOnlyUser(
+            user_id=str(u.id),
+            email=u.email,
+            display_name=u.display_name,
+            clerk_errored=u.clerk_errored,
+        )
+        for u in db_users
+        if u.clerk_user_id not in clerk_ids
+    ]
+
+    return ReconcileReport(clerk_only=clerk_only, db_only=db_only)
+
+
+@router.post("/reconcile/backfill/{clerk_user_id}", response_model=BackfillResponse, status_code=201)
+async def backfill_clerk_user(
+    clerk_user_id: str,
+    body: BackfillRequest,
+    admin: User = Depends(require_superuser),
+    db: AsyncSession = Depends(get_db),
+) -> BackfillResponse:
+    existing = await db.scalar(select(User).where(User.clerk_user_id == clerk_user_id, User.deleted_at.is_(None)))
+    if existing:
+        raise HTTPException(status_code=409, detail="User already exists in DB")
+
+    clerk_data = await get_clerk_user(clerk_user_id)
+    if clerk_data is None:
+        raise HTTPException(status_code=404, detail="Clerk user not found")
+
+    email = clerk_data["email"]
+    display_name = clerk_data["display_name"]
+
+    # Attach to a pre-created User (unclaimed invite) if one exists for this email.
+    pre_user = await db.scalar(
+        select(User).where(
+            User.email == email,
+            User.clerk_user_id.is_(None),
+            User.deleted_at.is_(None),
+        )
+    )
+    if pre_user:
+        pre_user.clerk_user_id = clerk_user_id
+        pre_user.display_name = display_name
+        pre_user.is_active = True
+        user = pre_user
+        result_status = "attached"
+    else:
+        user = User(
+            email=email,
+            display_name=display_name,
+            clerk_user_id=clerk_user_id,
+            is_active=True,
+            is_admin=(body.role == "admin"),
+        )
+        db.add(user)
+        result_status = "created"
+
+    await write_audit_log(
+        db,
+        event_type="user.backfilled",
+        actor=admin,
+        target_email=email,
+        details={"clerk_user_id": clerk_user_id, "status": result_status},
+    )
+    await db.commit()
+    await db.refresh(user)
+    await set_user_metadata(clerk_user_id, {"status": "active"})
+
+    log.info("backfill clerk_user_id=%s user_id=%s status=%s", clerk_user_id, user.id, result_status)
+    return BackfillResponse(status=result_status, user_id=str(user.id), email=email)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -203,9 +203,10 @@ async def _handle_user_deleted(db: AsyncSession, data: dict) -> None:
         return
 
     # Unexpected Clerk-side deletion (e.g. deleted via Clerk dashboard).
-    # Flag the record so admins can review and choose to delete all data.
+    # Null the clerk_user_id so the record is detached, and flag for admin review.
     user.clerk_errored = True
     user.is_active = False
+    user.clerk_user_id = None
     await write_audit_log(db, event_type="user.clerk_errored", target_user_id=user.id, target_email=user.email)
     await db.commit()
     log.warning(

--- a/backend/app/services/clerk.py
+++ b/backend/app/services/clerk.py
@@ -15,6 +15,50 @@ def _headers() -> dict[str, str]:
     return {"Authorization": f"Bearer {get_settings().clerk_secret_key}"}
 
 
+def _parse_clerk_user(u: dict) -> dict:
+    email = (u.get("email_addresses") or [{}])[0].get("email_address", "")
+    first = u.get("first_name") or ""
+    last = u.get("last_name") or ""
+    display_name = f"{first} {last}".strip() or email
+    return {"id": u["id"], "email": email, "display_name": display_name}
+
+
+async def get_clerk_user(clerk_user_id: str) -> dict | None:
+    """Fetch a single Clerk user. Returns None if not found."""
+    try:
+        async with httpx.AsyncClient() as client:
+            r = await client.get(f"{_BASE}/users/{clerk_user_id}", headers=_headers(), timeout=10)
+            if r.status_code == 404:
+                return None
+            r.raise_for_status()
+            return _parse_clerk_user(r.json())
+    except Exception:
+        log.exception("Failed to fetch Clerk user %s", clerk_user_id)
+        return None
+
+
+async def list_clerk_users() -> list[dict]:
+    """Return all Clerk users as [{id, email, display_name}], paginated."""
+    users: list[dict] = []
+    limit = 500
+    offset = 0
+    async with httpx.AsyncClient() as client:
+        while True:
+            r = await client.get(
+                f"{_BASE}/users",
+                headers=_headers(),
+                params={"limit": limit, "offset": offset},
+                timeout=30,
+            )
+            r.raise_for_status()
+            batch = r.json()
+            users.extend(_parse_clerk_user(u) for u in batch)
+            if len(batch) < limit:
+                break
+            offset += limit
+    return users
+
+
 async def set_user_metadata(clerk_user_id: str, public_metadata: dict) -> None:
     """Merge public_metadata onto the Clerk user. Silently logs on failure."""
     try:

--- a/backend/tests/routers/test_admin.py
+++ b/backend/tests/routers/test_admin.py
@@ -941,6 +941,141 @@ class TestCreateEulaVersion:
         resp = await superuser_client.post("/api/admin/eula", json={"version": "2.0", "body_html": "<p>dup</p>"})
         assert resp.status_code == 409
 
+
+# ---------------------------------------------------------------------------
+# GET /api/admin/reconcile  (superuser only)
+# ---------------------------------------------------------------------------
+
+
+class TestGetReconcileReport:
+    @pytest.fixture(autouse=True)
+    def mock_list_clerk_users(self):
+        with patch(
+            "app.routers.admin.list_clerk_users",
+            new_callable=AsyncMock,
+            return_value=[
+                {"id": "clerk_abc", "email": "clerk_only@test.com", "display_name": "Clerk Only"},
+                {"id": "clerk_shared", "email": "shared@test.com", "display_name": "Shared"},
+            ],
+        ):
+            yield
+
+    async def test_returns_200(self, superuser_client: AsyncClient):
+        resp = await superuser_client.get("/api/admin/reconcile")
+        assert resp.status_code == 200
+
+    async def test_clerk_only_excludes_db_users(self, superuser_client: AsyncClient, db_session: AsyncSession):
+        user = User(email="shared@test.com", display_name="Shared", clerk_user_id="clerk_shared")
+        db_session.add(user)
+        await db_session.commit()
+
+        data = (await superuser_client.get("/api/admin/reconcile")).json()
+        clerk_ids = [u["clerk_user_id"] for u in data["clerk_only"]]
+        assert "clerk_shared" not in clerk_ids
+        assert "clerk_abc" in clerk_ids
+
+    async def test_clerk_only_excludes_pending_signups(self, superuser_client: AsyncClient, db_session: AsyncSession):
+        signup = PendingSignup(clerk_user_id="clerk_abc", email="clerk_only@test.com", display_name="Clerk Only")
+        db_session.add(signup)
+        await db_session.commit()
+
+        data = (await superuser_client.get("/api/admin/reconcile")).json()
+        clerk_ids = [u["clerk_user_id"] for u in data["clerk_only"]]
+        assert "clerk_abc" not in clerk_ids
+
+    async def test_db_only_lists_orphaned_users(self, superuser_client: AsyncClient, db_session: AsyncSession):
+        orphan = User(email="orphan@test.com", display_name="Orphan", clerk_user_id="clerk_gone_999")
+        db_session.add(orphan)
+        await db_session.commit()
+
+        data = (await superuser_client.get("/api/admin/reconcile")).json()
+        db_emails = [u["email"] for u in data["db_only"]]
+        assert "orphan@test.com" in db_emails
+
+    async def test_non_superuser_returns_403(self, admin_client: AsyncClient):
+        resp = await admin_client.get("/api/admin/reconcile")
+        assert resp.status_code == 403
+
+    async def test_unauthenticated_returns_401(self, client: AsyncClient):
+        resp = await client.get("/api/admin/reconcile")
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# POST /api/admin/reconcile/backfill/{clerk_user_id}  (superuser only)
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillClerkUser:
+    @pytest.fixture(autouse=True)
+    def mock_clerk_and_metadata(self):
+        with (
+            patch(
+                "app.routers.admin.get_clerk_user",
+                new_callable=AsyncMock,
+                return_value={
+                    "id": "clerk_backfill_001",
+                    "email": "backfill@test.com",
+                    "display_name": "Backfill User",
+                },
+            ),
+            patch("app.routers.admin.set_user_metadata", new_callable=AsyncMock),
+        ):
+            yield
+
+    async def test_returns_201(self, superuser_client: AsyncClient):
+        resp = await superuser_client.post("/api/admin/reconcile/backfill/clerk_backfill_001")
+        assert resp.status_code == 201
+
+    async def test_creates_user_in_db(self, superuser_client: AsyncClient, db_session: AsyncSession):
+        await superuser_client.post("/api/admin/reconcile/backfill/clerk_backfill_001")
+        user = await db_session.scalar(
+            select(User).where(User.clerk_user_id == "clerk_backfill_001", User.deleted_at.is_(None))
+        )
+        assert user is not None
+        assert user.email == "backfill@test.com"
+        assert user.is_active is True
+
+    async def test_returns_created_status(self, superuser_client: AsyncClient):
+        data = (await superuser_client.post("/api/admin/reconcile/backfill/clerk_backfill_001")).json()
+        assert data["status"] == "created"
+        assert data["email"] == "backfill@test.com"
+
+    async def test_attaches_to_pre_created_user(self, superuser_client: AsyncClient, db_session: AsyncSession):
+        pre = User(email="backfill@test.com", display_name="Pre User", clerk_user_id=None)
+        db_session.add(pre)
+        await db_session.commit()
+        await db_session.refresh(pre)
+
+        data = (await superuser_client.post("/api/admin/reconcile/backfill/clerk_backfill_001")).json()
+        assert data["status"] == "attached"
+        assert data["user_id"] == str(pre.id)
+
+    async def test_conflict_if_user_already_exists(self, superuser_client: AsyncClient, db_session: AsyncSession):
+        user = User(email="backfill@test.com", display_name="Existing", clerk_user_id="clerk_backfill_001")
+        db_session.add(user)
+        await db_session.commit()
+
+        resp = await superuser_client.post("/api/admin/reconcile/backfill/clerk_backfill_001")
+        assert resp.status_code == 409
+
+    async def test_not_found_if_clerk_user_missing(self, superuser_client: AsyncClient):
+        with patch("app.routers.admin.get_clerk_user", new_callable=AsyncMock, return_value=None):
+            resp = await superuser_client.post("/api/admin/reconcile/backfill/clerk_gone")
+        assert resp.status_code == 404
+
+    async def test_admin_role_sets_is_admin(self, superuser_client: AsyncClient, db_session: AsyncSession):
+        await superuser_client.post("/api/admin/reconcile/backfill/clerk_backfill_001", json={"role": "admin"})
+        user = await db_session.scalar(
+            select(User).where(User.clerk_user_id == "clerk_backfill_001", User.deleted_at.is_(None))
+        )
+        assert user is not None
+        assert user.is_admin is True
+
+    async def test_non_superuser_returns_403(self, admin_client: AsyncClient):
+        resp = await admin_client.post("/api/admin/reconcile/backfill/clerk_backfill_001")
+        assert resp.status_code == 403
+
     async def test_new_version_becomes_current(self, superuser_client: AsyncClient, client: AsyncClient):
         await superuser_client.post(
             "/api/admin/eula",

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -188,3 +188,25 @@ export const getAuditLog = (params: { page?: number; page_size?: number; event_t
   const query = qs.toString();
   return api.get<AuditLogPage>(`/api/admin/audit-log${query ? `?${query}` : ""}`);
 };
+
+export interface ReconcileClerkOnlyUser {
+  clerk_user_id: string;
+  email: string;
+  display_name: string;
+}
+
+export interface ReconcileDbOnlyUser {
+  user_id: string;
+  email: string;
+  display_name: string;
+  clerk_errored: boolean;
+}
+
+export interface ReconcileReport {
+  clerk_only: ReconcileClerkOnlyUser[];
+  db_only: ReconcileDbOnlyUser[];
+}
+
+export const getReconcileReport = () => api.get<ReconcileReport>("/api/admin/reconcile");
+export const backfillClerkUser = (clerkUserId: string, role: "user" | "admin" = "user") =>
+  api.post<{ status: string; user_id: string; email: string }>(`/api/admin/reconcile/backfill/${clerkUserId}`, { role });

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -22,6 +22,8 @@ import {
   getAdminServices,
   sendTestEmail,
   getAuditLog,
+  getReconcileReport,
+  backfillClerkUser,
   type AdminUser,
   type AdminHealth,
   type AuditLogEntry,
@@ -29,6 +31,7 @@ import {
   type PendingSignup,
   type ServiceCheck,
   type ServicePermCheck,
+  type ReconcileReport,
 } from "@/api/admin";
 import { getHealthDetailed, type ReadinessResponse, type ReadinessService } from "@/api/health";
 import { EulaContent } from "@/components/EulaContent";
@@ -1307,7 +1310,7 @@ function EulaTab() {
 // Superuser tab
 // ---------------------------------------------------------------------------
 
-type SuperuserSubTab = "eula" | "storage" | "deletion";
+type SuperuserSubTab = "eula" | "storage" | "deletion" | "reconcile";
 
 function SuperuserTab() {
   const [sub, setSub] = useState<SuperuserSubTab>("eula");
@@ -1315,7 +1318,7 @@ function SuperuserTab() {
   return (
     <div className="space-y-4">
       <div className="flex gap-2 border-b pb-2">
-        {(["eula", "storage", "deletion"] as SuperuserSubTab[]).map((t) => (
+        {(["eula", "storage", "deletion", "reconcile"] as SuperuserSubTab[]).map((t) => (
           <button
             key={t}
             onClick={() => setSub(t)}
@@ -1333,6 +1336,7 @@ function SuperuserTab() {
       {sub === "eula" && <EulaTab />}
       {sub === "storage" && <StorageAuditTab />}
       {sub === "deletion" && <DeletionTab />}
+      {sub === "reconcile" && <ReconcileTab />}
     </div>
   );
 }
@@ -1355,6 +1359,150 @@ function DeletionTab() {
   );
 }
 
+function ReconcileTab() {
+  const queryClient = useQueryClient();
+  const [ran, setRan] = useState(false);
+  const [report, setReport] = useState<ReconcileReport | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [backfilling, setBackfilling] = useState<string | null>(null);
+  const [backfillResults, setBackfillResults] = useState<Record<string, string>>({});
+
+  async function runReconcile() {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getReconcileReport();
+      setReport(data);
+      setRan(true);
+    } catch {
+      setError("Failed to run reconciliation. Check that the Clerk API key is configured.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleBackfill(clerkUserId: string, role: "user" | "admin") {
+    setBackfilling(clerkUserId);
+    try {
+      const result = await backfillClerkUser(clerkUserId, role);
+      setBackfillResults((prev) => ({ ...prev, [clerkUserId]: result.status }));
+      setReport((prev) =>
+        prev
+          ? { ...prev, clerk_only: prev.clerk_only.filter((u) => u.clerk_user_id !== clerkUserId) }
+          : prev
+      );
+      queryClient.invalidateQueries({ queryKey: ["admin-users"] });
+    } catch {
+      setBackfillResults((prev) => ({ ...prev, [clerkUserId]: "error" }));
+    } finally {
+      setBackfilling(null);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h2 className="text-sm font-medium">Clerk ↔ DB Reconciliation</h2>
+        <p className="text-xs text-muted-foreground">
+          Cross-references Clerk accounts against the database. Use this to backfill users created
+          directly in the Clerk dashboard.
+        </p>
+      </div>
+
+      <Button onClick={runReconcile} disabled={loading} size="sm">
+        {loading ? "Running…" : ran ? "Re-run reconciliation" : "Run reconciliation"}
+      </Button>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      {report && (
+        <div className="space-y-6">
+          {/* In Clerk, not in DB */}
+          <div className="space-y-2">
+            <h3 className="text-sm font-medium">
+              In Clerk, not in DB
+              <span className="ml-2 text-xs font-normal text-muted-foreground">
+                ({report.clerk_only.length} {report.clerk_only.length === 1 ? "user" : "users"})
+              </span>
+            </h3>
+            {report.clerk_only.length === 0 ? (
+              <p className="text-xs text-muted-foreground">No unmatched Clerk accounts.</p>
+            ) : (
+              <div className="rounded-lg border divide-y text-sm">
+                {report.clerk_only.map((u) => (
+                  <div key={u.clerk_user_id} className="flex items-center justify-between px-3 py-2 gap-4">
+                    <div className="min-w-0">
+                      <p className="font-medium truncate">{u.display_name}</p>
+                      <p className="text-xs text-muted-foreground truncate">{u.email}</p>
+                      <p className="text-xs text-muted-foreground font-mono">{u.clerk_user_id}</p>
+                    </div>
+                    <div className="flex gap-2 shrink-0">
+                      {backfillResults[u.clerk_user_id] ? (
+                        <span className="text-xs text-green-600 font-medium capitalize">
+                          {backfillResults[u.clerk_user_id]}
+                        </span>
+                      ) : (
+                        <>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            disabled={backfilling === u.clerk_user_id}
+                            onClick={() => handleBackfill(u.clerk_user_id, "user")}
+                          >
+                            Backfill as user
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            disabled={backfilling === u.clerk_user_id}
+                            onClick={() => handleBackfill(u.clerk_user_id, "admin")}
+                          >
+                            Backfill as admin
+                          </Button>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* In DB, not in Clerk */}
+          <div className="space-y-2">
+            <h3 className="text-sm font-medium">
+              In DB, not in Clerk
+              <span className="ml-2 text-xs font-normal text-muted-foreground">
+                ({report.db_only.length} {report.db_only.length === 1 ? "user" : "users"})
+              </span>
+            </h3>
+            {report.db_only.length === 0 ? (
+              <p className="text-xs text-muted-foreground">No orphaned DB records.</p>
+            ) : (
+              <div className="rounded-lg border divide-y text-sm">
+                {report.db_only.map((u) => (
+                  <div key={u.user_id} className="flex items-center justify-between px-3 py-2 gap-4">
+                    <div className="min-w-0">
+                      <p className="font-medium truncate">{u.display_name}</p>
+                      <p className="text-xs text-muted-foreground truncate">{u.email}</p>
+                    </div>
+                    {u.clerk_errored && (
+                      <span className="text-xs bg-destructive/10 text-destructive px-2 py-0.5 rounded shrink-0">
+                        clerk errored
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Audit log tab
 // ---------------------------------------------------------------------------
@@ -1365,6 +1513,8 @@ const EVENT_TYPES = [
   "user.unbanned",
   "user.deleted",
   "user.elevated",
+  "user.backfilled",
+  "user.clerk_errored",
   "signup.approved",
   "signup.dismissed",
   "signup.banned",


### PR DESCRIPTION
## Summary

- Adds `GET /api/admin/reconcile` (superuser) — cross-references all Clerk accounts against the DB, returning two lists: users in Clerk with no DB record, and DB records whose Clerk account no longer exists
- Adds `POST /api/admin/reconcile/backfill/{clerk_user_id}` (superuser) — creates a DB User from a Clerk account; attaches to a pre-created invite record if one exists for that email, otherwise creates fresh
- Updates `_handle_user_deleted` webhook handler to null `clerk_user_id` on unexpected Clerk-side deletions (previously only set `clerk_errored=True`)
- Adds a **Reconcile** sub-tab in the admin superuser panel with Run/Re-run button, two result tables, and per-row Backfill as user / Backfill as admin actions
- Adds `user.backfilled` and `user.clerk_errored` to the audit log event type filter

Closes #237

## Test plan

- [ ] Build and open the admin panel → Superuser → Reconcile tab
- [ ] Create a user directly in the Clerk dashboard (skip invite flow)
- [ ] Run reconciliation — confirm the Clerk-only user appears in the top table
- [ ] Click "Backfill as user" — confirm the user disappears from the list and can now sign in
- [ ] Check Users tab — confirm the backfilled user appears with correct email and active status
- [ ] Check Audit log — confirm a `user.backfilled` entry was recorded
- [ ] Delete a user from the Clerk dashboard — confirm `user.deleted` webhook fires, DB record has `clerk_user_id=NULL` and `clerk_errored=TRUE`, and re-running reconciliation shows nothing in the DB-only list for that user

🤖 Generated with [Claude Code](https://claude.com/claude-code)