### PR TITLE
feat: admin services webhook row with auto-run diagnostics (#205)

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -900,18 +900,24 @@ def _probe_webhook_info() -> ServiceCheckResult:
         )
 
     if settings.cf_zero_trust_enabled:
-        checks.append(ServicePermCheck(name="cf_access", status="ok", message="Enabled"))
+        checks.append(
+            ServicePermCheck(
+                name="cf_access",
+                status="ok",
+                message="Enabled — requests pass through Cloudflare Zero Trust / Access",
+            )
+        )
         if settings.cf_access_client_id:
-            checks.append(ServicePermCheck(name="client_id", status="ok", message=settings.cf_access_client_id))
+            checks.append(ServicePermCheck(name="cf_client_id", status="ok", message=settings.cf_access_client_id))
         else:
-            checks.append(ServicePermCheck(name="client_id", status="error", message="CF_ACCESS_CLIENT_ID not set"))
+            checks.append(ServicePermCheck(name="cf_client_id", status="error", message="CF_ACCESS_CLIENT_ID not set"))
         if settings.cf_access_client_secret:
             s = settings.cf_access_client_secret
             obfuscated = s[:6] + "••••••" if len(s) > 6 else "••••••"
-            checks.append(ServicePermCheck(name="client_secret", status="ok", message=obfuscated))
+            checks.append(ServicePermCheck(name="cf_client_secret", status="ok", message=obfuscated))
         else:
             checks.append(
-                ServicePermCheck(name="client_secret", status="error", message="CF_ACCESS_CLIENT_SECRET not set")
+                ServicePermCheck(name="cf_client_secret", status="error", message="CF_ACCESS_CLIENT_SECRET not set")
             )
     else:
         checks.append(ServicePermCheck(name="cf_access", status="ok", message="Disabled"))


### PR DESCRIPTION
## Summary

- Adds **Clerk Webhook** service row to `/api/admin/services`, showing resolved webhook URL and Cloudflare Zero Trust state
- CF check names use `cf_` prefix (`cf_access`, `cf_client_id`, `cf_client_secret`); `cf_access` message distinguishes "Enabled — requests pass through Cloudflare Zero Trust / Access" vs "Disabled"
- Admin Services panel **auto-runs diagnostics on tab open** (no manual trigger needed); Re-run button shows last-run timestamp
- **Test Webhook** inline button on the Clerk Webhook row for round-trip probe
- **Test Email** moved inline into the SMTP service row (removed standalone card)

## Test plan

- [ ] Open Admin → Services tab — diagnostics run automatically without clicking
- [ ] Re-run button appears with timestamp after first run
- [ ] Clerk Webhook row shows resolved URL ending in \`/auth/clerk/webhook\`
- [ ] With CF Zero Trust disabled: \`cf_access\` check shows "Disabled"
- [ ] With CF Zero Trust enabled: \`cf_access\` shows "Enabled — requests pass through Cloudflare Zero Trust / Access"; \`cf_client_id\` / \`cf_client_secret\` visible in row expansion
- [ ] Test button in Clerk Webhook row triggers webhook round-trip probe and shows result
- [ ] Send Test Email button appears inside the SMTP row expansion (no separate card)
- [ ] \`pytest backend/tests/routers/test_admin.py\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)