### PR TITLE
feat: overhaul email templates with shared base layout (#259)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,11 +68,14 @@ Three tiers: `main` (production-ready), `dev` (integration), working branches (`
 | `ci-main-pr.yml` | PR to `main` | lint, typecheck, dep audit, docker build; **no file writes allowed** |
 | `ci-main-push.yml` | push to `main` | promote version tag, SBOM artifacts, publish versioned + `:latest` images |
 | `check-merge-source.yml` | PR to `main` | enforces source must be `dev` or `hotfix/*` |
-| `publish-dev.yml` | manual dispatch | publishes `:dev` + `:{version}-dev` images to ghcr.io |
+| `publish-dev.yml` | manual dispatch | publishes `:dev` + `:{version}-dev` images to ghcr.io; auto-opens a QA issue listing test plans from all PRs in the build range |
+| `sync-main-to-dev.yml` | push to `main` | auto-opens `chore: sync main → dev` PR to keep branches in sync; skipped if already open or nothing to sync |
+| `sync-eula.yml` | manual dispatch | runs `tools/export_eula_migration.py` against the live API, commits new Alembic migration files, opens PR to `dev` |
+| `triage.yml` | issue opened / labeled | adds `needs-triage` label to new unlabelled issues; removes it when any other label is added |
 
 After every push, check CI status proactively: `gh run list --repo weftmark/weftmark --limit 3`. If failed, pull logs with `gh run view <id> --log-failed` and surface errors immediately.
 
-Bot actor: `weftmark-bot[bot]`. Post-merge jobs use `if: github.actor != 'weftmark-bot[bot]'` to prevent infinite re-triggering. Bot commits use `[skip actions]` in the message.
+Bot actor: `weftmark-bot[bot]`. Post-merge jobs use `if: github.actor != 'weftmark-bot[bot]'` to prevent infinite re-triggering. Bot commits do **not** use `[skip actions]` — that token propagates into merge commit bodies and suppresses PR CI on the target branch. The actor guard is sufficient.
 
 Append `[skip ci]` to commit messages for documentation-only changes (`.md` files, comments) to avoid unnecessary CI runs.
 

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -9,9 +9,16 @@ from app.config import get_settings
 _TEMPLATES = Path(__file__).parent.parent / "templates" / "email"
 
 
-def _render(name: str, **kwargs: str) -> tuple[str, str]:
-    txt = (_TEMPLATES / f"{name}.txt").read_text().format(**kwargs)
-    html = (_TEMPLATES / f"{name}.html").read_text().format(**kwargs)
+def _render(name: str, **kwargs) -> tuple[str, str]:
+    settings = get_settings()
+    kwargs.setdefault("app_name", settings.smtp_from_name)
+    kwargs.setdefault("frontend_url", settings.frontend_url)
+    raw_base_html = (_TEMPLATES / "_base.html").read_text()
+    raw_base_txt = (_TEMPLATES / "_base.txt").read_text()
+    raw_body_html = (_TEMPLATES / f"{name}.html").read_text()
+    raw_body_txt = (_TEMPLATES / f"{name}.txt").read_text()
+    html = raw_base_html.replace("__BODY__", raw_body_html).format(**kwargs)
+    txt = raw_base_txt.replace("__BODY__", raw_body_txt).format(**kwargs)
     return txt, html
 
 
@@ -20,12 +27,15 @@ async def _send(to: list[str], subject: str, txt: str, html: str) -> None:
     if settings.app_env == "dev":
         subject = f"[DEV] {subject}"
         txt = "*** DEV ENVIRONMENT — this email was sent from a non-production system ***\n\n" + txt
-        html = (
+        html = html.replace(
+            "<!-- DEV_BANNER -->",
             '<div style="background:#f59e0b;color:#000;font-weight:bold;padding:8px 12px;'
-            'margin-bottom:16px;border-radius:4px;font-family:sans-serif;">'
-            "⚠️ DEV ENVIRONMENT — this email was sent from a non-production system"
-            "</div>\n" + html
+            'font-family:Arial,Helvetica,sans-serif;">'
+            "DEV ENVIRONMENT — this email was sent from a non-production system"
+            "</div>",
         )
+    else:
+        html = html.replace("<!-- DEV_BANNER -->", "")
     msg = MIMEMultipart("alternative")
     msg["Subject"] = subject
     msg["From"] = f"{settings.smtp_from_name} <{settings.smtp_from_email}>"
@@ -55,11 +65,7 @@ async def send_pending_signup_notification(admin_emails: list[str], display_name
 
 async def send_signup_received_email(to_email: str, display_name: str) -> None:
     settings = get_settings()
-    txt, html = _render(
-        "pending_signup_user_confirmation",
-        display_name=display_name,
-        app_name=settings.smtp_from_name,
-    )
+    txt, html = _render("pending_signup_user_confirmation", display_name=display_name)
     await _send([to_email], f"Your {settings.smtp_from_name} sign-up request was received", txt, html)
 
 
@@ -68,7 +74,6 @@ async def send_account_approved_email(to_email: str, display_name: str) -> None:
     txt, html = _render(
         "account_approved",
         display_name=display_name,
-        app_name=settings.smtp_from_name,
         login_url=f"{settings.frontend_url}/login",
     )
     await _send([to_email], f"Your {settings.smtp_from_name} account is ready", txt, html)
@@ -76,24 +81,18 @@ async def send_account_approved_email(to_email: str, display_name: str) -> None:
 
 async def send_account_denied_email(to_email: str, display_name: str) -> None:
     settings = get_settings()
-    txt, html = _render(
-        "account_denied",
-        display_name=display_name,
-        app_name=settings.smtp_from_name,
-    )
+    txt, html = _render("account_denied", display_name=display_name)
     await _send([to_email], f"Your {settings.smtp_from_name} sign-up request", txt, html)
 
 
 async def send_approval_confirmation_to_admins(
     admin_emails: list[str], display_name: str, email: str, approved_by: str
 ) -> None:
-    settings = get_settings()
     txt, html = _render(
         "approval_admin_confirmation",
         display_name=display_name,
         email=email,
         approved_by=approved_by,
-        app_name=settings.smtp_from_name,
     )
     await _send(admin_emails, f"Account approved — {display_name} ({email})", txt, html)
 
@@ -104,20 +103,13 @@ async def send_deletion_created_admin(admin_emails: list[str], display_name: str
         "deletion_created_admin",
         display_name=display_name,
         email=email,
-        app_name=settings.smtp_from_name,
         admin_url=f"{settings.frontend_url}/admin",
     )
     await _send(admin_emails, f"User deletion queued — {display_name} ({email})", txt, html)
 
 
 async def send_deletion_completed_admin(admin_emails: list[str], display_name: str, email: str) -> None:
-    settings = get_settings()
-    txt, html = _render(
-        "deletion_completed_admin",
-        display_name=display_name,
-        email=email,
-        app_name=settings.smtp_from_name,
-    )
+    txt, html = _render("deletion_completed_admin", display_name=display_name, email=email)
     await _send(admin_emails, f"User deletion complete — {display_name} ({email})", txt, html)
 
 
@@ -130,7 +122,6 @@ async def send_deletion_stalled_superuser(
         display_name=display_name,
         email=email,
         user_id=user_id,
-        app_name=settings.smtp_from_name,
         admin_url=f"{settings.frontend_url}/admin",
     )
     await _send(superuser_emails, f"User deletion stalled — {display_name} ({email})", txt, html)
@@ -138,45 +129,12 @@ async def send_deletion_stalled_superuser(
 
 async def send_test_email(to_email: str) -> None:
     settings = get_settings()
-    txt = (
-        f"This is a test email from {settings.smtp_from_name}.\n\n"
-        "If you received this, your SMTP configuration is working correctly."
-    )
-    html = (
-        f"<p>This is a test email from <strong>{settings.smtp_from_name}</strong>.</p>"
-        "<p>If you received this, your SMTP configuration is working correctly.</p>"
-    )
-    await _send([to_email], f"{settings.smtp_from_name} — Test Email", txt, html)
+    txt, html = _render("test_email")
+    await _send([to_email], f"{settings.smtp_from_name} — SMTP Test", txt, html)
 
 
 async def send_invite_email(to_email: str, invite_token: str, expires_days: int) -> None:
     settings = get_settings()
     invite_url = f"{settings.frontend_url}/register?token={invite_token}"
-
-    message = MIMEMultipart("alternative")
-    message["Subject"] = f"You've been invited to {settings.smtp_from_name}"
-    message["From"] = f"{settings.smtp_from_name} <{settings.smtp_from_email}>"
-    message["To"] = to_email
-
-    text_body = (
-        f"You've been invited to join {settings.smtp_from_name}.\n\n"
-        f"Click the link below to accept your invitation:\n{invite_url}\n\n"
-        f"This link expires in {expires_days} day(s) and can only be used once."
-    )
-    html_body = f"""
-    <p>You've been invited to join <strong>{settings.smtp_from_name}</strong>.</p>
-    <p><a href="{invite_url}">Accept Invitation</a></p>
-    <p>This link expires in {expires_days} day(s) and can only be used once.</p>
-    """
-
-    message.attach(MIMEText(text_body, "plain"))
-    message.attach(MIMEText(html_body, "html"))
-
-    await aiosmtplib.send(
-        message,
-        hostname=settings.smtp_host,
-        port=settings.smtp_port,
-        username=settings.smtp_user,
-        password=settings.smtp_password,
-        start_tls=True,
-    )
+    txt, html = _render("invite", invite_url=invite_url, expires_days=expires_days)
+    await _send([to_email], f"You've been invited to {settings.smtp_from_name}", txt, html)

--- a/backend/app/templates/email/_base.html
+++ b/backend/app/templates/email/_base.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>{app_name}</title>
+</head>
+<body style="margin:0;padding:0;background:#f3f4f6;font-family:Arial,Helvetica,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="background:#f3f4f6;padding:32px 16px;">
+    <tr>
+      <td align="center">
+        <table width="600" cellpadding="0" cellspacing="0" role="presentation" style="max-width:600px;width:100%;">
+
+          <!-- Header -->
+          <tr>
+            <td style="background:#1d3557;padding:24px 32px;border-radius:8px 8px 0 0;">
+              <p style="margin:0;font-size:22px;font-weight:bold;color:#ffffff;letter-spacing:0.5px;font-family:Arial,Helvetica,sans-serif;">{app_name}</p>
+            </td>
+          </tr>
+
+          <!-- Dev environment banner (injected by _send in dev; stripped in production) -->
+          <tr><td><!-- DEV_BANNER --></td></tr>
+
+          <!-- Body -->
+          <tr>
+            <td style="background:#ffffff;padding:32px;color:#111827;font-size:15px;line-height:1.7;font-family:Arial,Helvetica,sans-serif;">
+              __BODY__
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="background:#f9fafb;padding:20px 32px;border-top:1px solid #e5e7eb;border-radius:0 0 8px 8px;">
+              <p style="margin:0;font-size:12px;color:#6b7280;font-family:Arial,Helvetica,sans-serif;">This is an automated message from <a href="{frontend_url}" style="color:#6b7280;text-decoration:underline;">{app_name}</a>. Please do not reply to this email.</p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/backend/app/templates/email/_base.txt
+++ b/backend/app/templates/email/_base.txt
@@ -1,0 +1,6 @@
+__BODY__
+
+---
+This is an automated message from {app_name}.
+{frontend_url}
+Do not reply to this email.

--- a/backend/app/templates/email/account_approved.html
+++ b/backend/app/templates/email/account_approved.html
@@ -1,3 +1,10 @@
-<p>Hi <strong>{display_name}</strong>,</p>
-<p>Your <strong>{app_name}</strong> account has been approved.</p>
-<p><a href="{login_url}">Sign in now</a></p>
+<p style="margin:0 0 16px;">Hi <strong>{display_name}</strong>,</p>
+<p style="margin:0 0 20px;">Great news &mdash; your <strong>{app_name}</strong> account has been approved. You can now sign in and start managing your weaving projects.</p>
+<table cellpadding="0" cellspacing="0" role="presentation" style="margin:0 0 24px;">
+  <tr>
+    <td style="background:#1d3557;border-radius:6px;">
+      <a href="{login_url}" style="display:inline-block;padding:12px 28px;color:#ffffff;font-weight:bold;text-decoration:none;font-size:15px;font-family:Arial,Helvetica,sans-serif;">Sign in to {app_name}</a>
+    </td>
+  </tr>
+</table>
+<p style="margin:0;font-size:14px;color:#6b7280;">If the button above doesn't work, copy and paste this link into your browser: {login_url}</p>

--- a/backend/app/templates/email/account_approved.txt
+++ b/backend/app/templates/email/account_approved.txt
@@ -1,4 +1,6 @@
 Hi {display_name},
 
-Your {app_name} account has been approved. You can sign in now:
-{login_url}
+Great news -- your {app_name} account has been approved. You can now
+sign in and start managing your weaving projects.
+
+Sign in: {login_url}

--- a/backend/app/templates/email/account_denied.html
+++ b/backend/app/templates/email/account_denied.html
@@ -1,3 +1,3 @@
-<p>Hi <strong>{display_name}</strong>,</p>
-<p><strong>{app_name}</strong> is currently invite only and your sign-up request was not approved at this time.</p>
-<p>If you believe this is an error, please contact the administrator.</p>
+<p style="margin:0 0 16px;">Hi <strong>{display_name}</strong>,</p>
+<p style="margin:0 0 16px;">Thank you for your interest in <strong>{app_name}</strong>. After review, we are unable to approve your sign-up request at this time.</p>
+<p style="margin:0;font-size:14px;color:#6b7280;">If you believe this is an error or would like to discuss further, please contact the site administrator.</p>

--- a/backend/app/templates/email/account_denied.txt
+++ b/backend/app/templates/email/account_denied.txt
@@ -1,5 +1,7 @@
 Hi {display_name},
 
-{app_name} is currently invite only and your sign-up request was not approved at this time.
+Thank you for your interest in {app_name}. After review, we are unable
+to approve your sign-up request at this time.
 
-If you believe this is an error, please contact the administrator.
+If you believe this is an error or would like to discuss further,
+please contact the site administrator.

--- a/backend/app/templates/email/approval_admin_confirmation.html
+++ b/backend/app/templates/email/approval_admin_confirmation.html
@@ -1,1 +1,16 @@
-<p><strong>{display_name}</strong> ({email}) was approved by <strong>{approved_by}</strong> and can now sign in to <strong>{app_name}</strong>.</p>
+<p style="margin:0 0 16px;font-size:16px;font-weight:bold;color:#1d3557;">Account Approved</p>
+<p style="margin:0 0 16px;"><strong>{display_name}</strong> can now sign in to <strong>{app_name}</strong>.</p>
+<table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;margin:0 0 8px;background:#f9fafb;border-radius:6px;overflow:hidden;">
+  <tr>
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;vertical-align:top;width:100px;">User</td>
+    <td style="padding:10px 16px;font-size:14px;vertical-align:top;"><strong>{display_name}</strong></td>
+  </tr>
+  <tr style="background:#f3f4f6;">
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;vertical-align:top;">Email</td>
+    <td style="padding:10px 16px;font-size:14px;vertical-align:top;">{email}</td>
+  </tr>
+  <tr>
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;vertical-align:top;">Approved by</td>
+    <td style="padding:10px 16px;font-size:14px;vertical-align:top;">{approved_by}</td>
+  </tr>
+</table>

--- a/backend/app/templates/email/approval_admin_confirmation.txt
+++ b/backend/app/templates/email/approval_admin_confirmation.txt
@@ -1,1 +1,4 @@
-{display_name} ({email}) was approved by {approved_by} and can now sign in to {app_name}.
+Account Approved
+
+{display_name} ({email}) was approved by {approved_by} and can now
+sign in to {app_name}.

--- a/backend/app/templates/email/credential_expiring_admin.html
+++ b/backend/app/templates/email/credential_expiring_admin.html
@@ -1,0 +1,24 @@
+<div style="background:#fffbeb;border-left:4px solid #d97706;padding:12px 16px;margin:0 0 20px;border-radius:0 4px 4px 0;">
+  <p style="margin:0;color:#92400e;font-weight:bold;font-size:15px;">Notice: Credential Expiring in {days_remaining} Day{days_plural}</p>
+</div>
+<p style="margin:0 0 16px;">A managed credential for <strong>{app_name}</strong> is approaching its expiration date. The superuser has also been notified and is responsible for rotating this credential.</p>
+<table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;margin:0 0 20px;background:#f9fafb;border-radius:6px;overflow:hidden;">
+  <tr>
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;vertical-align:top;width:120px;">Credential</td>
+    <td style="padding:10px 16px;font-size:14px;vertical-align:top;"><strong>{credential_name}</strong></td>
+  </tr>
+  <tr style="background:#f3f4f6;">
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;vertical-align:top;">Service</td>
+    <td style="padding:10px 16px;font-size:14px;vertical-align:top;">{resource}</td>
+  </tr>
+  <tr>
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;vertical-align:top;">Expires On</td>
+    <td style="padding:10px 16px;font-size:14px;vertical-align:top;font-weight:bold;color:#b45309;">{expires_on}</td>
+  </tr>
+  <tr style="background:#f3f4f6;">
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;vertical-align:top;">Days Remaining</td>
+    <td style="padding:10px 16px;font-size:14px;vertical-align:top;"><strong>{days_remaining}</strong></td>
+  </tr>
+</table>
+<p style="margin:0 0 16px;font-size:14px;background:#fef3c7;border:1px solid #fde68a;border-radius:6px;padding:12px 16px;color:#78350f;">You do not have access to rotate this credential. If you have not heard from the superuser, please contact them directly to confirm they are aware.</p>
+<p style="margin:0;font-size:14px;color:#6b7280;">These alerts are sent weekly starting 30 days before expiration, then daily in the final 7 days.</p>

--- a/backend/app/templates/email/credential_expiring_admin.txt
+++ b/backend/app/templates/email/credential_expiring_admin.txt
@@ -1,0 +1,16 @@
+NOTICE: Credential Expiring in {days_remaining} Day{days_plural}
+
+A managed credential for {app_name} is approaching its expiration date.
+The superuser has also been notified and is responsible for rotating
+this credential.
+
+Credential:      {credential_name}
+Service:         {resource}
+Expires On:      {expires_on}
+Days Remaining:  {days_remaining}
+
+You do not have access to rotate this credential. If you have not heard
+from the superuser, please contact them directly to confirm they are aware.
+
+These alerts are sent weekly starting 30 days before expiration, then
+daily in the final 7 days.

--- a/backend/app/templates/email/credential_expiring_superuser.html
+++ b/backend/app/templates/email/credential_expiring_superuser.html
@@ -1,0 +1,30 @@
+<div style="background:#fffbeb;border-left:4px solid #d97706;padding:12px 16px;margin:0 0 20px;border-radius:0 4px 4px 0;">
+  <p style="margin:0;color:#92400e;font-weight:bold;font-size:15px;">Action Required: Credential Expiring in {days_remaining} Day{days_plural}</p>
+</div>
+<p style="margin:0 0 16px;">A managed credential for <strong>{app_name}</strong> is approaching its expiration date. Please rotate this credential before it expires to avoid service disruption.</p>
+<table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;margin:0 0 20px;background:#f9fafb;border-radius:6px;overflow:hidden;">
+  <tr>
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;vertical-align:top;width:120px;">Credential</td>
+    <td style="padding:10px 16px;font-size:14px;vertical-align:top;"><strong>{credential_name}</strong></td>
+  </tr>
+  <tr style="background:#f3f4f6;">
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;vertical-align:top;">Service</td>
+    <td style="padding:10px 16px;font-size:14px;vertical-align:top;">{resource}</td>
+  </tr>
+  <tr>
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;vertical-align:top;">Expires On</td>
+    <td style="padding:10px 16px;font-size:14px;vertical-align:top;font-weight:bold;color:#b45309;">{expires_on}</td>
+  </tr>
+  <tr style="background:#f3f4f6;">
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;vertical-align:top;">Days Remaining</td>
+    <td style="padding:10px 16px;font-size:14px;vertical-align:top;"><strong>{days_remaining}</strong></td>
+  </tr>
+</table>
+<p style="margin:0 0 20px;font-size:14px;">After rotation, update the corresponding environment variable and redeploy the affected service. Admins have also been notified and may follow up with you directly.</p>
+<table cellpadding="0" cellspacing="0" role="presentation">
+  <tr>
+    <td style="background:#d97706;border-radius:6px;">
+      <a href="{admin_url}" style="display:inline-block;padding:12px 28px;color:#ffffff;font-weight:bold;text-decoration:none;font-size:15px;font-family:Arial,Helvetica,sans-serif;">View Admin Panel</a>
+    </td>
+  </tr>
+</table>

--- a/backend/app/templates/email/credential_expiring_superuser.txt
+++ b/backend/app/templates/email/credential_expiring_superuser.txt
@@ -1,0 +1,16 @@
+ACTION REQUIRED: Credential Expiring in {days_remaining} Day{days_plural}
+
+A managed credential for {app_name} is approaching its expiration date.
+Please rotate this credential before it expires to avoid service disruption.
+
+Credential:      {credential_name}
+Service:         {resource}
+Expires On:      {expires_on}
+Days Remaining:  {days_remaining}
+
+After rotation, update the corresponding environment variable and redeploy
+the affected service. Admins have also been notified and may follow up
+with you directly.
+
+View the admin panel:
+{admin_url}

--- a/backend/app/templates/email/deletion_completed_admin.html
+++ b/backend/app/templates/email/deletion_completed_admin.html
@@ -1,6 +1,12 @@
-<p>User deletion completed successfully in <strong>{app_name}</strong>.</p>
-
-<table style="border-collapse:collapse;margin:16px 0;">
-  <tr><td style="padding:4px 12px 4px 0;color:#6b7280;">User</td><td style="padding:4px 0;"><strong>{display_name}</strong> ({email})</td></tr>
-  <tr><td style="padding:4px 0;color:#6b7280;">Status</td><td style="padding:4px 0;color:#16a34a;font-weight:bold;">Complete — all data permanently deleted</td></tr>
+<p style="margin:0 0 16px;font-size:16px;font-weight:bold;color:#1d3557;">User Deletion Complete</p>
+<table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;margin:0 0 16px;background:#f9fafb;border-radius:6px;overflow:hidden;">
+  <tr>
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;vertical-align:top;width:80px;">User</td>
+    <td style="padding:10px 16px;font-size:14px;vertical-align:top;"><strong>{display_name}</strong> ({email})</td>
+  </tr>
+  <tr style="background:#f3f4f6;">
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;vertical-align:top;">Status</td>
+    <td style="padding:10px 16px;font-size:14px;vertical-align:top;color:#16a34a;font-weight:bold;">Complete &mdash; all data permanently deleted</td>
+  </tr>
 </table>
+<p style="margin:0;font-size:14px;color:#6b7280;">All data for this account has been permanently deleted from {app_name}.</p>

--- a/backend/app/templates/email/deletion_completed_admin.txt
+++ b/backend/app/templates/email/deletion_completed_admin.txt
@@ -1,4 +1,6 @@
-User deletion completed successfully in {app_name}.
+User Deletion Complete
 
 User:    {display_name} ({email})
-Status:  Complete — all data has been permanently deleted
+Status:  Complete -- all data permanently deleted
+
+All data for this account has been permanently deleted from {app_name}.

--- a/backend/app/templates/email/deletion_created_admin.html
+++ b/backend/app/templates/email/deletion_created_admin.html
@@ -1,11 +1,19 @@
-<p>A user deletion has been queued in <strong>{app_name}</strong>.</p>
-
-<table style="border-collapse:collapse;margin:16px 0;">
-  <tr><td style="padding:4px 12px 4px 0;color:#6b7280;">User</td><td style="padding:4px 0;"><strong>{display_name}</strong> ({email})</td></tr>
-  <tr><td style="padding:4px 12px 4px 0;color:#6b7280;">Status</td><td style="padding:4px 0;">Pending — data cascade in progress</td></tr>
+<p style="margin:0 0 16px;font-size:16px;font-weight:bold;color:#1d3557;">User Deletion Queued</p>
+<table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;margin:0 0 16px;background:#f9fafb;border-radius:6px;overflow:hidden;">
+  <tr>
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;vertical-align:top;width:80px;">User</td>
+    <td style="padding:10px 16px;font-size:14px;vertical-align:top;"><strong>{display_name}</strong> ({email})</td>
+  </tr>
+  <tr style="background:#f3f4f6;">
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;vertical-align:top;">Status</td>
+    <td style="padding:10px 16px;font-size:14px;vertical-align:top;color:#d97706;font-weight:bold;">Pending &mdash; data cascade in progress</td>
+  </tr>
 </table>
-
-<p>All user data (projects, activities, looms, uploads) will be permanently
-deleted by the background task. The user's account is already blocked.</p>
-
-<p><a href="{admin_url}">View Admin Panel</a></p>
+<p style="margin:0 0 20px;font-size:14px;">All user data (projects, activities, looms, and uploads) will be permanently deleted by the background worker. The user's account is already blocked.</p>
+<table cellpadding="0" cellspacing="0" role="presentation">
+  <tr>
+    <td style="background:#1d3557;border-radius:6px;">
+      <a href="{admin_url}" style="display:inline-block;padding:12px 28px;color:#ffffff;font-weight:bold;text-decoration:none;font-size:15px;font-family:Arial,Helvetica,sans-serif;">View Admin Panel</a>
+    </td>
+  </tr>
+</table>

--- a/backend/app/templates/email/deletion_created_admin.txt
+++ b/backend/app/templates/email/deletion_created_admin.txt
@@ -1,10 +1,10 @@
-A user deletion has been queued in {app_name}.
+User Deletion Queued
 
-User:        {display_name} ({email})
-Status:      Pending — data cascade in progress
+User:    {display_name} ({email})
+Status:  Pending -- data cascade in progress
 
-All user data (projects, activities, looms, uploads) will be permanently
-deleted by the background task. The user's account is already blocked.
+All user data (projects, activities, looms, and uploads) will be
+permanently deleted by the background worker. The user's account is
+already blocked.
 
-View the admin panel for status updates:
-{admin_url}
+View admin panel: {admin_url}

--- a/backend/app/templates/email/deletion_stalled_superuser.html
+++ b/backend/app/templates/email/deletion_stalled_superuser.html
@@ -1,12 +1,26 @@
-<p style="color:#b91c1c;font-weight:bold;">A user deletion task has stalled and requires attention in <strong>{app_name}</strong>.</p>
-
-<table style="border-collapse:collapse;margin:16px 0;">
-  <tr><td style="padding:4px 12px 4px 0;color:#6b7280;">User</td><td style="padding:4px 0;"><strong>{display_name}</strong> ({email})</td></tr>
-  <tr><td style="padding:4px 12px 4px 0;color:#6b7280;">User ID</td><td style="padding:4px 0;font-family:monospace;">{user_id}</td></tr>
-  <tr><td style="padding:4px 12px 4px 0;color:#6b7280;">Status</td><td style="padding:4px 0;color:#b91c1c;font-weight:bold;">Stalled — retry limit exceeded</td></tr>
+<div style="background:#fef2f2;border-left:4px solid #dc2626;padding:12px 16px;margin:0 0 20px;border-radius:0 4px 4px 0;">
+  <p style="margin:0;color:#b91c1c;font-weight:bold;font-size:15px;">Action Required: Deletion Task Stalled</p>
+</div>
+<p style="margin:0 0 16px;">The background deletion task has exceeded its retry limit. The user's account remains blocked but data has not been fully purged. Manual intervention is required.</p>
+<table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;margin:0 0 20px;background:#f9fafb;border-radius:6px;overflow:hidden;">
+  <tr>
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;vertical-align:top;width:80px;">User</td>
+    <td style="padding:10px 16px;font-size:14px;vertical-align:top;"><strong>{display_name}</strong> ({email})</td>
+  </tr>
+  <tr style="background:#f3f4f6;">
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;vertical-align:top;">User ID</td>
+    <td style="padding:10px 16px;font-size:14px;vertical-align:top;font-family:monospace;">{user_id}</td>
+  </tr>
+  <tr>
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;vertical-align:top;">Status</td>
+    <td style="padding:10px 16px;font-size:14px;vertical-align:top;color:#b91c1c;font-weight:bold;">Stalled &mdash; retry limit exceeded</td>
+  </tr>
 </table>
-
-<p>The user's account remains blocked but their data has not been fully purged.
-Check the worker logs for details and re-trigger deletion from the admin panel.</p>
-
-<p><a href="{admin_url}">View Admin Panel</a></p>
+<p style="margin:0 0 20px;font-size:14px;">Check the worker logs and re-trigger deletion from the admin panel.</p>
+<table cellpadding="0" cellspacing="0" role="presentation">
+  <tr>
+    <td style="background:#b91c1c;border-radius:6px;">
+      <a href="{admin_url}" style="display:inline-block;padding:12px 28px;color:#ffffff;font-weight:bold;text-decoration:none;font-size:15px;font-family:Arial,Helvetica,sans-serif;">View Admin Panel</a>
+    </td>
+  </tr>
+</table>

--- a/backend/app/templates/email/deletion_stalled_superuser.txt
+++ b/backend/app/templates/email/deletion_stalled_superuser.txt
@@ -1,11 +1,12 @@
-A user deletion task has stalled and requires attention in {app_name}.
+ACTION REQUIRED: User Deletion Stalled
+
+The background deletion task has exceeded its retry limit. The user's
+account remains blocked but data has not been fully purged. Manual
+intervention is required.
 
 User:     {display_name} ({email})
 User ID:  {user_id}
-Status:   Stalled — the background task exceeded its retry limit
+Status:   Stalled -- retry limit exceeded
 
-Manual intervention is required. The user's account remains blocked but their
-data has not been fully purged. Check the worker logs for details and
-re-trigger deletion from the admin panel.
-
+Check the worker logs and re-trigger deletion from the admin panel:
 {admin_url}

--- a/backend/app/templates/email/invite.html
+++ b/backend/app/templates/email/invite.html
@@ -1,0 +1,12 @@
+<p style="margin:0 0 16px;font-size:18px;font-weight:bold;color:#1d3557;">You've been invited to join {app_name}</p>
+<p style="margin:0 0 20px;">An admin has invited you to create an account. Click the button below to accept your invitation and set up your account.</p>
+<table cellpadding="0" cellspacing="0" role="presentation" style="margin:0 0 24px;">
+  <tr>
+    <td style="background:#1d3557;border-radius:6px;">
+      <a href="{invite_url}" style="display:inline-block;padding:12px 28px;color:#ffffff;font-weight:bold;text-decoration:none;font-size:15px;font-family:Arial,Helvetica,sans-serif;">Accept Invitation</a>
+    </td>
+  </tr>
+</table>
+<p style="margin:0 0 8px;font-size:14px;color:#6b7280;">If the button above doesn't work, copy and paste this link into your browser:</p>
+<p style="margin:0 0 20px;font-size:13px;word-break:break-all;"><a href="{invite_url}" style="color:#1d3557;">{invite_url}</a></p>
+<p style="margin:0;font-size:14px;color:#6b7280;">This invitation expires in {expires_days} day(s) and can only be used once. If you were not expecting this, you can safely ignore this email.</p>

--- a/backend/app/templates/email/invite.txt
+++ b/backend/app/templates/email/invite.txt
@@ -1,0 +1,9 @@
+You've been invited to join {app_name}.
+
+An admin has invited you to create an account. Click the link below
+to accept your invitation and set up your account:
+
+{invite_url}
+
+This invitation expires in {expires_days} day(s) and can only be used
+once. If you were not expecting this, you can safely ignore this email.

--- a/backend/app/templates/email/pending_signup_admin_notification.html
+++ b/backend/app/templates/email/pending_signup_admin_notification.html
@@ -1,2 +1,20 @@
-<p><strong>{display_name}</strong> ({email}) signed up but has no invite.</p>
-<p><a href="{admin_url}">Review in admin console</a> → Invites → Waiting to join</p>
+<p style="margin:0 0 16px;font-size:16px;font-weight:bold;color:#1d3557;">New Sign-up Request</p>
+<p style="margin:0 0 16px;">A new user has requested access to <strong>{app_name}</strong> and is waiting for approval.</p>
+<table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;margin:0 0 20px;background:#f9fafb;border-radius:6px;overflow:hidden;">
+  <tr>
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;vertical-align:top;width:80px;">Name</td>
+    <td style="padding:10px 16px;font-size:14px;vertical-align:top;"><strong>{display_name}</strong></td>
+  </tr>
+  <tr style="background:#f3f4f6;">
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;vertical-align:top;">Email</td>
+    <td style="padding:10px 16px;font-size:14px;vertical-align:top;">{email}</td>
+  </tr>
+</table>
+<table cellpadding="0" cellspacing="0" role="presentation" style="margin:0 0 16px;">
+  <tr>
+    <td style="background:#1d3557;border-radius:6px;">
+      <a href="{admin_url}" style="display:inline-block;padding:12px 28px;color:#ffffff;font-weight:bold;text-decoration:none;font-size:15px;font-family:Arial,Helvetica,sans-serif;">Review in Admin Console</a>
+    </td>
+  </tr>
+</table>
+<p style="margin:0;font-size:14px;color:#6b7280;">Navigate to Admin &rarr; Invites &rarr; Waiting to Join.</p>

--- a/backend/app/templates/email/pending_signup_admin_notification.txt
+++ b/backend/app/templates/email/pending_signup_admin_notification.txt
@@ -1,4 +1,10 @@
-{display_name} ({email}) signed up but has no invite.
+New Sign-up Request
 
-Review and approve at: {admin_url}
-Admin → Invites → Waiting to join
+A new user has requested access to {app_name} and is waiting for
+approval.
+
+Name:   {display_name}
+Email:  {email}
+
+Review and approve: {admin_url}
+Navigate to Admin > Invites > Waiting to Join.

--- a/backend/app/templates/email/pending_signup_user_confirmation.html
+++ b/backend/app/templates/email/pending_signup_user_confirmation.html
@@ -1,3 +1,4 @@
-<p>Hi <strong>{display_name}</strong>,</p>
-<p>Thanks for signing up for <strong>{app_name}</strong>.</p>
-<p>{app_name} is currently invite only. Your request has been received and the admins have been notified. You'll get an email when your account is approved.</p>
+<p style="margin:0 0 16px;">Hi <strong>{display_name}</strong>,</p>
+<p style="margin:0 0 16px;">Thank you for signing up for <strong>{app_name}</strong>. Your request has been received and is waiting for admin review.</p>
+<p style="margin:0 0 16px;">You will receive an email as soon as your account is approved. No action is required from you right now.</p>
+<p style="margin:0;font-size:14px;color:#6b7280;">If you did not create this request, you can safely ignore this email.</p>

--- a/backend/app/templates/email/pending_signup_user_confirmation.txt
+++ b/backend/app/templates/email/pending_signup_user_confirmation.txt
@@ -1,5 +1,9 @@
 Hi {display_name},
 
-Thanks for signing up for {app_name}.
+Thank you for signing up for {app_name}. Your request has been
+received and is waiting for admin review.
 
-{app_name} is currently invite only. Your request has been received and the admins have been notified. You'll get an email when your account is approved.
+You will receive an email as soon as your account is approved. No
+action is required from you right now.
+
+If you did not create this request, you can safely ignore this email.

--- a/backend/app/templates/email/test_email.html
+++ b/backend/app/templates/email/test_email.html
@@ -1,0 +1,13 @@
+<p style="margin:0 0 16px;font-size:18px;font-weight:bold;color:#1d3557;">SMTP Test</p>
+<p style="margin:0 0 20px;">This is a test email from <strong>{app_name}</strong>. If you received this message, your SMTP configuration is working correctly.</p>
+<table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;margin:0 0 20px;background:#f9fafb;border-radius:6px;overflow:hidden;">
+  <tr>
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;vertical-align:top;width:120px;">Status</td>
+    <td style="padding:10px 16px;font-size:14px;vertical-align:top;color:#16a34a;font-weight:bold;">Delivered successfully</td>
+  </tr>
+  <tr style="background:#f3f4f6;">
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;vertical-align:top;">Sent from</td>
+    <td style="padding:10px 16px;font-size:14px;vertical-align:top;">{app_name}</td>
+  </tr>
+</table>
+<p style="margin:0;font-size:14px;color:#6b7280;">No action is required. This message was triggered from the Admin &rarr; Services tab.</p>

--- a/backend/app/templates/email/test_email.txt
+++ b/backend/app/templates/email/test_email.txt
@@ -1,0 +1,10 @@
+SMTP Test — {app_name}
+
+This is a test email. If you received this message, your SMTP
+configuration is working correctly.
+
+Status:    Delivered successfully
+Sent from: {app_name}
+
+No action is required. This message was triggered from the
+Admin > Services tab.

--- a/backend/tests/services/test_email.py
+++ b/backend/tests/services/test_email.py
@@ -17,16 +17,25 @@ from app.services.email import (
     send_invite_email,
     send_pending_signup_notification,
     send_signup_received_email,
+    send_test_email,
 )
 
 
 def _decoded_body(msg) -> str:
-    """Return all MIME body parts as a single decoded string.
-
-    MIMEText encodes non-ASCII content (e.g. → arrows in templates) as
-    base64. get_payload(decode=True) handles both plain and base64 parts.
-    """
+    """Return all MIME body parts as a single decoded string."""
     return " ".join(p.get_payload(decode=True).decode("utf-8") for p in msg.get_payload())
+
+
+def _plain_body(msg) -> str:
+    """Return the plain-text MIME part decoded as a string."""
+    part = next(p for p in msg.get_payload() if p.get_content_type() == "text/plain")
+    return part.get_payload(decode=True).decode("utf-8")
+
+
+def _html_body(msg) -> str:
+    """Return the HTML MIME part decoded as a string."""
+    part = next(p for p in msg.get_payload() if p.get_content_type() == "text/html")
+    return part.get_payload(decode=True).decode("utf-8")
 
 
 # ---------------------------------------------------------------------------
@@ -41,12 +50,12 @@ SETTINGS_OVERRIDES = {
     "smtp_port": 587,
     "smtp_user": "smtpuser",
     "smtp_password": "smtppass",
+    "app_env": "test",
 }
 
 
 @pytest.fixture(autouse=True)
 def _patch_settings(monkeypatch):
-    """Override all settings consumed by send_invite_email."""
     from app.config import get_settings
 
     settings = get_settings()
@@ -55,11 +64,11 @@ def _patch_settings(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Helper: run send_invite_email with a mock SMTP sender
+# Helper: call send_invite_email with a mock SMTP sender
 # ---------------------------------------------------------------------------
 
 
-async def _send(to="user@test.com", token="tok123", days=7):
+async def _send_invite(to="user@test.com", token="tok123", days=7):
     mock_send = AsyncMock()
     with patch("app.services.email.aiosmtplib.send", mock_send):
         await send_invite_email(to, token, days)
@@ -67,37 +76,37 @@ async def _send(to="user@test.com", token="tok123", days=7):
 
 
 # ---------------------------------------------------------------------------
-# SMTP transport — what aiosmtplib.send receives
+# SMTP transport
 # ---------------------------------------------------------------------------
 
 
 class TestSmtpTransport:
     async def test_send_called_once(self):
-        mock = await _send()
+        mock = await _send_invite()
         mock.assert_called_once()
 
     async def test_smtp_hostname(self):
-        mock = await _send()
+        mock = await _send_invite()
         _, kwargs = mock.call_args
         assert kwargs["hostname"] == "smtp.example.com"
 
     async def test_smtp_port(self):
-        mock = await _send()
+        mock = await _send_invite()
         _, kwargs = mock.call_args
         assert kwargs["port"] == 587
 
     async def test_smtp_username(self):
-        mock = await _send()
+        mock = await _send_invite()
         _, kwargs = mock.call_args
         assert kwargs["username"] == "smtpuser"
 
     async def test_smtp_password(self):
-        mock = await _send()
+        mock = await _send_invite()
         _, kwargs = mock.call_args
         assert kwargs["password"] == "smtppass"
 
     async def test_start_tls_enabled(self):
-        mock = await _send()
+        mock = await _send_invite()
         _, kwargs = mock.call_args
         assert kwargs["start_tls"] is True
 
@@ -143,7 +152,7 @@ class TestMessageHeaders:
 
 
 # ---------------------------------------------------------------------------
-# Message body content
+# Invite plain text body
 # ---------------------------------------------------------------------------
 
 
@@ -153,7 +162,7 @@ class TestPlainTextBody:
         with patch("app.services.email.aiosmtplib.send", mock_send):
             await send_invite_email(to, token, days)
         msg, *_ = mock_send.call_args.args
-        return next(p for p in msg.get_payload() if p.get_content_type() == "text/plain").get_payload()
+        return _plain_body(msg)
 
     async def test_contains_invite_url(self):
         body = await self._plain(token="mytoken")
@@ -176,13 +185,18 @@ class TestPlainTextBody:
         assert "once" in body.lower()
 
 
+# ---------------------------------------------------------------------------
+# Invite HTML body
+# ---------------------------------------------------------------------------
+
+
 class TestHtmlBody:
     async def _html(self, token="abc", days=7):
         mock_send = AsyncMock()
         with patch("app.services.email.aiosmtplib.send", mock_send):
             await send_invite_email("u@t.com", token, days)
         msg, *_ = mock_send.call_args.args
-        return next(p for p in msg.get_payload() if p.get_content_type() == "text/html").get_payload()
+        return _html_body(msg)
 
     async def test_contains_invite_url(self):
         html = await self._html(token="htmltoken")
@@ -215,7 +229,7 @@ class TestInviteUrl:
         with patch("app.services.email.aiosmtplib.send", mock_send):
             await send_invite_email("u@t.com", token, 7)
         msg, *_ = mock_send.call_args.args
-        return next(p for p in msg.get_payload() if p.get_content_type() == "text/plain").get_payload()
+        return _plain_body(msg)
 
     async def test_token_appended_as_query_param(self):
         body = await self._url_in_plain("secrettoken")
@@ -245,24 +259,84 @@ class TestTemplateRendering:
         txt, html = _render(
             "account_approved",
             display_name="Alice",
-            app_name="TestApp",
             login_url="http://example.com/login",
         )
         assert "Alice" in txt
         assert "Alice" in html
-        assert "TestApp" in txt
-        assert "TestApp" in html
+        assert "Test Site" in txt
+        assert "Test Site" in html
 
     def test_render_substitutes_all_placeholders(self):
         from app.services.email import _render
 
-        txt, _ = _render(
-            "account_denied",
-            display_name="Bob",
-            app_name="TestApp",
-        )
+        txt, _ = _render("account_denied", display_name="Bob")
         assert "Bob" in txt
         assert "{" not in txt
+
+    def test_render_includes_base_footer(self):
+        from app.services.email import _render
+
+        txt, html = _render("account_approved", display_name="X", login_url="http://example.com/login")
+        assert "example.com" in txt
+        assert "example.com" in html
+
+    def test_render_invite_template(self):
+        from app.services.email import _render
+
+        txt, html = _render(
+            "invite",
+            invite_url="http://example.com/register?token=abc",
+            expires_days=7,
+        )
+        assert "http://example.com/register?token=abc" in txt
+        assert "http://example.com/register?token=abc" in html
+        assert "7" in txt
+
+    def test_render_test_email_template(self):
+        from app.services.email import _render
+
+        txt, html = _render("test_email")
+        assert "Test Site" in txt
+        assert "Test Site" in html
+
+
+# ---------------------------------------------------------------------------
+# send_test_email
+# ---------------------------------------------------------------------------
+
+
+class TestSendTestEmail:
+    async def _call(self, to="admin@test.com"):
+        mock_send = AsyncMock()
+        with patch("app.services.email.aiosmtplib.send", mock_send):
+            await send_test_email(to)
+        return mock_send
+
+    async def test_send_called_once(self):
+        mock = await self._call()
+        mock.assert_called_once()
+
+    async def test_recipient_is_to_email(self):
+        mock = await self._call(to="specific@test.com")
+        msg, *_ = mock.call_args.args
+        assert "specific@test.com" in msg["To"]
+
+    async def test_subject_mentions_site_name(self):
+        mock = await self._call()
+        msg, *_ = mock.call_args.args
+        assert "Test Site" in msg["Subject"]
+
+    async def test_subject_mentions_smtp(self):
+        mock = await self._call()
+        msg, *_ = mock.call_args.args
+        assert "SMTP" in msg["Subject"] or "Test" in msg["Subject"]
+
+    async def test_body_confirms_delivery(self):
+        mock = await self._call()
+        msg, *_ = mock.call_args.args
+        combined = _decoded_body(msg)
+        assert "test" in combined.lower()
+        assert "Test Site" in combined
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Introduces `_base.html` / `_base.txt` shared wrapper used by all emails: navy `#1d3557` header, white content area, grey footer with app URL
- Moves `send_invite_email` and `send_test_email` from inline Python strings to proper template files — dev banner now applies to invites too
- Rewrites all 8 existing templates with consistent copy, striped data tables, and table-based CTA buttons
- Refactors `_render()` to auto-inject `app_name` / `frontend_url` from settings and compose base + body with a sentinel replace before `str.format()`
- Updates tests: `_plain_body` / `_html_body` decode helpers, `app_env=test` fixture override, `TestSendTestEmail` class, three new rendering assertions

Closes #259

## Test plan

- [ ] Send test email from Admin → Services tab — confirm it arrives with WeftMark header, correct copy, and footer
- [ ] Invite a new user — confirm invite email renders with Accept Invitation button and correct expiry note
- [ ] Approve a pending signup — confirm account-approved email arrives with Sign in button
- [ ] Deny a pending signup — confirm account-denied email arrives with correct copy
- [ ] Self-register as a new user — confirm pending confirmation email arrives
- [ ] `pytest backend/tests/services/test_email.py` passes (52 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)