### PR TITLE
docs: update deployment docs and testing history for v0.74.0 prod launch; fix tsconfig baseUrl

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,8 +78,6 @@ After every push, check CI status proactively: `gh run list --repo weftmark/weft
 
 Bot actor: `weftmark-bot[bot]`. Post-merge jobs use `if: github.actor != 'weftmark-bot[bot]'` to prevent infinite re-triggering. Bot commits do **not** use `[skip actions]` — that token propagates into merge commit bodies and suppresses PR CI on the target branch. The actor guard is sufficient.
 
-Append `[skip ci]` to commit messages for documentation-only changes (`.md` files, comments) to avoid unnecessary CI runs.
-
 ## Development rules
 
 ### Pull before starting work

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ WeftMark is a multi-user web platform for managing weaving (loom) projects. All 
 - Requirements: `docs/requirements/` (start with `docs/requirements/README.md`)
 - WIF 1.1 spec: `docs/standard/standard-wif1-1.txt`
 - Sample WIF files: `docs/samples/`
+- License: Business Source License 1.1 (BSL) — see `LICENSE`. Non-production use permitted; converts to MIT on 2029-01-01. Do not ask about licensing — it is already decided.
 
 ## Tech stack
 

--- a/docs/deployment/environments.md
+++ b/docs/deployment/environments.md
@@ -60,6 +60,7 @@ The "test" slot becomes a **Neon branch + ephemeral deployment** — created on 
 - **Data:** Real data, never read or modified outside normal app operations.
 - **Update cadence:** Manual deploy after staging validation.
 - **Clerk:** Prod project. This is the source of truth for user identities.
+- **Status:** Live as of May 3, 2026 at v0.74.0. Full smoke test passed.
 
 ---
 

--- a/docs/deployment/hosting-decisions.md
+++ b/docs/deployment/hosting-decisions.md
@@ -130,7 +130,7 @@
 
 **Decision:** SMTP2Go for transactional email (invitations).
 
-**Status:** Account creation pending — weftmark.com domain must be active for 3 days before SMTP2Go will approve. Tracked in issue #62, due 2026-05-01.
+**Status:** Confirmed working in production (May 3, 2026). All transactional email flows validated — signup notifications, approval emails, and invite emails all delivered correctly.
 
 **Sender:** `admin@weftmark.com` / display name `WeftMark`
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -118,3 +118,4 @@ Reassess coverage completeness when:
 | 2026-04-25 | v0.2.x | 55% | Model imports provide baseline via `app.main` import in conftest |
 | 2026-04-25 | v0.2.x | 68% | Added router tests (health) + model tests (User); DB integration test infrastructure in place |
 | 2026-04-25 | v0.5.0 | 67% | 266 tests; activity creation, restart, clone covered; auth `/me` + token validation added; loom CRUD partially covered |
+| 2026-05-03 | v0.74.0 | — | First production deployment smoke test; 63 items tested end-to-end; 11 issues filed (#266–#275); 2 closed (see GitHub issue #277) |

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -17,7 +17,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary

Documentation updates following the May 3, 2026 production deployment and smoke test, plus a TypeScript config fix and a CLAUDE.md workflow change.

- `CLAUDE.md` — add BSL license note; remove `[skip ci]` instruction (always run CI regardless of change type)
- `docs/deployment/hosting-decisions.md` — mark SMTP2Go as confirmed working in production
- `docs/deployment/environments.md` — note prod live at v0.74.0 since May 3, 2026
- `docs/testing.md` — add prod smoke test history row (63 items tested, 11 issues filed, see #277)
- `frontend/tsconfig.app.json` — remove deprecated `baseUrl` (redundant with `moduleResolution: bundler` in TS 5+)

## Test plan

- [x] `tsc -b && vite build` passes clean after tsconfig change
- [ ] Docs-only changes — no functional code modified beyond tsconfig