### PR TITLE
fix: widen video column on large screens, centre button text

### DIFF
--- a/docs/assets/preview-clay.html
+++ b/docs/assets/preview-clay.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Preview — Clay & Cream</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>.card{transition:transform .2s ease,box-shadow .2s ease}.card:hover{transform:translateY(-3px);box-shadow:0 12px 32px -4px rgba(0,0,0,.12)}</style>
+</head>
+<body class="bg-stone-50 text-stone-900 font-sans">
+  <svg class="pointer-events-none fixed inset-0 z-50 h-full w-full opacity-[0.045]" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><filter id="g"><feTurbulence type="fractalNoise" baseFrequency="0.72" numOctaves="4" stitchTiles="stitch"/></filter><rect width="100%" height="100%" filter="url(#g)"/></svg>
+
+  <header class="sticky top-0 z-10 bg-stone-50/95 px-6 py-4 backdrop-blur shadow-sm shadow-stone-900/5">
+    <div class="mx-auto flex max-w-6xl items-center justify-between">
+      <div class="flex items-center gap-2.5">
+        <svg viewBox="0 0 200 72" xmlns="http://www.w3.org/2000/svg" class="h-7 w-auto text-orange-800"><ellipse cx="100" cy="36" rx="90" ry="30" fill="currentColor"/><polyline points="55,24 75,50 100,34 125,50 145,24" fill="none" stroke="white" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <span class="text-base font-semibold tracking-tight">Weftmark</span>
+      </div>
+      <a href="#" class="text-sm font-medium text-stone-600 hover:text-stone-900">Sign in</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="relative bg-gradient-to-br from-stone-100 via-stone-50 to-white px-6 pt-16 pb-32 lg:pt-24 lg:pb-40" style="clip-path:polygon(0 0,100% 0,100% 88%,0 100%)">
+      <div class="mx-auto max-w-6xl">
+        <div class="grid items-center gap-12 lg:grid-cols-[1fr_1.4fr]">
+          <div class="order-2 lg:order-1">
+            <span class="mb-5 inline-block rounded-full bg-orange-100 px-3.5 py-1 text-xs font-medium tracking-wide text-orange-800">Weaving companion for handweavers</span>
+            <h1 class="mb-5 text-4xl font-bold tracking-tight text-stone-900 sm:text-5xl lg:text-6xl">Your weaving,<br><span class="text-orange-800">row by row.</span></h1>
+            <p class="mb-8 max-w-lg text-lg leading-relaxed text-stone-600">Upload your WIF draft, follow along pick by pick, and keep a complete record of every project from first warp to last pick.</p>
+            <div class="flex flex-col gap-3 sm:flex-row">
+              <a href="#" class="rounded-lg bg-orange-800 px-6 py-3 text-center text-sm font-semibold text-white shadow-md shadow-orange-900/25 hover:bg-orange-900">Sign In</a>
+              <a href="#" class="rounded-lg border border-stone-300 bg-white/60 px-6 py-3 text-center text-sm font-semibold text-stone-700 hover:bg-white">Create Account</a>
+            </div>
+          </div>
+          <div class="order-1 lg:order-2">
+            <div class="overflow-hidden rounded-2xl shadow-2xl shadow-stone-900/20 ring-1 ring-stone-300/60">
+              <div class="flex items-center gap-1.5 border-b border-stone-200 bg-stone-200/80 px-4 py-3">
+                <span class="h-3 w-3 rounded-full bg-red-400"></span><span class="h-3 w-3 rounded-full bg-amber-400"></span><span class="h-3 w-3 rounded-full bg-green-500"></span>
+                <span class="ml-3 flex-1 rounded bg-stone-300/60 px-3 py-1 text-center text-xs text-stone-500">weftmark.com</span>
+              </div>
+              <video autoplay muted loop playsinline class="w-full"><source src="hearts-treadle.mp4" type="video/mp4"></video>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="relative z-10 -mt-12 px-6 pb-20">
+      <div class="mx-auto max-w-6xl">
+        <h2 class="mb-10 text-center text-2xl font-bold tracking-tight text-stone-900">Everything you need at the loom</h2>
+        <div class="grid gap-6 sm:grid-cols-3">
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-orange-100 text-orange-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. Weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-orange-100 text-orange-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Record every pick</h3><p class="text-sm leading-relaxed text-stone-500">Advance, reverse, or jump to any row. Mark a project complete when the last pick is woven in.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-orange-100 text-orange-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Manage your tools</h3><p class="text-sm leading-relaxed text-stone-500">Keep a record of your looms and yarn. Assign a loom to a project and track what's on the beam.</p></div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 Weftmark. All rights reserved.</div></footer>
+  <div class="fixed bottom-4 right-4 rounded-full bg-orange-800 px-4 py-2 text-xs font-semibold text-white shadow-lg">Clay & Cream</div>
+</body>
+</html>

--- a/docs/assets/preview-cream-copper.html
+++ b/docs/assets/preview-cream-copper.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Preview — Cream & Copper</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>.card{transition:transform .2s ease,box-shadow .2s ease}.card:hover{transform:translateY(-3px);box-shadow:0 12px 32px -4px rgba(0,0,0,.12)}</style>
+</head>
+<body class="bg-stone-50 text-stone-900 font-sans">
+  <svg class="pointer-events-none fixed inset-0 z-50 h-full w-full opacity-[0.045]" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><filter id="g"><feTurbulence type="fractalNoise" baseFrequency="0.72" numOctaves="4" stitchTiles="stitch"/></filter><rect width="100%" height="100%" filter="url(#g)"/></svg>
+
+  <header class="sticky top-0 z-10 bg-stone-50/95 px-6 py-4 backdrop-blur shadow-sm shadow-stone-900/5">
+    <div class="mx-auto flex max-w-6xl items-center justify-between">
+      <div class="flex items-center gap-2.5">
+        <svg viewBox="0 0 200 72" xmlns="http://www.w3.org/2000/svg" class="h-7 w-auto text-amber-600"><ellipse cx="100" cy="36" rx="90" ry="30" fill="currentColor"/><polyline points="55,24 75,50 100,34 125,50 145,24" fill="none" stroke="white" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <span class="text-base font-semibold tracking-tight">Weftmark</span>
+      </div>
+      <a href="#" class="text-sm font-medium text-stone-600 hover:text-stone-900">Sign in</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="relative bg-gradient-to-br from-stone-100 via-stone-50 to-white px-6 pt-16 pb-32 lg:pt-24 lg:pb-40" style="clip-path:polygon(0 0,100% 0,100% 88%,0 100%)">
+      <div class="mx-auto max-w-6xl">
+        <div class="grid items-center gap-12 lg:grid-cols-[1fr_1.4fr]">
+          <div class="order-2 lg:order-1">
+            <span class="mb-5 inline-block rounded-full bg-amber-100 px-3.5 py-1 text-xs font-medium tracking-wide text-amber-700">Weaving companion for handweavers</span>
+            <h1 class="mb-5 text-4xl font-bold tracking-tight text-stone-900 sm:text-5xl lg:text-6xl">Your weaving,<br><span class="text-amber-600">row by row.</span></h1>
+            <p class="mb-8 max-w-lg text-lg leading-relaxed text-stone-600">Upload your WIF draft, follow along pick by pick, and keep a complete record of every project from first warp to last pick.</p>
+            <div class="flex flex-col gap-3 sm:flex-row">
+              <a href="#" class="rounded-lg bg-amber-600 px-6 py-3 text-center text-sm font-semibold text-white shadow-md shadow-amber-700/30 hover:bg-amber-700">Sign In</a>
+              <a href="#" class="rounded-lg border border-stone-300 bg-white/60 px-6 py-3 text-center text-sm font-semibold text-stone-700 hover:bg-white">Create Account</a>
+            </div>
+          </div>
+          <div class="order-1 lg:order-2">
+            <div class="overflow-hidden rounded-2xl shadow-2xl shadow-stone-900/20 ring-1 ring-stone-300/60">
+              <div class="flex items-center gap-1.5 border-b border-stone-200 bg-stone-200/80 px-4 py-3">
+                <span class="h-3 w-3 rounded-full bg-red-400"></span><span class="h-3 w-3 rounded-full bg-amber-400"></span><span class="h-3 w-3 rounded-full bg-green-500"></span>
+                <span class="ml-3 flex-1 rounded bg-stone-300/60 px-3 py-1 text-center text-xs text-stone-500">weftmark.com</span>
+              </div>
+              <video autoplay muted loop playsinline class="w-full"><source src="hearts-treadle.mp4" type="video/mp4"></video>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="relative z-10 -mt-12 px-6 pb-20">
+      <div class="mx-auto max-w-6xl">
+        <h2 class="mb-10 text-center text-2xl font-bold tracking-tight text-stone-900">Everything you need at the loom</h2>
+        <div class="grid gap-6 sm:grid-cols-3">
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-100 text-amber-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. Weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-100 text-amber-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Record every pick</h3><p class="text-sm leading-relaxed text-stone-500">Advance, reverse, or jump to any row. Mark a project complete when the last pick is woven in.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-100 text-amber-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Manage your tools</h3><p class="text-sm leading-relaxed text-stone-500">Keep a record of your looms and yarn. Assign a loom to a project and track what's on the beam.</p></div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 Weftmark. All rights reserved.</div></footer>
+  <div class="fixed bottom-4 right-4 rounded-full bg-amber-600 px-4 py-2 text-xs font-semibold text-white shadow-lg">Cream & Copper</div>
+</body>
+</html>

--- a/docs/assets/preview-layout-depth.html
+++ b/docs/assets/preview-layout-depth.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Preview — Layout Depth</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    /* Hover lift on feature cards */
+    .card { transition: transform 0.2s ease, box-shadow 0.2s ease; }
+    .card:hover { transform: translateY(-3px); box-shadow: 0 12px 32px -4px rgba(0,0,0,0.12); }
+  </style>
+</head>
+<body class="bg-stone-100 text-stone-900 font-sans">
+
+  <!-- Full-page grain overlay — fixed, non-interactive, very faint -->
+  <svg class="pointer-events-none fixed inset-0 z-50 h-full w-full opacity-[0.045]" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <filter id="grain">
+      <feTurbulence type="fractalNoise" baseFrequency="0.72" numOctaves="4" stitchTiles="stitch"/>
+    </filter>
+    <rect width="100%" height="100%" filter="url(#grain)"/>
+  </svg>
+
+  <!-- Header — sits above the tinted hero, subtle shadow grounds it -->
+  <header class="sticky top-0 z-10 bg-stone-100/95 px-6 py-4 backdrop-blur shadow-sm shadow-stone-900/5">
+    <div class="mx-auto flex max-w-6xl items-center justify-between">
+      <div class="flex items-center gap-2.5">
+        <svg viewBox="0 0 200 72" xmlns="http://www.w3.org/2000/svg" class="h-7 w-auto text-amber-800" aria-label="Weftmark" role="img">
+          <ellipse cx="100" cy="36" rx="90" ry="30" fill="currentColor"/>
+          <polyline points="55,24 75,50 100,34 125,50 145,24" fill="none" stroke="white" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span class="text-base font-semibold tracking-tight">Weftmark</span>
+      </div>
+      <a href="#" class="text-sm font-medium text-stone-600 hover:text-stone-900">Sign in</a>
+    </div>
+  </header>
+
+  <main>
+
+    <!-- Hero — warm stone-100 base with angled bottom clip -->
+    <section class="relative bg-gradient-to-br from-stone-100 via-stone-50 to-amber-50/40 px-6 pt-16 pb-32 lg:pt-24 lg:pb-40"
+             style="clip-path: polygon(0 0, 100% 0, 100% 88%, 0 100%);">
+      <div class="mx-auto max-w-6xl">
+        <div class="grid items-center gap-12 lg:grid-cols-[1fr_1.4fr]">
+
+          <!-- Text -->
+          <div class="order-2 lg:order-1">
+            <span class="mb-5 inline-block rounded-full bg-amber-200/70 px-3.5 py-1 text-xs font-medium tracking-wide text-amber-900">
+              Weaving companion for handweavers
+            </span>
+            <h1 class="mb-5 text-4xl font-bold tracking-tight text-stone-900 sm:text-5xl lg:text-6xl">
+              Your weaving,<br>
+              <span class="text-amber-800">row by row.</span>
+            </h1>
+            <p class="mb-8 max-w-lg text-lg leading-relaxed text-stone-600">
+              Upload your WIF draft, follow along pick by pick, and keep a complete record of every
+              project from first warp to last pick.
+            </p>
+            <div class="flex flex-col gap-3 sm:flex-row">
+              <a href="#" class="rounded-lg bg-amber-800 px-6 py-3 text-center text-sm font-semibold text-white shadow-md shadow-amber-900/25 transition-colors hover:bg-amber-900">Sign In</a>
+              <a href="#" class="rounded-lg border border-stone-300 bg-white/60 px-6 py-3 text-center text-sm font-semibold text-stone-700 transition-colors hover:bg-white">Create Account</a>
+            </div>
+          </div>
+
+          <!-- Video — ring colour slightly warmer to match hero -->
+          <div class="order-1 lg:order-2">
+            <div class="overflow-hidden rounded-2xl shadow-2xl shadow-stone-900/20 ring-1 ring-stone-300/60">
+              <div class="flex items-center gap-1.5 border-b border-stone-200 bg-stone-200/80 px-4 py-3">
+                <span class="h-3 w-3 rounded-full bg-red-400"></span>
+                <span class="h-3 w-3 rounded-full bg-amber-400"></span>
+                <span class="h-3 w-3 rounded-full bg-green-500"></span>
+                <span class="ml-3 flex-1 rounded bg-stone-300/60 px-3 py-1 text-center text-xs text-stone-500">weftmark.com</span>
+              </div>
+              <video autoplay muted loop playsinline class="w-full">
+                <source src="hearts-treadle.mp4" type="video/mp4">
+              </video>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </section>
+
+    <!-- Features — white section, floats over the clipped hero -->
+    <section class="relative z-10 -mt-12 px-6 pb-20">
+      <div class="mx-auto max-w-6xl">
+
+        <h2 class="mb-10 text-center text-2xl font-bold tracking-tight text-stone-900">
+          Everything you need at the loom
+        </h2>
+
+        <div class="grid gap-6 sm:grid-cols-3">
+
+          <div class="card rounded-2xl bg-white p-7 shadow-md shadow-stone-900/8 ring-1 ring-stone-200/80">
+            <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-100 text-amber-700">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5">
+                <rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/>
+                <rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/>
+              </svg>
+            </div>
+            <h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3>
+            <p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. Weftmark keeps your place so you can put down the shuttle and pick it right back up.</p>
+          </div>
+
+          <div class="card rounded-2xl bg-white p-7 shadow-md shadow-stone-900/8 ring-1 ring-stone-200/80">
+            <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-100 text-amber-700">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5">
+                <path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/>
+              </svg>
+            </div>
+            <h3 class="mb-2 text-base font-semibold text-stone-900">Record every pick</h3>
+            <p class="text-sm leading-relaxed text-stone-500">Advance, reverse, or jump to any row. Mark a project complete when the last pick is woven in.</p>
+          </div>
+
+          <div class="card rounded-2xl bg-white p-7 shadow-md shadow-stone-900/8 ring-1 ring-stone-200/80">
+            <div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-100 text-amber-700">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5">
+                <path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/>
+              </svg>
+            </div>
+            <h3 class="mb-2 text-base font-semibold text-stone-900">Manage your tools</h3>
+            <p class="text-sm leading-relaxed text-stone-500">Keep a record of your looms and yarn. Assign a loom to a project and track what's on the beam.</p>
+          </div>
+
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <footer class="border-t border-stone-200 bg-stone-100 px-6 py-8">
+    <div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 Weftmark. All rights reserved.</div>
+  </footer>
+
+  <div class="fixed bottom-4 right-4 rounded-full bg-stone-800 px-4 py-2 text-xs font-semibold text-white shadow-lg">Layout Depth</div>
+
+</body>
+</html>

--- a/docs/assets/preview-natural-indigo.html
+++ b/docs/assets/preview-natural-indigo.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Preview — Natural Indigo</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>.card{transition:transform .2s ease,box-shadow .2s ease}.card:hover{transform:translateY(-3px);box-shadow:0 12px 32px -4px rgba(0,0,0,.12)}</style>
+</head>
+<body class="bg-stone-50 text-stone-900 font-sans">
+  <svg class="pointer-events-none fixed inset-0 z-50 h-full w-full opacity-[0.045]" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><filter id="g"><feTurbulence type="fractalNoise" baseFrequency="0.72" numOctaves="4" stitchTiles="stitch"/></filter><rect width="100%" height="100%" filter="url(#g)"/></svg>
+
+  <header class="sticky top-0 z-10 bg-stone-50/95 px-6 py-4 backdrop-blur shadow-sm shadow-stone-900/5">
+    <div class="mx-auto flex max-w-6xl items-center justify-between">
+      <div class="flex items-center gap-2.5">
+        <svg viewBox="0 0 200 72" xmlns="http://www.w3.org/2000/svg" class="h-7 w-auto text-indigo-700"><ellipse cx="100" cy="36" rx="90" ry="30" fill="currentColor"/><polyline points="55,24 75,50 100,34 125,50 145,24" fill="none" stroke="white" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <span class="text-base font-semibold tracking-tight">Weftmark</span>
+      </div>
+      <a href="#" class="text-sm font-medium text-stone-600 hover:text-stone-900">Sign in</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="relative bg-gradient-to-br from-stone-100 via-stone-50 to-white px-6 pt-16 pb-32 lg:pt-24 lg:pb-40" style="clip-path:polygon(0 0,100% 0,100% 88%,0 100%)">
+      <div class="mx-auto max-w-6xl">
+        <div class="grid items-center gap-12 lg:grid-cols-[1fr_1.4fr]">
+          <div class="order-2 lg:order-1">
+            <span class="mb-5 inline-block rounded-full bg-indigo-100 px-3.5 py-1 text-xs font-medium tracking-wide text-indigo-700">Weaving companion for handweavers</span>
+            <h1 class="mb-5 text-4xl font-bold tracking-tight text-stone-900 sm:text-5xl lg:text-6xl">Your weaving,<br><span class="text-indigo-700">row by row.</span></h1>
+            <p class="mb-8 max-w-lg text-lg leading-relaxed text-stone-600">Upload your WIF draft, follow along pick by pick, and keep a complete record of every project from first warp to last pick.</p>
+            <div class="flex flex-col gap-3 sm:flex-row">
+              <a href="#" class="rounded-lg bg-indigo-700 px-6 py-3 text-center text-sm font-semibold text-white shadow-md shadow-indigo-900/25 hover:bg-indigo-800">Sign In</a>
+              <a href="#" class="rounded-lg border border-stone-300 bg-white/60 px-6 py-3 text-center text-sm font-semibold text-stone-700 hover:bg-white">Create Account</a>
+            </div>
+          </div>
+          <div class="order-1 lg:order-2">
+            <div class="overflow-hidden rounded-2xl shadow-2xl shadow-stone-900/20 ring-1 ring-stone-300/60">
+              <div class="flex items-center gap-1.5 border-b border-stone-200 bg-stone-200/80 px-4 py-3">
+                <span class="h-3 w-3 rounded-full bg-red-400"></span><span class="h-3 w-3 rounded-full bg-amber-400"></span><span class="h-3 w-3 rounded-full bg-green-500"></span>
+                <span class="ml-3 flex-1 rounded bg-stone-300/60 px-3 py-1 text-center text-xs text-stone-500">weftmark.com</span>
+              </div>
+              <video autoplay muted loop playsinline class="w-full"><source src="hearts-treadle.mp4" type="video/mp4"></video>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="relative z-10 -mt-12 px-6 pb-20">
+      <div class="mx-auto max-w-6xl">
+        <h2 class="mb-10 text-center text-2xl font-bold tracking-tight text-stone-900">Everything you need at the loom</h2>
+        <div class="grid gap-6 sm:grid-cols-3">
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-indigo-100 text-indigo-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. Weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-indigo-100 text-indigo-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Record every pick</h3><p class="text-sm leading-relaxed text-stone-500">Advance, reverse, or jump to any row. Mark a project complete when the last pick is woven in.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-indigo-100 text-indigo-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Manage your tools</h3><p class="text-sm leading-relaxed text-stone-500">Keep a record of your looms and yarn. Assign a loom to a project and track what's on the beam.</p></div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 Weftmark. All rights reserved.</div></footer>
+  <div class="fixed bottom-4 right-4 rounded-full bg-indigo-700 px-4 py-2 text-xs font-semibold text-white shadow-lg">Natural Indigo</div>
+</body>
+</html>

--- a/docs/assets/preview-plum.html
+++ b/docs/assets/preview-plum.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Preview — Plum</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>.card{transition:transform .2s ease,box-shadow .2s ease}.card:hover{transform:translateY(-3px);box-shadow:0 12px 32px -4px rgba(0,0,0,.12)}</style>
+</head>
+<body class="bg-stone-50 text-stone-900 font-sans">
+  <svg class="pointer-events-none fixed inset-0 z-50 h-full w-full opacity-[0.045]" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><filter id="g"><feTurbulence type="fractalNoise" baseFrequency="0.72" numOctaves="4" stitchTiles="stitch"/></filter><rect width="100%" height="100%" filter="url(#g)"/></svg>
+
+  <header class="sticky top-0 z-10 bg-stone-50/95 px-6 py-4 backdrop-blur shadow-sm shadow-stone-900/5">
+    <div class="mx-auto flex max-w-6xl items-center justify-between">
+      <div class="flex items-center gap-2.5">
+        <svg viewBox="0 0 200 72" xmlns="http://www.w3.org/2000/svg" class="h-7 w-auto text-violet-800"><ellipse cx="100" cy="36" rx="90" ry="30" fill="currentColor"/><polyline points="55,24 75,50 100,34 125,50 145,24" fill="none" stroke="white" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <span class="text-base font-semibold tracking-tight">Weftmark</span>
+      </div>
+      <a href="#" class="text-sm font-medium text-stone-600 hover:text-stone-900">Sign in</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="relative bg-gradient-to-br from-stone-100 via-stone-50 to-white px-6 pt-16 pb-32 lg:pt-24 lg:pb-40" style="clip-path:polygon(0 0,100% 0,100% 88%,0 100%)">
+      <div class="mx-auto max-w-6xl">
+        <div class="grid items-center gap-12 lg:grid-cols-[1fr_1.4fr]">
+          <div class="order-2 lg:order-1">
+            <span class="mb-5 inline-block rounded-full bg-violet-100 px-3.5 py-1 text-xs font-medium tracking-wide text-violet-800">Weaving companion for handweavers</span>
+            <h1 class="mb-5 text-4xl font-bold tracking-tight text-stone-900 sm:text-5xl lg:text-6xl">Your weaving,<br><span class="text-violet-800">row by row.</span></h1>
+            <p class="mb-8 max-w-lg text-lg leading-relaxed text-stone-600">Upload your WIF draft, follow along pick by pick, and keep a complete record of every project from first warp to last pick.</p>
+            <div class="flex flex-col gap-3 sm:flex-row">
+              <a href="#" class="rounded-lg bg-violet-800 px-6 py-3 text-center text-sm font-semibold text-white shadow-md shadow-violet-900/25 hover:bg-violet-900">Sign In</a>
+              <a href="#" class="rounded-lg border border-stone-300 bg-white/60 px-6 py-3 text-center text-sm font-semibold text-stone-700 hover:bg-white">Create Account</a>
+            </div>
+          </div>
+          <div class="order-1 lg:order-2">
+            <div class="overflow-hidden rounded-2xl shadow-2xl shadow-stone-900/20 ring-1 ring-stone-300/60">
+              <div class="flex items-center gap-1.5 border-b border-stone-200 bg-stone-200/80 px-4 py-3">
+                <span class="h-3 w-3 rounded-full bg-red-400"></span><span class="h-3 w-3 rounded-full bg-amber-400"></span><span class="h-3 w-3 rounded-full bg-green-500"></span>
+                <span class="ml-3 flex-1 rounded bg-stone-300/60 px-3 py-1 text-center text-xs text-stone-500">weftmark.com</span>
+              </div>
+              <video autoplay muted loop playsinline class="w-full"><source src="hearts-treadle.mp4" type="video/mp4"></video>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="relative z-10 -mt-12 px-6 pb-20">
+      <div class="mx-auto max-w-6xl">
+        <h2 class="mb-10 text-center text-2xl font-bold tracking-tight text-stone-900">Everything you need at the loom</h2>
+        <div class="grid gap-6 sm:grid-cols-3">
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-violet-100 text-violet-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. Weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-violet-100 text-violet-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Record every pick</h3><p class="text-sm leading-relaxed text-stone-500">Advance, reverse, or jump to any row. Mark a project complete when the last pick is woven in.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-violet-100 text-violet-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Manage your tools</h3><p class="text-sm leading-relaxed text-stone-500">Keep a record of your looms and yarn. Assign a loom to a project and track what's on the beam.</p></div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 Weftmark. All rights reserved.</div></footer>
+  <div class="fixed bottom-4 right-4 rounded-full bg-violet-800 px-4 py-2 text-xs font-semibold text-white shadow-lg">Plum</div>
+</body>
+</html>

--- a/docs/assets/preview-rose.html
+++ b/docs/assets/preview-rose.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Preview — Dusty Rose</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>.card{transition:transform .2s ease,box-shadow .2s ease}.card:hover{transform:translateY(-3px);box-shadow:0 12px 32px -4px rgba(0,0,0,.12)}</style>
+</head>
+<body class="bg-stone-50 text-stone-900 font-sans">
+  <svg class="pointer-events-none fixed inset-0 z-50 h-full w-full opacity-[0.045]" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><filter id="g"><feTurbulence type="fractalNoise" baseFrequency="0.72" numOctaves="4" stitchTiles="stitch"/></filter><rect width="100%" height="100%" filter="url(#g)"/></svg>
+
+  <header class="sticky top-0 z-10 bg-stone-50/95 px-6 py-4 backdrop-blur shadow-sm shadow-stone-900/5">
+    <div class="mx-auto flex max-w-6xl items-center justify-between">
+      <div class="flex items-center gap-2.5">
+        <svg viewBox="0 0 200 72" xmlns="http://www.w3.org/2000/svg" class="h-7 w-auto text-rose-800"><ellipse cx="100" cy="36" rx="90" ry="30" fill="currentColor"/><polyline points="55,24 75,50 100,34 125,50 145,24" fill="none" stroke="white" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <span class="text-base font-semibold tracking-tight">Weftmark</span>
+      </div>
+      <a href="#" class="text-sm font-medium text-stone-600 hover:text-stone-900">Sign in</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="relative bg-gradient-to-br from-stone-100 via-stone-50 to-white px-6 pt-16 pb-32 lg:pt-24 lg:pb-40" style="clip-path:polygon(0 0,100% 0,100% 88%,0 100%)">
+      <div class="mx-auto max-w-6xl">
+        <div class="grid items-center gap-12 lg:grid-cols-[1fr_1.4fr]">
+          <div class="order-2 lg:order-1">
+            <span class="mb-5 inline-block rounded-full bg-rose-100 px-3.5 py-1 text-xs font-medium tracking-wide text-rose-800">Weaving companion for handweavers</span>
+            <h1 class="mb-5 text-4xl font-bold tracking-tight text-stone-900 sm:text-5xl lg:text-6xl">Your weaving,<br><span class="text-rose-800">row by row.</span></h1>
+            <p class="mb-8 max-w-lg text-lg leading-relaxed text-stone-600">Upload your WIF draft, follow along pick by pick, and keep a complete record of every project from first warp to last pick.</p>
+            <div class="flex flex-col gap-3 sm:flex-row">
+              <a href="#" class="rounded-lg bg-rose-800 px-6 py-3 text-center text-sm font-semibold text-white shadow-md shadow-rose-900/25 hover:bg-rose-900">Sign In</a>
+              <a href="#" class="rounded-lg border border-stone-300 bg-white/60 px-6 py-3 text-center text-sm font-semibold text-stone-700 hover:bg-white">Create Account</a>
+            </div>
+          </div>
+          <div class="order-1 lg:order-2">
+            <div class="overflow-hidden rounded-2xl shadow-2xl shadow-stone-900/20 ring-1 ring-stone-300/60">
+              <div class="flex items-center gap-1.5 border-b border-stone-200 bg-stone-200/80 px-4 py-3">
+                <span class="h-3 w-3 rounded-full bg-red-400"></span><span class="h-3 w-3 rounded-full bg-amber-400"></span><span class="h-3 w-3 rounded-full bg-green-500"></span>
+                <span class="ml-3 flex-1 rounded bg-stone-300/60 px-3 py-1 text-center text-xs text-stone-500">weftmark.com</span>
+              </div>
+              <video autoplay muted loop playsinline class="w-full"><source src="hearts-treadle.mp4" type="video/mp4"></video>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="relative z-10 -mt-12 px-6 pb-20">
+      <div class="mx-auto max-w-6xl">
+        <h2 class="mb-10 text-center text-2xl font-bold tracking-tight text-stone-900">Everything you need at the loom</h2>
+        <div class="grid gap-6 sm:grid-cols-3">
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-rose-100 text-rose-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. Weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-rose-100 text-rose-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Record every pick</h3><p class="text-sm leading-relaxed text-stone-500">Advance, reverse, or jump to any row. Mark a project complete when the last pick is woven in.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-rose-100 text-rose-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Manage your tools</h3><p class="text-sm leading-relaxed text-stone-500">Keep a record of your looms and yarn. Assign a loom to a project and track what's on the beam.</p></div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 Weftmark. All rights reserved.</div></footer>
+  <div class="fixed bottom-4 right-4 rounded-full bg-rose-800 px-4 py-2 text-xs font-semibold text-white shadow-lg">Dusty Rose</div>
+</body>
+</html>

--- a/docs/assets/preview-sage-loom.html
+++ b/docs/assets/preview-sage-loom.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Preview — Sage Loom</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>.card{transition:transform .2s ease,box-shadow .2s ease}.card:hover{transform:translateY(-3px);box-shadow:0 12px 32px -4px rgba(0,0,0,.12)}</style>
+</head>
+<body class="bg-stone-50 text-stone-900 font-sans">
+  <svg class="pointer-events-none fixed inset-0 z-50 h-full w-full opacity-[0.045]" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><filter id="g"><feTurbulence type="fractalNoise" baseFrequency="0.72" numOctaves="4" stitchTiles="stitch"/></filter><rect width="100%" height="100%" filter="url(#g)"/></svg>
+
+  <header class="sticky top-0 z-10 bg-stone-50/95 px-6 py-4 backdrop-blur shadow-sm shadow-stone-900/5">
+    <div class="mx-auto flex max-w-6xl items-center justify-between">
+      <div class="flex items-center gap-2.5">
+        <svg viewBox="0 0 200 72" xmlns="http://www.w3.org/2000/svg" class="h-7 w-auto text-emerald-800"><ellipse cx="100" cy="36" rx="90" ry="30" fill="currentColor"/><polyline points="55,24 75,50 100,34 125,50 145,24" fill="none" stroke="white" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <span class="text-base font-semibold tracking-tight">Weftmark</span>
+      </div>
+      <a href="#" class="text-sm font-medium text-stone-600 hover:text-stone-900">Sign in</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="relative bg-gradient-to-br from-stone-100 via-stone-50 to-white px-6 pt-16 pb-32 lg:pt-24 lg:pb-40" style="clip-path:polygon(0 0,100% 0,100% 88%,0 100%)">
+      <div class="mx-auto max-w-6xl">
+        <div class="grid items-center gap-12 lg:grid-cols-[1fr_1.4fr]">
+          <div class="order-2 lg:order-1">
+            <span class="mb-5 inline-block rounded-full bg-emerald-100 px-3.5 py-1 text-xs font-medium tracking-wide text-emerald-800">Weaving companion for handweavers</span>
+            <h1 class="mb-5 text-4xl font-bold tracking-tight text-stone-900 sm:text-5xl lg:text-6xl">Your weaving,<br><span class="text-emerald-800">row by row.</span></h1>
+            <p class="mb-8 max-w-lg text-lg leading-relaxed text-stone-600">Upload your WIF draft, follow along pick by pick, and keep a complete record of every project from first warp to last pick.</p>
+            <div class="flex flex-col gap-3 sm:flex-row">
+              <a href="#" class="rounded-lg bg-emerald-800 px-6 py-3 text-center text-sm font-semibold text-white shadow-md shadow-emerald-900/25 hover:bg-emerald-900">Sign In</a>
+              <a href="#" class="rounded-lg border border-stone-300 bg-white/60 px-6 py-3 text-center text-sm font-semibold text-stone-700 hover:bg-white">Create Account</a>
+            </div>
+          </div>
+          <div class="order-1 lg:order-2">
+            <div class="overflow-hidden rounded-2xl shadow-2xl shadow-stone-900/20 ring-1 ring-stone-300/60">
+              <div class="flex items-center gap-1.5 border-b border-stone-200 bg-stone-200/80 px-4 py-3">
+                <span class="h-3 w-3 rounded-full bg-red-400"></span><span class="h-3 w-3 rounded-full bg-amber-400"></span><span class="h-3 w-3 rounded-full bg-green-500"></span>
+                <span class="ml-3 flex-1 rounded bg-stone-300/60 px-3 py-1 text-center text-xs text-stone-500">weftmark.com</span>
+              </div>
+              <video autoplay muted loop playsinline class="w-full"><source src="hearts-treadle.mp4" type="video/mp4"></video>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="relative z-10 -mt-12 px-6 pb-20">
+      <div class="mx-auto max-w-6xl">
+        <h2 class="mb-10 text-center text-2xl font-bold tracking-tight text-stone-900">Everything you need at the loom</h2>
+        <div class="grid gap-6 sm:grid-cols-3">
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-100 text-emerald-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. Weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-100 text-emerald-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Record every pick</h3><p class="text-sm leading-relaxed text-stone-500">Advance, reverse, or jump to any row. Mark a project complete when the last pick is woven in.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-100 text-emerald-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Manage your tools</h3><p class="text-sm leading-relaxed text-stone-500">Keep a record of your looms and yarn. Assign a loom to a project and track what's on the beam.</p></div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 Weftmark. All rights reserved.</div></footer>
+  <div class="fixed bottom-4 right-4 rounded-full bg-emerald-800 px-4 py-2 text-xs font-semibold text-white shadow-lg">Sage Loom</div>
+</body>
+</html>

--- a/docs/assets/preview-slate-copper.html
+++ b/docs/assets/preview-slate-copper.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Preview — Slate & Copper</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>.card{transition:transform .2s ease,box-shadow .2s ease}.card:hover{transform:translateY(-3px);box-shadow:0 12px 32px -4px rgba(0,0,0,.12)}</style>
+</head>
+<body class="bg-stone-50 text-stone-900 font-sans">
+  <svg class="pointer-events-none fixed inset-0 z-50 h-full w-full opacity-[0.045]" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><filter id="g"><feTurbulence type="fractalNoise" baseFrequency="0.72" numOctaves="4" stitchTiles="stitch"/></filter><rect width="100%" height="100%" filter="url(#g)"/></svg>
+
+  <header class="sticky top-0 z-10 bg-stone-50/95 px-6 py-4 backdrop-blur shadow-sm shadow-stone-900/5">
+    <div class="mx-auto flex max-w-6xl items-center justify-between">
+      <div class="flex items-center gap-2.5">
+        <svg viewBox="0 0 200 72" xmlns="http://www.w3.org/2000/svg" class="h-7 w-auto text-zinc-800"><ellipse cx="100" cy="36" rx="90" ry="30" fill="currentColor"/><polyline points="55,24 75,50 100,34 125,50 145,24" fill="none" stroke="white" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <span class="text-base font-semibold tracking-tight">Weftmark</span>
+      </div>
+      <a href="#" class="text-sm font-medium text-stone-600 hover:text-stone-900">Sign in</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="relative bg-gradient-to-br from-stone-100 via-stone-50 to-white px-6 pt-16 pb-32 lg:pt-24 lg:pb-40" style="clip-path:polygon(0 0,100% 0,100% 88%,0 100%)">
+      <div class="mx-auto max-w-6xl">
+        <div class="grid items-center gap-12 lg:grid-cols-[1fr_1.4fr]">
+          <div class="order-2 lg:order-1">
+            <span class="mb-5 inline-block rounded-full bg-amber-100 px-3.5 py-1 text-xs font-medium tracking-wide text-amber-700">Weaving companion for handweavers</span>
+            <h1 class="mb-5 text-4xl font-bold tracking-tight text-stone-900 sm:text-5xl lg:text-6xl">Your weaving,<br><span class="text-amber-600">row by row.</span></h1>
+            <p class="mb-8 max-w-lg text-lg leading-relaxed text-stone-600">Upload your WIF draft, follow along pick by pick, and keep a complete record of every project from first warp to last pick.</p>
+            <div class="flex flex-col gap-3 sm:flex-row">
+              <a href="#" class="rounded-lg bg-zinc-800 px-6 py-3 text-center text-sm font-semibold text-white shadow-md shadow-zinc-900/30 hover:bg-zinc-900">Sign In</a>
+              <a href="#" class="rounded-lg border border-stone-300 bg-white/60 px-6 py-3 text-center text-sm font-semibold text-stone-700 hover:bg-white">Create Account</a>
+            </div>
+          </div>
+          <div class="order-1 lg:order-2">
+            <div class="overflow-hidden rounded-2xl shadow-2xl shadow-stone-900/20 ring-1 ring-stone-300/60">
+              <div class="flex items-center gap-1.5 border-b border-stone-200 bg-stone-200/80 px-4 py-3">
+                <span class="h-3 w-3 rounded-full bg-red-400"></span><span class="h-3 w-3 rounded-full bg-amber-400"></span><span class="h-3 w-3 rounded-full bg-green-500"></span>
+                <span class="ml-3 flex-1 rounded bg-stone-300/60 px-3 py-1 text-center text-xs text-stone-500">weftmark.com</span>
+              </div>
+              <video autoplay muted loop playsinline class="w-full"><source src="hearts-treadle.mp4" type="video/mp4"></video>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="relative z-10 -mt-12 px-6 pb-20">
+      <div class="mx-auto max-w-6xl">
+        <h2 class="mb-10 text-center text-2xl font-bold tracking-tight text-stone-900">Everything you need at the loom</h2>
+        <div class="grid gap-6 sm:grid-cols-3">
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-100 text-amber-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. Weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-100 text-amber-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Record every pick</h3><p class="text-sm leading-relaxed text-stone-500">Advance, reverse, or jump to any row. Mark a project complete when the last pick is woven in.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-100 text-amber-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Manage your tools</h3><p class="text-sm leading-relaxed text-stone-500">Keep a record of your looms and yarn. Assign a loom to a project and track what's on the beam.</p></div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 Weftmark. All rights reserved.</div></footer>
+  <div class="fixed bottom-4 right-4 rounded-full bg-zinc-800 px-4 py-2 text-xs font-semibold text-white shadow-lg">Slate & Copper</div>
+</body>
+</html>

--- a/docs/assets/preview-teal.html
+++ b/docs/assets/preview-teal.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Preview — Deep Teal</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>.card{transition:transform .2s ease,box-shadow .2s ease}.card:hover{transform:translateY(-3px);box-shadow:0 12px 32px -4px rgba(0,0,0,.12)}</style>
+</head>
+<body class="bg-stone-50 text-stone-900 font-sans">
+  <svg class="pointer-events-none fixed inset-0 z-50 h-full w-full opacity-[0.045]" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><filter id="g"><feTurbulence type="fractalNoise" baseFrequency="0.72" numOctaves="4" stitchTiles="stitch"/></filter><rect width="100%" height="100%" filter="url(#g)"/></svg>
+
+  <header class="sticky top-0 z-10 bg-stone-50/95 px-6 py-4 backdrop-blur shadow-sm shadow-stone-900/5">
+    <div class="mx-auto flex max-w-6xl items-center justify-between">
+      <div class="flex items-center gap-2.5">
+        <svg viewBox="0 0 200 72" xmlns="http://www.w3.org/2000/svg" class="h-7 w-auto text-teal-700"><ellipse cx="100" cy="36" rx="90" ry="30" fill="currentColor"/><polyline points="55,24 75,50 100,34 125,50 145,24" fill="none" stroke="white" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <span class="text-base font-semibold tracking-tight">Weftmark</span>
+      </div>
+      <a href="#" class="text-sm font-medium text-stone-600 hover:text-stone-900">Sign in</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="relative bg-gradient-to-br from-stone-100 via-stone-50 to-white px-6 pt-16 pb-32 lg:pt-24 lg:pb-40" style="clip-path:polygon(0 0,100% 0,100% 88%,0 100%)">
+      <div class="mx-auto max-w-6xl">
+        <div class="grid items-center gap-12 lg:grid-cols-[1fr_1.4fr]">
+          <div class="order-2 lg:order-1">
+            <span class="mb-5 inline-block rounded-full bg-teal-100 px-3.5 py-1 text-xs font-medium tracking-wide text-teal-700">Weaving companion for handweavers</span>
+            <h1 class="mb-5 text-4xl font-bold tracking-tight text-stone-900 sm:text-5xl lg:text-6xl">Your weaving,<br><span class="text-teal-700">row by row.</span></h1>
+            <p class="mb-8 max-w-lg text-lg leading-relaxed text-stone-600">Upload your WIF draft, follow along pick by pick, and keep a complete record of every project from first warp to last pick.</p>
+            <div class="flex flex-col gap-3 sm:flex-row">
+              <a href="#" class="rounded-lg bg-teal-700 px-6 py-3 text-center text-sm font-semibold text-white shadow-md shadow-teal-900/25 hover:bg-teal-800">Sign In</a>
+              <a href="#" class="rounded-lg border border-stone-300 bg-white/60 px-6 py-3 text-center text-sm font-semibold text-stone-700 hover:bg-white">Create Account</a>
+            </div>
+          </div>
+          <div class="order-1 lg:order-2">
+            <div class="overflow-hidden rounded-2xl shadow-2xl shadow-stone-900/20 ring-1 ring-stone-300/60">
+              <div class="flex items-center gap-1.5 border-b border-stone-200 bg-stone-200/80 px-4 py-3">
+                <span class="h-3 w-3 rounded-full bg-red-400"></span><span class="h-3 w-3 rounded-full bg-amber-400"></span><span class="h-3 w-3 rounded-full bg-green-500"></span>
+                <span class="ml-3 flex-1 rounded bg-stone-300/60 px-3 py-1 text-center text-xs text-stone-500">weftmark.com</span>
+              </div>
+              <video autoplay muted loop playsinline class="w-full"><source src="hearts-treadle.mp4" type="video/mp4"></video>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="relative z-10 -mt-12 px-6 pb-20">
+      <div class="mx-auto max-w-6xl">
+        <h2 class="mb-10 text-center text-2xl font-bold tracking-tight text-stone-900">Everything you need at the loom</h2>
+        <div class="grid gap-6 sm:grid-cols-3">
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-teal-100 text-teal-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. Weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-teal-100 text-teal-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Record every pick</h3><p class="text-sm leading-relaxed text-stone-500">Advance, reverse, or jump to any row. Mark a project complete when the last pick is woven in.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-teal-100 text-teal-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Manage your tools</h3><p class="text-sm leading-relaxed text-stone-500">Keep a record of your looms and yarn. Assign a loom to a project and track what's on the beam.</p></div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 Weftmark. All rights reserved.</div></footer>
+  <div class="fixed bottom-4 right-4 rounded-full bg-teal-700 px-4 py-2 text-xs font-semibold text-white shadow-lg">Deep Teal</div>
+</body>
+</html>

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,152 @@
+# WeftMark UI Design System
+
+> **Status:** Active — current palette is **Slate & Copper**. This direction is not frozen; the palette and layout patterns may evolve, but this document defines the reference baseline for consistent UX work.
+
+---
+
+## Palette — Slate & Copper
+
+Two-tone palette: a dark neutral primary paired with a warm amber accent. Backgrounds stay neutral; the accent color is reserved for focal points only.
+
+| Role | Tailwind token | Hex approx |
+|---|---|---|
+| Primary action / logo fill | `zinc-800` | `#27272a` |
+| Accent — headlines, icons, badges | `amber-600` | `#d97706` |
+| Page background | `stone-50` | `#fafaf9` |
+| Hero gradient start | `stone-100` | `#f5f5f4` |
+| Card / surface background | `white` | `#ffffff` |
+| Body text | `stone-900` | `#1c1917` |
+| Secondary text | `stone-600` | `#57534e` |
+| Muted text | `stone-500` | `#78716c` |
+| Border / ring | `stone-200` / `stone-300` | |
+
+### Do / Don't
+- **Do** use `stone-50` as the page base — not white, not tinted.
+- **Do** limit amber to: logo, h1 accent span, primary badge, icon badge bg/text.
+- **Don't** tint the hero or feature section background with amber — keep it neutral warm gray.
+- **Don't** use zinc-800 for decorative elements; reserve it for the primary CTA and logo only.
+
+---
+
+## Layout Depth Pattern
+
+These techniques add visual hierarchy without busy decoration.
+
+### Grain texture overlay
+A fixed SVG `feTurbulence` filter at 4.5% opacity layered over the entire page. Applied once at the top-level layout wrapper.
+
+```tsx
+<svg
+  className="pointer-events-none fixed inset-0 z-50 h-full w-full opacity-[0.045]"
+  xmlns="http://www.w3.org/2000/svg"
+  aria-hidden="true"
+>
+  <filter id="grain">
+    <feTurbulence type="fractalNoise" baseFrequency="0.72" numOctaves="4" stitchTiles="stitch" />
+  </filter>
+  <rect width="100%" height="100%" filter="url(#grain)" />
+</svg>
+```
+
+### Angled section divider
+Hero sections use a `clip-path` polygon to create a diagonal bottom edge. The next section floats over it with a negative top margin.
+
+```tsx
+// Hero section
+<section
+  className="relative bg-gradient-to-br from-stone-100 via-stone-50 to-white px-6 pt-16 pb-32 lg:pt-24 lg:pb-40"
+  style={{ clipPath: "polygon(0 0, 100% 0, 100% 88%, 0 100%)" }}
+>
+
+// Floating section below
+<section className="relative z-10 -mt-12 px-6 pb-20">
+```
+
+### Feature cards
+Cards sit on white with a subtle shadow and ring. They lift on hover.
+
+```tsx
+<div className="rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80 transition-all duration-200 hover:-translate-y-1 hover:shadow-xl">
+  <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-100 text-amber-600">
+    <Icon className="h-5 w-5" strokeWidth={1.75} aria-hidden="true" />
+  </div>
+  ...
+</div>
+```
+
+---
+
+## Header
+
+Sticky, blurred, no visible border — separation comes from a soft shadow.
+
+```tsx
+<header className="sticky top-0 z-10 bg-stone-50/95 px-6 py-4 backdrop-blur shadow-sm shadow-stone-900/5">
+```
+
+Logo color: `text-zinc-800`. Sign-in link: `text-stone-600 hover:text-stone-900`.
+
+---
+
+## CTA Buttons
+
+```tsx
+// Primary
+<Link className="rounded-lg bg-zinc-800 px-6 py-3 text-center text-sm font-semibold text-white shadow-md shadow-zinc-900/30 transition-colors hover:bg-zinc-900">
+
+// Secondary
+<Link className="rounded-lg border border-stone-300 bg-white/60 px-6 py-3 text-center text-sm font-semibold text-stone-700 transition-colors hover:bg-white">
+```
+
+Always `text-center` on both. Horizontal on `sm:` breakpoint, stacked below.
+
+---
+
+## Hero Layout
+
+Two-column grid on large screens: text left (narrower), media right (wider).
+
+```tsx
+<div className="grid items-center gap-12 lg:grid-cols-[1fr_1.4fr]">
+  <div className="order-2 lg:order-1">/* text */</div>
+  <div className="order-1 lg:order-2">/* media */</div>
+</div>
+```
+
+Media column gets `1.4fr` to give the video/screenshot more visual weight.
+
+---
+
+## Badge Pill
+
+```tsx
+<span className="mb-5 inline-block rounded-full bg-amber-100 px-3.5 py-1 text-xs font-medium tracking-wide text-amber-700">
+  Weaving companion for handweavers
+</span>
+```
+
+---
+
+## Browser Chrome Frame (video/screenshot mockup)
+
+```tsx
+<div className="overflow-hidden rounded-2xl shadow-2xl shadow-stone-900/20 ring-1 ring-stone-300/60">
+  <div className="flex items-center gap-1.5 border-b border-stone-200 bg-stone-200/80 px-4 py-3">
+    <span className="h-3 w-3 rounded-full bg-red-400" />
+    <span className="h-3 w-3 rounded-full bg-amber-400" />
+    <span className="h-3 w-3 rounded-full bg-green-500" />
+    <span className="ml-3 flex-1 rounded bg-stone-300/60 px-3 py-1 text-center text-xs text-stone-500">
+      weftmark.com
+    </span>
+  </div>
+  {/* content */}
+</div>
+```
+
+---
+
+## Palette Exploration Previews
+
+Standalone HTML previews (no build required) are in `docs/assets/preview-*.html`. Each loads Tailwind via CDN and references `hearts-treadle.mp4` from the same directory. Use these to test new palettes before touching the React source.
+
+Available previews: `cream-copper`, `slate-copper`, `natural-indigo`, `sage-loom`, `clay`, `teal`, `rose`, `plum`.

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -43,7 +43,7 @@ export function LandingPage() {
         {/* Hero */}
         <section className="bg-gradient-to-br from-stone-50 via-white to-amber-50/30 px-6 py-16 lg:py-24">
           <div className="mx-auto max-w-6xl">
-            <div className="grid items-center gap-12 lg:grid-cols-2">
+            <div className="grid items-center gap-12 lg:grid-cols-[1fr_1.4fr]">
               {/* Text */}
               <div className="order-2 lg:order-1">
                 <span className="mb-5 inline-block rounded-full bg-amber-100 px-3.5 py-1 text-xs font-medium tracking-wide text-amber-800">
@@ -61,13 +61,13 @@ export function LandingPage() {
                 <div className="flex flex-col gap-3 sm:flex-row">
                   <Link
                     to="/login"
-                    className="rounded-lg bg-amber-800 px-6 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-amber-900"
+                    className="rounded-lg bg-amber-800 px-6 py-3 text-center text-sm font-semibold text-white shadow-sm transition-colors hover:bg-amber-900"
                   >
                     Sign In
                   </Link>
                   <Link
                     to="/register"
-                    className="rounded-lg border border-stone-300 px-6 py-3 text-sm font-semibold text-stone-700 transition-colors hover:bg-stone-50"
+                    className="rounded-lg border border-stone-300 px-6 py-3 text-center text-sm font-semibold text-stone-700 transition-colors hover:bg-stone-50"
                   >
                     Create Account
                   </Link>

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -23,11 +23,23 @@ const FEATURES = [
 
 export function LandingPage() {
   return (
-    <div className="flex min-h-screen flex-col bg-white text-stone-900">
-      <header className="sticky top-0 z-10 border-b border-stone-200 bg-white/95 px-6 py-4 backdrop-blur">
+    <div className="flex min-h-screen flex-col bg-stone-50 text-stone-900">
+      {/* Grain texture overlay */}
+      <svg
+        className="pointer-events-none fixed inset-0 z-50 h-full w-full opacity-[0.045]"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <filter id="grain">
+          <feTurbulence type="fractalNoise" baseFrequency="0.72" numOctaves="4" stitchTiles="stitch" />
+        </filter>
+        <rect width="100%" height="100%" filter="url(#grain)" />
+      </svg>
+
+      <header className="sticky top-0 z-10 bg-stone-50/95 px-6 py-4 backdrop-blur shadow-sm shadow-stone-900/5">
         <div className="mx-auto flex max-w-6xl items-center justify-between">
           <div className="flex items-center gap-2.5">
-            <WeftmarkLogo className="h-7 w-auto text-amber-800" />
+            <WeftmarkLogo className="h-7 w-auto text-zinc-800" />
             <span className="text-base font-semibold tracking-tight">Weftmark</span>
           </div>
           <Link
@@ -41,18 +53,20 @@ export function LandingPage() {
 
       <main className="flex-1">
         {/* Hero */}
-        <section className="bg-gradient-to-br from-stone-50 via-white to-amber-50/30 px-6 py-16 lg:py-24">
+        <section
+          className="relative bg-gradient-to-br from-stone-100 via-stone-50 to-white px-6 pt-16 pb-32 lg:pt-24 lg:pb-40"
+          style={{ clipPath: "polygon(0 0, 100% 0, 100% 88%, 0 100%)" }}
+        >
           <div className="mx-auto max-w-6xl">
             <div className="grid items-center gap-12 lg:grid-cols-[1fr_1.4fr]">
-              {/* Text */}
               <div className="order-2 lg:order-1">
-                <span className="mb-5 inline-block rounded-full bg-amber-100 px-3.5 py-1 text-xs font-medium tracking-wide text-amber-800">
+                <span className="mb-5 inline-block rounded-full bg-amber-100 px-3.5 py-1 text-xs font-medium tracking-wide text-amber-700">
                   Weaving companion for handweavers
                 </span>
                 <h1 className="mb-5 text-4xl font-bold tracking-tight text-stone-900 sm:text-5xl lg:text-6xl">
                   Your weaving,
                   <br />
-                  <span className="text-amber-800">row by row.</span>
+                  <span className="text-amber-600">row by row.</span>
                 </h1>
                 <p className="mb-8 max-w-lg text-lg leading-relaxed text-stone-600">
                   Upload your WIF draft, follow along pick by pick, and keep a complete record of every
@@ -61,28 +75,26 @@ export function LandingPage() {
                 <div className="flex flex-col gap-3 sm:flex-row">
                   <Link
                     to="/login"
-                    className="rounded-lg bg-amber-800 px-6 py-3 text-center text-sm font-semibold text-white shadow-sm transition-colors hover:bg-amber-900"
+                    className="rounded-lg bg-zinc-800 px-6 py-3 text-center text-sm font-semibold text-white shadow-md shadow-zinc-900/30 transition-colors hover:bg-zinc-900"
                   >
                     Sign In
                   </Link>
                   <Link
                     to="/register"
-                    className="rounded-lg border border-stone-300 px-6 py-3 text-center text-sm font-semibold text-stone-700 transition-colors hover:bg-stone-50"
+                    className="rounded-lg border border-stone-300 bg-white/60 px-6 py-3 text-center text-sm font-semibold text-stone-700 transition-colors hover:bg-white"
                   >
                     Create Account
                   </Link>
                 </div>
               </div>
 
-              {/* Video demo */}
               <div className="order-1 lg:order-2">
-                <div className="overflow-hidden rounded-2xl shadow-2xl ring-1 ring-stone-200/80">
-                  {/* Browser chrome */}
-                  <div className="flex items-center gap-1.5 border-b border-stone-200 bg-stone-100 px-4 py-3">
+                <div className="overflow-hidden rounded-2xl shadow-2xl shadow-stone-900/20 ring-1 ring-stone-300/60">
+                  <div className="flex items-center gap-1.5 border-b border-stone-200 bg-stone-200/80 px-4 py-3">
                     <span className="h-3 w-3 rounded-full bg-red-400" />
                     <span className="h-3 w-3 rounded-full bg-amber-400" />
                     <span className="h-3 w-3 rounded-full bg-green-500" />
-                    <span className="ml-3 flex-1 rounded bg-stone-200 px-3 py-1 text-center text-xs text-stone-400">
+                    <span className="ml-3 flex-1 rounded bg-stone-300/60 px-3 py-1 text-center text-xs text-stone-500">
                       weftmark.com
                     </span>
                   </div>
@@ -96,8 +108,8 @@ export function LandingPage() {
           </div>
         </section>
 
-        {/* Features */}
-        <section className="border-t border-stone-200 bg-stone-50 px-6 py-16">
+        {/* Features — floats over angled hero clip */}
+        <section className="relative z-10 -mt-12 px-6 pb-20">
           <div className="mx-auto max-w-6xl">
             <h2 className="mb-10 text-center text-2xl font-bold tracking-tight text-stone-900">
               Everything you need at the loom
@@ -106,13 +118,13 @@ export function LandingPage() {
               {FEATURES.map(({ title, body, Icon }) => (
                 <div
                   key={title}
-                  className="rounded-xl bg-white p-6 shadow-sm ring-1 ring-stone-200"
+                  className="rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80 transition-all duration-200 hover:-translate-y-1 hover:shadow-xl"
                 >
-                  <div className="mb-3 text-amber-700">
-                    <Icon className="h-6 w-6" strokeWidth={1.75} aria-hidden="true" />
+                  <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-100 text-amber-600">
+                    <Icon className="h-5 w-5" strokeWidth={1.75} aria-hidden="true" />
                   </div>
                   <h3 className="mb-2 text-base font-semibold text-stone-900">{title}</h3>
-                  <p className="text-sm leading-relaxed text-stone-600">{body}</p>
+                  <p className="text-sm leading-relaxed text-stone-500">{body}</p>
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary

- Redesigned landing page hero with two-column layout (`lg:grid-cols-[1fr_1.4fr]`), giving the video demo more visual weight on large screens
- Applied **Slate & Copper** palette: `zinc-800` primary, `amber-600` accent, neutral `stone-50` background throughout
- Added layout depth: SVG grain texture overlay, angled `clip-path` section divider, floating feature cards with hover-lift animation
- Icon badges with `rounded-xl bg-amber-100` containers replace plain inline icons
- Header updated to sticky blur with soft shadow (no hard border)
- Added `docs/design-system.md` — colour tokens, layout patterns, and component snippets as a reference baseline for future UX work
- Colour palette exploration previews added to `docs/assets/preview-*.html` (8 options; no build required)

Closes part of #27

## Test plan

- [ ] Landing page renders correctly at mobile (375px), tablet (768px), and desktop (1280px+)
- [ ] Video demo column is visibly wider than the text column on large screens
- [ ] Both CTA buttons are full-width with centred text on mobile
- [ ] Angled hero clip-path displays cleanly with no gap or overlap at the feature card boundary
- [ ] Feature cards lift on hover
- [ ] Sign-in and Create Account links route correctly
- [ ] No regression in auth flow (login, register)

🤖 Generated with [Claude Code](https://claude.com/claude-code)