### PR TITLE
feat: UI design system, icon registry, and card visual improvements

### DIFF
--- a/backend/alembic/versions/0001_baseline.py
+++ b/backend/alembic/versions/0001_baseline.py
@@ -758,7 +758,7 @@ def downgrade() -> None:
     op.drop_index(op.f("ix_users_email"), table_name="users")
     op.drop_index(op.f("ix_users_clerk_user_id"), table_name="users")
     op.drop_table("users")
-    op.drop_table("seed_runs")
+    op.execute("DROP TABLE IF EXISTS seed_runs")
     op.drop_index(op.f("ix_pending_signups_clerk_user_id"), table_name="pending_signups")
     op.drop_table("pending_signups")
     op.drop_table("eula_versions")

--- a/backend/alembic/versions/0003_project_effective_counts.py
+++ b/backend/alembic/versions/0003_project_effective_counts.py
@@ -1,0 +1,33 @@
+"""Add effective_num_treadles and effective_num_shafts to projects.
+
+Revision ID: b7e4f1a8c302
+Revises: a3f8c2d19e74
+Create Date: 2026-05-03
+
+These columns store the highest treadle/shaft index actually used in the
+[TREADLING] / [LIFTPLAN] sections of the WIF file, which may differ from the
+declared metadata in [WEAVING]. Used for loom compatibility checks so that a
+design that declares 11 treadles but only uses 1-10 can still be run on a
+10-treadle loom.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b7e4f1a8c302"
+down_revision: str | None = "a3f8c2d19e74"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("projects", sa.Column("effective_num_treadles", sa.Integer(), nullable=True))
+    op.add_column("projects", sa.Column("effective_num_shafts", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("projects", "effective_num_shafts")
+    op.drop_column("projects", "effective_num_treadles")

--- a/backend/alembic/versions/0004_project_wif_liftplan_path.py
+++ b/backend/alembic/versions/0004_project_wif_liftplan_path.py
@@ -1,0 +1,28 @@
+"""Add wif_liftplan_path to projects.
+
+Revision ID: c9a2e5f0b416
+Revises: b7e4f1a8c302
+Create Date: 2026-05-03
+
+Stores the path to the liftplan-augmented WIF file separately from the original
+wif_path so the original upload is never overwritten.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "c9a2e5f0b416"
+down_revision: str | None = "b7e4f1a8c302"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("projects", sa.Column("wif_liftplan_path", sa.String(512), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("projects", "wif_liftplan_path")

--- a/backend/alembic/versions/0005_project_wif_modified_and_overrides.py
+++ b/backend/alembic/versions/0005_project_wif_modified_and_overrides.py
@@ -1,0 +1,33 @@
+"""Rename wif_liftplan_path to wif_modified_path; add metadata_overrides.
+
+Revision ID: d3b6a9e2f518
+Revises: c9a2e5f0b416
+Create Date: 2026-05-03
+
+- Renames wif_liftplan_path -> wif_modified_path so the column reflects its
+  broader purpose (liftplan generation, metadata overrides, future tools)
+- Adds metadata_overrides JSONB to record user-initiated WIF metadata changes,
+  e.g. {"num_treadles": {"original": 11, "override": 10}}
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "d3b6a9e2f518"
+down_revision: str | None = "c9a2e5f0b416"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column("projects", "wif_liftplan_path", new_column_name="wif_modified_path")
+    op.add_column("projects", sa.Column("metadata_overrides", postgresql.JSONB(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("projects", "metadata_overrides")
+    op.alter_column("projects", "wif_modified_path", new_column_name="wif_liftplan_path")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -92,7 +92,7 @@ class Settings(BaseSettings):
     smtp_user: str = ""
     smtp_password: str = ""
     smtp_from_email: str = ""
-    smtp_from_name: str = "WeftMark"
+    smtp_from_name: str = "weftmark"
 
     # Invites
     invite_expiry_days_default: int = 7

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -26,6 +26,10 @@ class Project(Base, TimestampMixin, SoftDeleteMixin):
     warp_threads: Mapped[int | None] = mapped_column(Integer, nullable=True)
     weft_threads: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
+    # Effective counts derived from actual treadling/liftplan data (may differ from declared metadata)
+    effective_num_treadles: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    effective_num_shafts: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
     # Feature availability flags
     has_threading: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     has_tieup: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -19,8 +19,11 @@ class Project(Base, TimestampMixin, SoftDeleteMixin):
     # Original WIF file (never mutated after upload)
     wif_filename: Mapped[str] = mapped_column(String(512), nullable=False)
     wif_path: Mapped[str] = mapped_column(String(512), nullable=False)
-    # Liftplan-augmented WIF (set only after generate_liftplan; original wif_path is preserved)
-    wif_liftplan_path: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    # App-modified WIF (accumulates changes like generated liftplan, metadata overrides;
+    # original wif_path is never mutated after upload)
+    wif_modified_path: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    # Tracks metadata values overridden by the user e.g. {"num_treadles": {"original": 11, "override": 10}}
+    metadata_overrides: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
 
     # Parsed WIF metadata
     num_shafts: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -16,9 +16,11 @@ class Project(Base, TimestampMixin, SoftDeleteMixin):
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
 
-    # Original WIF file
+    # Original WIF file (never mutated after upload)
     wif_filename: Mapped[str] = mapped_column(String(512), nullable=False)
     wif_path: Mapped[str] = mapped_column(String(512), nullable=False)
+    # Liftplan-augmented WIF (set only after generate_liftplan; original wif_path is preserved)
+    wif_liftplan_path: Mapped[str | None] = mapped_column(String(512), nullable=True)
 
     # Parsed WIF metadata
     num_shafts: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/backend/app/routers/activities.py
+++ b/backend/app/routers/activities.py
@@ -70,6 +70,8 @@ class ActivityDetail(ActivitySummary):
     project_name: str
     project_num_shafts: int | None
     project_num_treadles: int | None
+    project_effective_num_treadles: int | None
+    project_effective_num_shafts: int | None
     loom_name: str | None
     photos: list[ActivityPhotoSchema] = []
 
@@ -176,6 +178,8 @@ def _to_detail(
         project_name=project.name,
         project_num_shafts=project.num_shafts,
         project_num_treadles=project.num_treadles,
+        project_effective_num_treadles=project.effective_num_treadles,
+        project_effective_num_shafts=project.effective_num_shafts,
         loom_name=f"{loom.manufacturer} {loom.model_name}" if loom else None,
         photos=[ActivityPhotoSchema.model_validate(p) for p in (photos or [])],
     )

--- a/backend/app/routers/activities.py
+++ b/backend/app/routers/activities.py
@@ -72,6 +72,7 @@ class ActivityDetail(ActivitySummary):
     project_num_treadles: int | None
     project_effective_num_treadles: int | None
     project_effective_num_shafts: int | None
+    project_metadata_overrides: dict | None
     loom_name: str | None
     photos: list[ActivityPhotoSchema] = []
 
@@ -148,8 +149,8 @@ def _wif_path_for_activity(project: Project, activity_type: str) -> str:
     the case where the liftplan was embedded in the original WIF by the user's
     design software).
     """
-    if activity_type == "lift" and project.wif_liftplan_path and storage.file_exists(project.wif_liftplan_path):
-        return project.wif_liftplan_path
+    if activity_type == "lift" and project.wif_modified_path and storage.file_exists(project.wif_modified_path):
+        return project.wif_modified_path
     return project.wif_path
 
 
@@ -193,6 +194,7 @@ def _to_detail(
         project_num_treadles=project.num_treadles,
         project_effective_num_treadles=project.effective_num_treadles,
         project_effective_num_shafts=project.effective_num_shafts,
+        project_metadata_overrides=project.metadata_overrides,
         loom_name=f"{loom.manufacturer} {loom.model_name}" if loom else None,
         photos=[ActivityPhotoSchema.model_validate(p) for p in (photos or [])],
     )

--- a/backend/app/routers/activities.py
+++ b/backend/app/routers/activities.py
@@ -140,6 +140,19 @@ async def _check_loom_conflict(
         raise HTTPException(status_code=409, detail="This loom already has an active activity")
 
 
+def _wif_path_for_activity(project: Project, activity_type: str) -> str:
+    """Return the correct WIF path for an activity type.
+
+    For lift activities, prefer the liftplan-augmented file when available so
+    that the original upload is never mutated. Falls back to wif_path (covers
+    the case where the liftplan was embedded in the original WIF by the user's
+    design software).
+    """
+    if activity_type == "lift" and project.wif_liftplan_path and storage.file_exists(project.wif_liftplan_path):
+        return project.wif_liftplan_path
+    return project.wif_path
+
+
 async def _get_owned_activity(activity_id: uuid.UUID, user: User, db: AsyncSession) -> Activity:
     activity = await db.scalar(
         select(Activity).where(
@@ -216,7 +229,7 @@ async def create_activity(
         raise HTTPException(status_code=400, detail="WIF file has no [LIFTPLAN] section")
 
     # Parse pick count from WIF
-    wif_bytes = storage.read_file(project.wif_path)
+    wif_bytes = storage.read_file(_wif_path_for_activity(project, body.activity_type))
     try:
         pick_data = wif_parser.parse_picks(wif_bytes, body.activity_type)
     except ValueError as exc:
@@ -636,7 +649,7 @@ async def get_picks(
     if project is None:
         raise HTTPException(status_code=404, detail="Project not found")
 
-    wif_bytes = storage.read_file(project.wif_path)
+    wif_bytes = storage.read_file(_wif_path_for_activity(project, activity.activity_type))
     try:
         pick_data = wif_parser.parse_picks(wif_bytes, activity.activity_type)
     except ValueError as exc:

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -30,6 +30,8 @@ class ProjectSummary(BaseModel):
     wif_filename: str
     num_shafts: int | None
     num_treadles: int | None
+    effective_num_treadles: int | None
+    effective_num_shafts: int | None
     warp_threads: int | None
     weft_threads: int | None
     has_threading: bool
@@ -89,6 +91,8 @@ async def create_project(
         wif_path="",  # set after we have the project id
         num_shafts=lint.num_shafts,
         num_treadles=lint.num_treadles,
+        effective_num_treadles=lint.effective_num_treadles,
+        effective_num_shafts=lint.effective_num_shafts,
         warp_threads=lint.warp_threads,
         weft_threads=lint.weft_threads,
         has_threading=lint.has_threading,

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -12,7 +12,7 @@ from app.config import get_settings
 from app.deps import get_current_user, get_db
 from app.models.project import Project
 from app.models.user import User
-from app.services import rendering, storage, wif_linter, wif_parser
+from app.services import rendering, storage, wif_linter, wif_modifier, wif_parser
 
 router = APIRouter(prefix="/api/projects", tags=["projects"])
 settings = get_settings()
@@ -43,7 +43,8 @@ class ProjectSummary(BaseModel):
     lint_warnings: list[str]
     lint_errors: list[str]
     has_preview: bool
-    has_liftplan_file: bool
+    has_modified_file: bool
+    metadata_overrides: dict | None
     is_shared: bool
     created_at: datetime
     updated_at: datetime
@@ -54,7 +55,7 @@ class ProjectSummary(BaseModel):
     def from_project(cls, p: Project) -> "ProjectSummary":
         data = {c.key: getattr(p, c.key) for c in p.__table__.columns}
         data["has_preview"] = storage.preview_exists(p.preview_path)
-        data["has_liftplan_file"] = bool(p.wif_liftplan_path and storage.file_exists(p.wif_liftplan_path))
+        data["has_modified_file"] = bool(p.wif_modified_path and storage.file_exists(p.wif_modified_path))
         return cls(**data)
 
 
@@ -246,18 +247,18 @@ async def download_wif(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/{project_id}/wif-liftplan")
-async def download_wif_liftplan(
+@router.get("/{project_id}/wif-modified")
+async def download_wif_modified(
     project_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     project = await _get_owned_project(project_id, current_user, db)
-    if not project.wif_liftplan_path or not storage.file_exists(project.wif_liftplan_path):
-        raise HTTPException(status_code=404, detail="No generated lift plan file for this project")
-    wif_bytes = storage.read_file(project.wif_liftplan_path)
+    if not project.wif_modified_path or not storage.file_exists(project.wif_modified_path):
+        raise HTTPException(status_code=404, detail="No modified WIF file for this project")
+    wif_bytes = storage.read_file(project.wif_modified_path)
     base = (project.wif_filename or "project.wif").rsplit(".", 1)[0]
-    filename = f"{base}-liftplan.wif"
+    filename = f"{base}-modified.wif"
     return Response(
         content=wif_bytes,
         media_type="application/octet-stream",
@@ -299,14 +300,17 @@ async def generate_liftplan(
     if not project.has_tieup:
         raise HTTPException(status_code=400, detail="WIF file has no [TIEUP] section — cannot compute lift plan")
 
-    wif_bytes = storage.read_file(project.wif_path)
+    # Read from modified file if one exists (to chain onto prior modifications)
+    has_mod = project.wif_modified_path and storage.file_exists(project.wif_modified_path)
+    source_path = project.wif_modified_path if has_mod else project.wif_path
+    wif_bytes = storage.read_file(source_path)
     try:
         updated_bytes = wif_parser.compute_liftplan(wif_bytes)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
-    liftplan_filename = project.wif_filename.rsplit(".", 1)[0] + "-liftplan.wif"
-    project.wif_liftplan_path = storage.save_wif(project.id, liftplan_filename, updated_bytes)
+    modified_filename = project.wif_filename.rsplit(".", 1)[0] + "-modified.wif"
+    project.wif_modified_path = storage.save_wif(project.id, modified_filename, updated_bytes)
     project.has_liftplan = True
     project.liftplan_generated = True
 
@@ -314,6 +318,71 @@ async def generate_liftplan(
     await db.refresh(project)
     data = {c.key: getattr(project, c.key) for c in project.__table__.columns}
     data["has_preview"] = storage.preview_exists(project.preview_path)
+    return ProjectDetail(**data)
+
+
+# ---------------------------------------------------------------------------
+# Override WIF metadata
+# ---------------------------------------------------------------------------
+
+_OVERRIDE_FIELDS = {
+    "num_treadles": "Treadles",
+    "num_shafts": "Shafts",
+}
+
+
+class OverrideMetadataRequest(BaseModel):
+    field: str  # "num_treadles" | "num_shafts"
+    value: int
+
+
+@router.post("/{project_id}/override-metadata", response_model=ProjectDetail)
+async def override_metadata(
+    project_id: uuid.UUID,
+    body: OverrideMetadataRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ProjectDetail:
+    if body.field not in _OVERRIDE_FIELDS:
+        raise HTTPException(
+            status_code=400, detail=f"Unsupported field '{body.field}'. Allowed: {list(_OVERRIDE_FIELDS)}"
+        )
+    if body.value < 1:
+        raise HTTPException(status_code=400, detail="Value must be >= 1")
+
+    project = await _get_owned_project(project_id, current_user, db)
+
+    # Read from modified file if one already exists, otherwise original
+    source_path = (
+        project.wif_modified_path
+        if project.wif_modified_path and storage.file_exists(project.wif_modified_path)
+        else project.wif_path
+    )
+    wif_bytes = storage.read_file(source_path)
+
+    wif_key = _OVERRIDE_FIELDS[body.field]
+    try:
+        updated_bytes = wif_modifier.set_weaving_int(wif_bytes, wif_key, body.value)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    modified_filename = project.wif_filename.rsplit(".", 1)[0] + "-modified.wif"
+    project.wif_modified_path = storage.save_wif(project.id, modified_filename, updated_bytes)
+
+    # Record the override (original value preserved for display)
+    original_value = getattr(project, body.field)
+    overrides = dict(project.metadata_overrides or {})
+    overrides[body.field] = {"original": original_value, "override": body.value}
+    project.metadata_overrides = overrides
+
+    # Update the live metadata value on the project
+    setattr(project, body.field, body.value)
+
+    await db.commit()
+    await db.refresh(project)
+    data = {c.key: getattr(project, c.key) for c in project.__table__.columns}
+    data["has_preview"] = storage.preview_exists(project.preview_path)
+    data["has_modified_file"] = bool(project.wif_modified_path and storage.file_exists(project.wif_modified_path))
     return ProjectDetail(**data)
 
 

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -157,10 +157,7 @@ async def get_project(
     db: AsyncSession = Depends(get_db),
 ) -> ProjectDetail:
     project = await _get_owned_project(project_id, current_user, db)
-    data = {c.key: getattr(project, c.key) for c in project.__table__.columns}
-    data["has_preview"] = storage.preview_exists(project.preview_path)
-    data["has_modified_file"] = bool(project.wif_modified_path and storage.file_exists(project.wif_modified_path))
-    return ProjectDetail(**data)
+    return ProjectDetail(**_project_detail_data(project))
 
 
 # ---------------------------------------------------------------------------
@@ -317,10 +314,7 @@ async def generate_liftplan(
 
     await db.commit()
     await db.refresh(project)
-    data = {c.key: getattr(project, c.key) for c in project.__table__.columns}
-    data["has_preview"] = storage.preview_exists(project.preview_path)
-    data["has_modified_file"] = bool(project.wif_modified_path and storage.file_exists(project.wif_modified_path))
-    return ProjectDetail(**data)
+    return ProjectDetail(**_project_detail_data(project))
 
 
 # ---------------------------------------------------------------------------
@@ -380,17 +374,35 @@ async def override_metadata(
     # Update the live metadata value on the project
     setattr(project, body.field, body.value)
 
+    # Re-lint the updated WIF so the mismatch warning is cleared
+    lint = wif_linter.lint(updated_bytes)
+    project.lint_warnings = lint.warnings
+    project.lint_errors = lint.errors
+
     await db.commit()
     await db.refresh(project)
-    data = {c.key: getattr(project, c.key) for c in project.__table__.columns}
-    data["has_preview"] = storage.preview_exists(project.preview_path)
-    data["has_modified_file"] = bool(project.wif_modified_path and storage.file_exists(project.wif_modified_path))
-    return ProjectDetail(**data)
+    return ProjectDetail(**_project_detail_data(project))
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _project_detail_data(project: Project) -> dict:
+    """Build the data dict for ProjectDetail, filtering any mismatch lint warnings
+    that are already covered by a metadata override so stale DB entries don't show."""
+    data = {c.key: getattr(project, c.key) for c in project.__table__.columns}
+    data["has_preview"] = storage.preview_exists(project.preview_path)
+    data["has_modified_file"] = bool(project.wif_modified_path and storage.file_exists(project.wif_modified_path))
+    overrides = project.metadata_overrides or {}
+    warnings = list(data.get("lint_warnings") or [])
+    if "num_treadles" in overrides:
+        warnings = [w for w in warnings if "[WEAVING] declares Treadles=" not in w]
+    if "num_shafts" in overrides:
+        warnings = [w for w in warnings if "[WEAVING] declares Shafts=" not in w]
+    data["lint_warnings"] = warnings
+    return data
 
 
 async def _get_owned_project(project_id: uuid.UUID, user: User, db: AsyncSession) -> Project:

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -43,6 +43,7 @@ class ProjectSummary(BaseModel):
     lint_warnings: list[str]
     lint_errors: list[str]
     has_preview: bool
+    has_liftplan_file: bool
     is_shared: bool
     created_at: datetime
     updated_at: datetime
@@ -53,6 +54,7 @@ class ProjectSummary(BaseModel):
     def from_project(cls, p: Project) -> "ProjectSummary":
         data = {c.key: getattr(p, c.key) for c in p.__table__.columns}
         data["has_preview"] = storage.preview_exists(p.preview_path)
+        data["has_liftplan_file"] = bool(p.wif_liftplan_path and storage.file_exists(p.wif_liftplan_path))
         return cls(**data)
 
 
@@ -240,6 +242,30 @@ async def download_wif(
 
 
 # ---------------------------------------------------------------------------
+# WIF with generated lift plan download
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{project_id}/wif-liftplan")
+async def download_wif_liftplan(
+    project_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    project = await _get_owned_project(project_id, current_user, db)
+    if not project.wif_liftplan_path or not storage.file_exists(project.wif_liftplan_path):
+        raise HTTPException(status_code=404, detail="No generated lift plan file for this project")
+    wif_bytes = storage.read_file(project.wif_liftplan_path)
+    base = (project.wif_filename or "project.wif").rsplit(".", 1)[0]
+    filename = f"{base}-liftplan.wif"
+    return Response(
+        content=wif_bytes,
+        media_type="application/octet-stream",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+# ---------------------------------------------------------------------------
 # Delete (soft)
 # ---------------------------------------------------------------------------
 
@@ -279,7 +305,8 @@ async def generate_liftplan(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
-    project.wif_path = storage.save_wif(project.id, project.wif_filename, updated_bytes)
+    liftplan_filename = project.wif_filename.rsplit(".", 1)[0] + "-liftplan.wif"
+    project.wif_liftplan_path = storage.save_wif(project.id, liftplan_filename, updated_bytes)
     project.has_liftplan = True
     project.liftplan_generated = True
 

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -159,6 +159,7 @@ async def get_project(
     project = await _get_owned_project(project_id, current_user, db)
     data = {c.key: getattr(project, c.key) for c in project.__table__.columns}
     data["has_preview"] = storage.preview_exists(project.preview_path)
+    data["has_modified_file"] = bool(project.wif_modified_path and storage.file_exists(project.wif_modified_path))
     return ProjectDetail(**data)
 
 
@@ -318,6 +319,7 @@ async def generate_liftplan(
     await db.refresh(project)
     data = {c.key: getattr(project, c.key) for c in project.__table__.columns}
     data["has_preview"] = storage.preview_exists(project.preview_path)
+    data["has_modified_file"] = bool(project.wif_modified_path and storage.file_exists(project.wif_modified_path))
     return ProjectDetail(**data)
 
 

--- a/backend/app/services/wif_linter.py
+++ b/backend/app/services/wif_linter.py
@@ -17,11 +17,15 @@ class LintResult:
     errors: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
 
-    # Parsed metadata
+    # Parsed metadata (from [WEAVING] section)
     num_shafts: int | None = None
     num_treadles: int | None = None
     warp_threads: int | None = None
     weft_threads: int | None = None
+
+    # Effective counts derived from actual treadling/liftplan data
+    effective_num_treadles: int | None = None
+    effective_num_shafts: int | None = None
 
     # Feature flags
     has_threading: bool = False
@@ -86,6 +90,28 @@ def lint(wif_bytes: bytes) -> LintResult:
     result.has_liftplan = "LIFTPLAN" in sections
     result.has_color_palette = "COLOR PALETTE" in sections or "COLOR TABLE" in sections
 
+    # --- Effective counts from actual pick data ---
+    if result.has_treadling:
+        result.effective_num_treadles = _max_index_used(config, "TREADLING")
+    if result.has_liftplan:
+        result.effective_num_shafts = _max_index_used(config, "LIFTPLAN")
+
+    # Warn if declared metadata doesn't match actual usage
+    if result.num_treadles is not None and result.effective_num_treadles is not None:
+        if result.effective_num_treadles != result.num_treadles:
+            result.warnings.append(
+                f"[WEAVING] declares Treadles={result.num_treadles} but the highest treadle used "
+                f"in [TREADLING] is {result.effective_num_treadles}. "
+                f"Loom compatibility is based on the actual usage ({result.effective_num_treadles})."
+            )
+    if result.num_shafts is not None and result.effective_num_shafts is not None:
+        if result.effective_num_shafts != result.num_shafts:
+            result.warnings.append(
+                f"[WEAVING] declares Shafts={result.num_shafts} but the highest shaft used "
+                f"in [LIFTPLAN] is {result.effective_num_shafts}. "
+                f"Loom compatibility is based on the actual usage ({result.effective_num_shafts})."
+            )
+
     # Warp/weft thread counts
     if "WARP" in sections:
         try:
@@ -122,3 +148,28 @@ def _get(config: RawConfigParser, section: str, key: str) -> str | None:
         return config.get(section, key).strip() or None
     except Exception:
         return None
+
+
+def _max_index_used(config: RawConfigParser, section: str) -> int | None:
+    """Return the highest 1-based index referenced in any value of `section`.
+
+    TREADLING values look like "3" or "2,5". LIFTPLAN looks like "1,3,5".
+    We parse every comma-separated integer across all entries and return the max.
+    Returns None if the section is empty or no integers are found.
+    """
+    try:
+        items = config.items(section)
+    except Exception:
+        return None
+    max_val: int | None = None
+    for _key, val in items:
+        for token in val.split(","):
+            token = token.strip()
+            if token:
+                try:
+                    n = int(token)
+                    if max_val is None or n > max_val:
+                        max_val = n
+                except ValueError:
+                    continue
+    return max_val

--- a/backend/app/services/wif_modifier.py
+++ b/backend/app/services/wif_modifier.py
@@ -1,0 +1,51 @@
+"""
+Modify WIF file bytes in place (non-destructive — callers always write to
+wif_modified_path, never to wif_path).
+
+Currently supports:
+  - set_weaving_int: update a single integer key in [WEAVING] (e.g. Treadles, Shafts)
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def set_weaving_int(wif_bytes: bytes, key: str, value: int) -> bytes:
+    """Return new WIF bytes with `key=value` set in the [WEAVING] section.
+
+    If the key already exists it is replaced; if it is absent it is appended
+    at the end of the [WEAVING] block. Works on the raw bytes to avoid
+    configparser re-serialisation changing formatting or encoding.
+    """
+    try:
+        text = wif_bytes.decode("utf-8")
+        encoding = "utf-8"
+    except UnicodeDecodeError:
+        text = wif_bytes.decode("latin-1")
+        encoding = "latin-1"
+
+    # Replace existing key=... line inside [WEAVING] (case-insensitive key)
+    pattern = re.compile(
+        r"(?m)^(" + re.escape(key) + r"\s*=\s*).*$",
+        re.IGNORECASE,
+    )
+
+    # Check if [WEAVING] section exists
+    weaving_section = re.search(r"(?im)^\[WEAVING\]", text)
+    if not weaving_section:
+        raise ValueError("WIF file has no [WEAVING] section")
+
+    if pattern.search(text):
+        # Replace the existing line
+        updated = pattern.sub(lambda m: f"{key}={value}", text, count=1)
+    else:
+        # Append the key after the [WEAVING] header line
+        updated = re.sub(
+            r"(?im)(^\[WEAVING\][^\n]*\n)",
+            lambda m: m.group(0) + f"{key}={value}\n",
+            text,
+            count=1,
+        )
+
+    return updated.encode(encoding)

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -21,7 +21,7 @@ services:
       CLERK_PUBLISHABLE_KEY: ${CLERK_PUBLISHABLE_KEY}
     container_name: weaving_site_frontend
     ports:
-      - "127.0.0.1:3000:80"
+      - "3000:80"
     networks:
       - public
     depends_on:

--- a/docs/assets/preview-clay.html
+++ b/docs/assets/preview-clay.html
@@ -13,7 +13,7 @@
     <div class="mx-auto flex max-w-6xl items-center justify-between">
       <div class="flex items-center gap-2.5">
         <svg viewBox="0 0 200 72" xmlns="http://www.w3.org/2000/svg" class="h-7 w-auto text-orange-800"><ellipse cx="100" cy="36" rx="90" ry="30" fill="currentColor"/><polyline points="55,24 75,50 100,34 125,50 145,24" fill="none" stroke="white" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <span class="text-base font-semibold tracking-tight">Weftmark</span>
+        <span class="text-base font-semibold tracking-tight">weftmark</span>
       </div>
       <a href="#" class="text-sm font-medium text-stone-600 hover:text-stone-900">Sign in</a>
     </div>
@@ -49,7 +49,7 @@
       <div class="mx-auto max-w-6xl">
         <h2 class="mb-10 text-center text-2xl font-bold tracking-tight text-stone-900">Everything you need at the loom</h2>
         <div class="grid gap-6 sm:grid-cols-3">
-          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-orange-100 text-orange-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. Weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-orange-100 text-orange-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
           <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-orange-100 text-orange-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Record every pick</h3><p class="text-sm leading-relaxed text-stone-500">Advance, reverse, or jump to any row. Mark a project complete when the last pick is woven in.</p></div>
           <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-orange-100 text-orange-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Manage your tools</h3><p class="text-sm leading-relaxed text-stone-500">Keep a record of your looms and yarn. Assign a loom to a project and track what's on the beam.</p></div>
         </div>
@@ -57,7 +57,7 @@
     </section>
   </main>
 
-  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 Weftmark. All rights reserved.</div></footer>
+  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 weftmark. All rights reserved.</div></footer>
   <div class="fixed bottom-4 right-4 rounded-full bg-orange-800 px-4 py-2 text-xs font-semibold text-white shadow-lg">Clay & Cream</div>
 </body>
 </html>

--- a/docs/assets/preview-cream-copper.html
+++ b/docs/assets/preview-cream-copper.html
@@ -13,7 +13,7 @@
     <div class="mx-auto flex max-w-6xl items-center justify-between">
       <div class="flex items-center gap-2.5">
         <svg viewBox="0 0 200 72" xmlns="http://www.w3.org/2000/svg" class="h-7 w-auto text-amber-600"><ellipse cx="100" cy="36" rx="90" ry="30" fill="currentColor"/><polyline points="55,24 75,50 100,34 125,50 145,24" fill="none" stroke="white" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <span class="text-base font-semibold tracking-tight">Weftmark</span>
+        <span class="text-base font-semibold tracking-tight">weftmark</span>
       </div>
       <a href="#" class="text-sm font-medium text-stone-600 hover:text-stone-900">Sign in</a>
     </div>
@@ -49,7 +49,7 @@
       <div class="mx-auto max-w-6xl">
         <h2 class="mb-10 text-center text-2xl font-bold tracking-tight text-stone-900">Everything you need at the loom</h2>
         <div class="grid gap-6 sm:grid-cols-3">
-          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-100 text-amber-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. Weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-100 text-amber-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
           <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-100 text-amber-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Record every pick</h3><p class="text-sm leading-relaxed text-stone-500">Advance, reverse, or jump to any row. Mark a project complete when the last pick is woven in.</p></div>
           <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-100 text-amber-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Manage your tools</h3><p class="text-sm leading-relaxed text-stone-500">Keep a record of your looms and yarn. Assign a loom to a project and track what's on the beam.</p></div>
         </div>
@@ -57,7 +57,7 @@
     </section>
   </main>
 
-  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 Weftmark. All rights reserved.</div></footer>
+  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 weftmark. All rights reserved.</div></footer>
   <div class="fixed bottom-4 right-4 rounded-full bg-amber-600 px-4 py-2 text-xs font-semibold text-white shadow-lg">Cream & Copper</div>
 </body>
 </html>

--- a/docs/assets/preview-layout-depth.html
+++ b/docs/assets/preview-layout-depth.html
@@ -25,11 +25,11 @@
   <header class="sticky top-0 z-10 bg-stone-100/95 px-6 py-4 backdrop-blur shadow-sm shadow-stone-900/5">
     <div class="mx-auto flex max-w-6xl items-center justify-between">
       <div class="flex items-center gap-2.5">
-        <svg viewBox="0 0 200 72" xmlns="http://www.w3.org/2000/svg" class="h-7 w-auto text-amber-800" aria-label="Weftmark" role="img">
+        <svg viewBox="0 0 200 72" xmlns="http://www.w3.org/2000/svg" class="h-7 w-auto text-amber-800" aria-label="weftmark" role="img">
           <ellipse cx="100" cy="36" rx="90" ry="30" fill="currentColor"/>
           <polyline points="55,24 75,50 100,34 125,50 145,24" fill="none" stroke="white" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
-        <span class="text-base font-semibold tracking-tight">Weftmark</span>
+        <span class="text-base font-semibold tracking-tight">weftmark</span>
       </div>
       <a href="#" class="text-sm font-medium text-stone-600 hover:text-stone-900">Sign in</a>
     </div>
@@ -99,7 +99,7 @@
               </svg>
             </div>
             <h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3>
-            <p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. Weftmark keeps your place so you can put down the shuttle and pick it right back up.</p>
+            <p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. weftmark keeps your place so you can put down the shuttle and pick it right back up.</p>
           </div>
 
           <div class="card rounded-2xl bg-white p-7 shadow-md shadow-stone-900/8 ring-1 ring-stone-200/80">
@@ -129,7 +129,7 @@
   </main>
 
   <footer class="border-t border-stone-200 bg-stone-100 px-6 py-8">
-    <div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 Weftmark. All rights reserved.</div>
+    <div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 weftmark. All rights reserved.</div>
   </footer>
 
   <div class="fixed bottom-4 right-4 rounded-full bg-stone-800 px-4 py-2 text-xs font-semibold text-white shadow-lg">Layout Depth</div>

--- a/docs/assets/preview-natural-indigo.html
+++ b/docs/assets/preview-natural-indigo.html
@@ -13,7 +13,7 @@
     <div class="mx-auto flex max-w-6xl items-center justify-between">
       <div class="flex items-center gap-2.5">
         <svg viewBox="0 0 200 72" xmlns="http://www.w3.org/2000/svg" class="h-7 w-auto text-indigo-700"><ellipse cx="100" cy="36" rx="90" ry="30" fill="currentColor"/><polyline points="55,24 75,50 100,34 125,50 145,24" fill="none" stroke="white" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <span class="text-base font-semibold tracking-tight">Weftmark</span>
+        <span class="text-base font-semibold tracking-tight">weftmark</span>
       </div>
       <a href="#" class="text-sm font-medium text-stone-600 hover:text-stone-900">Sign in</a>
     </div>
@@ -49,7 +49,7 @@
       <div class="mx-auto max-w-6xl">
         <h2 class="mb-10 text-center text-2xl font-bold tracking-tight text-stone-900">Everything you need at the loom</h2>
         <div class="grid gap-6 sm:grid-cols-3">
-          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-indigo-100 text-indigo-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. Weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-indigo-100 text-indigo-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
           <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-indigo-100 text-indigo-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Record every pick</h3><p class="text-sm leading-relaxed text-stone-500">Advance, reverse, or jump to any row. Mark a project complete when the last pick is woven in.</p></div>
           <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-indigo-100 text-indigo-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Manage your tools</h3><p class="text-sm leading-relaxed text-stone-500">Keep a record of your looms and yarn. Assign a loom to a project and track what's on the beam.</p></div>
         </div>
@@ -57,7 +57,7 @@
     </section>
   </main>
 
-  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 Weftmark. All rights reserved.</div></footer>
+  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 weftmark. All rights reserved.</div></footer>
   <div class="fixed bottom-4 right-4 rounded-full bg-indigo-700 px-4 py-2 text-xs font-semibold text-white shadow-lg">Natural Indigo</div>
 </body>
 </html>

--- a/docs/assets/preview-plum.html
+++ b/docs/assets/preview-plum.html
@@ -13,7 +13,7 @@
     <div class="mx-auto flex max-w-6xl items-center justify-between">
       <div class="flex items-center gap-2.5">
         <svg viewBox="0 0 200 72" xmlns="http://www.w3.org/2000/svg" class="h-7 w-auto text-violet-800"><ellipse cx="100" cy="36" rx="90" ry="30" fill="currentColor"/><polyline points="55,24 75,50 100,34 125,50 145,24" fill="none" stroke="white" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <span class="text-base font-semibold tracking-tight">Weftmark</span>
+        <span class="text-base font-semibold tracking-tight">weftmark</span>
       </div>
       <a href="#" class="text-sm font-medium text-stone-600 hover:text-stone-900">Sign in</a>
     </div>
@@ -49,7 +49,7 @@
       <div class="mx-auto max-w-6xl">
         <h2 class="mb-10 text-center text-2xl font-bold tracking-tight text-stone-900">Everything you need at the loom</h2>
         <div class="grid gap-6 sm:grid-cols-3">
-          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-violet-100 text-violet-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. Weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-violet-100 text-violet-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
           <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-violet-100 text-violet-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Record every pick</h3><p class="text-sm leading-relaxed text-stone-500">Advance, reverse, or jump to any row. Mark a project complete when the last pick is woven in.</p></div>
           <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-violet-100 text-violet-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Manage your tools</h3><p class="text-sm leading-relaxed text-stone-500">Keep a record of your looms and yarn. Assign a loom to a project and track what's on the beam.</p></div>
         </div>
@@ -57,7 +57,7 @@
     </section>
   </main>
 
-  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 Weftmark. All rights reserved.</div></footer>
+  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 weftmark. All rights reserved.</div></footer>
   <div class="fixed bottom-4 right-4 rounded-full bg-violet-800 px-4 py-2 text-xs font-semibold text-white shadow-lg">Plum</div>
 </body>
 </html>

--- a/docs/assets/preview-rose.html
+++ b/docs/assets/preview-rose.html
@@ -13,7 +13,7 @@
     <div class="mx-auto flex max-w-6xl items-center justify-between">
       <div class="flex items-center gap-2.5">
         <svg viewBox="0 0 200 72" xmlns="http://www.w3.org/2000/svg" class="h-7 w-auto text-rose-800"><ellipse cx="100" cy="36" rx="90" ry="30" fill="currentColor"/><polyline points="55,24 75,50 100,34 125,50 145,24" fill="none" stroke="white" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <span class="text-base font-semibold tracking-tight">Weftmark</span>
+        <span class="text-base font-semibold tracking-tight">weftmark</span>
       </div>
       <a href="#" class="text-sm font-medium text-stone-600 hover:text-stone-900">Sign in</a>
     </div>
@@ -49,7 +49,7 @@
       <div class="mx-auto max-w-6xl">
         <h2 class="mb-10 text-center text-2xl font-bold tracking-tight text-stone-900">Everything you need at the loom</h2>
         <div class="grid gap-6 sm:grid-cols-3">
-          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-rose-100 text-rose-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. Weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-rose-100 text-rose-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
           <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-rose-100 text-rose-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Record every pick</h3><p class="text-sm leading-relaxed text-stone-500">Advance, reverse, or jump to any row. Mark a project complete when the last pick is woven in.</p></div>
           <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-rose-100 text-rose-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Manage your tools</h3><p class="text-sm leading-relaxed text-stone-500">Keep a record of your looms and yarn. Assign a loom to a project and track what's on the beam.</p></div>
         </div>
@@ -57,7 +57,7 @@
     </section>
   </main>
 
-  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 Weftmark. All rights reserved.</div></footer>
+  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 weftmark. All rights reserved.</div></footer>
   <div class="fixed bottom-4 right-4 rounded-full bg-rose-800 px-4 py-2 text-xs font-semibold text-white shadow-lg">Dusty Rose</div>
 </body>
 </html>

--- a/docs/assets/preview-sage-loom.html
+++ b/docs/assets/preview-sage-loom.html
@@ -13,7 +13,7 @@
     <div class="mx-auto flex max-w-6xl items-center justify-between">
       <div class="flex items-center gap-2.5">
         <svg viewBox="0 0 200 72" xmlns="http://www.w3.org/2000/svg" class="h-7 w-auto text-emerald-800"><ellipse cx="100" cy="36" rx="90" ry="30" fill="currentColor"/><polyline points="55,24 75,50 100,34 125,50 145,24" fill="none" stroke="white" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <span class="text-base font-semibold tracking-tight">Weftmark</span>
+        <span class="text-base font-semibold tracking-tight">weftmark</span>
       </div>
       <a href="#" class="text-sm font-medium text-stone-600 hover:text-stone-900">Sign in</a>
     </div>
@@ -49,7 +49,7 @@
       <div class="mx-auto max-w-6xl">
         <h2 class="mb-10 text-center text-2xl font-bold tracking-tight text-stone-900">Everything you need at the loom</h2>
         <div class="grid gap-6 sm:grid-cols-3">
-          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-100 text-emerald-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. Weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-100 text-emerald-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
           <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-100 text-emerald-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Record every pick</h3><p class="text-sm leading-relaxed text-stone-500">Advance, reverse, or jump to any row. Mark a project complete when the last pick is woven in.</p></div>
           <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-100 text-emerald-700"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Manage your tools</h3><p class="text-sm leading-relaxed text-stone-500">Keep a record of your looms and yarn. Assign a loom to a project and track what's on the beam.</p></div>
         </div>
@@ -57,7 +57,7 @@
     </section>
   </main>
 
-  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 Weftmark. All rights reserved.</div></footer>
+  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 weftmark. All rights reserved.</div></footer>
   <div class="fixed bottom-4 right-4 rounded-full bg-emerald-800 px-4 py-2 text-xs font-semibold text-white shadow-lg">Sage Loom</div>
 </body>
 </html>

--- a/docs/assets/preview-slate-copper.html
+++ b/docs/assets/preview-slate-copper.html
@@ -13,7 +13,7 @@
     <div class="mx-auto flex max-w-6xl items-center justify-between">
       <div class="flex items-center gap-2.5">
         <svg viewBox="0 0 200 72" xmlns="http://www.w3.org/2000/svg" class="h-7 w-auto text-zinc-800"><ellipse cx="100" cy="36" rx="90" ry="30" fill="currentColor"/><polyline points="55,24 75,50 100,34 125,50 145,24" fill="none" stroke="white" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <span class="text-base font-semibold tracking-tight">Weftmark</span>
+        <span class="text-base font-semibold tracking-tight">weftmark</span>
       </div>
       <a href="#" class="text-sm font-medium text-stone-600 hover:text-stone-900">Sign in</a>
     </div>
@@ -49,7 +49,7 @@
       <div class="mx-auto max-w-6xl">
         <h2 class="mb-10 text-center text-2xl font-bold tracking-tight text-stone-900">Everything you need at the loom</h2>
         <div class="grid gap-6 sm:grid-cols-3">
-          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-100 text-amber-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. Weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-100 text-amber-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
           <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-100 text-amber-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Record every pick</h3><p class="text-sm leading-relaxed text-stone-500">Advance, reverse, or jump to any row. Mark a project complete when the last pick is woven in.</p></div>
           <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-amber-100 text-amber-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Manage your tools</h3><p class="text-sm leading-relaxed text-stone-500">Keep a record of your looms and yarn. Assign a loom to a project and track what's on the beam.</p></div>
         </div>
@@ -57,7 +57,7 @@
     </section>
   </main>
 
-  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 Weftmark. All rights reserved.</div></footer>
+  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 weftmark. All rights reserved.</div></footer>
   <div class="fixed bottom-4 right-4 rounded-full bg-zinc-800 px-4 py-2 text-xs font-semibold text-white shadow-lg">Slate & Copper</div>
 </body>
 </html>

--- a/docs/assets/preview-teal.html
+++ b/docs/assets/preview-teal.html
@@ -13,7 +13,7 @@
     <div class="mx-auto flex max-w-6xl items-center justify-between">
       <div class="flex items-center gap-2.5">
         <svg viewBox="0 0 200 72" xmlns="http://www.w3.org/2000/svg" class="h-7 w-auto text-teal-700"><ellipse cx="100" cy="36" rx="90" ry="30" fill="currentColor"/><polyline points="55,24 75,50 100,34 125,50 145,24" fill="none" stroke="white" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <span class="text-base font-semibold tracking-tight">Weftmark</span>
+        <span class="text-base font-semibold tracking-tight">weftmark</span>
       </div>
       <a href="#" class="text-sm font-medium text-stone-600 hover:text-stone-900">Sign in</a>
     </div>
@@ -49,7 +49,7 @@
       <div class="mx-auto max-w-6xl">
         <h2 class="mb-10 text-center text-2xl font-bold tracking-tight text-stone-900">Everything you need at the loom</h2>
         <div class="grid gap-6 sm:grid-cols-3">
-          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-teal-100 text-teal-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. Weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
+          <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-teal-100 text-teal-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 17.5h7M17.5 14v7"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Track your weaves</h3><p class="text-sm leading-relaxed text-stone-500">Upload your WIF draft and step through every pick. weftmark keeps your place so you can put down the shuttle and pick it right back up.</p></div>
           <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-teal-100 text-teal-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Record every pick</h3><p class="text-sm leading-relaxed text-stone-500">Advance, reverse, or jump to any row. Mark a project complete when the last pick is woven in.</p></div>
           <div class="card rounded-2xl bg-white p-7 shadow-md ring-1 ring-stone-200/80"><div class="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-teal-100 text-teal-600"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg></div><h3 class="mb-2 text-base font-semibold text-stone-900">Manage your tools</h3><p class="text-sm leading-relaxed text-stone-500">Keep a record of your looms and yarn. Assign a loom to a project and track what's on the beam.</p></div>
         </div>
@@ -57,7 +57,7 @@
     </section>
   </main>
 
-  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 Weftmark. All rights reserved.</div></footer>
+  <footer class="border-t border-stone-200 bg-stone-50 px-6 py-8"><div class="mx-auto max-w-6xl text-center text-xs text-stone-400">© 2025 weftmark. All rights reserved.</div></footer>
   <div class="fixed bottom-4 right-4 rounded-full bg-teal-700 px-4 py-2 text-xs font-semibold text-white shadow-lg">Deep Teal</div>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>WeftMark</title>
+    <title>weftmark</title>
     <script src="/env-config.js"></script>
   </head>
   <body>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ClerkProvider } from "@clerk/clerk-react";
 import { AuthProvider } from "@/context/AuthContext";
 import { ProtectedRoute } from "@/components/layout/ProtectedRoute";
+import { AppLayout } from "@/components/layout/AppLayout";
+import type { ReactNode } from "react";
 import { EulaGate } from "@/components/EulaGate";
 import { VersionGate } from "@/components/VersionGate";
 import { LoginPage } from "@/pages/LoginPage";
@@ -30,6 +32,14 @@ import { ServiceHealthBanner } from "@/components/ServiceHealthBanner";
 import { SystemGate } from "@/components/SystemGate";
 import { clerkPublishableKey, clerkKeyMissing } from "@/lib/env";
 import { useAuth } from "@/hooks/useAuth";
+
+function AuthRoute({ children, requireAdmin = false }: { children: ReactNode; requireAdmin?: boolean }) {
+  return (
+    <ProtectedRoute requireAdmin={requireAdmin}>
+      <AppLayout>{children}</AppLayout>
+    </ProtectedRoute>
+  );
+}
 
 function RootRoute() {
   const { isAuthenticated, isLoading } = useAuth();
@@ -84,94 +94,17 @@ export default function App() {
                   <Route path="/privacy" element={<PrivacyPage />} />
                   <Route path="/terms" element={<TermsPage />} />
                   <Route path="/" element={<RootRoute />} />
-                  <Route
-                    path="/home"
-                    element={
-                      <ProtectedRoute>
-                        <DashboardPage />
-                      </ProtectedRoute>
-                    }
-                  />
-                  <Route
-                    path="/projects"
-                    element={
-                      <ProtectedRoute>
-                        <ProjectsPage />
-                      </ProtectedRoute>
-                    }
-                  />
-                  <Route
-                    path="/projects/:id"
-                    element={
-                      <ProtectedRoute>
-                        <ProjectDetailPage />
-                      </ProtectedRoute>
-                    }
-                  />
-                  <Route
-                    path="/looms"
-                    element={
-                      <ProtectedRoute>
-                        <LoomsPage />
-                      </ProtectedRoute>
-                    }
-                  />
-                  <Route
-                    path="/looms/:id"
-                    element={
-                      <ProtectedRoute>
-                        <LoomDetailPage />
-                      </ProtectedRoute>
-                    }
-                  />
-                  <Route
-                    path="/yarn"
-                    element={
-                      <ProtectedRoute>
-                        <YarnPage />
-                      </ProtectedRoute>
-                    }
-                  />
-                  <Route
-                    path="/yarn/:id"
-                    element={
-                      <ProtectedRoute>
-                        <YarnDetailPage />
-                      </ProtectedRoute>
-                    }
-                  />
-                  <Route
-                    path="/activities"
-                    element={
-                      <ProtectedRoute>
-                        <ActivitiesPage />
-                      </ProtectedRoute>
-                    }
-                  />
-                  <Route
-                    path="/activities/:id"
-                    element={
-                      <ProtectedRoute>
-                        <ActivityDetailPage />
-                      </ProtectedRoute>
-                    }
-                  />
-                  <Route
-                    path="/admin"
-                    element={
-                      <ProtectedRoute requireAdmin>
-                        <AdminPage />
-                      </ProtectedRoute>
-                    }
-                  />
-                  <Route
-                    path="/settings"
-                    element={
-                      <ProtectedRoute>
-                        <SettingsPage />
-                      </ProtectedRoute>
-                    }
-                  />
+                  <Route path="/home" element={<AuthRoute><DashboardPage /></AuthRoute>} />
+                  <Route path="/projects" element={<AuthRoute><ProjectsPage /></AuthRoute>} />
+                  <Route path="/projects/:id" element={<AuthRoute><ProjectDetailPage /></AuthRoute>} />
+                  <Route path="/looms" element={<AuthRoute><LoomsPage /></AuthRoute>} />
+                  <Route path="/looms/:id" element={<AuthRoute><LoomDetailPage /></AuthRoute>} />
+                  <Route path="/yarn" element={<AuthRoute><YarnPage /></AuthRoute>} />
+                  <Route path="/yarn/:id" element={<AuthRoute><YarnDetailPage /></AuthRoute>} />
+                  <Route path="/activities" element={<AuthRoute><ActivitiesPage /></AuthRoute>} />
+                  <Route path="/activities/:id" element={<AuthRoute><ActivityDetailPage /></AuthRoute>} />
+                  <Route path="/admin" element={<AuthRoute requireAdmin><AdminPage /></AuthRoute>} />
+                  <Route path="/settings" element={<AuthRoute><SettingsPage /></AuthRoute>} />
                   <Route path="*" element={<Navigate to="/" replace />} />
                 </Routes>
               </EulaGate>

--- a/frontend/src/api/activities.ts
+++ b/frontend/src/api/activities.ts
@@ -45,6 +45,8 @@ export interface ActivityDetail extends ActivitySummary {
   project_name: string;
   project_num_shafts: number | null;
   project_num_treadles: number | null;
+  project_effective_num_treadles: number | null;
+  project_effective_num_shafts: number | null;
   loom_name: string | null;
   photos: ActivityPhoto[];
 }

--- a/frontend/src/api/activities.ts
+++ b/frontend/src/api/activities.ts
@@ -47,6 +47,7 @@ export interface ActivityDetail extends ActivitySummary {
   project_num_treadles: number | null;
   project_effective_num_treadles: number | null;
   project_effective_num_shafts: number | null;
+  project_metadata_overrides: Record<string, { original: number | null; override: number }> | null;
   loom_name: string | null;
   photos: ActivityPhoto[];
 }

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -18,7 +18,8 @@ export interface Project {
   lint_warnings: string[];
   lint_errors: string[];
   has_preview: boolean;
-  has_liftplan_file: boolean;
+  has_modified_file: boolean;
+  metadata_overrides: Record<string, { original: number | null; override: number }> | null;
   is_shared: boolean;
   created_at: string;
   updated_at: string;
@@ -92,17 +93,29 @@ export async function downloadWif(id: string, filename: string): Promise<void> {
   URL.revokeObjectURL(url);
 }
 
-export async function downloadWifLiftplan(id: string, filename: string): Promise<void> {
+export async function downloadWifModified(id: string, filename: string): Promise<void> {
   const token = await getAuthToken();
   const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
-  const res = await fetch(`/api/projects/${id}/wif-liftplan`, { credentials: "include", headers });
-  if (!res.ok) throw new Error("Lift plan file not available");
+  const res = await fetch(`/api/projects/${id}/wif-modified`, { credentials: "include", headers });
+  if (!res.ok) throw new Error("Modified file not available");
   const blob = await res.blob();
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
   const base = filename.replace(/\.wif$/i, "");
-  a.download = `${base}-liftplan.wif`;
+  a.download = `${base}-modified.wif`;
   a.click();
   URL.revokeObjectURL(url);
+}
+
+export async function overrideProjectMetadata(
+  id: string,
+  field: "num_treadles" | "num_shafts",
+  value: number,
+): Promise<ProjectDetail> {
+  return req(`/api/projects/${id}/override-metadata`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ field, value }),
+  });
 }

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -18,6 +18,7 @@ export interface Project {
   lint_warnings: string[];
   lint_errors: string[];
   has_preview: boolean;
+  has_liftplan_file: boolean;
   is_shared: boolean;
   created_at: string;
   updated_at: string;
@@ -87,6 +88,21 @@ export async function downloadWif(id: string, filename: string): Promise<void> {
   const a = document.createElement("a");
   a.href = url;
   a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export async function downloadWifLiftplan(id: string, filename: string): Promise<void> {
+  const token = await getAuthToken();
+  const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
+  const res = await fetch(`/api/projects/${id}/wif-liftplan`, { credentials: "include", headers });
+  if (!res.ok) throw new Error("Lift plan file not available");
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  const base = filename.replace(/\.wif$/i, "");
+  a.download = `${base}-liftplan.wif`;
   a.click();
   URL.revokeObjectURL(url);
 }

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -5,6 +5,8 @@ export interface Project {
   wif_filename: string;
   num_shafts: number | null;
   num_treadles: number | null;
+  effective_num_treadles: number | null;
+  effective_num_shafts: number | null;
   warp_threads: number | null;
   weft_threads: number | null;
   has_threading: boolean;

--- a/frontend/src/components/WeftmarkLogo.tsx
+++ b/frontend/src/components/WeftmarkLogo.tsx
@@ -8,7 +8,7 @@ export function WeftmarkLogo({ className = "" }: Props) {
       viewBox="0 0 200 72"
       xmlns="http://www.w3.org/2000/svg"
       className={className}
-      aria-label="Weftmark"
+      aria-label="weftmark"
       role="img"
     >
       <ellipse cx="100" cy="36" rx="90" ry="30" fill="currentColor" />

--- a/frontend/src/components/activities/AssignLoomModal.tsx
+++ b/frontend/src/components/activities/AssignLoomModal.tsx
@@ -7,13 +7,18 @@ import { Button } from "@/components/ui/button";
 interface Props {
   activityId: string;
   activeActivities: ActivitySummary[];
+  activityType?: string;
+  projectNumTreadles?: number | null;
+  projectNumShafts?: number | null;
+  projectEffectiveNumTreadles?: number | null;
+  projectEffectiveNumShafts?: number | null;
   onSuccess: () => void;
   onClose: () => void;
 }
 
 const f = "w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
 
-export function AssignLoomModal({ activityId, activeActivities, onSuccess, onClose }: Props) {
+export function AssignLoomModal({ activityId, activeActivities, activityType, projectNumTreadles, projectNumShafts, projectEffectiveNumTreadles, projectEffectiveNumShafts, onSuccess, onClose }: Props) {
   const [loomId, setLoomId] = useState("");
   const [loomVersionId, setLoomVersionId] = useState("");
   const [loading, setLoading] = useState(false);
@@ -28,6 +33,38 @@ export function AssignLoomModal({ activityId, activeActivities, onSuccess, onClo
   });
 
   const loomVersions = loomDetail?.versions ?? [];
+  const selectedLoom = looms.find((l) => l.id === loomId);
+
+  const loomTreadles = selectedLoom?.current_version?.num_treadles ?? null;
+  const loomShafts = selectedLoom?.current_version?.num_shafts ?? null;
+
+  // Use effective counts for compatibility; fall back to declared
+  const effectiveTreadles = projectEffectiveNumTreadles ?? projectNumTreadles ?? null;
+  const effectiveShafts = projectEffectiveNumShafts ?? projectNumShafts ?? null;
+
+  const treadleMismatch =
+    !!selectedLoom &&
+    (activityType === "treadle" || !activityType) &&
+    (effectiveTreadles ?? 0) > 0 &&
+    (loomTreadles ?? 0) > 0 &&
+    (effectiveTreadles ?? 0) > (loomTreadles ?? 0);
+
+  const shaftMismatch =
+    !!selectedLoom &&
+    (activityType === "lift" || !activityType) &&
+    (effectiveShafts ?? 0) > 0 &&
+    (loomShafts ?? 0) > 0 &&
+    (effectiveShafts ?? 0) > (loomShafts ?? 0);
+
+  const treadleMetaMismatch =
+    projectNumTreadles != null &&
+    projectEffectiveNumTreadles != null &&
+    projectNumTreadles !== projectEffectiveNumTreadles;
+
+  const shaftMetaMismatch =
+    projectNumShafts != null &&
+    projectEffectiveNumShafts != null &&
+    projectNumShafts !== projectEffectiveNumShafts;
 
   const handleLoomChange = (newLoomId: string) => {
     setLoomId(newLoomId);
@@ -108,6 +145,30 @@ export function AssignLoomModal({ activityId, activeActivities, onSuccess, onClo
                   <option key={v.id} value={v.id}>{v.name ?? `Version ${v.version_number}`}</option>
                 ))}
               </select>
+            </div>
+          )}
+
+          {(treadleMismatch || shaftMismatch) && selectedLoom && (
+            <div className="rounded-md border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 px-3 py-2.5 text-sm">
+              <p className="font-medium text-amber-900 dark:text-amber-200">
+                {treadleMismatch ? "Treadle count mismatch" : "Shaft count mismatch"}
+              </p>
+              <p className="mt-0.5 text-xs text-amber-800 dark:text-amber-300">
+                {treadleMismatch
+                  ? `This design uses up to ${effectiveTreadles} treadles, but ${selectedLoom.manufacturer} ${selectedLoom.model_name} only has ${loomTreadles}. Treadle positions beyond ${loomTreadles} cannot be pressed.`
+                  : `This design uses up to ${effectiveShafts} shafts, but ${selectedLoom.manufacturer} ${selectedLoom.model_name} only has ${loomShafts}. Shaft positions beyond ${loomShafts} cannot be raised.`}
+              </p>
+            </div>
+          )}
+
+          {(treadleMetaMismatch || shaftMetaMismatch) && !treadleMismatch && !shaftMismatch && (
+            <div className="rounded-md border border-stone-200 bg-stone-50 dark:bg-stone-900/30 dark:border-stone-700 px-3 py-2.5 text-sm">
+              <p className="font-medium text-stone-700 dark:text-stone-300">WIF metadata note</p>
+              <p className="mt-0.5 text-xs text-stone-600 dark:text-stone-400">
+                {treadleMetaMismatch
+                  ? `The WIF file declares ${projectNumTreadles} treadles in metadata, but the treadling data only uses ${projectEffectiveNumTreadles}. Loom compatibility uses the actual count (${projectEffectiveNumTreadles}). You can fix the declared count in your design software.`
+                  : `The WIF file declares ${projectNumShafts} shafts in metadata, but the lift plan only uses ${projectEffectiveNumShafts}. Loom compatibility uses the actual count (${projectEffectiveNumShafts}). You can fix the declared count in your design software.`}
+              </p>
             </div>
           )}
 

--- a/frontend/src/components/activities/CreateActivityModal.tsx
+++ b/frontend/src/components/activities/CreateActivityModal.tsx
@@ -79,6 +79,38 @@ export function CreateActivityModal({ onSuccess, onClose, defaultProjectId }: Pr
   const loomVersions = loomDetail?.versions ?? [];
   const selectedVersion = loomVersions.find((v) => v.id === loomVersionId);
 
+  const loomTreadles = selectedLoom?.current_version?.num_treadles ?? null;
+  const loomShafts = selectedLoom?.current_version?.num_shafts ?? null;
+
+  // Use effective counts (from actual treadling data) for compatibility; fall back to declared
+  const effectiveTreadles = selectedProject?.effective_num_treadles ?? selectedProject?.num_treadles ?? null;
+  const effectiveShafts = selectedProject?.effective_num_shafts ?? selectedProject?.num_shafts ?? null;
+
+  const treadleMismatch =
+    !!selectedLoom &&
+    (effectiveType === "treadle" || (!effectiveType && availableTypes.includes("treadle"))) &&
+    (effectiveTreadles ?? 0) > 0 &&
+    (loomTreadles ?? 0) > 0 &&
+    (effectiveTreadles ?? 0) > (loomTreadles ?? 0);
+
+  const shaftMismatch =
+    !!selectedLoom &&
+    (effectiveType === "lift" || (!effectiveType && availableTypes.includes("lift"))) &&
+    (effectiveShafts ?? 0) > 0 &&
+    (loomShafts ?? 0) > 0 &&
+    (effectiveShafts ?? 0) > (loomShafts ?? 0);
+
+  // Informational: declared metadata doesn't match actual usage
+  const treadleMetaMismatch =
+    selectedProject?.num_treadles != null &&
+    selectedProject?.effective_num_treadles != null &&
+    selectedProject.num_treadles !== selectedProject.effective_num_treadles;
+
+  const shaftMetaMismatch =
+    selectedProject?.num_shafts != null &&
+    selectedProject?.effective_num_shafts != null &&
+    selectedProject.num_shafts !== selectedProject.effective_num_shafts;
+
   const loomWasteInCurrentUnit = (allowance: string | null | undefined, wasteUnit: string): string => {
     if (!allowance) return "";
     return wasteUnit === lengthUnit ? allowance : convertLen(allowance, lengthUnit);
@@ -203,6 +235,30 @@ export function CreateActivityModal({ onSuccess, onClose, defaultProjectId }: Pr
                   <option key={v.id} value={v.id}>{v.name ?? `Version ${v.version_number}`}</option>
                 ))}
               </select>
+            </div>
+          )}
+
+          {(treadleMismatch || shaftMismatch) && selectedLoom && (
+            <div className="rounded-md border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 px-3 py-2.5 text-sm">
+              <p className="font-medium text-amber-900 dark:text-amber-200">
+                {treadleMismatch ? "Treadle count mismatch" : "Shaft count mismatch"}
+              </p>
+              <p className="mt-0.5 text-xs text-amber-800 dark:text-amber-300">
+                {treadleMismatch
+                  ? `This design uses up to ${effectiveTreadles} treadles, but ${selectedLoom.manufacturer} ${selectedLoom.model_name} only has ${loomTreadles}. Treadle positions beyond ${loomTreadles} cannot be pressed.`
+                  : `This design uses up to ${effectiveShafts} shafts, but ${selectedLoom.manufacturer} ${selectedLoom.model_name} only has ${loomShafts}. Shaft positions beyond ${loomShafts} cannot be raised.`}
+              </p>
+            </div>
+          )}
+
+          {(treadleMetaMismatch || shaftMetaMismatch) && !treadleMismatch && !shaftMismatch && (
+            <div className="rounded-md border border-stone-200 bg-stone-50 dark:bg-stone-900/30 dark:border-stone-700 px-3 py-2.5 text-sm">
+              <p className="font-medium text-stone-700 dark:text-stone-300">WIF metadata note</p>
+              <p className="mt-0.5 text-xs text-stone-600 dark:text-stone-400">
+                {treadleMetaMismatch
+                  ? `The WIF file declares ${selectedProject!.num_treadles} treadles in metadata, but the treadling data only uses ${selectedProject!.effective_num_treadles}. Loom compatibility uses the actual count (${selectedProject!.effective_num_treadles}). You can fix the declared count in your design software.`
+                  : `The WIF file declares ${selectedProject!.num_shafts} shafts in metadata, but the lift plan only uses ${selectedProject!.effective_num_shafts}. Loom compatibility uses the actual count (${selectedProject!.effective_num_shafts}). You can fix the declared count in your design software.`}
+              </p>
             </div>
           )}
 

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Menu } from "lucide-react";
+import { AppIcons } from "@/lib/icons";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { VersionBadge } from "@/components/layout/VersionFooter";
 import type { ReactNode } from "react";
@@ -23,7 +23,7 @@ export function AppLayout({ children }: Props) {
             className="rounded-md p-1.5 text-stone-500 hover:bg-stone-100 hover:text-stone-900"
             aria-label="Open navigation"
           >
-            <Menu className="h-5 w-5" />
+            <AppIcons.mobileMenu className="h-5 w-5" />
           </button>
         </div>
 

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import { Menu } from "lucide-react";
+import { Sidebar } from "@/components/layout/Sidebar";
+import { VersionBadge } from "@/components/layout/VersionFooter";
+import type { ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+}
+
+export function AppLayout({ children }: Props) {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  return (
+    <div className="flex h-screen overflow-hidden bg-stone-50">
+      <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+
+      <div className="flex flex-1 flex-col overflow-hidden">
+        {/* Mobile top bar — hidden on lg+ where sidebar is always visible */}
+        <div className="flex h-14 shrink-0 items-center border-b border-stone-200 bg-white px-4 lg:hidden">
+          <button
+            onClick={() => setSidebarOpen(true)}
+            className="rounded-md p-1.5 text-stone-500 hover:bg-stone-100 hover:text-stone-900"
+            aria-label="Open navigation"
+          >
+            <Menu className="h-5 w-5" />
+          </button>
+        </div>
+
+        <main className="flex-1 overflow-y-auto">
+          {children}
+        </main>
+      </div>
+
+      <VersionBadge />
+    </div>
+  );
+}

--- a/frontend/src/components/layout/ProtectedRoute.tsx
+++ b/frontend/src/components/layout/ProtectedRoute.tsx
@@ -1,6 +1,5 @@
 import { Navigate, useLocation } from "react-router-dom";
 import { useAuth } from "@/hooks/useAuth";
-import { VersionBadge } from "@/components/layout/VersionFooter";
 import type { ReactNode } from "react";
 
 interface Props {
@@ -33,10 +32,5 @@ export function ProtectedRoute({ children, requireAdmin = false }: Props) {
     return <Navigate to="/unauthorized" replace />;
   }
 
-  return (
-    <>
-      {children}
-      <VersionBadge />
-    </>
-  );
+  return <>{children}</>;
 }

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -13,9 +13,9 @@ interface NavItem {
 
 const NAV_ITEMS: NavItem[] = [
   { label: "Dashboard", href: "/home", icon: AppIcons.dashboard, exact: true },
+  { label: "Equipment", href: "/looms", icon: AppIcons.equipment },
   { label: "Projects", href: "/projects", icon: AppIcons.projects },
   { label: "Activities", href: "/activities", icon: AppIcons.activities },
-  { label: "Equipment", href: "/looms", icon: AppIcons.equipment },
 ];
 
 interface Props {

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,16 +1,6 @@
 import { Link, useLocation } from "react-router-dom";
 import { useClerk } from "@clerk/clerk-react";
-import {
-  LayoutDashboard,
-  FolderOpen,
-  Activity,
-  Wrench,
-  Settings,
-  ShieldCheck,
-  LogOut,
-  X,
-} from "lucide-react";
-import type { LucideIcon } from "lucide-react";
+import { AppIcons, type LucideIcon } from "@/lib/icons";
 import { WeftmarkLogo } from "@/components/WeftmarkLogo";
 import { useAuth } from "@/hooks/useAuth";
 
@@ -22,10 +12,10 @@ interface NavItem {
 }
 
 const NAV_ITEMS: NavItem[] = [
-  { label: "Dashboard", href: "/home", icon: LayoutDashboard, exact: true },
-  { label: "Projects", href: "/projects", icon: FolderOpen },
-  { label: "Activities", href: "/activities", icon: Activity },
-  { label: "Equipment", href: "/looms", icon: Wrench },
+  { label: "Dashboard", href: "/home", icon: AppIcons.dashboard, exact: true },
+  { label: "Projects", href: "/projects", icon: AppIcons.projects },
+  { label: "Activities", href: "/activities", icon: AppIcons.activities },
+  { label: "Equipment", href: "/looms", icon: AppIcons.equipment },
 ];
 
 interface Props {
@@ -85,7 +75,7 @@ export function Sidebar({ open, onClose }: Props) {
             className="rounded-md p-1 text-stone-400 hover:text-stone-600 lg:hidden"
             aria-label="Close menu"
           >
-            <X className="h-4 w-4" />
+            <AppIcons.close className="h-4 w-4" />
           </button>
         </div>
 
@@ -112,13 +102,13 @@ export function Sidebar({ open, onClose }: Props) {
         {/* Bottom nav */}
         <div className="shrink-0 border-t border-stone-200 px-3 py-3 space-y-0.5">
           <Link to="/settings" onClick={onClose} className={navCls("/settings")}>
-            <Settings className={iconCls("/settings")} strokeWidth={1.75} />
+            <AppIcons.settings className={iconCls("/settings")} strokeWidth={1.75} />
             Settings
           </Link>
 
           {user?.is_admin && (
             <Link to="/admin" onClick={onClose} className={navCls("/admin")}>
-              <ShieldCheck className={iconCls("/admin")} strokeWidth={1.75} />
+              <AppIcons.admin className={iconCls("/admin")} strokeWidth={1.75} />
               Admin
             </Link>
           )}
@@ -127,7 +117,7 @@ export function Sidebar({ open, onClose }: Props) {
             onClick={() => signOut()}
             className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-stone-600 transition-colors hover:bg-stone-100 hover:text-stone-900"
           >
-            <LogOut className="h-4 w-4 shrink-0 text-stone-400" strokeWidth={1.75} />
+            <AppIcons.logout className="h-4 w-4 shrink-0 text-stone-400" strokeWidth={1.75} />
             Sign out
           </button>
         </div>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,0 +1,145 @@
+import { Link, useLocation } from "react-router-dom";
+import { useClerk } from "@clerk/clerk-react";
+import {
+  LayoutDashboard,
+  FolderOpen,
+  Activity,
+  Wrench,
+  Settings,
+  ShieldCheck,
+  LogOut,
+  X,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { WeftmarkLogo } from "@/components/WeftmarkLogo";
+import { useAuth } from "@/hooks/useAuth";
+
+interface NavItem {
+  label: string;
+  href: string;
+  icon: LucideIcon;
+  exact?: boolean;
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { label: "Dashboard", href: "/home", icon: LayoutDashboard, exact: true },
+  { label: "Projects", href: "/projects", icon: FolderOpen },
+  { label: "Activities", href: "/activities", icon: Activity },
+  { label: "Equipment", href: "/looms", icon: Wrench },
+];
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function Sidebar({ open, onClose }: Props) {
+  const location = useLocation();
+  const { user } = useAuth();
+  const { signOut } = useClerk();
+
+  function isActive(href: string, exact = false) {
+    if (exact) return location.pathname === href;
+    return location.pathname === href || location.pathname.startsWith(href + "/");
+  }
+
+  function navCls(href: string, exact?: boolean) {
+    const active = isActive(href, exact);
+    return `flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+      active
+        ? "bg-amber-50 text-amber-800"
+        : "text-stone-600 hover:bg-stone-100 hover:text-stone-900"
+    }`;
+  }
+
+  function iconCls(href: string, exact?: boolean) {
+    return `h-4 w-4 shrink-0 ${
+      isActive(href, exact) ? "text-amber-600" : "text-stone-400"
+    }`;
+  }
+
+  return (
+    <>
+      {/* Mobile backdrop */}
+      {open && (
+        <div
+          className="fixed inset-0 z-20 bg-black/40 lg:hidden"
+          onClick={onClose}
+        />
+      )}
+
+      {/* Sidebar panel */}
+      <aside
+        className={`fixed inset-y-0 left-0 z-30 flex w-60 flex-col bg-white border-r border-stone-200 transition-transform duration-200 ease-in-out lg:static lg:z-auto lg:translate-x-0 ${
+          open ? "translate-x-0" : "-translate-x-full"
+        }`}
+      >
+        {/* Logo */}
+        <div className="flex h-16 shrink-0 items-center justify-between border-b border-stone-200 px-4">
+          <Link to="/home" className="flex items-center gap-2.5" onClick={onClose}>
+            <WeftmarkLogo className="h-6 w-auto text-zinc-800" />
+            <span className="text-sm font-semibold tracking-tight text-stone-900" style={{ fontFamily: '"Segoe UI", system-ui, sans-serif' }}>weftmark</span>
+          </Link>
+          <button
+            onClick={onClose}
+            className="rounded-md p-1 text-stone-400 hover:text-stone-600 lg:hidden"
+            aria-label="Close menu"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Primary nav — hidden for superusers (they only use /admin) */}
+        {!user?.is_superuser && (
+          <nav className="flex-1 overflow-y-auto px-3 py-3 space-y-0.5">
+            {NAV_ITEMS.map(({ label, href, icon: Icon, exact }) => (
+              <Link
+                key={href}
+                to={href}
+                onClick={onClose}
+                className={navCls(href, exact)}
+              >
+                <Icon className={iconCls(href, exact)} strokeWidth={1.75} />
+                {label}
+              </Link>
+            ))}
+          </nav>
+        )}
+
+        {/* Spacer for superusers */}
+        {user?.is_superuser && <div className="flex-1" />}
+
+        {/* Bottom nav */}
+        <div className="shrink-0 border-t border-stone-200 px-3 py-3 space-y-0.5">
+          <Link to="/settings" onClick={onClose} className={navCls("/settings")}>
+            <Settings className={iconCls("/settings")} strokeWidth={1.75} />
+            Settings
+          </Link>
+
+          {user?.is_admin && (
+            <Link to="/admin" onClick={onClose} className={navCls("/admin")}>
+              <ShieldCheck className={iconCls("/admin")} strokeWidth={1.75} />
+              Admin
+            </Link>
+          )}
+
+          <button
+            onClick={() => signOut()}
+            className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-stone-600 transition-colors hover:bg-stone-100 hover:text-stone-900"
+          >
+            <LogOut className="h-4 w-4 shrink-0 text-stone-400" strokeWidth={1.75} />
+            Sign out
+          </button>
+        </div>
+
+        {/* User identity */}
+        {user && (
+          <div className="shrink-0 border-t border-stone-200 bg-stone-50 px-4 py-3">
+            <p className="truncate text-xs font-medium text-stone-900">{user.display_name}</p>
+            <p className="truncate text-xs text-stone-400">{user.email}</p>
+          </div>
+        )}
+      </aside>
+    </>
+  );
+}

--- a/frontend/src/components/projects/ProjectCard.tsx
+++ b/frontend/src/components/projects/ProjectCard.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import type { Project } from "@/api/projects";
+import { AppIcons } from "@/lib/icons";
 
 interface ActivityCounts {
   active: number;
@@ -17,8 +18,6 @@ export function ProjectCard({ project, activityCounts }: Props) {
   const navigate = useNavigate();
 
   const featureBadges = [
-    project.has_liftplan && "Lift-tracking",
-    project.has_treadling && "Treadle-tracking",
     project.has_threading && "Threading",
     project.has_tieup && "Tie-up",
   ].filter(Boolean) as string[];
@@ -33,11 +32,19 @@ export function ProjectCard({ project, activityCounts }: Props) {
           <h3 className="truncate font-medium">{project.name}</h3>
           <p className="text-xs text-muted-foreground mt-0.5 truncate">{project.wif_filename}</p>
         </div>
-        {project.lint_errors.length > 0 && (
-          <span className="shrink-0 rounded bg-destructive/10 px-1.5 py-0.5 text-xs text-destructive">
-            {project.lint_errors.length} error{project.lint_errors.length > 1 ? "s" : ""}
-          </span>
-        )}
+        <div className="flex items-center gap-2 shrink-0">
+          {project.has_liftplan && (
+            <AppIcons.lift className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
+          )}
+          {project.has_treadling && (
+            <AppIcons.treadle className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
+          )}
+          {project.lint_errors.length > 0 && (
+            <span className="rounded bg-destructive/10 px-1.5 py-0.5 text-xs text-destructive">
+              {project.lint_errors.length} error{project.lint_errors.length > 1 ? "s" : ""}
+            </span>
+          )}
+        </div>
       </div>
 
       {project.num_shafts != null && (
@@ -47,8 +54,19 @@ export function ProjectCard({ project, activityCounts }: Props) {
         </p>
       )}
 
+      {(project.has_liftplan || project.has_treadling) && (
+        <div className="mt-2 flex flex-wrap gap-2">
+          {project.has_liftplan && (
+            <span className="rounded bg-muted px-1.5 py-0.5 text-xs">lift tracking</span>
+          )}
+          {project.has_treadling && (
+            <span className="rounded bg-muted px-1.5 py-0.5 text-xs">treadle tracking</span>
+          )}
+        </div>
+      )}
+
       {featureBadges.length > 0 && (
-        <div className="mt-2 flex flex-wrap gap-1">
+        <div className="mt-1.5 flex flex-wrap gap-1">
           {featureBadges.map((b) => (
             <span
               key={b}

--- a/frontend/src/lib/icons.ts
+++ b/frontend/src/lib/icons.ts
@@ -1,0 +1,47 @@
+/**
+ * Centralized icon registry — change a key here to update every usage site.
+ * Import icons and the LucideIcon type from this module, not from lucide-react.
+ */
+import {
+  Activity,
+  CheckSquare,
+  ChevronRight,
+  ChevronsUp,
+  FolderOpen,
+  Footprints,
+  LayoutDashboard,
+  Layers,
+  LogOut,
+  Menu,
+  Settings,
+  ShieldCheck,
+  Wrench,
+  X,
+} from "lucide-react";
+
+export type { LucideIcon } from "lucide-react";
+
+export const AppIcons = {
+  // ── Weaving — activity types ──────────────────────────────────────────────
+  treadle: Footprints,
+  lift: ChevronsUp,
+
+  // ── Navigation ────────────────────────────────────────────────────────────
+  dashboard: LayoutDashboard,
+  projects: FolderOpen,
+  activities: Activity,
+  equipment: Wrench,
+  settings: Settings,
+  admin: ShieldCheck,
+  logout: LogOut,
+
+  // ── UI chrome ─────────────────────────────────────────────────────────────
+  mobileMenu: Menu,
+  close: X,
+  chevronRight: ChevronRight,
+
+  // ── Landing page features ─────────────────────────────────────────────────
+  designLibrary: Layers,
+  pickTracking: CheckSquare,
+  toolManagement: Wrench,
+} as const;

--- a/frontend/src/lib/icons.ts
+++ b/frontend/src/lib/icons.ts
@@ -7,6 +7,7 @@ import {
   CheckSquare,
   ChevronRight,
   ChevronsUp,
+  CircleHelp,
   FolderOpen,
   Footprints,
   LayoutDashboard,
@@ -25,6 +26,7 @@ export const AppIcons = {
   // ── Weaving — activity types ──────────────────────────────────────────────
   treadle: Footprints,
   lift: ChevronsUp,
+  planning: CircleHelp,
 
   // ── Navigation ────────────────────────────────────────────────────────────
   dashboard: LayoutDashboard,

--- a/frontend/src/lib/icons.ts
+++ b/frontend/src/lib/icons.ts
@@ -7,6 +7,7 @@ import {
   CheckSquare,
   ChevronRight,
   ChevronsUp,
+  CircleCheck,
   CircleHelp,
   FolderOpen,
   Footprints,
@@ -14,10 +15,12 @@ import {
   Layers,
   LogOut,
   Menu,
+  Scroll,
   Settings,
   ShieldCheck,
   Wrench,
   X,
+  Zap,
 } from "lucide-react";
 
 export type { LucideIcon } from "lucide-react";
@@ -27,10 +30,13 @@ export const AppIcons = {
   treadle: Footprints,
   lift: ChevronsUp,
   planning: CircleHelp,
+  activityActive: Zap,
+  activityCompleted: CircleCheck,
 
   // ── Navigation ────────────────────────────────────────────────────────────
   dashboard: LayoutDashboard,
   projects: FolderOpen,
+  project: Scroll,
   activities: Activity,
   equipment: Wrench,
   settings: Settings,

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -9,7 +9,7 @@ export function AboutPage() {
         <div className="mx-auto flex max-w-4xl items-center gap-3">
           <Link to="/" className="flex items-center gap-3 hover:opacity-80 transition-opacity">
             <WeftmarkLogo className="h-8 w-auto text-amber-800" />
-            <span className="text-lg font-semibold tracking-tight">Weftmark</span>
+            <span className="text-lg font-semibold tracking-tight" style={{ fontFamily: '"Segoe UI", system-ui, sans-serif' }}>weftmark</span>
           </Link>
         </div>
       </header>
@@ -17,9 +17,9 @@ export function AboutPage() {
       <main className="flex-1 px-6 py-16">
         <div className="mx-auto max-w-2xl space-y-10">
           <div>
-            <h1 className="text-3xl font-bold tracking-tight mb-4">About Weftmark</h1>
+            <h1 className="text-3xl font-bold tracking-tight mb-4">About weftmark</h1>
             <p className="text-stone-600 leading-relaxed">
-              Weftmark is a weaving companion built by a weaver to solve a weaver's problem: keeping
+              weftmark is a weaving companion built by a weaver to solve a weaver's problem: keeping
               track of where you are in a long treadling sequence. It is not a commercial product. It
               is a personal project, built in spare hours, to scratch a specific itch.
             </p>
@@ -28,7 +28,7 @@ export function AboutPage() {
           <div className="space-y-3">
             <h2 className="text-lg font-semibold">How it was built</h2>
             <p className="text-stone-600 leading-relaxed">
-              Weftmark was built with significant assistance from AI tools — specifically Anthropic's
+              weftmark was built with significant assistance from AI tools — specifically Anthropic's
               Claude. Claude helped with code generation, architecture decisions, and code review
               throughout the project. The developer is not a professional software engineer.
             </p>

--- a/frontend/src/pages/ActivitiesPage.tsx
+++ b/frontend/src/pages/ActivitiesPage.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { listActivities, ACTIVITY_TYPE_LABELS, ACTIVITY_STATUS_LABELS, type ActivitySummary } from "@/api/activities";
+import { AppIcons } from "@/lib/icons";
 import { previewUrl } from "@/api/projects";
 import { AuthedImage } from "@/components/ui/AuthedImage";
 import { CreateActivityModal } from "@/components/activities/CreateActivityModal";
@@ -58,43 +59,54 @@ function ActivityCard({ activity, onAssign }: {
   return (
     <div className="relative rounded-lg border hover:border-ring transition-colors">
       <Link to={`/activities/${activity.id}`} className="block p-4">
-        <div className="flex items-start justify-between gap-2">
-          <span className="font-medium">{activity.name}</span>
-          <div className="flex items-center gap-1.5 shrink-0">
-            <button
-              type="button"
-              aria-label="Preview design"
-              onClick={(e) => { e.preventDefault(); setShowPreview(true); }}
-              className="text-muted-foreground hover:text-foreground transition-colors"
-              title="Preview design"
-            >
-              <svg width="13" height="13" viewBox="0 0 12 12" fill="currentColor" aria-hidden>
-                <rect x="0" y="0" width="5" height="5" rx="1" />
-                <rect x="7" y="0" width="5" height="5" rx="1" />
-                <rect x="0" y="7" width="5" height="5" rx="1" />
-                <rect x="7" y="7" width="5" height="5" rx="1" />
-              </svg>
-            </button>
-            <span className={`min-w-[5.5rem] text-center rounded px-1.5 py-0.5 text-xs font-medium ${STATUS_COLORS[badgeKey]}`}>
-              {badgeLabel}
-            </span>
+        <div className="flex gap-3">
+          <div className="shrink-0 mt-0.5">
+            {isPlanning
+              ? <AppIcons.planning className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
+              : activity.activity_type === "treadle"
+                ? <AppIcons.treadle className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
+                : <AppIcons.lift className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />}
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-start justify-between gap-2">
+              <span className="font-medium">{activity.name}</span>
+              <div className="flex items-center gap-1.5 shrink-0">
+                <button
+                  type="button"
+                  aria-label="Preview design"
+                  onClick={(e) => { e.preventDefault(); setShowPreview(true); }}
+                  className="text-muted-foreground hover:text-foreground transition-colors"
+                  title="Preview design"
+                >
+                  <svg width="13" height="13" viewBox="0 0 12 12" fill="currentColor" aria-hidden>
+                    <rect x="0" y="0" width="5" height="5" rx="1" />
+                    <rect x="7" y="0" width="5" height="5" rx="1" />
+                    <rect x="0" y="7" width="5" height="5" rx="1" />
+                    <rect x="7" y="7" width="5" height="5" rx="1" />
+                  </svg>
+                </button>
+                <span className={`min-w-[5.5rem] text-center rounded px-1.5 py-0.5 text-xs font-medium ${STATUS_COLORS[badgeKey]}`}>
+                  {badgeLabel}
+                </span>
+              </div>
+            </div>
+            <p className="mt-0.5 text-sm text-muted-foreground">{ACTIVITY_TYPE_LABELS[activity.activity_type]}</p>
+            {endDate && (
+              <p className="mt-0.5 text-xs text-muted-foreground">{fmtDate(endDate)}</p>
+            )}
+            {!isPlanning && activity.status === "active" && (
+              <div className="mt-3">
+                <div className="mb-1 flex justify-between text-xs text-muted-foreground">
+                  <span>Pick {Math.min(activity.current_pick, activity.total_picks)} of {activity.total_picks}</span>
+                  <span>{pct}%</span>
+                </div>
+                <div className="h-1.5 w-full rounded-full bg-muted overflow-hidden">
+                  <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${pct}%` }} />
+                </div>
+              </div>
+            )}
           </div>
         </div>
-        <p className="mt-0.5 text-sm text-muted-foreground">{ACTIVITY_TYPE_LABELS[activity.activity_type]}</p>
-        {endDate && (
-          <p className="mt-0.5 text-xs text-muted-foreground">{fmtDate(endDate)}</p>
-        )}
-        {!isPlanning && activity.status === "active" && (
-          <div className="mt-3">
-            <div className="mb-1 flex justify-between text-xs text-muted-foreground">
-              <span>Pick {Math.min(activity.current_pick, activity.total_picks)} of {activity.total_picks}</span>
-              <span>{pct}%</span>
-            </div>
-            <div className="h-1.5 w-full rounded-full bg-muted overflow-hidden">
-              <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${pct}%` }} />
-            </div>
-          </div>
-        )}
       </Link>
       {isPlanning && onAssign && (
         <div className="border-t px-3 pb-3 pt-2">

--- a/frontend/src/pages/ActivitiesPage.tsx
+++ b/frontend/src/pages/ActivitiesPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { listActivities, ACTIVITY_TYPE_LABELS, ACTIVITY_STATUS_LABELS, type ActivitySummary } from "@/api/activities";
 import { previewUrl } from "@/api/projects";
@@ -7,6 +7,7 @@ import { AuthedImage } from "@/components/ui/AuthedImage";
 import { CreateActivityModal } from "@/components/activities/CreateActivityModal";
 import { AssignLoomModal } from "@/components/activities/AssignLoomModal";
 import { Button } from "@/components/ui/button";
+import { Link } from "react-router-dom";
 
 const STATUS_COLORS: Record<string, string> = {
   active: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
@@ -191,76 +192,71 @@ export function ActivitiesPage() {
   const abandonedByYear = groupByYear(abandoned, (a) => a.abandoned_at);
 
   return (
-    <div className="flex min-h-screen flex-col">
-      <header className="border-b px-6 py-4 flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <Link to="/" className="text-sm text-muted-foreground hover:text-foreground">← Dashboard</Link>
-          <span className="font-semibold">Activities</span>
-        </div>
+    <div className="p-6 max-w-3xl mx-auto w-full space-y-8">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold">Activities</h1>
         <Button size="sm" onClick={() => setShowCreate(true)}>New activity</Button>
-      </header>
+      </div>
 
-      <main className="flex-1 p-6 max-w-3xl mx-auto w-full space-y-8">
-        {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
-        {error && <p className="text-sm text-destructive">Failed to load activities.</p>}
+      {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+      {error && <p className="text-sm text-destructive">Failed to load activities.</p>}
 
-        {!isLoading && activities.length === 0 && (
-          <div className="rounded-lg border border-dashed p-12 text-center">
-            <p className="text-sm text-muted-foreground">No activities yet. Start one to begin tracking a weaving session.</p>
-            <Button className="mt-4" onClick={() => setShowCreate(true)}>New activity</Button>
+      {!isLoading && activities.length === 0 && (
+        <div className="rounded-lg border border-dashed p-12 text-center">
+          <p className="text-sm text-muted-foreground">No activities yet. Start one to begin tracking a weaving session.</p>
+          <Button className="mt-4" onClick={() => setShowCreate(true)}>New activity</Button>
+        </div>
+      )}
+
+      {active.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-sm font-medium text-muted-foreground uppercase tracking-wide">Active</h2>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {active.map((a) => <ActivityCard key={a.id} activity={a} />)}
           </div>
-        )}
+        </section>
+      )}
 
-        {active.length > 0 && (
-          <section>
-            <h2 className="mb-3 text-sm font-medium text-muted-foreground uppercase tracking-wide">Active</h2>
-            <div className="grid gap-3 sm:grid-cols-2">
-              {active.map((a) => <ActivityCard key={a.id} activity={a} />)}
-            </div>
-          </section>
-        )}
+      {planning.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-sm font-medium text-muted-foreground uppercase tracking-wide">Planning</h2>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {planning.map((a) => <ActivityCard key={a.id} activity={a} onAssign={setAssigningActivityId} />)}
+          </div>
+        </section>
+      )}
 
-        {planning.length > 0 && (
-          <section>
-            <h2 className="mb-3 text-sm font-medium text-muted-foreground uppercase tracking-wide">Planning</h2>
-            <div className="grid gap-3 sm:grid-cols-2">
-              {planning.map((a) => <ActivityCard key={a.id} activity={a} onAssign={setAssigningActivityId} />)}
-            </div>
-          </section>
-        )}
+      {completedByYear.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-sm font-medium text-muted-foreground uppercase tracking-wide">Completed</h2>
+          <div className="space-y-4">
+            {completedByYear.map(({ year, items }) => (
+              <YearGroup
+                key={year}
+                year={year}
+                items={items}
+                defaultExpanded={year === currentYear}
+              />
+            ))}
+          </div>
+        </section>
+      )}
 
-        {completedByYear.length > 0 && (
-          <section>
-            <h2 className="mb-3 text-sm font-medium text-muted-foreground uppercase tracking-wide">Completed</h2>
-            <div className="space-y-4">
-              {completedByYear.map(({ year, items }) => (
-                <YearGroup
-                  key={year}
-                  year={year}
-                  items={items}
-                  defaultExpanded={year === currentYear}
-                />
-              ))}
-            </div>
-          </section>
-        )}
-
-        {abandonedByYear.length > 0 && (
-          <section>
-            <h2 className="mb-3 text-sm font-medium text-muted-foreground uppercase tracking-wide">Abandoned</h2>
-            <div className="space-y-4">
-              {abandonedByYear.map(({ year, items }) => (
-                <YearGroup
-                  key={year}
-                  year={year}
-                  items={items}
-                  defaultExpanded={false}
-                />
-              ))}
-            </div>
-          </section>
-        )}
-      </main>
+      {abandonedByYear.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-sm font-medium text-muted-foreground uppercase tracking-wide">Abandoned</h2>
+          <div className="space-y-4">
+            {abandonedByYear.map(({ year, items }) => (
+              <YearGroup
+                key={year}
+                year={year}
+                items={items}
+                defaultExpanded={false}
+              />
+            ))}
+          </div>
+        </section>
+      )}
 
       {showCreate && (
         <CreateActivityModal

--- a/frontend/src/pages/ActivityDetailPage.tsx
+++ b/frontend/src/pages/ActivityDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
+import { ChevronRight, Footprints, ChevronsUp } from "lucide-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   getActivity, getActivityPicks, stepActivity, jumpActivity, completeActivity, abandonActivity,
@@ -103,65 +104,71 @@ function PickDisplay({
   colorMode: ColorMode;
   showWeftColor: boolean;
 }) {
-  const label = activityType === "lift" ? "Raise shafts" : "Press treadles";
-  const count = Math.max(totalCount, pick.active.length > 0 ? Math.max(...pick.active) : 0, 1);
+  const count = Math.max(totalCount, 1);
   const weftHex = pick.color ?? null;
 
-  const boxCls =
-    count <= 4  ? "h-14 w-14 text-base"
-    : count <= 8  ? "h-10 w-10 text-sm"
-    : count <= 16 ? "h-8 w-8 text-xs"
-    : "h-6 w-6 text-xs";
-
   return (
-    <div className="rounded-xl border-2 border-primary/30 bg-primary/5 dark:bg-primary/10 px-6 py-5 space-y-4">
-      <p className="text-center text-xs font-medium text-primary/80 uppercase tracking-wider">
-        {label} · pick {pick.pick}
-      </p>
-      <div className="flex flex-wrap justify-center gap-2">
-        {Array.from({ length: count }, (_, i) => i + 1).map((n) => {
-          const active = pick.active.includes(n);
-          if (colorMode !== "theme" && active && weftHex) {
-            if (colorMode === "filled") {
-              const fg = contrastColor(weftHex);
-              return (
-                <div key={n} style={{ backgroundColor: weftHex, borderColor: fg }}
-                  className={`${boxCls} rounded-md border-2 flex items-center justify-center font-bold`}>
-                  <span style={{ color: fg }}>{n}</span>
-                </div>
-              );
-            }
-            if (colorMode === "strip") {
-              return (
-                <div key={n}
-                  className={`${boxCls} rounded-md border-2 relative overflow-hidden border-primary bg-primary flex items-center justify-center font-bold`}>
-                  <span className="absolute bottom-0 left-0 right-0 h-[20%]"
-                    style={{ backgroundColor: weftHex }} />
-                  <span className="relative text-primary-foreground">{n}</span>
-                </div>
-              );
-            }
-          }
-          return (
-            <div key={n}
-              className={`${boxCls} rounded-md border-2 flex items-center justify-center font-bold ${
-                active
-                  ? "bg-primary border-primary text-primary-foreground"
-                  : "border-muted bg-muted/30 text-muted-foreground"
-              }`}>
-              {n}
-            </div>
-          );
-        })}
+    <div className="rounded-xl border-2 border-primary/30 bg-primary/5 dark:bg-primary/10 px-4 py-4 h-28 flex items-stretch gap-4">
+      {/* Activity type icon — centered vertically */}
+      <div className="shrink-0 flex items-center text-primary/50">
+        {activityType === "lift" ? (
+          <ChevronsUp className="h-8 w-8" strokeWidth={1.5} />
+        ) : (
+          <Footprints className="h-8 w-8" strokeWidth={1.5} />
+        )}
       </div>
-      {showWeftColor && weftHex && (
+
+      {/* Box grid + optional weft bar — fills remaining height */}
+      <div className="flex-1 flex flex-col gap-2 min-h-0">
         <div
-          className="h-7 w-full rounded-md flex items-center justify-center text-xs font-semibold uppercase tracking-wider"
-          style={{ backgroundColor: weftHex, color: contrastColor(weftHex) }}
+          className="flex-1 grid gap-1.5 min-h-0"
+          style={{ gridTemplateColumns: `repeat(${count}, 1fr)` }}
         >
-          Weft Color
+          {Array.from({ length: count }, (_, i) => i + 1).map((n) => {
+            const active = pick.active.includes(n);
+            if (colorMode !== "theme" && active && weftHex) {
+              if (colorMode === "filled") {
+                const fg = contrastColor(weftHex);
+                return (
+                  <div key={n} style={{ backgroundColor: weftHex, borderColor: fg }}
+                    className="rounded-md border-2 flex items-center justify-center text-xs font-bold">
+                    <span style={{ color: fg }}>{n}</span>
+                  </div>
+                );
+              }
+              if (colorMode === "strip") {
+                return (
+                  <div key={n}
+                    className="rounded-md border-2 relative overflow-hidden border-primary bg-primary flex items-center justify-center text-xs font-bold">
+                    <span className="absolute bottom-0 left-0 right-0 h-[20%]"
+                      style={{ backgroundColor: weftHex }} />
+                    <span className="relative text-primary-foreground">{n}</span>
+                  </div>
+                );
+              }
+            }
+            return (
+              <div key={n}
+                className={`rounded-md border-2 flex items-center justify-center text-xs font-bold ${
+                  active
+                    ? "bg-primary border-primary text-primary-foreground"
+                    : "border-muted bg-muted/30 text-muted-foreground"
+                }`}>
+                {n}
+              </div>
+            );
+          })}
         </div>
-      )}
+
+        {showWeftColor && weftHex && (
+          <div
+            className="h-6 w-full shrink-0 rounded-md flex items-center justify-center text-xs font-semibold uppercase tracking-wider"
+            style={{ backgroundColor: weftHex, color: contrastColor(weftHex) }}
+          >
+            Weft Color
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -456,7 +463,7 @@ function StepControls({
       <button
         onClick={() => onJump(Math.max(1, currentPick - 10))}
         disabled={atStart || disabled}
-        className="hidden sm:flex h-12 w-12 items-center justify-center rounded-full border-2 border-input text-lg font-medium transition-colors hover:border-ring hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed"
+        className="hidden sm:flex h-12 w-12 items-center justify-center rounded-full border-2 border-primary/40 text-primary/70 text-lg font-medium transition-colors hover:border-primary hover:bg-primary/10 disabled:opacity-30 disabled:cursor-not-allowed"
         aria-label="Back 10 picks"
         title="Back 10"
       >
@@ -466,7 +473,7 @@ function StepControls({
       <button
         onClick={() => onStep("reverse")}
         disabled={atStart || disabled}
-        className="flex h-20 w-20 items-center justify-center rounded-full border-2 border-input text-3xl font-light transition-colors hover:border-ring hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed"
+        className="flex h-20 w-20 items-center justify-center rounded-full border-2 border-primary text-primary text-3xl font-light transition-colors hover:bg-primary hover:text-primary-foreground disabled:opacity-30 disabled:cursor-not-allowed"
         aria-label="Previous pick"
       >
         ‹
@@ -482,7 +489,7 @@ function StepControls({
       <button
         onClick={() => onStep("advance")}
         disabled={pastEnd || disabled}
-        className="flex h-20 w-20 items-center justify-center rounded-full border-2 border-input text-3xl font-light transition-colors hover:border-ring hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed"
+        className="flex h-20 w-20 items-center justify-center rounded-full border-2 border-primary text-primary text-3xl font-light transition-colors hover:bg-primary hover:text-primary-foreground disabled:opacity-30 disabled:cursor-not-allowed"
         aria-label="Next pick"
       >
         ›
@@ -492,7 +499,7 @@ function StepControls({
       <button
         onClick={() => onJump(Math.min(total + 1, currentPick + 10))}
         disabled={pastEnd || disabled}
-        className="hidden sm:flex h-12 w-12 items-center justify-center rounded-full border-2 border-input text-lg font-medium transition-colors hover:border-ring hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed"
+        className="hidden sm:flex h-12 w-12 items-center justify-center rounded-full border-2 border-primary/40 text-primary/70 text-lg font-medium transition-colors hover:border-primary hover:bg-primary/10 disabled:opacity-30 disabled:cursor-not-allowed"
         aria-label="Forward 10 picks"
         title="Forward 10"
       >
@@ -527,8 +534,8 @@ function JumpToPick({
   };
 
   return (
-    <form onSubmit={handleSubmit} className="flex items-center justify-center gap-2">
-      <label className="text-xs text-muted-foreground">Go to pick</label>
+    <form onSubmit={handleSubmit} className="flex items-center justify-center gap-3">
+      <label className="text-sm text-muted-foreground whitespace-nowrap">Go to pick</label>
       <input
         type="number"
         min={1}
@@ -536,13 +543,17 @@ function JumpToPick({
         value={value}
         onChange={(e) => setValue(e.target.value)}
         disabled={disabled}
-        className="w-20 rounded border border-input bg-background px-2 py-1 text-sm text-center focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-50 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none"
+        className="w-24 rounded-md border border-input bg-background px-3 py-1.5 text-sm text-center focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-50 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none"
         placeholder="—"
       />
       <button
         type="submit"
         disabled={disabled || !value}
-        className="text-xs text-muted-foreground hover:text-foreground disabled:opacity-30"
+        className={`rounded-md border px-3 py-1.5 text-sm font-medium transition-colors disabled:cursor-not-allowed ${
+          value && !disabled
+            ? "border-primary bg-primary text-primary-foreground hover:bg-primary/90"
+            : "border-input bg-background text-muted-foreground opacity-40"
+        }`}
       >
         Go
       </button>
@@ -558,7 +569,7 @@ function ProgressBar({ current, total }: { current: number; total: number }) {
   const pct = total > 0 ? Math.round((Math.min(current - 1, total) / total) * 100) : 0;
   return (
     <div>
-      <div className="mb-1 flex justify-between text-xs text-muted-foreground">
+      <div className="mb-1 flex justify-between text-sm text-muted-foreground">
         <span>{pct}% complete</span>
         <span>{Math.max(0, total - current + 1)} picks remaining</span>
       </div>
@@ -1065,64 +1076,72 @@ export function ActivityDetailPage() {
   const badgeLabel = isPlanning ? "Plan" : ACTIVITY_STATUS_LABELS[activity.status];
 
   return (
-    <div className="flex min-h-screen flex-col">
-      {/* Header */}
-      <header className="shrink-0 border-b px-6 py-4 flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <Link to="/activities" className="text-sm text-muted-foreground hover:text-foreground">
-            ← Activities
-          </Link>
-          <div className="flex items-center gap-2">
-            {editingName ? (
-              <form
-                onSubmit={async (e) => {
-                  e.preventDefault();
+    <div className="flex flex-col">
+      {/* Page header */}
+      <div className="shrink-0 border-b border-stone-200 bg-white px-6 py-3 flex items-center justify-between">
+        <div className="flex items-center gap-3 min-w-0">
+          {/* Breadcrumb — hidden on mobile/tablet, shown on desktop only */}
+          <div className="hidden lg:flex items-center gap-1.5 text-sm shrink-0">
+            {activity.loom_id && (
+              <>
+                <Link to="/looms" className="text-stone-500 hover:text-stone-900">Equipment</Link>
+                <ChevronRight className="h-3.5 w-3.5 text-stone-400" />
+              </>
+            )}
+            <Link to="/projects" className="text-stone-500 hover:text-stone-900">Projects</Link>
+            <ChevronRight className="h-3.5 w-3.5 text-stone-400" />
+            <Link to="/activities" className="text-stone-500 hover:text-stone-900">Activities</Link>
+            <ChevronRight className="h-3.5 w-3.5 text-stone-400" />
+          </div>
+          {editingName ? (
+            <form
+              onSubmit={async (e) => {
+                e.preventDefault();
+                const trimmed = nameInput.trim();
+                if (!trimmed) { setEditingName(false); return; }
+                const updated = await renameActivity(id!, trimmed);
+                queryClient.setQueryData<typeof activity>(["activity", id], (old) =>
+                  old ? { ...updated, photos: old.photos } : updated
+                );
+                queryClient.invalidateQueries({ queryKey: ["activities"] });
+                setEditingName(false);
+              }}
+              className="flex items-center gap-2 min-w-0"
+            >
+              <input
+                autoFocus
+                className="rounded border border-input bg-background px-2 py-0.5 text-sm font-semibold focus:outline-none focus:ring-1 focus:ring-ring"
+                value={nameInput}
+                onChange={(e) => setNameInput(e.target.value)}
+                onKeyDown={(e) => { if (e.key === "Escape") setEditingName(false); }}
+                onBlur={async () => {
                   const trimmed = nameInput.trim();
-                  if (!trimmed) { setEditingName(false); return; }
-                  const updated = await renameActivity(id!, trimmed);
-                  queryClient.setQueryData<typeof activity>(["activity", id], (old) =>
-                    old ? { ...updated, photos: old.photos } : updated
-                  );
-                  queryClient.invalidateQueries({ queryKey: ["activities"] });
+                  if (trimmed && trimmed !== activity.name) {
+                    const updated = await renameActivity(id!, trimmed);
+                    queryClient.setQueryData<typeof activity>(["activity", id], (old) =>
+                      old ? { ...updated, photos: old.photos } : updated
+                    );
+                    queryClient.invalidateQueries({ queryKey: ["activities"] });
+                  }
                   setEditingName(false);
                 }}
-                className="flex items-center gap-2"
-              >
-                <input
-                  autoFocus
-                  className="rounded border border-input bg-background px-2 py-0.5 text-sm font-semibold focus:outline-none focus:ring-1 focus:ring-ring"
-                  value={nameInput}
-                  onChange={(e) => setNameInput(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === "Escape") setEditingName(false); }}
-                  onBlur={async () => {
-                    const trimmed = nameInput.trim();
-                    if (trimmed && trimmed !== activity.name) {
-                      const updated = await renameActivity(id!, trimmed);
-                      queryClient.setQueryData<typeof activity>(["activity", id], (old) =>
-                        old ? { ...updated, photos: old.photos } : updated
-                      );
-                      queryClient.invalidateQueries({ queryKey: ["activities"] });
-                    }
-                    setEditingName(false);
-                  }}
-                />
-              </form>
-            ) : (
-              <button
-                onClick={() => { setNameInput(activity.name); setEditingName(true); }}
-                className="font-semibold hover:underline decoration-dashed underline-offset-2 cursor-text"
-                title="Click to rename"
-              >
-                {activity.name}
-              </button>
-            )}
-            <span className="text-sm text-muted-foreground">{activity.project_name}</span>
-          </div>
+              />
+            </form>
+          ) : (
+            <button
+              onClick={() => { setNameInput(activity.name); setEditingName(true); }}
+              className="font-semibold hover:underline decoration-dashed underline-offset-2 cursor-text truncate"
+              title="Click to rename"
+            >
+              {activity.name}
+            </button>
+          )}
+          <span className="text-sm text-muted-foreground truncate hidden sm:block">{activity.project_name}</span>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 shrink-0">
           <button
             onClick={() => setShowDesignPreview(true)}
-            className="text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+            className="rounded-md border border-primary/30 bg-primary/5 px-3 py-1.5 text-xs font-medium text-primary transition-colors hover:bg-primary/10"
             title="View WIF design preview"
           >
             View design
@@ -1131,10 +1150,10 @@ export function ActivityDetailPage() {
             {badgeLabel}
           </span>
         </div>
-      </header>
+      </div>
 
       {/* Main */}
-      <main className="flex-1 overflow-y-auto">
+      <div className="flex-1 overflow-y-auto">
         {/* Completed summary */}
         {isCompleted && (
           <CompletedSummary
@@ -1181,25 +1200,28 @@ export function ActivityDetailPage() {
           </div>
         )}
 
-        {/* Progress + color mode */}
-        <div className="mx-auto max-w-2xl px-8 pt-6 space-y-3">
-          {!isPlanning && !isCompleted && <ProgressBar current={activity.current_pick} total={activity.total_picks} />}
-          {picksData?.has_weft_colors && !isFinished && !isCompleted && (
-            <div className="flex items-center justify-end gap-4">
-              <label className="flex items-center gap-2 cursor-pointer select-none">
-                <span className="text-xs text-muted-foreground">Weft color</span>
-                <button
-                  role="switch"
-                  aria-checked={showWeftColor}
-                  onClick={() => setShowWeftColor((v) => !v)}
-                  className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 ${showWeftColor ? "bg-primary" : "bg-muted"}`}
-                >
-                  <span className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform ${showWeftColor ? "translate-x-4" : "translate-x-1"}`} />
-                </button>
-              </label>
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-muted-foreground">Color mode</span>
-                <div className="inline-flex rounded-md border border-input overflow-hidden text-xs">
+        {/* Progress bar + color controls — same row to save vertical space */}
+        {(!isPlanning && !isCompleted) || (picksData?.has_weft_colors && !isFinished && !isCompleted) ? (
+          <div className="mx-auto max-w-2xl px-8 pt-6 flex items-center gap-4">
+            {!isPlanning && !isCompleted && (
+              <div className="flex-1">
+                <ProgressBar current={activity.current_pick} total={activity.total_picks} />
+              </div>
+            )}
+            {picksData?.has_weft_colors && !isFinished && !isCompleted && (
+              <div className="shrink-0 flex items-center gap-3">
+                <label className="flex items-center gap-2 cursor-pointer select-none">
+                  <span className="text-sm text-muted-foreground">Weft</span>
+                  <button
+                    role="switch"
+                    aria-checked={showWeftColor}
+                    onClick={() => setShowWeftColor((v) => !v)}
+                    className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 ${showWeftColor ? "bg-primary" : "bg-muted"}`}
+                  >
+                    <span className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform ${showWeftColor ? "translate-x-4" : "translate-x-1"}`} />
+                  </button>
+                </label>
+                <div className="inline-flex rounded-md border border-input overflow-hidden text-sm">
                   {(["theme", "strip", "filled"] as ColorMode[]).map((mode) => (
                     <button
                       key={mode}
@@ -1215,9 +1237,9 @@ export function ActivityDetailPage() {
                   ))}
                 </div>
               </div>
-            </div>
-          )}
-        </div>
+            )}
+          </div>
+        ) : null}
 
         {/* Pick instruction — stays compact */}
         {!isCompleted && <div className="mx-auto max-w-2xl px-8 pt-4">
@@ -1281,27 +1303,34 @@ export function ActivityDetailPage() {
         )}
 
         {/* Step controls — active tracking and planning */}
-        <div className="mx-auto max-w-lg px-8 pb-6 space-y-6">
+        <div className="w-full px-4 pb-6">
           {(isActiveTracking || isPlanning) && !isFinished && (
-            <StepControls
-              currentPick={displayPick}
-              total={activity.total_picks}
-              onStep={isPlanning ? handleLocalStep : handleStep}
-              onJump={isPlanning ? handleLocalJump : handleJump}
-              stepping={stepping}
-            />
-          )}
-
-          {(isActiveTracking || isPlanning) && !isFinished && (
-            <JumpToPick
-              total={activity.total_picks}
-              onJump={isPlanning ? handleLocalJump : handleJump}
-              disabled={stepping}
-            />
+            <div className="flex flex-col gap-6 lg:grid lg:grid-cols-[1fr_auto_1fr] lg:items-center lg:gap-8 mb-4">
+              {/* Left 1/3 on desktop, below step buttons on mobile */}
+              <div className="order-2 lg:order-1 lg:flex lg:justify-center">
+                <JumpToPick
+                  total={activity.total_picks}
+                  onJump={isPlanning ? handleLocalJump : handleJump}
+                  disabled={stepping}
+                />
+              </div>
+              {/* Center 1/3 on desktop, top on mobile */}
+              <div className="order-1 lg:order-2 flex justify-center">
+                <StepControls
+                  currentPick={displayPick}
+                  total={activity.total_picks}
+                  onStep={isPlanning ? handleLocalStep : handleStep}
+                  onJump={isPlanning ? handleLocalJump : handleJump}
+                  stepping={stepping}
+                />
+              </div>
+              {/* Right 1/3 reserved for future use */}
+              <div className="hidden lg:block lg:order-3" />
+            </div>
           )}
 
           {(isActiveTracking || isPlanning) && (
-            <p className="text-center text-xs text-muted-foreground">
+            <p className="text-center text-sm text-muted-foreground">
               ← → arrow keys or spacebar to navigate picks
             </p>
           )}
@@ -1485,7 +1514,7 @@ export function ActivityDetailPage() {
             )}
           </CollapsibleSection>
         </div>
-      </main>
+      </div>
 
       {showDesignPreview && (
         <DesignPreviewModal
@@ -1498,6 +1527,11 @@ export function ActivityDetailPage() {
         <AssignLoomModal
           activityId={activity.id}
           activeActivities={allActivities.filter((a) => a.status === "active")}
+          activityType={activity.activity_type}
+          projectNumTreadles={activity.project_num_treadles}
+          projectNumShafts={activity.project_num_shafts}
+          projectEffectiveNumTreadles={activity.project_effective_num_treadles}
+          projectEffectiveNumShafts={activity.project_effective_num_shafts}
           onSuccess={() => {
             setShowAssignLoom(false);
             invalidate();

--- a/frontend/src/pages/ActivityDetailPage.tsx
+++ b/frontend/src/pages/ActivityDetailPage.tsx
@@ -1364,6 +1364,20 @@ export function ActivityDetailPage() {
               {activity.loom_name && (
                 <><dt className="text-muted-foreground">Loom</dt><dd>{activity.loom_name}</dd></>
               )}
+              {activity.project_metadata_overrides?.num_treadles && (
+                <><dt className="text-muted-foreground">Treadle count</dt>
+                <dd className="flex items-center gap-1.5">
+                  {activity.project_num_treadles}
+                  <span className="text-xs text-muted-foreground">(overridden from {activity.project_metadata_overrides.num_treadles.original})</span>
+                </dd></>
+              )}
+              {activity.project_metadata_overrides?.num_shafts && (
+                <><dt className="text-muted-foreground">Shaft count</dt>
+                <dd className="flex items-center gap-1.5">
+                  {activity.project_num_shafts}
+                  <span className="text-xs text-muted-foreground">(overridden from {activity.project_metadata_overrides.num_shafts.original})</span>
+                </dd></>
+              )}
               {activity.num_items > 1 && (
                 <><dt className="text-muted-foreground">Items</dt><dd>{activity.num_items}</dd></>
               )}

--- a/frontend/src/pages/ActivityDetailPage.tsx
+++ b/frontend/src/pages/ActivityDetailPage.tsx
@@ -570,8 +570,8 @@ function ProgressBar({ current, total }: { current: number; total: number }) {
   return (
     <div>
       <div className="mb-1 flex justify-between text-sm text-muted-foreground">
-        <span>{pct}% complete</span>
-        <span>{Math.max(0, total - current + 1)} picks remaining</span>
+        <span>{pct}%<span className="hidden sm:inline"> complete</span></span>
+        <span>{Math.max(0, total - current + 1)} picks<span className="hidden sm:inline"> remaining</span></span>
       </div>
       <div className="h-2 w-full rounded-full bg-muted overflow-hidden">
         <div className="h-full rounded-full bg-primary transition-all duration-300" style={{ width: `${pct}%` }} />

--- a/frontend/src/pages/ActivityDetailPage.tsx
+++ b/frontend/src/pages/ActivityDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
-import { ChevronRight, Footprints, ChevronsUp } from "lucide-react";
+import { AppIcons } from "@/lib/icons";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   getActivity, getActivityPicks, stepActivity, jumpActivity, completeActivity, abandonActivity,
@@ -112,9 +112,9 @@ function PickDisplay({
       {/* Activity type icon — centered vertically */}
       <div className="shrink-0 flex items-center text-primary/50">
         {activityType === "lift" ? (
-          <ChevronsUp className="h-8 w-8" strokeWidth={1.5} />
+          <AppIcons.lift className="h-8 w-8" strokeWidth={1.5} />
         ) : (
-          <Footprints className="h-8 w-8" strokeWidth={1.5} />
+          <AppIcons.treadle className="h-8 w-8" strokeWidth={1.5} />
         )}
       </div>
 
@@ -1085,13 +1085,13 @@ export function ActivityDetailPage() {
             {activity.loom_id && (
               <>
                 <Link to="/looms" className="text-stone-500 hover:text-stone-900">Equipment</Link>
-                <ChevronRight className="h-3.5 w-3.5 text-stone-400" />
+                <AppIcons.chevronRight className="h-3.5 w-3.5 text-stone-400" />
               </>
             )}
             <Link to="/projects" className="text-stone-500 hover:text-stone-900">Projects</Link>
-            <ChevronRight className="h-3.5 w-3.5 text-stone-400" />
+            <AppIcons.chevronRight className="h-3.5 w-3.5 text-stone-400" />
             <Link to="/activities" className="text-stone-500 hover:text-stone-900">Activities</Link>
-            <ChevronRight className="h-3.5 w-3.5 text-stone-400" />
+            <AppIcons.chevronRight className="h-3.5 w-3.5 text-stone-400" />
           </div>
           {editingName ? (
             <form

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1,8 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import { UserDetailModal, type UserDetailTarget } from "@/components/admin/UserDetailModal";
-import { Link } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useClerk } from "@clerk/clerk-react";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/useAuth";
 import {
@@ -65,33 +63,15 @@ function formatUptime(seconds: number): string {
 export function AdminPage() {
   const [tab, setTab] = useState<Tab>("users");
   const { user: currentUser } = useAuth();
-  const { signOut } = useClerk();
 
   return (
-    <div className="flex min-h-screen flex-col">
-      <header className="border-b px-6 py-4 flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          {!currentUser?.is_superuser && (
-            <Link to="/" className="text-sm text-muted-foreground hover:text-foreground">
-              ← Dashboard
-            </Link>
-          )}
-          <span className="font-semibold">Admin</span>
-          {currentUser?.is_superuser && (
-            <span className="text-xs border rounded px-1.5 py-0.5 text-muted-foreground">superuser</span>
-          )}
-        </div>
+    <div className="p-6 max-w-4xl mx-auto w-full space-y-6">
+      <div className="flex items-center gap-3">
+        <h1 className="text-xl font-semibold">Admin</h1>
         {currentUser?.is_superuser && (
-          <button
-            onClick={() => signOut()}
-            className="text-sm text-muted-foreground hover:text-foreground"
-          >
-            Sign out
-          </button>
+          <span className="text-xs border rounded px-1.5 py-0.5 text-muted-foreground">superuser</span>
         )}
-      </header>
-
-      <main className="flex-1 p-6 max-w-4xl mx-auto w-full space-y-6">
+      </div>
         <div className="flex gap-2 border-b pb-2 flex-wrap">
           {(["users", "invites", "stats", "health", "services", "audit"] as Tab[]).map((t) => (
             <button
@@ -127,7 +107,6 @@ export function AdminPage() {
         {tab === "services" && <ServicesTab />}
         {tab === "audit" && <AuditLogTab />}
         {tab === "superuser" && <SuperuserTab />}
-      </main>
     </div>
   );
 }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,15 +1,12 @@
 import { useAuth } from "@/hooks/useAuth";
-import { useClerk } from "@clerk/clerk-react";
 import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { Button } from "@/components/ui/button";
 import { listActivities, ACTIVITY_TYPE_LABELS } from "@/api/activities";
 import { listProjects } from "@/api/projects";
 import { listLooms } from "@/api/looms";
 
 export function DashboardPage() {
   const { user } = useAuth();
-  const { signOut } = useClerk();
 
   const { data: activities = [] } = useQuery({
     queryKey: ["activities"],
@@ -26,236 +23,214 @@ export function DashboardPage() {
     queryFn: listLooms,
   });
 
-  const handleLogout = () => signOut();
-
   const activeActivities = activities.filter((a) => a.status === "active" && !!a.loom_id);
   const planningActivities = activities.filter((a) => a.status === "active" && !a.loom_id);
   const completedCount = activities.filter((a) => a.status === "completed").length;
 
   return (
-    <div className="flex min-h-screen flex-col">
-      <header className="border-b px-6 py-4 flex items-center justify-between">
-        <span className="font-semibold">Weaving Tracker</span>
-        <div className="flex items-center gap-4">
-          <span className="text-sm text-muted-foreground">{user?.email}</span>
-          <Link to="/settings" className="text-sm text-muted-foreground hover:text-foreground">
-            Settings
+    <div className="p-6 max-w-3xl mx-auto w-full space-y-8">
+      <div>
+        <h1 className="text-xl font-semibold">Dashboard</h1>
+        <p className="mt-1 text-sm text-muted-foreground">Welcome back, {user?.display_name}.</p>
+      </div>
+
+      {/* Equipment */}
+      <section>
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">Equipment</h2>
+          <Link to="/looms" className="text-xs text-muted-foreground hover:text-foreground">
+            View all →
           </Link>
-          {user?.is_admin && (
-            <Link to="/admin" className="text-sm text-muted-foreground hover:text-foreground">
-              Admin
-            </Link>
-          )}
-          <Button variant="outline" size="sm" onClick={handleLogout}>
-            Sign out
-          </Button>
         </div>
-      </header>
+        {looms.length === 0 ? (
+          <div className="rounded-lg border border-dashed p-6 text-center">
+            <p className="text-sm text-muted-foreground">No looms added yet.</p>
+            <Link to="/looms" className="mt-2 inline-block text-sm text-foreground underline underline-offset-2">
+              Add your first loom →
+            </Link>
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            {looms.slice(0, 3).map((loom) => (
+              <Link
+                key={loom.id}
+                to="/looms"
+                className="rounded-lg border p-4 hover:border-ring transition-colors"
+              >
+                <p className="text-sm font-medium truncate">{loom.model_name}</p>
+                <p className="mt-0.5 text-xs text-muted-foreground truncate">{loom.manufacturer}</p>
+              </Link>
+            ))}
+            {looms.length > 3 && (
+              <Link
+                to="/looms"
+                className="rounded-lg border border-dashed p-4 flex items-center justify-center hover:border-ring transition-colors"
+              >
+                <span className="text-xs text-muted-foreground">+{looms.length - 3} more</span>
+              </Link>
+            )}
+          </div>
+        )}
+      </section>
 
-      <main className="flex-1 p-6 max-w-3xl mx-auto w-full space-y-8">
-        <div>
-          <h1 className="text-xl font-semibold">Dashboard</h1>
-          <p className="mt-1 text-sm text-muted-foreground">Welcome back, {user?.display_name}.</p>
+      {/* Projects */}
+      <section>
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">Projects</h2>
+          <Link to="/projects" className="text-xs text-muted-foreground hover:text-foreground">
+            View all →
+          </Link>
+        </div>
+        {projects.length === 0 ? (
+          <div className="rounded-lg border border-dashed p-6 text-center">
+            <p className="text-sm text-muted-foreground">No projects uploaded yet.</p>
+            <Link to="/projects" className="mt-2 inline-block text-sm text-foreground underline underline-offset-2">
+              Upload a WIF file →
+            </Link>
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            {projects.slice(0, 3).map((project) => (
+              <Link
+                key={project.id}
+                to="/projects"
+                className="rounded-lg border p-4 hover:border-ring transition-colors"
+              >
+                <p className="text-sm font-medium truncate">{project.name}</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">{project.wif_filename}</p>
+              </Link>
+            ))}
+            {projects.length > 3 && (
+              <Link
+                to="/projects"
+                className="rounded-lg border border-dashed p-4 flex items-center justify-center hover:border-ring transition-colors"
+              >
+                <span className="text-xs text-muted-foreground">+{projects.length - 3} more</span>
+              </Link>
+            )}
+          </div>
+        )}
+      </section>
+
+      {/* Activities */}
+      <section>
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">Activities</h2>
+          <Link to="/activities" className="text-xs text-muted-foreground hover:text-foreground">
+            View all →
+          </Link>
         </div>
 
-        {/* Equipment */}
-        <section>
-          <div className="mb-3 flex items-center justify-between">
-            <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">Equipment</h2>
-            <Link to="/looms" className="text-xs text-muted-foreground hover:text-foreground">
-              View all →
-            </Link>
-          </div>
-          {looms.length === 0 ? (
-            <div className="rounded-lg border border-dashed p-6 text-center">
-              <p className="text-sm text-muted-foreground">No looms added yet.</p>
-              <Link to="/looms" className="mt-2 inline-block text-sm text-foreground underline underline-offset-2">
-                Add your first loom →
-              </Link>
-            </div>
-          ) : (
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-              {looms.slice(0, 3).map((loom) => (
-                <Link
-                  key={loom.id}
-                  to="/looms"
-                  className="rounded-lg border p-4 hover:border-ring transition-colors"
-                >
-                  <p className="text-sm font-medium truncate">{loom.model_name}</p>
-                  <p className="mt-0.5 text-xs text-muted-foreground truncate">{loom.manufacturer}</p>
-                </Link>
-              ))}
-              {looms.length > 3 && (
-                <Link
-                  to="/looms"
-                  className="rounded-lg border border-dashed p-4 flex items-center justify-center hover:border-ring transition-colors"
-                >
-                  <span className="text-xs text-muted-foreground">+{looms.length - 3} more</span>
-                </Link>
-              )}
-            </div>
-          )}
-        </section>
-
-        {/* Projects */}
-        <section>
-          <div className="mb-3 flex items-center justify-between">
-            <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">Projects</h2>
-            <Link to="/projects" className="text-xs text-muted-foreground hover:text-foreground">
-              View all →
-            </Link>
-          </div>
-          {projects.length === 0 ? (
-            <div className="rounded-lg border border-dashed p-6 text-center">
-              <p className="text-sm text-muted-foreground">No projects uploaded yet.</p>
-              <Link to="/projects" className="mt-2 inline-block text-sm text-foreground underline underline-offset-2">
-                Upload a WIF file →
-              </Link>
-            </div>
-          ) : (
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-              {projects.slice(0, 3).map((project) => (
-                <Link
-                  key={project.id}
-                  to="/projects"
-                  className="rounded-lg border p-4 hover:border-ring transition-colors"
-                >
-                  <p className="text-sm font-medium truncate">{project.name}</p>
-                  <p className="mt-0.5 text-xs text-muted-foreground">{project.wif_filename}</p>
-                </Link>
-              ))}
-              {projects.length > 3 && (
-                <Link
-                  to="/projects"
-                  className="rounded-lg border border-dashed p-4 flex items-center justify-center hover:border-ring transition-colors"
-                >
-                  <span className="text-xs text-muted-foreground">+{projects.length - 3} more</span>
-                </Link>
-              )}
-            </div>
-          )}
-        </section>
-
-        {/* Activities */}
-        <section>
-          <div className="mb-3 flex items-center justify-between">
-            <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">Activities</h2>
-            <Link to="/activities" className="text-xs text-muted-foreground hover:text-foreground">
-              View all →
-            </Link>
-          </div>
-
-          {activeActivities.length > 0 && (
-            <div className="space-y-3 mb-3">
-              {activeActivities.map((a) => {
-                const pct =
-                  a.total_picks > 0
-                    ? Math.round((Math.min(a.current_pick - 1, a.total_picks) / a.total_picks) * 100)
-                    : 0;
-                return (
-                  <Link
-                    key={a.id}
-                    to={`/activities/${a.id}`}
-                    className="flex items-center gap-4 rounded-lg border p-4 hover:border-ring transition-colors"
-                  >
-                    <div className="flex-1 min-w-0">
-                      <p className="font-medium truncate">{a.name}</p>
-                      <p className="text-xs text-muted-foreground mt-0.5">
-                        {ACTIVITY_TYPE_LABELS[a.activity_type]}
-                      </p>
-                      <div className="mt-2">
-                        <div className="mb-1 flex justify-between text-xs text-muted-foreground">
-                          <span>
-                            Pick {Math.min(a.current_pick, a.total_picks)} of {a.total_picks}
-                          </span>
-                          <span>{pct}%</span>
-                        </div>
-                        <div className="h-1.5 w-full rounded-full bg-muted overflow-hidden">
-                          <div
-                            className="h-full rounded-full bg-primary transition-all"
-                            style={{ width: `${pct}%` }}
-                          />
-                        </div>
-                      </div>
-                    </div>
-                    <span className="shrink-0 text-sm text-muted-foreground">Continue →</span>
-                  </Link>
-                );
-              })}
-            </div>
-          )}
-
-          {planningActivities.length > 0 && (
-            <div className="space-y-2 mb-3">
-              {planningActivities.map((a) => (
+        {activeActivities.length > 0 && (
+          <div className="space-y-3 mb-3">
+            {activeActivities.map((a) => {
+              const pct =
+                a.total_picks > 0
+                  ? Math.round((Math.min(a.current_pick - 1, a.total_picks) / a.total_picks) * 100)
+                  : 0;
+              return (
                 <Link
                   key={a.id}
                   to={`/activities/${a.id}`}
-                  className="flex items-center justify-between rounded-lg border px-4 py-3 hover:border-ring transition-colors"
+                  className="flex items-center gap-4 rounded-lg border p-4 hover:border-ring transition-colors"
                 >
-                  <div>
-                    <p className="text-sm font-medium">{a.name}</p>
-                    <p className="text-xs text-muted-foreground">{a.total_picks} picks planned</p>
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium truncate">{a.name}</p>
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      {ACTIVITY_TYPE_LABELS[a.activity_type]}
+                    </p>
+                    <div className="mt-2">
+                      <div className="mb-1 flex justify-between text-xs text-muted-foreground">
+                        <span>
+                          Pick {Math.min(a.current_pick, a.total_picks)} of {a.total_picks}
+                        </span>
+                        <span>{pct}%</span>
+                      </div>
+                      <div className="h-1.5 w-full rounded-full bg-muted overflow-hidden">
+                        <div
+                          className="h-full rounded-full bg-primary transition-all"
+                          style={{ width: `${pct}%` }}
+                        />
+                      </div>
+                    </div>
                   </div>
-                  <span className="rounded px-1.5 py-0.5 text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
-                    Plan
-                  </span>
+                  <span className="shrink-0 text-sm text-muted-foreground">Continue →</span>
                 </Link>
-              ))}
-            </div>
-          )}
+              );
+            })}
+          </div>
+        )}
 
-          {activeActivities.length === 0 && planningActivities.length === 0 && (
-            <div className="rounded-lg border border-dashed p-6 text-center">
-              <p className="text-sm text-muted-foreground">No active activities.</p>
+        {planningActivities.length > 0 && (
+          <div className="space-y-2 mb-3">
+            {planningActivities.map((a) => (
               <Link
-                to="/activities"
-                className="mt-2 inline-block text-sm text-foreground underline underline-offset-2"
+                key={a.id}
+                to={`/activities/${a.id}`}
+                className="flex items-center justify-between rounded-lg border px-4 py-3 hover:border-ring transition-colors"
               >
-                Start or plan an activity →
+                <div>
+                  <p className="text-sm font-medium">{a.name}</p>
+                  <p className="text-xs text-muted-foreground">{a.total_picks} picks planned</p>
+                </div>
+                <span className="rounded px-1.5 py-0.5 text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+                  Plan
+                </span>
               </Link>
-            </div>
-          )}
+            ))}
+          </div>
+        )}
 
-          <div className="mt-3 grid grid-cols-2 gap-3">
-            <div className="rounded-lg border p-4 text-center">
-              <p className="text-2xl font-bold tabular-nums">{completedCount}</p>
-              <p className="mt-1 text-xs text-muted-foreground">Completed</p>
-            </div>
-            <div className="rounded-lg border p-4 text-center">
-              <p className="text-2xl font-bold tabular-nums">{activities.length}</p>
-              <p className="mt-1 text-xs text-muted-foreground">Total activities</p>
-            </div>
+        {activeActivities.length === 0 && planningActivities.length === 0 && (
+          <div className="rounded-lg border border-dashed p-6 text-center">
+            <p className="text-sm text-muted-foreground">No active activities.</p>
+            <Link
+              to="/activities"
+              className="mt-2 inline-block text-sm text-foreground underline underline-offset-2"
+            >
+              Start or plan an activity →
+            </Link>
+          </div>
+        )}
+
+        <div className="mt-3 grid grid-cols-2 gap-3">
+          <div className="rounded-lg border p-4 text-center">
+            <p className="text-2xl font-bold tabular-nums">{completedCount}</p>
+            <p className="mt-1 text-xs text-muted-foreground">Completed</p>
+          </div>
+          <div className="rounded-lg border p-4 text-center">
+            <p className="text-2xl font-bold tabular-nums">{activities.length}</p>
+            <p className="mt-1 text-xs text-muted-foreground">Total activities</p>
+          </div>
+        </div>
+      </section>
+
+      {/* Storage */}
+      {user && (
+        <section>
+          <h2 className="mb-3 text-sm font-medium text-muted-foreground uppercase tracking-wide">Storage</h2>
+          <div className="rounded-lg border p-4">
+            {(() => {
+              const usedMB = user.storage_used_bytes / (1024 * 1024);
+              const quotaMB = user.storage_quota_bytes / (1024 * 1024);
+              const pct = Math.min(Math.round((user.storage_used_bytes / user.storage_quota_bytes) * 100), 100);
+              const barColor = pct >= 90 ? "bg-red-500" : pct >= 75 ? "bg-amber-500" : "bg-primary";
+              return (
+                <>
+                  <div className="mb-2 flex justify-between text-sm">
+                    <span>{usedMB < 1 ? `${Math.round(usedMB * 1024)} KB` : `${usedMB.toFixed(1)} MB`} used</span>
+                    <span className="text-muted-foreground">{Math.round(quotaMB)} MB total</span>
+                  </div>
+                  <div className="h-2 w-full rounded-full bg-muted overflow-hidden">
+                    <div className={`h-full rounded-full transition-all ${barColor}`} style={{ width: `${pct}%` }} />
+                  </div>
+                  <p className="mt-1.5 text-xs text-muted-foreground text-right">{pct}% used</p>
+                </>
+              );
+            })()}
           </div>
         </section>
-
-        {/* Storage */}
-        {user && (
-          <section>
-            <h2 className="mb-3 text-sm font-medium text-muted-foreground uppercase tracking-wide">Storage</h2>
-            <div className="rounded-lg border p-4">
-              {(() => {
-                const usedMB = user.storage_used_bytes / (1024 * 1024);
-                const quotaMB = user.storage_quota_bytes / (1024 * 1024);
-                const pct = Math.min(Math.round((user.storage_used_bytes / user.storage_quota_bytes) * 100), 100);
-                const barColor = pct >= 90 ? "bg-red-500" : pct >= 75 ? "bg-amber-500" : "bg-primary";
-                return (
-                  <>
-                    <div className="mb-2 flex justify-between text-sm">
-                      <span>{usedMB < 1 ? `${Math.round(usedMB * 1024)} KB` : `${usedMB.toFixed(1)} MB`} used</span>
-                      <span className="text-muted-foreground">{Math.round(quotaMB)} MB total</span>
-                    </div>
-                    <div className="h-2 w-full rounded-full bg-muted overflow-hidden">
-                      <div className={`h-full rounded-full transition-all ${barColor}`} style={{ width: `${pct}%` }} />
-                    </div>
-                    <p className="mt-1.5 text-xs text-muted-foreground text-right">{pct}% used</p>
-                  </>
-                );
-              })()}
-            </div>
-          </section>
-        )}
-      </main>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { listActivities, ACTIVITY_TYPE_LABELS } from "@/api/activities";
 import { listProjects } from "@/api/projects";
 import { listLooms } from "@/api/looms";
+import { AppIcons } from "@/lib/icons";
 
 export function DashboardPage() {
   const { user } = useAuth();
@@ -55,10 +56,19 @@ export function DashboardPage() {
               <Link
                 key={loom.id}
                 to="/looms"
-                className="rounded-lg border p-4 hover:border-ring transition-colors"
+                className="rounded-lg border p-4 hover:border-ring transition-colors flex items-start gap-3"
               >
-                <p className="text-sm font-medium truncate">{loom.model_name}</p>
-                <p className="mt-0.5 text-xs text-muted-foreground truncate">{loom.manufacturer}</p>
+                <div className="shrink-0 mt-0.5">
+                  {loom.supports_lift_tracking
+                    ? <AppIcons.lift className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
+                    : loom.supports_treadle_tracking
+                      ? <AppIcons.treadle className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
+                      : <AppIcons.equipment className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />}
+                </div>
+                <div className="min-w-0">
+                  <p className="text-sm font-medium truncate">{loom.model_name}</p>
+                  <p className="mt-0.5 text-xs text-muted-foreground truncate">{loom.manufacturer}</p>
+                </div>
               </Link>
             ))}
             {looms.length > 3 && (
@@ -134,6 +144,11 @@ export function DashboardPage() {
                   to={`/activities/${a.id}`}
                   className="flex items-center gap-4 rounded-lg border p-4 hover:border-ring transition-colors"
                 >
+                  <div className="shrink-0">
+                    {a.activity_type === "treadle"
+                      ? <AppIcons.treadle className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
+                      : <AppIcons.lift className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />}
+                  </div>
                   <div className="flex-1 min-w-0">
                     <p className="font-medium truncate">{a.name}</p>
                     <p className="text-xs text-muted-foreground mt-0.5">
@@ -167,9 +182,10 @@ export function DashboardPage() {
               <Link
                 key={a.id}
                 to={`/activities/${a.id}`}
-                className="flex items-center justify-between rounded-lg border px-4 py-3 hover:border-ring transition-colors"
+                className="flex items-center gap-4 rounded-lg border px-4 py-3 hover:border-ring transition-colors"
               >
-                <div>
+                <AppIcons.planning className="h-6 w-6 text-muted-foreground shrink-0" strokeWidth={1.75} />
+                <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium">{a.name}</p>
                   <p className="text-xs text-muted-foreground">{a.total_picks} picks planned</p>
                 </div>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -104,10 +104,15 @@ export function DashboardPage() {
               <Link
                 key={project.id}
                 to="/projects"
-                className="rounded-lg border p-4 hover:border-ring transition-colors"
+                className="rounded-lg border p-4 hover:border-ring transition-colors flex items-start gap-3"
               >
-                <p className="text-sm font-medium truncate">{project.name}</p>
-                <p className="mt-0.5 text-xs text-muted-foreground">{project.wif_filename}</p>
+                <div className="shrink-0 mt-0.5">
+                  <AppIcons.project className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
+                </div>
+                <div className="min-w-0">
+                  <p className="text-sm font-medium truncate">{project.name}</p>
+                  <p className="mt-0.5 text-xs text-muted-foreground truncate">{project.wif_filename}</p>
+                </div>
               </Link>
             ))}
             {projects.length > 3 && (
@@ -210,13 +215,19 @@ export function DashboardPage() {
         )}
 
         <div className="mt-3 grid grid-cols-2 gap-3">
-          <div className="rounded-lg border p-4 text-center">
-            <p className="text-2xl font-bold tabular-nums">{completedCount}</p>
-            <p className="mt-1 text-xs text-muted-foreground">Completed</p>
+          <div className="rounded-lg border p-4 flex items-center gap-3">
+            <AppIcons.activityCompleted className="h-6 w-6 text-muted-foreground shrink-0" strokeWidth={1.75} />
+            <div>
+              <p className="text-2xl font-bold tabular-nums">{completedCount}</p>
+              <p className="text-xs text-muted-foreground">Completed</p>
+            </div>
           </div>
-          <div className="rounded-lg border p-4 text-center">
-            <p className="text-2xl font-bold tabular-nums">{activities.length}</p>
-            <p className="mt-1 text-xs text-muted-foreground">Total activities</p>
+          <div className="rounded-lg border p-4 flex items-center gap-3">
+            <AppIcons.activityActive className="h-6 w-6 text-muted-foreground shrink-0" strokeWidth={1.75} />
+            <div>
+              <p className="text-2xl font-bold tabular-nums">{activeActivities.length + planningActivities.length}</p>
+              <p className="text-xs text-muted-foreground">Active</p>
+            </div>
           </div>
         </div>
       </section>

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -6,7 +6,7 @@ import { PublicFooter } from "@/components/PublicFooter";
 const FEATURES = [
   {
     title: "Track your weaves",
-    body: "Upload your WIF draft and step through every pick. Weftmark keeps your place so you can put down the shuttle and pick it right back up.",
+    body: "Upload your WIF draft and step through every pick. weftmark keeps your place so you can put down the shuttle and pick it right back up.",
     Icon: Layers,
   },
   {
@@ -40,7 +40,7 @@ export function LandingPage() {
         <div className="mx-auto flex max-w-6xl items-center justify-between">
           <div className="flex items-center gap-2.5">
             <WeftmarkLogo className="h-7 w-auto text-zinc-800" />
-            <span className="text-base font-semibold tracking-tight">Weftmark</span>
+            <span className="text-base font-semibold tracking-tight" style={{ fontFamily: '"Segoe UI", system-ui, sans-serif' }}>weftmark</span>
           </div>
           <Link
             to="/login"

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { Layers, CheckSquare, Wrench } from "lucide-react";
+import { AppIcons } from "@/lib/icons";
 import { WeftmarkLogo } from "@/components/WeftmarkLogo";
 import { PublicFooter } from "@/components/PublicFooter";
 
@@ -7,17 +7,17 @@ const FEATURES = [
   {
     title: "Track your weaves",
     body: "Upload your WIF draft and step through every pick. weftmark keeps your place so you can put down the shuttle and pick it right back up.",
-    Icon: Layers,
+    Icon: AppIcons.designLibrary,
   },
   {
     title: "Record every pick",
     body: "Advance, reverse, or jump to any row. Mark a project complete when the last pick is woven in.",
-    Icon: CheckSquare,
+    Icon: AppIcons.pickTracking,
   },
   {
     title: "Manage your tools",
     body: "Keep a record of your looms and yarn. Assign a loom to a project and track what's on the beam.",
-    Icon: Wrench,
+    Icon: AppIcons.toolManagement,
   },
 ];
 

--- a/frontend/src/pages/LoomDetailPage.tsx
+++ b/frontend/src/pages/LoomDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
-import { ChevronRight } from "lucide-react";
+import { AppIcons } from "@/lib/icons";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { listActivities } from "@/api/activities";
 import { ActivitySummaryList } from "@/components/activities/ActivitySummaryList";
@@ -656,7 +656,7 @@ export function LoomDetailPage() {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2 text-sm">
           <Link to="/looms" className="text-stone-500 hover:text-stone-900">Equipment</Link>
-          <ChevronRight className="h-3.5 w-3.5 text-stone-400" />
+          <AppIcons.chevronRight className="h-3.5 w-3.5 text-stone-400" />
           <span className="font-medium text-stone-900">{loom.manufacturer} {loom.model_name}</span>
           <span className="text-xs text-stone-400">{LOOM_TYPE_LABELS[loom.loom_type]}</span>
         </div>

--- a/frontend/src/pages/LoomDetailPage.tsx
+++ b/frontend/src/pages/LoomDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
+import { ChevronRight } from "lucide-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { listActivities } from "@/api/activities";
 import { ActivitySummaryList } from "@/components/activities/ActivitySummaryList";
@@ -651,20 +652,19 @@ export function LoomDetailPage() {
   const currentVersionId = loom.current_version?.id;
 
   return (
-    <div className="flex min-h-screen flex-col">
-      <header className="border-b px-6 py-4 flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <Link to="/looms" className="text-sm text-muted-foreground hover:text-foreground">← Equipment</Link>
-          <span className="font-semibold">{loom.manufacturer} {loom.model_name}</span>
-          <span className="text-xs text-muted-foreground">{LOOM_TYPE_LABELS[loom.loom_type]}</span>
+    <div className="p-6 max-w-3xl mx-auto w-full space-y-8">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-sm">
+          <Link to="/looms" className="text-stone-500 hover:text-stone-900">Equipment</Link>
+          <ChevronRight className="h-3.5 w-3.5 text-stone-400" />
+          <span className="font-medium text-stone-900">{loom.manufacturer} {loom.model_name}</span>
+          <span className="text-xs text-stone-400">{LOOM_TYPE_LABELS[loom.loom_type]}</span>
         </div>
         <div className="flex gap-2">
           <Button size="sm" variant="outline" onClick={() => setShowEdit(true)}>Edit</Button>
           <Button size="sm" onClick={() => setShowAddVersion(true)}>Add version</Button>
         </div>
-      </header>
-
-      <main className="flex-1 p-6 max-w-3xl mx-auto w-full space-y-8">
+      </div>
         {!SUPPORTED_LOOM_TYPES.has(loom.loom_type) && (
           <div className="rounded-md border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 px-4 py-3 text-sm text-amber-800 dark:text-amber-300">
             <span className="font-medium">Activity tracking not supported</span> — this loom type is not currently
@@ -761,7 +761,6 @@ export function LoomDetailPage() {
             </div>
           )}
         </section>
-      </main>
 
       {showAddVersion && (
         <AddVersionModal loomId={loom.id} loomType={loom.loom_type} onSuccess={handleVersionAdded} onClose={() => setShowAddVersion(false)} />

--- a/frontend/src/pages/LoomsPage.tsx
+++ b/frontend/src/pages/LoomsPage.tsx
@@ -98,42 +98,33 @@ export function LoomsPage() {
   };
 
   return (
-    <div className="flex min-h-screen flex-col">
-      <header className="border-b px-6 py-4 flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <Link to="/" className="text-sm text-muted-foreground hover:text-foreground">
-            ← Dashboard
-          </Link>
-          <span className="font-semibold">Equipment</span>
-        </div>
-        <Button size="sm" onClick={() => setShowNew(true)}>
-          New loom
-        </Button>
-      </header>
+    <div className="p-6 max-w-4xl mx-auto w-full">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-xl font-semibold">Equipment</h1>
+        <Button size="sm" onClick={() => setShowNew(true)}>New loom</Button>
+      </div>
 
-      <main className="flex-1 p-6 max-w-4xl mx-auto w-full">
-        {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
-        {error && (
-          <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
-            Failed to load looms
-          </p>
-        )}
-        {looms && looms.length === 0 && (
-          <div className="flex flex-col items-center justify-center py-20 text-center">
-            <p className="text-muted-foreground">No looms yet.</p>
-            <Button className="mt-4" onClick={() => setShowNew(true)}>
-              Add your first loom
-            </Button>
-          </div>
-        )}
-        {looms && looms.length > 0 && (
-          <div className="grid gap-4 sm:grid-cols-2">
-            {looms.map((l) => (
-              <LoomCard key={l.id} loom={l} activityCounts={activityCountsByLoom[l.id]} />
-            ))}
-          </div>
-        )}
-      </main>
+      {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+      {error && (
+        <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          Failed to load looms
+        </p>
+      )}
+      {looms && looms.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-20 text-center">
+          <p className="text-muted-foreground">No looms yet.</p>
+          <Button className="mt-4" onClick={() => setShowNew(true)}>
+            Add your first loom
+          </Button>
+        </div>
+      )}
+      {looms && looms.length > 0 && (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {looms.map((l) => (
+            <LoomCard key={l.id} loom={l} activityCounts={activityCountsByLoom[l.id]} />
+          ))}
+        </div>
+      )}
 
       {showNew && (
         <NewLoomModal onSuccess={handleSuccess} onClose={() => setShowNew(false)} />

--- a/frontend/src/pages/LoomsPage.tsx
+++ b/frontend/src/pages/LoomsPage.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import { listLooms, type Loom } from "@/api/looms";
+import { AppIcons } from "@/lib/icons";
 import { listActivities } from "@/api/activities";
 import { NewLoomModal } from "@/components/looms/NewLoomModal";
 import { Button } from "@/components/ui/button";
@@ -20,11 +21,20 @@ function LoomCard({ loom, activityCounts }: { loom: Loom; activityCounts?: LoomA
       className="rounded-lg border p-5 hover:border-ring transition-colors block"
     >
       <div className="flex items-start justify-between gap-2">
-        <div>
-          <p className="font-medium">{loom.manufacturer} {loom.model_name}</p>
-          {loom.serial_number && (
-            <p className="text-xs text-muted-foreground">S/N: {loom.serial_number}</p>
-          )}
+        <div className="flex items-start gap-3">
+          <div className="shrink-0 mt-0.5">
+            {loom.supports_lift_tracking
+              ? <AppIcons.lift className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
+              : loom.supports_treadle_tracking
+                ? <AppIcons.treadle className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
+                : <AppIcons.equipment className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />}
+          </div>
+          <div>
+            <p className="font-medium">{loom.manufacturer} {loom.model_name}</p>
+            {loom.serial_number && (
+              <p className="text-xs text-muted-foreground">S/N: {loom.serial_number}</p>
+            )}
+          </div>
         </div>
         <div className="text-right text-xs text-muted-foreground shrink-0">
           {v && <span>{v.num_shafts}S / {v.num_treadles}T</span>}
@@ -37,10 +47,16 @@ function LoomCard({ loom, activityCounts }: { loom: Loom; activityCounts?: LoomA
       )}
       <div className="mt-2 flex gap-2">
         {loom.supports_lift_tracking && (
-          <span className="rounded bg-muted px-1.5 py-0.5 text-xs">lift tracking</span>
+          <span className="rounded bg-muted px-1.5 py-0.5 text-xs flex items-center gap-1">
+            <AppIcons.lift className="h-3 w-3" />
+            lift tracking
+          </span>
         )}
         {loom.supports_treadle_tracking && (
-          <span className="rounded bg-muted px-1.5 py-0.5 text-xs">treadle tracking</span>
+          <span className="rounded bg-muted px-1.5 py-0.5 text-xs flex items-center gap-1">
+            <AppIcons.treadle className="h-3 w-3" />
+            treadle tracking
+          </span>
         )}
       </div>
       {activityCounts && (activityCounts.active + activityCounts.completed + activityCounts.abandoned) > 0 && (

--- a/frontend/src/pages/LoomsPage.tsx
+++ b/frontend/src/pages/LoomsPage.tsx
@@ -47,16 +47,10 @@ function LoomCard({ loom, activityCounts }: { loom: Loom; activityCounts?: LoomA
       )}
       <div className="mt-2 flex gap-2">
         {loom.supports_lift_tracking && (
-          <span className="rounded bg-muted px-1.5 py-0.5 text-xs flex items-center gap-1">
-            <AppIcons.lift className="h-3 w-3" />
-            lift tracking
-          </span>
+          <span className="rounded bg-muted px-1.5 py-0.5 text-xs">lift tracking</span>
         )}
         {loom.supports_treadle_tracking && (
-          <span className="rounded bg-muted px-1.5 py-0.5 text-xs flex items-center gap-1">
-            <AppIcons.treadle className="h-3 w-3" />
-            treadle tracking
-          </span>
+          <span className="rounded bg-muted px-1.5 py-0.5 text-xs">treadle tracking</span>
         )}
       </div>
       {activityCounts && (activityCounts.active + activityCounts.completed + activityCounts.abandoned) > 0 && (

--- a/frontend/src/pages/PrivacyPage.tsx
+++ b/frontend/src/pages/PrivacyPage.tsx
@@ -9,7 +9,7 @@ export function PrivacyPage() {
         <div className="mx-auto flex max-w-4xl items-center gap-3">
           <Link to="/" className="flex items-center gap-3 hover:opacity-80 transition-opacity">
             <WeftmarkLogo className="h-8 w-auto text-amber-800" />
-            <span className="text-lg font-semibold tracking-tight">Weftmark</span>
+            <span className="text-lg font-semibold tracking-tight" style={{ fontFamily: '"Segoe UI", system-ui, sans-serif' }}>weftmark</span>
           </Link>
         </div>
       </header>

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
+import { ChevronRight } from "lucide-react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getProject, deleteProject, generateLiftplan, previewUrl, downloadWif } from "@/api/projects";
 import { listActivities } from "@/api/activities";
@@ -63,15 +64,12 @@ export function ProjectDetailPage() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col">
-      <header className="border-b px-6 py-4 flex items-center gap-4">
-        <Link to="/projects" className="text-sm text-muted-foreground hover:text-foreground">
-          ← Projects
-        </Link>
-        <span className="font-semibold">{project.name}</span>
-      </header>
-
-      <main className="flex-1 p-6 max-w-5xl mx-auto w-full space-y-6">
+    <div className="p-6 max-w-5xl mx-auto w-full space-y-6">
+      <div className="flex items-center gap-2 text-sm">
+        <Link to="/projects" className="text-stone-500 hover:text-stone-900">Projects</Link>
+        <ChevronRight className="h-3.5 w-3.5 text-stone-400" />
+        <span className="font-medium text-stone-900">{project.name}</span>
+      </div>
 
         {/* Lint status */}
         {project.lint_errors.length > 0 && (
@@ -276,8 +274,6 @@ export function ProjectDetailPage() {
             </div>
           )}
         </div>
-
-      </main>
 
       {showCreateActivity && (
         <CreateActivityModal

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { ChevronRight } from "lucide-react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getProject, deleteProject, generateLiftplan, previewUrl, downloadWif } from "@/api/projects";
+import { getProject, deleteProject, generateLiftplan, previewUrl, downloadWif, downloadWifLiftplan } from "@/api/projects";
 import { listActivities } from "@/api/activities";
 import { ActivitySummaryList } from "@/components/activities/ActivitySummaryList";
 import { CreateActivityModal } from "@/components/activities/CreateActivityModal";
@@ -96,7 +96,7 @@ export function ProjectDetailPage() {
               <h2 className="text-base font-semibold">Design Info</h2>
               <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
                 <dt className="text-muted-foreground">File</dt>
-                <dd className="flex items-center gap-2">
+                <dd className="flex flex-wrap items-center gap-2">
                   <span>{project.wif_filename}</span>
                   <button
                     type="button"
@@ -114,8 +114,28 @@ export function ProjectDetailPage() {
                       }
                     }}
                   >
-                    {downloading ? "Downloading…" : "Download"}
+                    {downloading ? "Downloading…" : project.has_liftplan_file ? "Download original" : "Download"}
                   </button>
+                  {project.has_liftplan_file && (
+                    <button
+                      type="button"
+                      className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground disabled:opacity-50"
+                      disabled={downloading}
+                      onClick={async () => {
+                        setDownloadError(null);
+                        setDownloading(true);
+                        try {
+                          await downloadWifLiftplan(project.id, project.wif_filename);
+                        } catch {
+                          setDownloadError("Download failed");
+                        } finally {
+                          setDownloading(false);
+                        }
+                      }}
+                    >
+                      Download with lift plan
+                    </button>
+                  )}
                 </dd>
                 {downloadError && (
                   <dd className="col-span-2 text-xs text-destructive">{downloadError}</dd>

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
-import { ChevronRight } from "lucide-react";
+import { AppIcons } from "@/lib/icons";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getProject, deleteProject, generateLiftplan, overrideProjectMetadata, previewUrl, downloadWif, downloadWifModified } from "@/api/projects";
 import { listActivities } from "@/api/activities";
@@ -76,7 +76,7 @@ export function ProjectDetailPage() {
     <div className="p-6 max-w-5xl mx-auto w-full space-y-6">
       <div className="flex items-center gap-2 text-sm">
         <Link to="/projects" className="text-stone-500 hover:text-stone-900">Projects</Link>
-        <ChevronRight className="h-3.5 w-3.5 text-stone-400" />
+        <AppIcons.chevronRight className="h-3.5 w-3.5 text-stone-400" />
         <span className="font-medium text-stone-900">{project.name}</span>
       </div>
 

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -150,9 +150,19 @@ export function ProjectDetailPage() {
                   <dd className="col-span-2 text-xs text-destructive">{downloadError}</dd>
                 )}
                 <dt className="text-muted-foreground">Shafts</dt>
-                <dd>{project.num_shafts ?? "—"}</dd>
+                <dd className="flex items-center gap-1.5">
+                  {project.num_shafts ?? "—"}
+                  {project.metadata_overrides?.num_shafts && (
+                    <span className="text-xs text-muted-foreground">(value overwritten)</span>
+                  )}
+                </dd>
                 <dt className="text-muted-foreground">Treadles</dt>
-                <dd>{project.num_treadles ?? "—"}</dd>
+                <dd className="flex items-center gap-1.5">
+                  {project.num_treadles ?? "—"}
+                  {project.metadata_overrides?.num_treadles && (
+                    <span className="text-xs text-muted-foreground">(value overwritten)</span>
+                  )}
+                </dd>
                 <dt className="text-muted-foreground">Warp threads</dt>
                 <dd>{project.warp_threads ?? "—"}</dd>
                 <dt className="text-muted-foreground">Weft threads</dt>
@@ -190,7 +200,7 @@ export function ProjectDetailPage() {
                     <span className="text-foreground">
                       ✓ Available
                       {project.liftplan_generated && (
-                        <span className="ml-1.5 text-xs text-muted-foreground">(algorithmically generated)</span>
+                        <span className="ml-1.5 text-xs text-muted-foreground">(computed)</span>
                       )}
                     </span>
                   ) : (

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { ChevronRight } from "lucide-react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getProject, deleteProject, generateLiftplan, previewUrl, downloadWif, downloadWifLiftplan } from "@/api/projects";
+import { getProject, deleteProject, generateLiftplan, overrideProjectMetadata, previewUrl, downloadWif, downloadWifModified } from "@/api/projects";
 import { listActivities } from "@/api/activities";
 import { ActivitySummaryList } from "@/components/activities/ActivitySummaryList";
 import { CreateActivityModal } from "@/components/activities/CreateActivityModal";
@@ -41,6 +41,15 @@ export function ProjectDetailPage() {
 
   const generateMutation = useMutation({
     mutationFn: () => generateLiftplan(id!),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(["project", id], updated);
+      queryClient.invalidateQueries({ queryKey: ["projects"] });
+    },
+  });
+
+  const overrideMutation = useMutation({
+    mutationFn: ({ field, value }: { field: "num_treadles" | "num_shafts"; value: number }) =>
+      overrideProjectMetadata(id!, field, value),
     onSuccess: (updated) => {
       queryClient.setQueryData(["project", id], updated);
       queryClient.invalidateQueries({ queryKey: ["projects"] });
@@ -114,9 +123,9 @@ export function ProjectDetailPage() {
                       }
                     }}
                   >
-                    {downloading ? "Downloading…" : project.has_liftplan_file ? "Download original" : "Download"}
+                    {downloading ? "Downloading…" : project.has_modified_file ? "Download original" : "Download"}
                   </button>
-                  {project.has_liftplan_file && (
+                  {project.has_modified_file && (
                     <button
                       type="button"
                       className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground disabled:opacity-50"
@@ -125,7 +134,7 @@ export function ProjectDetailPage() {
                         setDownloadError(null);
                         setDownloading(true);
                         try {
-                          await downloadWifLiftplan(project.id, project.wif_filename);
+                          await downloadWifModified(project.id, project.wif_filename);
                         } catch {
                           setDownloadError("Download failed");
                         } finally {
@@ -133,7 +142,7 @@ export function ProjectDetailPage() {
                         }
                       }}
                     >
-                      Download with lift plan
+                      Download modified
                     </button>
                   )}
                 </dd>
@@ -210,6 +219,72 @@ export function ProjectDetailPage() {
                   >
                     {generateMutation.isPending ? "Generating…" : "Generate lift plan"}
                   </Button>
+                </div>
+              )}
+
+              {/* Treadle metadata mismatch — offer override */}
+              {project.effective_num_treadles != null &&
+                project.num_treadles != null &&
+                project.effective_num_treadles !== project.num_treadles && (
+                <div className="rounded-md border border-stone-200 bg-stone-50 px-3 py-2.5 text-sm dark:border-stone-700 dark:bg-stone-900/30">
+                  <p className="font-medium text-stone-700 dark:text-stone-300">Treadle metadata mismatch</p>
+                  <p className="mt-0.5 text-stone-600 dark:text-stone-400 text-xs">
+                    [WEAVING] declares {project.num_treadles} treadles but the treadling data only uses {project.effective_num_treadles}.
+                    {project.metadata_overrides?.num_treadles
+                      ? ` (overridden from ${project.metadata_overrides.num_treadles.original})`
+                      : " Override to fix loom compatibility checks and correct the exported file."}
+                  </p>
+                  {overrideMutation.isError && overrideMutation.variables?.field === "num_treadles" && (
+                    <p className="mt-1 text-xs text-destructive">
+                      {overrideMutation.error instanceof Error ? overrideMutation.error.message : "Override failed"}
+                    </p>
+                  )}
+                  {!project.metadata_overrides?.num_treadles && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="mt-2"
+                      onClick={() => overrideMutation.mutate({ field: "num_treadles", value: project.effective_num_treadles! })}
+                      disabled={overrideMutation.isPending}
+                    >
+                      {overrideMutation.isPending && overrideMutation.variables?.field === "num_treadles"
+                        ? "Overriding…"
+                        : `Set treadles to ${project.effective_num_treadles}`}
+                    </Button>
+                  )}
+                </div>
+              )}
+
+              {/* Shaft metadata mismatch — offer override */}
+              {project.effective_num_shafts != null &&
+                project.num_shafts != null &&
+                project.effective_num_shafts !== project.num_shafts && (
+                <div className="rounded-md border border-stone-200 bg-stone-50 px-3 py-2.5 text-sm dark:border-stone-700 dark:bg-stone-900/30">
+                  <p className="font-medium text-stone-700 dark:text-stone-300">Shaft metadata mismatch</p>
+                  <p className="mt-0.5 text-stone-600 dark:text-stone-400 text-xs">
+                    [WEAVING] declares {project.num_shafts} shafts but the lift plan only uses {project.effective_num_shafts}.
+                    {project.metadata_overrides?.num_shafts
+                      ? ` (overridden from ${project.metadata_overrides.num_shafts.original})`
+                      : " Override to fix loom compatibility checks and correct the exported file."}
+                  </p>
+                  {overrideMutation.isError && overrideMutation.variables?.field === "num_shafts" && (
+                    <p className="mt-1 text-xs text-destructive">
+                      {overrideMutation.error instanceof Error ? overrideMutation.error.message : "Override failed"}
+                    </p>
+                  )}
+                  {!project.metadata_overrides?.num_shafts && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="mt-2"
+                      onClick={() => overrideMutation.mutate({ field: "num_shafts", value: project.effective_num_shafts! })}
+                      disabled={overrideMutation.isPending}
+                    >
+                      {overrideMutation.isPending && overrideMutation.variables?.field === "num_shafts"
+                        ? "Overriding…"
+                        : `Set shafts to ${project.effective_num_shafts}`}
+                    </Button>
+                  )}
                 </div>
               )}
             </div>

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -5,13 +5,8 @@ import { listActivities } from "@/api/activities";
 import { ProjectCard } from "@/components/projects/ProjectCard";
 import { UploadWifModal } from "@/components/projects/UploadWifModal";
 import { Button } from "@/components/ui/button";
-import { useAuth } from "@/hooks/useAuth";
-import { useClerk } from "@clerk/clerk-react";
-import { Link } from "react-router-dom";
 
 export function ProjectsPage() {
-  const { user } = useAuth();
-  const { signOut } = useClerk();
   const queryClient = useQueryClient();
   const [showUpload, setShowUpload] = useState(false);
 
@@ -43,57 +38,32 @@ export function ProjectsPage() {
     queryClient.invalidateQueries({ queryKey: ["projects"] });
   };
 
-  const handleLogout = () => signOut();
-
   return (
-    <div className="flex min-h-screen flex-col">
-      <header className="border-b px-6 py-4 flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <Link to="/" className="text-sm text-muted-foreground hover:text-foreground">← Dashboard</Link>
-          <span className="font-semibold">Projects</span>
-        </div>
-        <div className="flex items-center gap-4">
-          <span className="text-sm text-muted-foreground">{user?.email}</span>
-          <Link to="/settings" className="text-sm text-muted-foreground hover:text-foreground">
-            Settings
-          </Link>
-          <Button variant="outline" size="sm" onClick={handleLogout}>
-            Sign out
+    <div className="p-6 max-w-4xl mx-auto w-full">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-xl font-semibold">Projects</h1>
+        <Button onClick={() => setShowUpload(true)}>New Project</Button>
+      </div>
+
+      {isLoading && <p className="text-sm text-muted-foreground">Loading projects…</p>}
+      {error && <p className="text-sm text-destructive">Failed to load projects.</p>}
+
+      {!isLoading && projects.length === 0 && (
+        <div className="rounded-lg border border-dashed p-12 text-center">
+          <p className="text-sm text-muted-foreground">
+            No projects yet. Upload a WIF file to get started.
+          </p>
+          <Button className="mt-4" onClick={() => setShowUpload(true)}>
+            New Project
           </Button>
         </div>
-      </header>
+      )}
 
-      <main className="flex-1 p-6 max-w-4xl mx-auto w-full">
-        <div className="flex items-center justify-between mb-6">
-          <h1 className="text-xl font-semibold">Projects</h1>
-          <Button onClick={() => setShowUpload(true)}>New Project</Button>
-        </div>
-
-        {isLoading && (
-          <p className="text-sm text-muted-foreground">Loading projects…</p>
-        )}
-
-        {error && (
-          <p className="text-sm text-destructive">Failed to load projects.</p>
-        )}
-
-        {!isLoading && projects.length === 0 && (
-          <div className="rounded-lg border border-dashed p-12 text-center">
-            <p className="text-sm text-muted-foreground">
-              No projects yet. Upload a WIF file to get started.
-            </p>
-            <Button className="mt-4" onClick={() => setShowUpload(true)}>
-              New Project
-            </Button>
-          </div>
-        )}
-
-        <div className="grid gap-4 sm:grid-cols-2">
-          {projects.map((p) => (
-            <ProjectCard key={p.id} project={p} activityCounts={activityCountsByProject[p.id]} />
-          ))}
-        </div>
-      </main>
+      <div className="grid gap-4 sm:grid-cols-2">
+        {projects.map((p) => (
+          <ProjectCard key={p.id} project={p} activityCounts={activityCountsByProject[p.id]} />
+        ))}
+      </div>
 
       {showUpload && (
         <UploadWifModal

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
 import { useAuth } from "@/hooks/useAuth";
 import { useQuery } from "@tanstack/react-query";
 import { updateSettings, deleteAccount, getDataExport, getCurrentEula } from "@/api/users";
@@ -11,7 +10,6 @@ type Section = "appearance" | "preferences" | "privacy" | "terms" | "account";
 
 export function SettingsPage() {
   const { user, refetch } = useAuth();
-  const navigate = useNavigate();
   const [activeSection, setActiveSection] = useState<Section>("appearance");
 
   const { data: projects = [] } = useQuery({
@@ -115,12 +113,8 @@ export function SettingsPage() {
   ];
 
   return (
-    <div className="min-h-screen bg-background">
-      <div className="mx-auto max-w-4xl px-4 py-8">
-        <div className="mb-6 flex items-center gap-4">
-          <Button variant="ghost" size="sm" onClick={() => navigate(-1)}>
-            ← Back
-          </Button>
+    <div className="mx-auto max-w-4xl px-4 py-8">
+        <div className="mb-6">
           <h1 className="text-xl font-semibold">Settings</h1>
         </div>
 
@@ -468,7 +462,6 @@ export function SettingsPage() {
             )}
           </div>
         </div>
-      </div>
     </div>
   );
 }

--- a/frontend/src/pages/TermsPage.tsx
+++ b/frontend/src/pages/TermsPage.tsx
@@ -18,7 +18,7 @@ export function TermsPage() {
         <div className="mx-auto flex max-w-4xl items-center gap-3">
           <Link to="/" className="flex items-center gap-3 hover:opacity-80 transition-opacity">
             <WeftmarkLogo className="h-8 w-auto text-amber-800" />
-            <span className="text-lg font-semibold tracking-tight">Weftmark</span>
+            <span className="text-lg font-semibold tracking-tight" style={{ fontFamily: '"Segoe UI", system-ui, sans-serif' }}>weftmark</span>
           </Link>
         </div>
       </header>

--- a/frontend/src/pages/YarnDetailPage.tsx
+++ b/frontend/src/pages/YarnDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
+import { ChevronRight } from "lucide-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   getYarn, deleteYarn, updateYarn,
@@ -517,11 +518,12 @@ export function YarnDetailPage() {
   if (error || !yarn) return <div className="flex min-h-screen items-center justify-center"><p className="text-sm text-destructive">Yarn not found.</p></div>;
 
   return (
-    <div className="flex min-h-screen flex-col">
-      <header className="border-b px-6 py-4 flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <Link to="/yarn" className="text-sm text-muted-foreground hover:text-foreground">← Yarn</Link>
-          <span className="font-semibold">{yarn.brand} — {yarn.name}</span>
+    <div className="p-6 max-w-3xl mx-auto w-full space-y-8">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-sm">
+          <Link to="/yarn" className="text-stone-500 hover:text-stone-900">Yarn</Link>
+          <ChevronRight className="h-3.5 w-3.5 text-stone-400" />
+          <span className="font-medium text-stone-900">{yarn.brand} — {yarn.name}</span>
         </div>
         <div className="flex items-center gap-2">
           <Button size="sm" variant="outline" onClick={() => setShowClone(true)}>Clone yarn</Button>
@@ -529,9 +531,7 @@ export function YarnDetailPage() {
             {editing ? "Cancel edit" : "Edit"}
           </Button>
         </div>
-      </header>
-
-      <main className="flex-1 p-6 max-w-3xl mx-auto w-full space-y-8">
+      </div>
 
         {/* Photo + summary */}
         <section className="space-y-4">
@@ -590,7 +590,6 @@ export function YarnDetailPage() {
             </div>
           )}
         </section>
-      </main>
 
       {showClone && (
         <CloneYarnModal

--- a/frontend/src/pages/YarnDetailPage.tsx
+++ b/frontend/src/pages/YarnDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
-import { ChevronRight } from "lucide-react";
+import { AppIcons } from "@/lib/icons";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   getYarn, deleteYarn, updateYarn,
@@ -522,7 +522,7 @@ export function YarnDetailPage() {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2 text-sm">
           <Link to="/yarn" className="text-stone-500 hover:text-stone-900">Yarn</Link>
-          <ChevronRight className="h-3.5 w-3.5 text-stone-400" />
+          <AppIcons.chevronRight className="h-3.5 w-3.5 text-stone-400" />
           <span className="font-medium text-stone-900">{yarn.brand} — {yarn.name}</span>
         </div>
         <div className="flex items-center gap-2">

--- a/frontend/src/pages/YarnPage.tsx
+++ b/frontend/src/pages/YarnPage.tsx
@@ -70,34 +70,25 @@ export function YarnPage() {
   };
 
   return (
-    <div className="flex min-h-screen flex-col">
-      <header className="border-b px-6 py-4 flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <Link to="/" className="text-sm text-muted-foreground hover:text-foreground">← Dashboard</Link>
-          <span className="font-semibold">Yarn</span>
+    <div className="p-6 max-w-3xl mx-auto w-full">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-xl font-semibold">Yarn inventory</h1>
+        <Button onClick={() => setShowAdd(true)}>Add yarn</Button>
+      </div>
+
+      {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+      {error && <p className="text-sm text-destructive">Failed to load yarn inventory.</p>}
+
+      {!isLoading && yarns.length === 0 && (
+        <div className="rounded-lg border border-dashed p-12 text-center">
+          <p className="text-sm text-muted-foreground">No yarn yet. Add your first entry to start tracking your stash.</p>
+          <Button className="mt-4" onClick={() => setShowAdd(true)}>Add yarn</Button>
         </div>
-      </header>
+      )}
 
-      <main className="flex-1 p-6 max-w-3xl mx-auto w-full">
-        <div className="flex items-center justify-between mb-6">
-          <h1 className="text-xl font-semibold">Yarn inventory</h1>
-          <Button onClick={() => setShowAdd(true)}>Add yarn</Button>
-        </div>
-
-        {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
-        {error && <p className="text-sm text-destructive">Failed to load yarn inventory.</p>}
-
-        {!isLoading && yarns.length === 0 && (
-          <div className="rounded-lg border border-dashed p-12 text-center">
-            <p className="text-sm text-muted-foreground">No yarn yet. Add your first entry to start tracking your stash.</p>
-            <Button className="mt-4" onClick={() => setShowAdd(true)}>Add yarn</Button>
-          </div>
-        )}
-
-        <div className="space-y-2">
-          {yarns.map((y) => <YarnCard key={y.id} yarn={y} />)}
-        </div>
-      </main>
+      <div className="space-y-2">
+        {yarns.map((y) => <YarnCard key={y.id} yarn={y} />)}
+      </div>
 
       {showAdd && (
         <AddYarnModal onSuccess={handleAdded} onClose={() => setShowAdd(false)} />


### PR DESCRIPTION
## Summary

- Introduced centralized icon registry (`src/lib/icons.ts`) with semantic keys for all app icons — treadle, lift, planning, project, loom types, nav items, and activity stats
- Added UI design system, branding updates, activity screen polish, and WIF metadata crosscheck
- Metadata override: preserve original WIF on lift plan generation; clear stale mismatch warnings after override; show "(value overwritten)" label
- Fix: `has_modified_file` missing from project detail responses; baseline migration downgrade tolerance
- Reordered nav: Dashboard → Equipment → Projects → Activities
- Added type icons (lift, treadle, planning, project) as prominent left-column indicators on loom, project, and activity cards across Dashboard, Equipment, Projects, and Activities screens
- Activity stat boxes on Dashboard show Completed / Active counts with icons
- Project cards show lift/treadle tracking icons in the header for each supported activity type

## Test plan

- [ ] Log in and verify nav order: Dashboard, Equipment, Projects, Activities
- [ ] Dashboard: loom cards show lift/treadle icon on left; project cards show Scroll icon on left; activity rows show type icon on left; stat boxes show Zap/CircleCheck icons
- [ ] Equipment page: each loom card shows the correct tracking icon (lift or treadle) to the left of the name; text badges remain text-only
- [ ] Projects page: cards with treadling show treadle icon in header; cards with lift plan show lift icon; both show when both apply (e.g. after generating a lift plan)
- [ ] Activities page: each card shows the correct type icon on the left; planning (no-loom) activities show the question mark icon
- [ ] Upload a WIF with treadling only — verify treadle icon appears on project card; generate lift plan — verify lift icon also appears
- [ ] Override shaft/treadle metadata — verify mismatch warning clears and "(value overwritten)" label appears
- [ ] Download original and modified WIF files from project detail page
- [ ] Verify no regressions on activity detail, loom detail, or settings pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)