### PR TITLE
refactor: consolidate theming to CSS variables, fix dark mode, settings nav in sidebar

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
 
 eula_router = APIRouter(prefix="/api/eula", tags=["users"])
 
-_VALID_THEMES = {"light", "dark"}
+_VALID_THEMES = {"light", "dark", "system"}
 _VALID_MEASUREMENT_SYSTEMS = {"metric", "imperial"}
 _VALID_ACTIVITY_THEMES = {"default", "compact", "high_contrast"}
 _VALID_IDLE_TIMEOUTS = {15, 30, 60, 120}

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -145,6 +145,53 @@ Media column gets `1.4fr` to give the video/screenshot more visual weight.
 
 ---
 
+## Authenticated App Theming (CSS Variables)
+
+The authenticated app shell (sidebar, pages, modals) uses CSS custom properties defined in `frontend/src/index.css` and mapped to Tailwind tokens in `tailwind.config.ts`. This is the single source of truth for both light and dark mode — never use hard-coded palette classes (e.g. `stone-50`, `amber-600`) inside authenticated pages/components.
+
+### Token Reference
+
+| Tailwind class | CSS variable | Light value | Dark value |
+| --- | --- | --- | --- |
+| `bg-background` | `--background` | stone-50 | stone-900 |
+| `text-foreground` | `--foreground` | stone-900 | stone-50 |
+| `bg-card` / `text-card-foreground` | `--card` | white | stone-800 |
+| `bg-popover` / `text-popover-foreground` | `--popover` | white | stone-800 |
+| `bg-primary` / `text-primary-foreground` | `--primary` | zinc-800 | amber-500 |
+| `bg-secondary` / `text-secondary-foreground` | `--secondary` | stone-100 | stone-700 |
+| `bg-muted` / `text-muted-foreground` | `--muted` | stone-100 | stone-700 |
+| `text-accent` / `bg-accent` | `--accent` | amber-600 | amber-500 |
+| `border-border` | `--border` | stone-200 | stone-700 |
+| `bg-input` | `--input` | stone-200 | stone-700 |
+| `ring-ring` | `--ring` | amber-600 | amber-500 |
+| `text-subdued` | `--subdued` | stone-600 | stone-400 |
+| `bg-copper-subtle` | `--copper-subtle` | amber-50 | amber-950 |
+| `text-copper-on-subtle` | `--copper-on-subtle` | amber-700 | amber-300 |
+
+### Semantic Intent
+
+- **`background`** — Page canvas
+- **`card`** — Surface for panels, sidebars, dialogs, cards
+- **`muted`** — Subtle backgrounds (hover states, inactive sections); `muted-foreground` for de-emphasized text
+- **`subdued`** — Text that's secondary but not as faint as `muted-foreground` (e.g. nav link labels when inactive)
+- **`accent`** — Amber highlight: active icons, focus rings, badges
+- **`copper-subtle` / `copper-on-subtle`** — Active nav item background and text (amber-tinted chip)
+
+### Dark Mode
+
+Dark mode is class-based (`darkMode: ["class"]` in `tailwind.config.ts`). The `.dark` class is applied to `<html>` by `AuthContext` from `user.theme` (stored in the backend DB). Unauthenticated pages (landing, login, register) are always light — do not add `dark:` variants there.
+
+All authenticated UI adapts automatically when the CSS variables change under `.dark` — no `dark:` variant classes are needed in component markup.
+
+### Rules
+
+- **Do** use semantic tokens for all authenticated pages and components.
+- **Do** use `bg-card` for panel/modal surfaces, `bg-background` for page canvas.
+- **Don't** use raw palette classes (`stone-*`, `amber-*`, `zinc-*`) inside authenticated components — changes to the palette would then require hunting down every hard-coded class.
+- **Don't** add dark mode overrides to public pages (landing, login, register, about, privacy, terms).
+
+---
+
 ## Palette Exploration Previews
 
 Standalone HTML previews (no build required) are in `docs/assets/preview-*.html`. Each loads Tailwind via CDN and references `hearts-treadle.mp4` from the same directory. Use these to test new palettes before touching the React source.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -104,7 +104,8 @@ export default function App() {
                   <Route path="/activities" element={<AuthRoute><ActivitiesPage /></AuthRoute>} />
                   <Route path="/activities/:id" element={<AuthRoute><ActivityDetailPage /></AuthRoute>} />
                   <Route path="/admin" element={<AuthRoute requireAdmin><AdminPage /></AuthRoute>} />
-                  <Route path="/settings" element={<AuthRoute><SettingsPage /></AuthRoute>} />
+                  <Route path="/settings" element={<Navigate to="/settings/appearance" replace />} />
+                  <Route path="/settings/:section" element={<AuthRoute><SettingsPage /></AuthRoute>} />
                   <Route path="*" element={<Navigate to="/" replace />} />
                 </Routes>
               </EulaGate>

--- a/frontend/src/components/PublicFooter.tsx
+++ b/frontend/src/components/PublicFooter.tsx
@@ -2,15 +2,15 @@ import { Link } from "react-router-dom";
 
 export function PublicFooter() {
   return (
-    <footer className="border-t border-stone-200 bg-stone-100 py-4 px-6">
+    <footer className="border-t border-border bg-muted py-4 px-6">
       <div className="mx-auto flex max-w-4xl flex-col items-center gap-2 sm:flex-row sm:justify-between">
-        <nav className="flex gap-4 text-sm text-stone-600">
-          <Link to="/about" className="hover:text-stone-900 transition-colors">About</Link>
-          <Link to="/privacy" className="hover:text-stone-900 transition-colors">Privacy</Link>
-          <Link to="/terms" className="hover:text-stone-900 transition-colors">Terms</Link>
-          <span className="text-stone-400">Contact</span>
+        <nav className="flex gap-4 text-sm text-subdued">
+          <Link to="/about" className="hover:text-foreground transition-colors">About</Link>
+          <Link to="/privacy" className="hover:text-foreground transition-colors">Privacy</Link>
+          <Link to="/terms" className="hover:text-foreground transition-colors">Terms</Link>
+          <span className="text-muted-foreground">Contact</span>
         </nav>
-        <p className="text-xs text-stone-500">Built by a weaver, with AI assistance.</p>
+        <p className="text-xs text-muted-foreground">Built by a weaver, with AI assistance.</p>
       </div>
     </footer>
   );

--- a/frontend/src/components/activities/AssignLoomModal.tsx
+++ b/frontend/src/components/activities/AssignLoomModal.tsx
@@ -149,11 +149,11 @@ export function AssignLoomModal({ activityId, activeActivities, activityType, pr
           )}
 
           {(treadleMismatch || shaftMismatch) && selectedLoom && (
-            <div className="rounded-md border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 px-3 py-2.5 text-sm">
-              <p className="font-medium text-amber-900 dark:text-amber-200">
+            <div className="rounded-md border border-copper-subtle bg-copper-subtle px-3 py-2.5 text-sm">
+              <p className="font-medium text-copper-on-subtle">
                 {treadleMismatch ? "Treadle count mismatch" : "Shaft count mismatch"}
               </p>
-              <p className="mt-0.5 text-xs text-amber-800 dark:text-amber-300">
+              <p className="mt-0.5 text-xs text-copper-on-subtle">
                 {treadleMismatch
                   ? `This design uses up to ${effectiveTreadles} treadles, but ${selectedLoom.manufacturer} ${selectedLoom.model_name} only has ${loomTreadles}. Treadle positions beyond ${loomTreadles} cannot be pressed.`
                   : `This design uses up to ${effectiveShafts} shafts, but ${selectedLoom.manufacturer} ${selectedLoom.model_name} only has ${loomShafts}. Shaft positions beyond ${loomShafts} cannot be raised.`}
@@ -162,9 +162,9 @@ export function AssignLoomModal({ activityId, activeActivities, activityType, pr
           )}
 
           {(treadleMetaMismatch || shaftMetaMismatch) && !treadleMismatch && !shaftMismatch && (
-            <div className="rounded-md border border-stone-200 bg-stone-50 dark:bg-stone-900/30 dark:border-stone-700 px-3 py-2.5 text-sm">
-              <p className="font-medium text-stone-700 dark:text-stone-300">WIF metadata note</p>
-              <p className="mt-0.5 text-xs text-stone-600 dark:text-stone-400">
+            <div className="rounded-md border border-border bg-muted px-3 py-2.5 text-sm">
+              <p className="font-medium text-foreground">WIF metadata note</p>
+              <p className="mt-0.5 text-xs text-subdued">
                 {treadleMetaMismatch
                   ? `The WIF file declares ${projectNumTreadles} treadles in metadata, but the treadling data only uses ${projectEffectiveNumTreadles}. Loom compatibility uses the actual count (${projectEffectiveNumTreadles}). You can fix the declared count in your design software.`
                   : `The WIF file declares ${projectNumShafts} shafts in metadata, but the lift plan only uses ${projectEffectiveNumShafts}. Loom compatibility uses the actual count (${projectEffectiveNumShafts}). You can fix the declared count in your design software.`}
@@ -173,11 +173,11 @@ export function AssignLoomModal({ activityId, activeActivities, activityType, pr
           )}
 
           {conflictActivity && (
-            <div className="rounded-md border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 px-3 py-3 text-sm space-y-2">
-              <p className="font-medium text-amber-900 dark:text-amber-200">
+            <div className="rounded-md border border-copper-subtle bg-copper-subtle px-3 py-3 text-sm space-y-2">
+              <p className="font-medium text-copper-on-subtle">
                 This loom has an active activity: <span className="font-semibold">{conflictActivity.name}</span>
               </p>
-              <p className="text-amber-800 dark:text-amber-300 text-xs">
+              <p className="text-copper-on-subtle text-xs">
                 Mark it as completed or abandon it to assign this loom, or choose a different loom.
               </p>
               <div className="flex flex-wrap gap-2 pt-1">

--- a/frontend/src/components/activities/CreateActivityModal.tsx
+++ b/frontend/src/components/activities/CreateActivityModal.tsx
@@ -239,11 +239,11 @@ export function CreateActivityModal({ onSuccess, onClose, defaultProjectId }: Pr
           )}
 
           {(treadleMismatch || shaftMismatch) && selectedLoom && (
-            <div className="rounded-md border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 px-3 py-2.5 text-sm">
-              <p className="font-medium text-amber-900 dark:text-amber-200">
+            <div className="rounded-md border border-copper-subtle bg-copper-subtle px-3 py-2.5 text-sm">
+              <p className="font-medium text-copper-on-subtle">
                 {treadleMismatch ? "Treadle count mismatch" : "Shaft count mismatch"}
               </p>
-              <p className="mt-0.5 text-xs text-amber-800 dark:text-amber-300">
+              <p className="mt-0.5 text-xs text-copper-on-subtle">
                 {treadleMismatch
                   ? `This design uses up to ${effectiveTreadles} treadles, but ${selectedLoom.manufacturer} ${selectedLoom.model_name} only has ${loomTreadles}. Treadle positions beyond ${loomTreadles} cannot be pressed.`
                   : `This design uses up to ${effectiveShafts} shafts, but ${selectedLoom.manufacturer} ${selectedLoom.model_name} only has ${loomShafts}. Shaft positions beyond ${loomShafts} cannot be raised.`}
@@ -252,9 +252,9 @@ export function CreateActivityModal({ onSuccess, onClose, defaultProjectId }: Pr
           )}
 
           {(treadleMetaMismatch || shaftMetaMismatch) && !treadleMismatch && !shaftMismatch && (
-            <div className="rounded-md border border-stone-200 bg-stone-50 dark:bg-stone-900/30 dark:border-stone-700 px-3 py-2.5 text-sm">
-              <p className="font-medium text-stone-700 dark:text-stone-300">WIF metadata note</p>
-              <p className="mt-0.5 text-xs text-stone-600 dark:text-stone-400">
+            <div className="rounded-md border border-border bg-muted px-3 py-2.5 text-sm">
+              <p className="font-medium text-foreground">WIF metadata note</p>
+              <p className="mt-0.5 text-xs text-subdued">
                 {treadleMetaMismatch
                   ? `The WIF file declares ${selectedProject!.num_treadles} treadles in metadata, but the treadling data only uses ${selectedProject!.effective_num_treadles}. Loom compatibility uses the actual count (${selectedProject!.effective_num_treadles}). You can fix the declared count in your design software.`
                   : `The WIF file declares ${selectedProject!.num_shafts} shafts in metadata, but the lift plan only uses ${selectedProject!.effective_num_shafts}. Loom compatibility uses the actual count (${selectedProject!.effective_num_shafts}). You can fix the declared count in your design software.`}
@@ -338,11 +338,11 @@ export function CreateActivityModal({ onSuccess, onClose, defaultProjectId }: Pr
           </div>
 
           {conflictActivity && (
-            <div className="rounded-md border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 px-3 py-3 text-sm space-y-2">
-              <p className="font-medium text-amber-900 dark:text-amber-200">
+            <div className="rounded-md border border-copper-subtle bg-copper-subtle px-3 py-3 text-sm space-y-2">
+              <p className="font-medium text-copper-on-subtle">
                 This loom has an active activity: <span className="font-semibold">{conflictActivity.name}</span>
               </p>
-              <p className="text-amber-800 dark:text-amber-300 text-xs">
+              <p className="text-copper-on-subtle text-xs">
                 Mark it as completed or abandon it to start this new activity, or choose a different loom.
               </p>
               <div className="flex flex-wrap gap-2 pt-1">

--- a/frontend/src/components/admin/UserDetailModal.tsx
+++ b/frontend/src/components/admin/UserDetailModal.tsx
@@ -183,7 +183,7 @@ export function UserDetailModal({ target, onClose }: Props) {
             <div>
               <div className="flex items-center gap-2">
                 <h2 className="text-base font-semibold">{s.display_name || s.email}</h2>
-                <Pill label="pending" cls="bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300" />
+                <Pill label="pending" cls="bg-copper-subtle text-copper-on-subtle" />
               </div>
               <p className="text-sm text-muted-foreground overflow-hidden"><CopyEmail email={s.email} /></p>
             </div>

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -12,15 +12,15 @@ export function AppLayout({ children }: Props) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   return (
-    <div className="flex h-screen overflow-hidden bg-stone-50">
+    <div className="flex h-screen overflow-hidden bg-background">
       <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
       <div className="flex flex-1 flex-col overflow-hidden">
         {/* Mobile top bar — hidden on lg+ where sidebar is always visible */}
-        <div className="flex h-14 shrink-0 items-center border-b border-stone-200 bg-white px-4 lg:hidden">
+        <div className="flex h-14 shrink-0 items-center border-b border-border bg-card px-4 lg:hidden">
           <button
             onClick={() => setSidebarOpen(true)}
-            className="rounded-md p-1.5 text-stone-500 hover:bg-stone-100 hover:text-stone-900"
+            className="rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
             aria-label="Open navigation"
           >
             <AppIcons.mobileMenu className="h-5 w-5" />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -37,14 +37,14 @@ export function Sidebar({ open, onClose }: Props) {
     const active = isActive(href, exact);
     return `flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
       active
-        ? "bg-amber-50 text-amber-800"
-        : "text-stone-600 hover:bg-stone-100 hover:text-stone-900"
+        ? "bg-accent text-accent-foreground"
+        : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
     }`;
   }
 
   function iconCls(href: string, exact?: boolean) {
     return `h-4 w-4 shrink-0 ${
-      isActive(href, exact) ? "text-amber-600" : "text-stone-400"
+      isActive(href, exact) ? "text-accent-foreground" : "text-muted-foreground"
     }`;
   }
 
@@ -60,19 +60,19 @@ export function Sidebar({ open, onClose }: Props) {
 
       {/* Sidebar panel */}
       <aside
-        className={`fixed inset-y-0 left-0 z-30 flex w-60 flex-col bg-white border-r border-stone-200 transition-transform duration-200 ease-in-out lg:static lg:z-auto lg:translate-x-0 ${
+        className={`fixed inset-y-0 left-0 z-30 flex w-60 flex-col bg-card border-r border-border transition-transform duration-200 ease-in-out lg:static lg:z-auto lg:translate-x-0 ${
           open ? "translate-x-0" : "-translate-x-full"
         }`}
       >
         {/* Logo */}
-        <div className="flex h-16 shrink-0 items-center justify-between border-b border-stone-200 px-4">
+        <div className="flex h-16 shrink-0 items-center justify-between border-b border-border px-4">
           <Link to="/home" className="flex items-center gap-2.5" onClick={onClose}>
-            <WeftmarkLogo className="h-6 w-auto text-zinc-800" />
-            <span className="text-sm font-semibold tracking-tight text-stone-900" style={{ fontFamily: '"Segoe UI", system-ui, sans-serif' }}>weftmark</span>
+            <WeftmarkLogo className="h-6 w-auto text-primary" />
+            <span className="text-sm font-semibold tracking-tight text-foreground" style={{ fontFamily: '"Segoe UI", system-ui, sans-serif' }}>weftmark</span>
           </Link>
           <button
             onClick={onClose}
-            className="rounded-md p-1 text-stone-400 hover:text-stone-600 lg:hidden"
+            className="rounded-md p-1 text-muted-foreground hover:text-subdued lg:hidden"
             aria-label="Close menu"
           >
             <AppIcons.close className="h-4 w-4" />
@@ -100,7 +100,7 @@ export function Sidebar({ open, onClose }: Props) {
         {user?.is_superuser && <div className="flex-1" />}
 
         {/* Bottom nav */}
-        <div className="shrink-0 border-t border-stone-200 px-3 py-3 space-y-0.5">
+        <div className="shrink-0 border-t border-border px-3 py-3 space-y-0.5">
           <Link to="/settings" onClick={onClose} className={navCls("/settings")}>
             <AppIcons.settings className={iconCls("/settings")} strokeWidth={1.75} />
             Settings
@@ -115,18 +115,18 @@ export function Sidebar({ open, onClose }: Props) {
 
           <button
             onClick={() => signOut()}
-            className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-stone-600 transition-colors hover:bg-stone-100 hover:text-stone-900"
+            className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-subdued transition-colors hover:bg-muted hover:text-foreground"
           >
-            <AppIcons.logout className="h-4 w-4 shrink-0 text-stone-400" strokeWidth={1.75} />
+            <AppIcons.logout className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} />
             Sign out
           </button>
         </div>
 
         {/* User identity */}
         {user && (
-          <div className="shrink-0 border-t border-stone-200 bg-stone-50 px-4 py-3">
-            <p className="truncate text-xs font-medium text-stone-900">{user.display_name}</p>
-            <p className="truncate text-xs text-stone-400">{user.email}</p>
+          <div className="shrink-0 border-t border-border bg-muted px-4 py-3">
+            <p className="truncate text-xs font-medium text-foreground">{user.display_name}</p>
+            <p className="truncate text-xs text-muted-foreground">{user.email}</p>
           </div>
         )}
       </aside>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -18,6 +18,14 @@ const NAV_ITEMS: NavItem[] = [
   { label: "Activities", href: "/activities", icon: AppIcons.activities },
 ];
 
+const SETTINGS_SECTIONS = [
+  { id: "appearance", label: "Appearance" },
+  { id: "preferences", label: "Preferences" },
+  { id: "privacy", label: "Privacy & data" },
+  { id: "terms", label: "Terms" },
+  { id: "account", label: "Account" },
+];
+
 interface Props {
   open: boolean;
   onClose: () => void;
@@ -101,10 +109,33 @@ export function Sidebar({ open, onClose }: Props) {
 
         {/* Bottom nav */}
         <div className="shrink-0 border-t border-border px-3 py-3 space-y-0.5">
-          <Link to="/settings" onClick={onClose} className={navCls("/settings")}>
+          <Link to="/settings/appearance" onClick={onClose} className={navCls("/settings")}>
             <AppIcons.settings className={iconCls("/settings")} strokeWidth={1.75} />
             Settings
           </Link>
+
+          {isActive("/settings") && (
+            <div className="ml-3 border-l border-border pl-2 space-y-0.5">
+              {SETTINGS_SECTIONS.map(({ id, label }) => {
+                const href = `/settings/${id}`;
+                const active = location.pathname === href;
+                return (
+                  <Link
+                    key={id}
+                    to={href}
+                    onClick={onClose}
+                    className={`block rounded-md px-2 py-1.5 text-xs transition-colors ${
+                      active
+                        ? "bg-accent/20 text-accent font-medium"
+                        : "text-muted-foreground hover:bg-accent/10 hover:text-foreground"
+                    }`}
+                  >
+                    {label}
+                  </Link>
+                );
+              })}
+            </div>
+          )}
 
           {user?.is_admin && (
             <Link to="/admin" onClick={onClose} className={navCls("/admin")}>

--- a/frontend/src/components/looms/EditLoomModal.tsx
+++ b/frontend/src/components/looms/EditLoomModal.tsx
@@ -71,7 +71,7 @@ export function EditLoomModal({ loom, onSuccess, onClose }: Props) {
 
           {/* Unsupported type info banner */}
           {isUnsupported && (
-            <div className="rounded-md border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 px-3 py-2 text-xs text-amber-800 dark:text-amber-300">
+            <div className="rounded-md border border-copper-subtle bg-copper-subtle px-3 py-2 text-xs text-copper-on-subtle">
               This loom type is not currently supported for activity tracking. Activities cannot be created using this loom.
             </div>
           )}

--- a/frontend/src/components/looms/NewLoomModal.tsx
+++ b/frontend/src/components/looms/NewLoomModal.tsx
@@ -105,13 +105,13 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
 
           {/* Unsupported type warning + acknowledgement */}
           {isUnsupported && (
-            <div className="rounded-md border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 px-3 py-3 text-sm space-y-2">
-              <p className="font-medium text-amber-900 dark:text-amber-200">Activity tracking not supported</p>
-              <p className="text-xs text-amber-800 dark:text-amber-300">
+            <div className="rounded-md border border-copper-subtle bg-copper-subtle px-3 py-3 text-sm space-y-2">
+              <p className="font-medium text-copper-on-subtle">Activity tracking not supported</p>
+              <p className="text-xs text-copper-on-subtle">
                 This loom type is not currently supported for activity tracking. You can save it for documentation
                 and it will be available if support is added later, but activities cannot be created using it.
               </p>
-              <label className="flex items-center gap-2 text-xs text-amber-900 dark:text-amber-200 cursor-pointer">
+              <label className="flex items-center gap-2 text-xs text-copper-on-subtle cursor-pointer">
                 <input
                   type="checkbox"
                   checked={acknowledged}

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -78,6 +78,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // Apply theme class to document root
   useEffect(() => {
     const theme = user?.theme ?? "light";
+    if (theme === "system") {
+      const mq = window.matchMedia("(prefers-color-scheme: dark)");
+      const apply = () => document.documentElement.classList.toggle("dark", mq.matches);
+      apply();
+      mq.addEventListener("change", apply);
+      return () => mq.removeEventListener("change", apply);
+    }
     document.documentElement.classList.toggle("dark", theme === "dark");
   }, [user?.theme]);
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,40 +4,60 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
+    /* === Slate & Copper — Light === */
+    --background: 60 9% 98%;            /* stone-50  */
+    --foreground: 20 10% 10%;           /* stone-900 */
+    --card: 0 0% 100%;                  /* white     */
+    --card-foreground: 20 10% 10%;      /* stone-900 */
+    --popover: 0 0% 100%;               /* white     */
+    --popover-foreground: 20 10% 10%;   /* stone-900 */
+    --primary: 240 4% 16%;              /* zinc-800  */
+    --primary-foreground: 0 0% 100%;    /* white     */
+    --secondary: 60 5% 96%;             /* stone-100 */
+    --secondary-foreground: 20 10% 10%; /* stone-900 */
+    --muted: 60 5% 96%;                 /* stone-100 */
+    --muted-foreground: 25 5% 45%;      /* stone-500 */
+    --accent: 32 95% 44%;               /* amber-600 */
+    --accent-foreground: 0 0% 100%;     /* white     */
+    --destructive: 0 84% 60%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 20 6% 90%;                /* stone-200 */
+    --input: 20 6% 90%;                 /* stone-200 */
+    --ring: 32 95% 44%;                 /* amber-600 */
     --radius: 0.5rem;
+
+    /* Slate & Copper extras */
+    --subdued: 33 5% 32%;               /* stone-600 */
+    --copper-subtle: 48 100% 96%;       /* amber-50  */
+    --copper-on-subtle: 26 91% 37%;     /* amber-700 */
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
+    /* === Slate & Copper — Dark === */
+    --background: 20 10% 10%;            /* stone-900 */
+    --foreground: 60 9% 98%;             /* stone-50  */
+    --card: 12 7% 15%;                   /* stone-800 */
+    --card-foreground: 60 9% 98%;        /* stone-50  */
+    --popover: 12 7% 15%;                /* stone-800 */
+    --popover-foreground: 60 9% 98%;     /* stone-50  */
+    --primary: 38 92% 50%;               /* amber-500 */
+    --primary-foreground: 20 10% 10%;    /* stone-900 */
+    --secondary: 31 6% 25%;              /* stone-700 */
+    --secondary-foreground: 60 9% 98%;   /* stone-50  */
+    --muted: 31 6% 25%;                  /* stone-700 */
+    --muted-foreground: 23 5% 64%;       /* stone-400 */
+    --accent: 38 92% 50%;                /* amber-500 */
+    --accent-foreground: 20 10% 10%;     /* stone-900 */
+    --destructive: 0 63% 31%;
+    --destructive-foreground: 60 9% 98%;
+    --border: 31 6% 25%;                 /* stone-700 */
+    --input: 31 6% 25%;                  /* stone-700 */
+    --ring: 38 92% 50%;                  /* amber-500 */
+
+    /* Slate & Copper extras */
+    --subdued: 23 5% 64%;                /* stone-400 */
+    --copper-subtle: 21 92% 14%;         /* amber-950 */
+    --copper-on-subtle: 46 97% 65%;      /* amber-300 */
   }
 }
 

--- a/frontend/src/pages/ActivityDetailPage.tsx
+++ b/frontend/src/pages/ActivityDetailPage.tsx
@@ -783,7 +783,7 @@ function CompletedSummary({
       {/* Design preview */}
       <div>
         <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide mb-2">Design Preview</h2>
-        <div className="overflow-auto rounded-lg border bg-white p-2">
+        <div className="overflow-auto rounded-lg border bg-card p-2">
           <AuthedImage
             src={previewUrl(activity.project_id)}
             alt={`Design for ${activity.project_name}`}
@@ -1078,20 +1078,20 @@ export function ActivityDetailPage() {
   return (
     <div className="flex flex-col">
       {/* Page header */}
-      <div className="shrink-0 border-b border-stone-200 bg-white px-6 py-3 flex items-center justify-between">
+      <div className="shrink-0 border-b border-border bg-card px-6 py-3 flex items-center justify-between">
         <div className="flex items-center gap-3 min-w-0">
           {/* Breadcrumb — hidden on mobile/tablet, shown on desktop only */}
           <div className="hidden lg:flex items-center gap-1.5 text-sm shrink-0">
             {activity.loom_id && (
               <>
-                <Link to="/looms" className="text-stone-500 hover:text-stone-900">Equipment</Link>
-                <AppIcons.chevronRight className="h-3.5 w-3.5 text-stone-400" />
+                <Link to="/looms" className="text-muted-foreground hover:text-foreground">Equipment</Link>
+                <AppIcons.chevronRight className="h-3.5 w-3.5 text-muted-foreground" />
               </>
             )}
-            <Link to="/projects" className="text-stone-500 hover:text-stone-900">Projects</Link>
-            <AppIcons.chevronRight className="h-3.5 w-3.5 text-stone-400" />
-            <Link to="/activities" className="text-stone-500 hover:text-stone-900">Activities</Link>
-            <AppIcons.chevronRight className="h-3.5 w-3.5 text-stone-400" />
+            <Link to="/projects" className="text-muted-foreground hover:text-foreground">Projects</Link>
+            <AppIcons.chevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+            <Link to="/activities" className="text-muted-foreground hover:text-foreground">Activities</Link>
+            <AppIcons.chevronRight className="h-3.5 w-3.5 text-muted-foreground" />
           </div>
           {editingName ? (
             <form
@@ -1189,9 +1189,9 @@ export function ActivityDetailPage() {
         {/* Abandoned banner */}
         {isAbandoned && (
           <div className="mx-auto max-w-2xl px-8 pt-6">
-            <div className="rounded-md border border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/30 px-4 py-3 text-sm">
-              <p className="font-medium text-amber-900 dark:text-amber-200">This activity was not completed</p>
-              <p className="mt-0.5 text-xs text-amber-800 dark:text-amber-300">
+            <div className="rounded-md border border-copper-subtle bg-copper-subtle px-4 py-3 text-sm">
+              <p className="font-medium text-copper-on-subtle">This activity was not completed</p>
+              <p className="mt-0.5 text-xs text-copper-on-subtle">
                 Abandoned at pick {activity.current_pick} of {activity.total_picks}
                 {" "}({Math.round((activity.current_pick - 1) / activity.total_picks * 100)}% woven)
                 {activity.abandoned_at && ` · ${new Date(activity.abandoned_at).toLocaleDateString(undefined, { year: "numeric", month: "long", day: "numeric" })}`}
@@ -1444,11 +1444,11 @@ export function ActivityDetailPage() {
                   </div>
                 )}
                 {restartConflict && (
-                  <div className="rounded-md border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 px-3 py-3 text-sm space-y-2">
-                    <p className="font-medium text-amber-900 dark:text-amber-200">
+                  <div className="rounded-md border border-copper-subtle bg-copper-subtle px-3 py-3 text-sm space-y-2">
+                    <p className="font-medium text-copper-on-subtle">
                       This loom has an active activity: <span className="font-semibold">{restartConflict.name}</span>
                     </p>
-                    <p className="text-amber-800 dark:text-amber-300 text-xs">Resolve it to restart this one.</p>
+                    <p className="text-copper-on-subtle text-xs">Resolve it to restart this one.</p>
                     <div className="flex flex-wrap gap-2 pt-1">
                       <Button type="button" size="sm" onClick={() => handleResolveAndRestart("complete")} disabled={actionLoading}>
                         {actionLoading ? "Working…" : "Mark completed & restart"}
@@ -1482,11 +1482,11 @@ export function ActivityDetailPage() {
                 </div>
               )}
               {cloneConflict && (
-                <div className="rounded-md border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 px-3 py-3 text-sm space-y-2">
-                  <p className="font-medium text-amber-900 dark:text-amber-200">
+                <div className="rounded-md border border-copper-subtle bg-copper-subtle px-3 py-3 text-sm space-y-2">
+                  <p className="font-medium text-copper-on-subtle">
                     This loom has an active activity: <span className="font-semibold">{cloneConflict.name}</span>
                   </p>
-                  <p className="text-amber-800 dark:text-amber-300 text-xs">Resolve it to start the clone.</p>
+                  <p className="text-copper-on-subtle text-xs">Resolve it to start the clone.</p>
                   <div className="flex flex-wrap gap-2 pt-1">
                     <Button type="button" size="sm" onClick={() => handleResolveAndClone("complete")} disabled={actionLoading}>
                       {actionLoading ? "Working…" : "Mark completed & clone"}

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -161,9 +161,9 @@ const STATUS_PILL: Record<UserRow["status"], string> = {
   active: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
   inactive: "bg-muted text-muted-foreground",
   banned: "bg-destructive/10 text-destructive",
-  pending: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
+  pending: "bg-copper-subtle text-copper-on-subtle",
   errored: "bg-destructive/10 text-destructive",
-  deleting: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
+  deleting: "bg-copper-subtle text-copper-on-subtle",
 };
 
 function StatusPill({ status }: { status: UserRow["status"] }) {

--- a/frontend/src/pages/LoomDetailPage.tsx
+++ b/frontend/src/pages/LoomDetailPage.tsx
@@ -150,16 +150,16 @@ function ProfilePhoto({ loom, onChanged }: { loom: LoomDetail; onChanged: () => 
           />
         )}
         {pendingFile && (
-          <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs dark:border-amber-800 dark:bg-amber-950">
-            <p className="font-medium text-amber-900 dark:text-amber-100">
+          <div className="rounded-md border border-copper-subtle bg-copper-subtle px-3 py-2 text-xs">
+            <p className="font-medium text-copper-on-subtle">
               Photo is {formatBytes(pendingFile.size)} — over the 5 MB limit
             </p>
             <div className="mt-1.5 flex gap-2">
-              <button onClick={handleResize} className="font-medium text-amber-800 hover:underline dark:text-amber-200">
+              <button onClick={handleResize} className="font-medium text-copper-on-subtle hover:underline">
                 Resize &amp; upload
               </button>
-              <span className="text-amber-400">·</span>
-              <button onClick={() => { setPendingFile(null); clearInput(); }} className="text-amber-700 hover:underline dark:text-amber-300">
+              <span className="text-muted-foreground">·</span>
+              <button onClick={() => { setPendingFile(null); clearInput(); }} className="text-copper-on-subtle hover:underline">
                 Cancel
               </button>
             </div>
@@ -275,16 +275,16 @@ function VersionPhotos({ loom, version, onChanged }: { loom: LoomDetail; version
         )}
       </div>
       {pendingFile && (
-        <div className="mt-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs dark:border-amber-800 dark:bg-amber-950">
-          <p className="font-medium text-amber-900 dark:text-amber-100">
+        <div className="mt-2 rounded-md border border-copper-subtle bg-copper-subtle px-3 py-2 text-xs">
+          <p className="font-medium text-copper-on-subtle">
             Photo is {formatBytes(pendingFile.size)} — over the 5 MB limit
           </p>
           <div className="mt-1.5 flex gap-2">
-            <button onClick={handleResize} className="font-medium text-amber-800 hover:underline dark:text-amber-200">
+            <button onClick={handleResize} className="font-medium text-copper-on-subtle hover:underline">
               Resize &amp; upload
             </button>
-            <span className="text-amber-400">·</span>
-            <button onClick={() => { setPendingFile(null); clearInput(); }} className="text-amber-700 hover:underline dark:text-amber-300">
+            <span className="text-muted-foreground">·</span>
+            <button onClick={() => { setPendingFile(null); clearInput(); }} className="text-copper-on-subtle hover:underline">
               Cancel
             </button>
           </div>
@@ -655,10 +655,10 @@ export function LoomDetailPage() {
     <div className="p-6 max-w-3xl mx-auto w-full space-y-8">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2 text-sm">
-          <Link to="/looms" className="text-stone-500 hover:text-stone-900">Equipment</Link>
-          <AppIcons.chevronRight className="h-3.5 w-3.5 text-stone-400" />
-          <span className="font-medium text-stone-900">{loom.manufacturer} {loom.model_name}</span>
-          <span className="text-xs text-stone-400">{LOOM_TYPE_LABELS[loom.loom_type]}</span>
+          <Link to="/looms" className="text-muted-foreground hover:text-foreground">Equipment</Link>
+          <AppIcons.chevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+          <span className="font-medium text-foreground">{loom.manufacturer} {loom.model_name}</span>
+          <span className="text-xs text-muted-foreground">{LOOM_TYPE_LABELS[loom.loom_type]}</span>
         </div>
         <div className="flex gap-2">
           <Button size="sm" variant="outline" onClick={() => setShowEdit(true)}>Edit</Button>
@@ -666,7 +666,7 @@ export function LoomDetailPage() {
         </div>
       </div>
         {!SUPPORTED_LOOM_TYPES.has(loom.loom_type) && (
-          <div className="rounded-md border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 px-4 py-3 text-sm text-amber-800 dark:text-amber-300">
+          <div className="rounded-md border border-copper-subtle bg-copper-subtle px-4 py-3 text-sm text-copper-on-subtle">
             <span className="font-medium">Activity tracking not supported</span> — this loom type is not currently
             supported for activity tracking. It has been saved for documentation and will be available if support
             is added later.

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -75,9 +75,9 @@ export function ProjectDetailPage() {
   return (
     <div className="p-6 max-w-5xl mx-auto w-full space-y-6">
       <div className="flex items-center gap-2 text-sm">
-        <Link to="/projects" className="text-stone-500 hover:text-stone-900">Projects</Link>
-        <AppIcons.chevronRight className="h-3.5 w-3.5 text-stone-400" />
-        <span className="font-medium text-stone-900">{project.name}</span>
+        <Link to="/projects" className="text-muted-foreground hover:text-foreground">Projects</Link>
+        <AppIcons.chevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+        <span className="font-medium text-foreground">{project.name}</span>
       </div>
 
         {/* Lint status */}
@@ -210,9 +210,9 @@ export function ProjectDetailPage() {
               </dl>
 
               {!project.has_liftplan && project.has_treadling && project.has_tieup && (
-                <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2.5 text-sm dark:border-amber-800 dark:bg-amber-950">
-                  <p className="font-medium text-amber-900 dark:text-amber-100">Lift plan not in file</p>
-                  <p className="mt-0.5 text-amber-800 dark:text-amber-200 text-xs">
+                <div className="rounded-md border border-copper-subtle bg-copper-subtle px-3 py-2.5 text-sm">
+                  <p className="font-medium text-copper-on-subtle">Lift plan not in file</p>
+                  <p className="mt-0.5 text-copper-on-subtle text-xs">
                     This WIF has treadling and tie-up data. A lift plan can be computed algorithmically and added to the project.
                   </p>
                   {generateMutation.isError && (
@@ -236,9 +236,9 @@ export function ProjectDetailPage() {
               {project.effective_num_treadles != null &&
                 project.num_treadles != null &&
                 project.effective_num_treadles !== project.num_treadles && (
-                <div className="rounded-md border border-stone-200 bg-stone-50 px-3 py-2.5 text-sm dark:border-stone-700 dark:bg-stone-900/30">
-                  <p className="font-medium text-stone-700 dark:text-stone-300">Treadle metadata mismatch</p>
-                  <p className="mt-0.5 text-stone-600 dark:text-stone-400 text-xs">
+                <div className="rounded-md border border-border bg-muted px-3 py-2.5 text-sm">
+                  <p className="font-medium text-foreground">Treadle metadata mismatch</p>
+                  <p className="mt-0.5 text-subdued text-xs">
                     [WEAVING] declares {project.num_treadles} treadles but the treadling data only uses {project.effective_num_treadles}.
                     {project.metadata_overrides?.num_treadles
                       ? ` (overridden from ${project.metadata_overrides.num_treadles.original})`
@@ -269,9 +269,9 @@ export function ProjectDetailPage() {
               {project.effective_num_shafts != null &&
                 project.num_shafts != null &&
                 project.effective_num_shafts !== project.num_shafts && (
-                <div className="rounded-md border border-stone-200 bg-stone-50 px-3 py-2.5 text-sm dark:border-stone-700 dark:bg-stone-900/30">
-                  <p className="font-medium text-stone-700 dark:text-stone-300">Shaft metadata mismatch</p>
-                  <p className="mt-0.5 text-stone-600 dark:text-stone-400 text-xs">
+                <div className="rounded-md border border-border bg-muted px-3 py-2.5 text-sm">
+                  <p className="font-medium text-foreground">Shaft metadata mismatch</p>
+                  <p className="mt-0.5 text-subdued text-xs">
                     [WEAVING] declares {project.num_shafts} shafts but the lift plan only uses {project.effective_num_shafts}.
                     {project.metadata_overrides?.num_shafts
                       ? ` (overridden from ${project.metadata_overrides.num_shafts.original})`
@@ -317,7 +317,7 @@ export function ProjectDetailPage() {
           <div>
             <h2 className="text-base font-semibold mb-3">Design Preview</h2>
             {project.has_preview ? (
-              <div className="overflow-auto rounded-lg border bg-white p-2">
+              <div className="overflow-auto rounded-lg border bg-card p-2">
                 <AuthedImage
                   src={previewUrl(project.id)}
                   alt={`Draft preview for ${project.name}`}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -126,7 +126,7 @@ export function SettingsPage() {
               <Section title="Appearance">
                 <Field label="Theme">
                   <div className="flex gap-2">
-                    {(["light", "dark"] as const).map((t) => (
+                    {(["light", "dark", "system"] as const).map((t) => (
                       <button
                         key={t}
                         onClick={() => {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useParams } from "react-router-dom";
 import { useAuth } from "@/hooks/useAuth";
 import { useQuery } from "@tanstack/react-query";
 import { updateSettings, deleteAccount, getDataExport, getCurrentEula } from "@/api/users";
@@ -10,7 +11,8 @@ type Section = "appearance" | "preferences" | "privacy" | "terms" | "account";
 
 export function SettingsPage() {
   const { user, refetch } = useAuth();
-  const [activeSection, setActiveSection] = useState<Section>("appearance");
+  const { section } = useParams<{ section: string }>();
+  const activeSection: Section = (section as Section) ?? "appearance";
 
   const { data: projects = [] } = useQuery({
     queryKey: ["projects"],
@@ -104,40 +106,9 @@ export function SettingsPage() {
     }
   }
 
-  const navItems: { id: Section; label: string }[] = [
-    { id: "appearance", label: "Appearance" },
-    { id: "preferences", label: "Preferences" },
-    { id: "privacy", label: "Privacy & data" },
-    { id: "terms", label: "Terms" },
-    { id: "account", label: "Account" },
-  ];
-
   return (
-    <div className="mx-auto max-w-4xl px-4 py-8">
-        <div className="mb-6">
-          <h1 className="text-xl font-semibold">Settings</h1>
-        </div>
-
-        <div className="flex gap-8">
-          {/* Sidebar nav */}
-          <nav className="w-44 shrink-0 space-y-1">
-            {navItems.map((item) => (
-              <button
-                key={item.id}
-                onClick={() => setActiveSection(item.id)}
-                className={`w-full rounded-md px-3 py-2 text-left text-sm transition-colors ${
-                  activeSection === item.id
-                    ? "bg-accent text-accent-foreground font-medium"
-                    : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
-                }`}
-              >
-                {item.label}
-              </button>
-            ))}
-          </nav>
-
-          {/* Content */}
-          <div className="flex-1 space-y-6">
+    <div className="mx-auto max-w-2xl px-4 py-8">
+        <div className="space-y-6">
             {(saveSuccess || saveError) && (
               <div
                 className={`rounded-md px-4 py-2 text-sm ${
@@ -460,7 +431,6 @@ export function SettingsPage() {
                 </div>
               </Section>
             )}
-          </div>
         </div>
     </div>
   );

--- a/frontend/src/pages/YarnDetailPage.tsx
+++ b/frontend/src/pages/YarnDetailPage.tsx
@@ -104,12 +104,12 @@ function YarnPhoto({ yarn, onChanged }: { yarn: YarnDetail; onChanged: () => voi
           </span>
         )}
         {pendingFile && (
-          <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs dark:border-amber-800 dark:bg-amber-950">
-            <p className="font-medium text-amber-900 dark:text-amber-100">Photo is {formatBytes(pendingFile.size)} — over 5 MB</p>
+          <div className="rounded-md border border-copper-subtle bg-copper-subtle px-3 py-2 text-xs">
+            <p className="font-medium text-copper-on-subtle">Photo is {formatBytes(pendingFile.size)} — over 5 MB</p>
             <div className="mt-1.5 flex gap-2">
-              <button onClick={handleResize} className="font-medium text-amber-800 hover:underline dark:text-amber-200">Resize &amp; upload</button>
-              <span className="text-amber-400">·</span>
-              <button onClick={() => { setPendingFile(null); clearInput(); }} className="text-amber-700 hover:underline dark:text-amber-300">Cancel</button>
+              <button onClick={handleResize} className="font-medium text-copper-on-subtle hover:underline">Resize &amp; upload</button>
+              <span className="text-muted-foreground">·</span>
+              <button onClick={() => { setPendingFile(null); clearInput(); }} className="text-copper-on-subtle hover:underline">Cancel</button>
             </div>
           </div>
         )}
@@ -521,9 +521,9 @@ export function YarnDetailPage() {
     <div className="p-6 max-w-3xl mx-auto w-full space-y-8">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2 text-sm">
-          <Link to="/yarn" className="text-stone-500 hover:text-stone-900">Yarn</Link>
-          <AppIcons.chevronRight className="h-3.5 w-3.5 text-stone-400" />
-          <span className="font-medium text-stone-900">{yarn.brand} — {yarn.name}</span>
+          <Link to="/yarn" className="text-muted-foreground hover:text-foreground">Yarn</Link>
+          <AppIcons.chevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+          <span className="font-medium text-foreground">{yarn.brand} — {yarn.name}</span>
         </div>
         <div className="flex items-center gap-2">
           <Button size="sm" variant="outline" onClick={() => setShowClone(true)}>Clone yarn</Button>

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -8,6 +8,14 @@ const config: Config = {
       colors: {
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
         primary: {
           DEFAULT: "hsl(var(--primary))",
           foreground: "hsl(var(--primary-foreground))",
@@ -31,6 +39,10 @@ const config: Config = {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
+        // Slate & Copper semantic tokens
+        subdued: "hsl(var(--subdued))",
+        "copper-subtle": "hsl(var(--copper-subtle))",
+        "copper-on-subtle": "hsl(var(--copper-on-subtle))",
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
Closes #301

## Summary

- Rewrites `index.css` with the full Slate & Copper HSL palette for both `:root` and `.dark`, replacing the default shadcn/ui blue/slate values that were never updated
- Adds `card`, `popover`, `subdued`, `copper-subtle`, and `copper-on-subtle` tokens to `tailwind.config.ts`
- Migrates app shell (Sidebar, AppLayout) and all authenticated pages/modals from hard-coded `stone-*`/`amber-*`/`zinc-*` classes to semantic tokens — dark mode now works end-to-end without any `dark:` variant overrides in component markup
- Updates `docs/design-system.md` with the full token reference table and usage rules
- Sidebar active nav item style aligned with Settings page accent style (`bg-accent text-accent-foreground`)
- Settings sub-sections moved into the sidebar as nested items; each section is a distinct URL (`/settings/appearance`, etc.) so active state is URL-driven and sections are bookmarkable
- Adds `system` theme option that reads `prefers-color-scheme` from the OS and listens for real-time changes; backend allowlist updated to accept the new value

## Test plan

- [ ] Light mode: sidebar, nav items, cards, modals all use warm stone/amber tones — no blue tints
- [ ] Dark mode: switch theme in Settings > Appearance; all authenticated pages flip to stone-900 backgrounds with amber accents
- [ ] System mode: matches OS preference; changing OS theme updates the app in real time
- [ ] Settings nav: clicking Settings in sidebar expands sub-items; navigating between them updates active highlight and content without a full-page reload
- [ ] `/settings` redirects to `/settings/appearance`
- [ ] No regressions on Dashboard, Equipment, Projects, Activities pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)