### PR TITLE
feat: rename Project→Draft throughout codebase and retheme auth pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project overview
 
-WeftMark is a multi-user web platform for managing weaving (loom) projects. All projects are private by default. Users can self-register via Clerk but are blocked until an admin approves them.
+WeftMark is a multi-user web platform for managing weaving drafts. All drafts are private by default. Users can self-register via Clerk but are blocked until an admin approves them.
 
 - Requirements: `docs/requirements/` (start with `docs/requirements/README.md`)
 - WIF 1.1 spec: `docs/standard/standard-wif1-1.txt`

--- a/backend/tests/routers/test_admin.py
+++ b/backend/tests/routers/test_admin.py
@@ -44,7 +44,7 @@ class TestListAdminUsers:
             owner_id=admin_user.id,
             name="Admin Draft",
             wif_filename="test.wif",
-            wif_path="projects/test/original.wif",
+            wif_path="drafts/test/original.wif",
         )
         db_session.add(draft)
         await db_session.commit()
@@ -813,7 +813,7 @@ class TestElevateToSuperuser:
             owner_id=target.id,
             name="Target Draft",
             wif_filename="test.wif",
-            wif_path="projects/test/original.wif",
+            wif_path="drafts/test/original.wif",
         )
         db_session.add(draft)
         await db_session.commit()
@@ -832,7 +832,7 @@ class TestElevateToSuperuser:
             owner_id=target.id,
             name="Target Draft 2",
             wif_filename="test2.wif",
-            wif_path="projects/test2/original.wif",
+            wif_path="drafts/test2/original.wif",
         )
         db_session.add(draft)
         await db_session.commit()

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -155,7 +155,7 @@ class TestDeleteAccount:
             owner_id=test_user.id,
             name="Test Draft",
             wif_filename="test.wif",
-            wif_path="projects/test/original.wif",
+            wif_path="drafts/test/original.wif",
         )
         db_session.add(draft)
         await db_session.commit()
@@ -171,7 +171,7 @@ class TestDeleteAccount:
             owner_id=test_user.id,
             name="P",
             wif_filename="x.wif",
-            wif_path="projects/x/original.wif",
+            wif_path="drafts/x/original.wif",
         )
         db_session.add(draft)
         await db_session.flush()

--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -13,7 +13,7 @@ This directory contains the formal requirements for the WeftMark platform.
 | [equipment-inventory.md](equipment-inventory.md) | Loom inventory with versioned state history |
 | [yarn-inventory.md](yarn-inventory.md) | Yarn and thread inventory with skein-level tracking |
 | [reports.md](reports.md) | Activity report generation (screen and PDF) |
-| [sharing-profiles.md](sharing-profiles.md) | User profiles and project sharing via slug URLs |
+| [sharing-profiles.md](sharing-profiles.md) | User profiles and draft sharing via slug URLs |
 | [admin.md](admin.md) | Admin capabilities — invites, monitoring, WIF records |
 | [phase2.md](phase2.md) | Deferred features for future consideration |
 

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -15,7 +15,7 @@
           "nullable": false
         },
         {
-          "name": "project_id",
+          "name": "draft_id",
           "position": 3,
           "type": "uuid",
           "nullable": false
@@ -154,10 +154,10 @@
           "constraint": "activities_owner_id_fkey"
         },
         {
-          "column": "project_id",
-          "references_table": "projects",
+          "column": "draft_id",
+          "references_table": "drafts",
           "references_column": "id",
-          "constraint": "activities_project_id_fkey"
+          "constraint": "activities_draft_id_fkey"
         }
       ],
       "unique_constraints": [],
@@ -179,9 +179,9 @@
           "primary": false
         },
         {
-          "name": "ix_activities_project_id",
+          "name": "ix_activities_draft_id",
           "columns": [
-            "project_id"
+            "draft_id"
           ],
           "unique": false,
           "primary": false
@@ -1214,7 +1214,7 @@
       ],
       "check_constraints": []
     },
-    "projects": {
+    "drafts": {
       "columns": [
         {
           "name": "id",
@@ -1383,12 +1383,12 @@
           "column": "owner_id",
           "references_table": "users",
           "references_column": "id",
-          "constraint": "projects_owner_id_fkey"
+          "constraint": "drafts_owner_id_fkey"
         }
       ],
       "unique_constraints": [
         {
-          "constraint": "projects_share_slug_key",
+          "constraint": "drafts_share_slug_key",
           "columns": [
             "share_slug"
           ]
@@ -1396,7 +1396,7 @@
       ],
       "indexes": [
         {
-          "name": "ix_projects_owner_id",
+          "name": "ix_drafts_owner_id",
           "columns": [
             "owner_id"
           ],
@@ -1404,7 +1404,7 @@
           "primary": false
         },
         {
-          "name": "projects_pkey",
+          "name": "drafts_pkey",
           "columns": [
             "id"
           ],
@@ -1412,7 +1412,7 @@
           "primary": true
         },
         {
-          "name": "projects_share_slug_key",
+          "name": "drafts_share_slug_key",
           "columns": [
             "share_slug"
           ],

--- a/docs/schema.mermaid
+++ b/docs/schema.mermaid
@@ -2,7 +2,7 @@ erDiagram
     activities {
         uuid id "PK"
         uuid owner_id "FK"
-        uuid project_id "FK"
+        uuid draft_id "FK"
         uuid loom_id "FK"
         uuid loom_version_id "FK"
         varchar name
@@ -143,7 +143,7 @@ erDiagram
         timestamptz created_at
         timestamptz updated_at
     }
-    projects {
+    drafts {
         uuid id "PK"
         uuid owner_id "FK"
         varchar name
@@ -250,7 +250,7 @@ erDiagram
     looms ||--o{ activities : "loom_id"
     loom_versions ||--o{ activities : "loom_version_id"
     users ||--o{ activities : "owner_id"
-    projects ||--o{ activities : "project_id"
+    drafts ||--o{ activities : "draft_id"
     activities ||--o{ activity_photos : "activity_id"
     activities ||--o{ activity_steps : "activity_id"
     users ||--o{ invites : "created_by_id"
@@ -260,7 +260,7 @@ erDiagram
     loom_versions ||--o{ loom_version_receipts : "loom_version_id"
     looms ||--o{ loom_versions : "loom_id"
     users ||--o{ looms : "owner_id"
-    users ||--o{ projects : "owner_id"
+    users ||--o{ drafts : "owner_id"
     yarns ||--o{ skeins : "yarn_id"
     users ||--o{ user_identities : "user_id"
     users ||--o{ yarns : "owner_id"

--- a/frontend/src/components/auth/AuthCard.tsx
+++ b/frontend/src/components/auth/AuthCard.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+import { WeftmarkLogo } from "@/components/WeftmarkLogo";
+
+interface Props {
+  children: ReactNode;
+  footer?: ReactNode;
+  /** Skip the white card wrapper — Clerk pages use this so Clerk renders its own card naturally. */
+  naked?: boolean;
+}
+
+export function AuthCard({ children, footer, naked = false }: Props) {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-stone-50 px-4 py-12">
+      <svg
+        className="pointer-events-none fixed inset-0 z-50 h-full w-full opacity-[0.045]"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <filter id="grain-auth">
+          <feTurbulence type="fractalNoise" baseFrequency="0.72" numOctaves="4" stitchTiles="stitch" />
+        </filter>
+        <rect width="100%" height="100%" filter="url(#grain-auth)" />
+      </svg>
+
+      <div className="mb-6 flex items-center gap-2.5">
+        <WeftmarkLogo className="h-7 w-auto text-zinc-800" />
+        <span
+          className="text-base font-semibold tracking-tight text-zinc-800"
+          style={{ fontFamily: '"Segoe UI", system-ui, sans-serif' }}
+        >
+          weftmark
+        </span>
+      </div>
+
+      {naked ? (
+        <div className="w-full max-w-sm">{children}</div>
+      ) : (
+        <div className="w-full max-w-sm rounded-2xl border border-stone-200 bg-white px-8 pb-8 pt-7 shadow-sm">
+          {children}
+        </div>
+      )}
+
+      {footer && <div className="mt-5 text-center text-xs text-stone-500">{footer}</div>}
+    </div>
+  );
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,7 +1,23 @@
 import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { SignIn, useAuth as useClerkAuth, useClerk, useUser } from "@clerk/clerk-react";
 import { useAuth } from "@/hooks/useAuth";
+import { AuthCard } from "@/components/auth/AuthCard";
+
+const CLERK_APPEARANCE = {
+  variables: {
+    colorPrimary: "#27272a",
+    colorBackground: "#ffffff",
+    colorInputBackground: "#fafaf9",
+    colorText: "#1c1917",
+    colorTextSecondary: "#57534e",
+    borderRadius: "0.5rem",
+  },
+  elements: {
+    headerTitle: "hidden",
+    headerSubtitle: "hidden",
+  },
+};
 
 export function LoginPage() {
   const { isAuthenticated, isLoading } = useAuth();
@@ -23,53 +39,48 @@ export function LoginPage() {
     }
   }, [clerkLoaded, isSignedIn, isLoading, isAuthenticated, clerkStatus, navigate]);
 
-  // Clerk-authenticated but no DB record and not pending — show denied/holding page.
+  // Clerk-authenticated but WeftMark hasn't approved the account
   if (clerkLoaded && isSignedIn && !isLoading && !isAuthenticated && clerkStatus !== "pending_signup") {
     const isDenied = clerkStatus === "denied" || clerkStatus === "banned";
     return (
-      <div className="flex min-h-screen items-center justify-center bg-background">
-        <div className="w-full max-w-sm space-y-4 px-4 text-center">
-          <h1 className="text-2xl font-semibold tracking-tight">WeftMark</h1>
-          {isDenied ? (
-            <p className="text-sm text-muted-foreground">
-              WeftMark is currently closed to new sign-ups, but your interest has been noted. We'll be in touch if that changes.
-            </p>
-          ) : (
-            <p className="text-sm text-muted-foreground">
-              WeftMark is currently invite only. Admins have been notified of your sign-up request.
-            </p>
-          )}
+      <AuthCard>
+        <div className="text-center">
+          <h1 className="text-lg font-semibold text-zinc-800">
+            {isDenied ? "Account not approved" : "Approval pending"}
+          </h1>
+          <p className="mt-2 text-sm text-stone-600">
+            {isDenied
+              ? "WeftMark is currently closed to new sign-ups, but your interest has been noted. We'll be in touch if that changes."
+              : "Your sign-up request has been received. You'll get an email when an admin approves your account."}
+          </p>
           <button
             onClick={() => signOut()}
-            className="text-sm underline underline-offset-2 text-muted-foreground hover:text-foreground"
+            className="mt-6 text-sm text-stone-500 underline underline-offset-2 hover:text-stone-700"
           >
             Sign out
           </button>
         </div>
-      </div>
+      </AuthCard>
     );
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background">
-      <div className="w-full max-w-sm space-y-6 px-4">
-        <div className="space-y-2 text-center">
-          <h1 className="text-2xl font-semibold tracking-tight">WeftMark</h1>
-          <p className="text-sm text-muted-foreground">Sign in to continue</p>
-          <p className="text-xs text-amber-500 font-mono">WeftMark custom login page — not Clerk hosted</p>
-        </div>
-        <SignIn
-          routing="hash"
-          appearance={{
-            elements: {
-              rootBox: "w-full",
-              card: "shadow-none border rounded-lg p-6 bg-card",
-              headerTitle: "hidden",
-              headerSubtitle: "hidden",
-            },
-          }}
-        />
+    <AuthCard
+      naked
+      footer={
+        <>
+          New to weftmark?{" "}
+          <Link to="/register" className="text-amber-700 underline underline-offset-2 hover:text-amber-800">
+            Request access
+          </Link>
+        </>
+      }
+    >
+      <div className="mb-5 text-center">
+        <h1 className="text-lg font-semibold text-zinc-800">Sign in</h1>
+        <p className="mt-1 text-sm text-stone-600">Welcome back</p>
       </div>
-    </div>
+      <SignIn routing="hash" appearance={CLERK_APPEARANCE} />
+    </AuthCard>
   );
 }

--- a/frontend/src/pages/PendingPage.tsx
+++ b/frontend/src/pages/PendingPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth as useClerkAuth, useClerk, useUser } from "@clerk/clerk-react";
 import { useAuth } from "@/hooks/useAuth";
+import { AuthCard } from "@/components/auth/AuthCard";
 
 const MAX_POLLS = 10;
 const POLL_INTERVAL_MS = 3000;
@@ -30,7 +31,6 @@ export function PendingPage() {
     }
   }, [clerkLoaded, isSignedIn, navigate]);
 
-  // Poll clerkUser.reload() until the webhook fires and sets status
   useEffect(() => {
     if (!clerkLoaded || !isSignedIn || !clerkUser) return;
     if (clerkStatus !== undefined) return;
@@ -48,40 +48,57 @@ export function PendingPage() {
 
   if (!clerkLoaded || isLoading || (clerkStatus === undefined && pollCount < MAX_POLLS)) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-background">
-        <div className="w-full max-w-sm space-y-4 px-4 text-center">
-          <h1 className="text-2xl font-semibold tracking-tight">WeftMark</h1>
-          <p className="text-sm text-muted-foreground">Setting up your account…</p>
+      <AuthCard>
+        <div className="text-center">
+          <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-2 border-stone-200 border-t-zinc-800" />
+          <h1 className="text-lg font-semibold text-zinc-800">Setting up your account</h1>
+          <p className="mt-2 text-sm text-stone-600">Just a moment…</p>
         </div>
-      </div>
+      </AuthCard>
     );
   }
 
   const isDenied = clerkStatus === "denied" || clerkStatus === "banned";
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background">
-      <div className="w-full max-w-sm space-y-4 px-4 text-center">
-        <h1 className="text-2xl font-semibold tracking-tight">WeftMark</h1>
+    <AuthCard>
+      <div className="text-center">
         {isDenied ? (
-          <p className="text-sm text-muted-foreground">
-            WeftMark is currently closed to new sign-ups, but your interest has been noted. We'll be in touch if that changes.
-          </p>
+          <>
+            <h1 className="text-lg font-semibold text-zinc-800">Account not approved</h1>
+            <p className="mt-2 text-sm text-stone-600">
+              WeftMark is currently closed to new sign-ups, but your interest has been noted. We'll be in touch if that
+              changes.
+            </p>
+          </>
         ) : (
           <>
-            <p className="text-sm text-muted-foreground">
-              Your sign-up request has been received. You'll get an email when an admin approves your account.
+            <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-amber-50">
+              <svg
+                className="h-5 w-5 text-amber-600"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.75}
+                aria-hidden="true"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6l4 2m6-2a10 10 0 11-20 0 10 10 0 0120 0z" />
+              </svg>
+            </div>
+            <h1 className="text-lg font-semibold text-zinc-800">Request received</h1>
+            <p className="mt-2 text-sm text-stone-600">
+              Your sign-up request has been submitted. You'll receive an email once an admin approves your account.
             </p>
-            <p className="text-xs text-muted-foreground">No action needed — sit tight.</p>
+            <p className="mt-3 text-xs text-stone-500">No action needed — sit tight.</p>
           </>
         )}
         <button
           onClick={() => signOut()}
-          className="text-sm underline underline-offset-2 text-muted-foreground hover:text-foreground"
+          className="mt-6 text-sm text-stone-500 underline underline-offset-2 hover:text-stone-700"
         >
           Sign out
         </button>
       </div>
-    </div>
+    </AuthCard>
   );
 }

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,26 +1,66 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { SignUp } from "@clerk/clerk-react";
+import { AuthCard } from "@/components/auth/AuthCard";
+
+const CLERK_APPEARANCE = {
+  variables: {
+    colorPrimary: "#27272a",
+    colorBackground: "#ffffff",
+    colorInputBackground: "#fafaf9",
+    colorText: "#1c1917",
+    colorTextSecondary: "#57534e",
+    borderRadius: "0.5rem",
+  },
+  elements: {
+    headerTitle: "hidden",
+    headerSubtitle: "hidden",
+  },
+};
+
+function isSSOStep() {
+  if (typeof window === "undefined") return false;
+  const h = window.location.hash;
+  return h.includes("sso") || h.includes("continue") || h.includes("oauth");
+}
 
 export function RegisterPage() {
+  const [ssoStep, setSSOStep] = useState(isSSOStep);
+
+  useEffect(() => {
+    const onHash = () => setSSOStep(isSSOStep());
+    window.addEventListener("hashchange", onHash);
+    return () => window.removeEventListener("hashchange", onHash);
+  }, []);
+
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background">
-      <div className="w-full max-w-sm space-y-6 px-4">
-        <div className="space-y-2 text-center">
-          <h1 className="text-2xl font-semibold tracking-tight">WeftMark</h1>
-          <p className="text-sm text-muted-foreground">Create your account</p>
-          <p className="text-xs text-amber-500 font-mono">WeftMark custom register page — not Clerk hosted</p>
-        </div>
-        <SignUp
-          routing="hash"
-          appearance={{
-            elements: {
-              rootBox: "w-full",
-              card: "shadow-none border rounded-lg p-6 bg-card",
-              headerTitle: "hidden",
-              headerSubtitle: "hidden",
-            },
-          }}
-        />
+    <AuthCard
+      naked
+      footer={
+        <>
+          Already have an account?{" "}
+          <Link to="/login" className="text-amber-700 underline underline-offset-2 hover:text-amber-800">
+            Sign in
+          </Link>
+        </>
+      }
+    >
+      <div className="mb-5 text-center">
+        {ssoStep ? (
+          <>
+            <h1 className="text-lg font-semibold text-zinc-800">One more step</h1>
+            <p className="mt-1 text-sm text-stone-600">
+              Your account was connected. Choose a display name to finish creating your weftmark account.
+            </p>
+          </>
+        ) : (
+          <>
+            <h1 className="text-lg font-semibold text-zinc-800">Create your account</h1>
+            <p className="mt-1 text-sm text-stone-600">Sign up with email or connect an existing account</p>
+          </>
+        )}
       </div>
-    </div>
+      <SignUp routing="hash" appearance={CLERK_APPEARANCE} />
+    </AuthCard>
   );
 }

--- a/frontend/src/pages/SignOutPage.tsx
+++ b/frontend/src/pages/SignOutPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth as useClerkAuth, useClerk } from "@clerk/clerk-react";
+import { AuthCard } from "@/components/auth/AuthCard";
 
 export function SignOutPage() {
   const { isSignedIn, isLoaded } = useClerkAuth();
@@ -18,15 +19,33 @@ export function SignOutPage() {
   }, [isLoaded, isSignedIn, signOut, navigate]);
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background">
-      <div className="space-y-2 text-center">
-        <h1 className="text-xl font-semibold">WeftMark</h1>
+    <AuthCard>
+      <div className="text-center">
         {!isLoaded || isSignedIn ? (
-          <p className="text-sm text-muted-foreground">Signing you out…</p>
+          <>
+            <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-2 border-stone-200 border-t-zinc-800" />
+            <h1 className="text-lg font-semibold text-zinc-800">Signing you out</h1>
+            <p className="mt-2 text-sm text-stone-600">Just a moment…</p>
+          </>
         ) : (
-          <p className="text-sm text-muted-foreground">You have been signed out. Redirecting…</p>
+          <>
+            <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-stone-100">
+              <svg
+                className="h-5 w-5 text-stone-500"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.75}
+                aria-hidden="true"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12h15m0 0l-6.75-6.75M19.5 12l-6.75 6.75" />
+              </svg>
+            </div>
+            <h1 className="text-lg font-semibold text-zinc-800">You've been signed out</h1>
+            <p className="mt-2 text-sm text-stone-600">Redirecting you to the home page…</p>
+          </>
         )}
       </div>
-    </div>
+    </AuthCard>
   );
 }

--- a/frontend/src/pages/UnauthorizedPage.tsx
+++ b/frontend/src/pages/UnauthorizedPage.tsx
@@ -1,23 +1,38 @@
 import { Link } from "react-router-dom";
 import { useAuth } from "@/hooks/useAuth";
+import { AuthCard } from "@/components/auth/AuthCard";
 
 export function UnauthorizedPage() {
   const { isAuthenticated } = useAuth();
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background">
-      <div className="max-w-sm space-y-4 px-4 text-center">
-        <h1 className="text-2xl font-semibold">Access denied</h1>
-        <p className="text-sm text-muted-foreground">
-          You don't have permission to view this page.
-        </p>
+    <AuthCard>
+      <div className="text-center">
+        <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-stone-100">
+          <svg
+            className="h-5 w-5 text-stone-500"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={1.75}
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+            />
+          </svg>
+        </div>
+        <h1 className="text-lg font-semibold text-zinc-800">Access denied</h1>
+        <p className="mt-2 text-sm text-stone-600">You don't have permission to view this page.</p>
         <Link
           to={isAuthenticated ? "/home" : "/login"}
-          className="inline-block text-sm underline underline-offset-2 text-muted-foreground hover:text-foreground"
+          className="mt-6 inline-block text-sm text-amber-700 underline underline-offset-2 hover:text-amber-800"
         >
           {isAuthenticated ? "Back to home" : "Sign in"}
         </Link>
       </div>
-    </div>
+    </AuthCard>
   );
 }


### PR DESCRIPTION
## Summary

- Full rename of the `Project` model, router, API paths, and frontend to `Draft`/`Drafts` (issues #296, #311, #312)
- Retheme all auth pages with Slate & Copper design system (issue #295)
- Remove all backward-compat `/projects` redirect routes — no legacy aliases

## What changed

### Backend
- `app/models/project.py` → `app/models/draft.py` (`Project` → `Draft`)
- `app/routers/projects.py` → `app/routers/drafts.py` (all routes `/api/drafts/...`)
- `app/services/storage.py` — new uploads write to `drafts/{id}/` prefix
- `app/routers/users.py`, `app/routers/admin.py`, `app/tasks/deletion.py` — all `Project` refs updated
- Alembic migrations 0006 (rename table/constraints/indexes) and 0007 (IF EXISTS guard for existing DBs)

### Frontend
- `api/projects.ts` → `api/drafts.ts`
- `pages/ProjectsPage.tsx` → `pages/DraftsPage.tsx`
- `pages/ProjectDetailPage.tsx` → `pages/DraftDetailPage.tsx`
- `components/projects/` → `components/drafts/` (DraftCard, UploadWifModal)
- App.tsx routes, Sidebar nav, Dashboard, Activities — all updated; no `/projects` redirects

### Auth pages (issue #295)
- New `AuthCard` shared shell: `bg-stone-50` page, grain texture, WeftmarkLogo + wordmark, card wrapper, footer slot
- LoginPage, RegisterPage, PendingPage, SignOutPage, UnauthorizedPage rethemed with consistent branding
- Removed all dev-mode placeholder labels ("WeftMark custom login page — not Clerk hosted")
- LoginPage/RegisterPage use `naked` AuthCard so Clerk renders its own card naturally (fixes alignment)
- RegisterPage detects SSO hash and shows username-step messaging

### Storage migration
- `tools/migrate_storage_paths.py` — script to copy R2 objects from `projects/{id}/` → `drafts/{id}/` and update DB paths; supports `--dry-run`

### Docs / tests
- Schema docs (`schema.json`, `schema.mermaid`) updated to `drafts` table and FK names
- All test fixtures with `wif_path="projects/..."` updated to `"drafts/..."`
- `CLAUDE.md`, requirements docs, testing.md updated to draft terminology

## Test plan

- [ ] `pytest` passes (823 tests)
- [ ] `tsc` clean
- [ ] Login page renders correctly — Clerk card aligned, no dev label
- [ ] Register page renders correctly — Clerk card aligned, no dev label
- [ ] SSO flow shows "One more step" username messaging
- [ ] Sign out page shows spinner then "You've been signed out"
- [ ] Unauthorized page shows warning icon and amber link
- [ ] Pending page shows clock icon and "Request received" copy
- [ ] `/drafts` route loads draft list
- [ ] WIF upload creates draft at `drafts/{id}/` storage path
- [ ] Activities create/list/detail work against draft records
- [ ] `/projects` and `/projects/:id` return 404 (no redirects)
- [ ] Admin user list shows `drafts` count correctly

Closes #295, #296, #311, #312