### PR TITLE
feat: complete auth pages color theming (#295)

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -45,12 +45,25 @@ export function LoginPage() {
     return (
       <AuthCard>
         <div className="text-center">
+          {isDenied ? (
+            <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-stone-100">
+              <svg className="h-5 w-5 text-stone-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75} aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+              </svg>
+            </div>
+          ) : (
+            <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-amber-50">
+              <svg className="h-5 w-5 text-amber-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75} aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6l4 2m6-2a10 10 0 11-20 0 10 10 0 0120 0z" />
+              </svg>
+            </div>
+          )}
           <h1 className="text-lg font-semibold text-zinc-800">
             {isDenied ? "Account not approved" : "Approval pending"}
           </h1>
           <p className="mt-2 text-sm text-stone-600">
             {isDenied
-              ? "WeftMark is currently closed to new sign-ups, but your interest has been noted. We'll be in touch if that changes."
+              ? "weftmark is currently closed to new sign-ups, but your interest has been noted. We'll be in touch if that changes."
               : "Your sign-up request has been received. You'll get an email when an admin approves your account."}
           </p>
           <button

--- a/frontend/src/pages/PendingPage.tsx
+++ b/frontend/src/pages/PendingPage.tsx
@@ -65,9 +65,21 @@ export function PendingPage() {
       <div className="text-center">
         {isDenied ? (
           <>
+            <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-stone-100">
+              <svg
+                className="h-5 w-5 text-stone-500"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.75}
+                aria-hidden="true"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+              </svg>
+            </div>
             <h1 className="text-lg font-semibold text-zinc-800">Account not approved</h1>
             <p className="mt-2 text-sm text-stone-600">
-              WeftMark is currently closed to new sign-ups, but your interest has been noted. We'll be in touch if that
+              weftmark is currently closed to new sign-ups, but your interest has been noted. We'll be in touch if that
               changes.
             </p>
           </>

--- a/frontend/src/pages/SignOutPage.tsx
+++ b/frontend/src/pages/SignOutPage.tsx
@@ -29,9 +29,9 @@ export function SignOutPage() {
           </>
         ) : (
           <>
-            <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-stone-100">
+            <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-amber-50">
               <svg
-                className="h-5 w-5 text-stone-500"
+                className="h-5 w-5 text-amber-600"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"

--- a/frontend/src/pages/UnauthorizedPage.tsx
+++ b/frontend/src/pages/UnauthorizedPage.tsx
@@ -8,9 +8,9 @@ export function UnauthorizedPage() {
   return (
     <AuthCard>
       <div className="text-center">
-        <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-stone-100">
+        <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-amber-50">
           <svg
-            className="h-5 w-5 text-stone-500"
+            className="h-5 w-5 text-amber-600"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"


### PR DESCRIPTION
## Summary

Completes issue #295 — consistent icon treatment and branding across all five auth flow pages.

### Icon treatment
All auth pages now use intentional icon colors rather than flat neutral stone:

| Page | State | Before | After |
|---|---|---|---|
| PendingPage | denied | no icon | no-entry circle, stone-100 / stone-500 |
| PendingPage | pending | amber clock ✓ | unchanged |
| UnauthorizedPage | — | warning triangle, stone-100 / stone-500 | warning triangle, amber-50 / amber-600 |
| SignOutPage | success | arrow, stone-100 / stone-500 | arrow, amber-50 / amber-600 |
| LoginPage | pending | no icon | amber clock, amber-50 / amber-600 |
| LoginPage | denied | no icon | no-entry circle, stone-100 / stone-500 |

### Branding fix
`"WeftMark is currently closed to new sign-ups"` → `"weftmark is currently closed to new sign-ups"` in LoginPage and PendingPage — matches the lowercase wordmark used everywhere else in user-facing copy.

## Test plan

- [ ] Sign in with a pending account → PendingPage shows amber clock icon
- [ ] Sign in with a denied/banned account → PendingPage shows stone no-entry icon, lowercase "weftmark" in copy
- [ ] Visit a protected route while unauthenticated → UnauthorizedPage shows amber warning triangle
- [ ] Sign out → SignOutPage completion state shows amber arrow
- [ ] Verify branding reads "weftmark" (lowercase) in denied copy on both LoginPage and PendingPage

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)