### PR TITLE
chore: upgrade Postgres 16→17 in dev compose and CI

### DIFF
--- a/.github/workflows/ci-dev-pr.yml
+++ b/.github/workflows/ci-dev-pr.yml
@@ -58,7 +58,7 @@ jobs:
     needs: [backend-lint]
     services:
       postgres:
-        image: postgres:16
+        image: postgres:17
         env:
           POSTGRES_DB: weaving_site
           POSTGRES_USER: weaving_user
@@ -91,7 +91,7 @@ jobs:
     needs: [backend-lint]
     services:
       postgres:
-        image: postgres:16
+        image: postgres:17
         env:
           POSTGRES_DB: weaving_site
           POSTGRES_USER: weaving_user

--- a/.github/workflows/ci-hotfix.yml
+++ b/.github/workflows/ci-hotfix.yml
@@ -55,7 +55,7 @@ jobs:
     needs: [backend-lint]
     services:
       postgres:
-        image: postgres:16
+        image: postgres:17
         env:
           POSTGRES_DB: weaving_site
           POSTGRES_USER: weaving_user
@@ -88,7 +88,7 @@ jobs:
     needs: [backend-lint]
     services:
       postgres:
-        image: postgres:16
+        image: postgres:17
         env:
           POSTGRES_DB: weaving_site
           POSTGRES_USER: weaving_user

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -190,7 +190,7 @@ services:
   # ----------------------------------------------------------
   db:
     profiles: ["local-db"]
-    image: postgres:16-alpine
+    image: postgres:17-alpine
     container_name: weaving_site_db
     networks:
       - internal


### PR DESCRIPTION
## Summary

- `docker-compose.build.yml`: `postgres:16-alpine` → `postgres:17-alpine`
- `ci-dev-pr.yml` (2 occurrences): `postgres:16` → `postgres:17`
- `ci-hotfix.yml` (2 occurrences): `postgres:16` → `postgres:17`

Aligns local dev and CI with production (Neon PG17). Version skew was a risk for PG17-specific behaviour passing in prod but failing CI.

## Data migration

Local dev volume migrated via `pg_dump` (custom format) on PG16 → `pg_restore` into fresh PG17 volume. Verified post-restore:
- PostgreSQL 17.9 running
- 4 users present
- `alembic_version` = `b3c4d5e6f7a8`
- Backend started cleanly, migrations no-op, health check passing

## Test plan

- [x] CI passes (migration-smoke-test confirms schema applies cleanly on PG17)
- [x] Golden path smoke test: login, create project, upload WIF

Closes #356. Part of #355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)