### PR TITLE
feat: add worker version to version badge, startup gate, and admin tab

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -1,6 +1,10 @@
 from celery import Celery
+from celery.signals import worker_ready
 
 from app.config import get_settings
+from app.version import VERSION
+
+WORKER_VERSION_KEY = "weftmark:worker_version"
 
 
 def _make_celery() -> Celery:
@@ -25,3 +29,17 @@ def _make_celery() -> Celery:
 
 
 celery_app = _make_celery()
+
+
+@worker_ready.connect
+def _publish_worker_version(**kwargs):
+    """Write VERSION to Redis when the worker process finishes startup."""
+    try:
+        import redis as _redis
+
+        settings = get_settings()
+        client = _redis.from_url(settings.redis_url, socket_connect_timeout=2)
+        client.set(WORKER_VERSION_KEY, VERSION)
+        client.close()
+    except Exception:
+        pass  # version badge degrades gracefully if Redis is unavailable

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -107,6 +107,7 @@ class AdminVersionsResponse(BaseModel):
     python: str
     redis_server: str
     celery: str
+    worker: str | None
     postgres: str
     postgres_source: str
     fastapi: str
@@ -1383,6 +1384,21 @@ async def _redis_server_version() -> str:
         return "unavailable"
 
 
+async def _worker_version() -> str | None:
+    try:
+        import redis.asyncio as aioredis
+
+        from app.celery_app import WORKER_VERSION_KEY
+
+        settings = get_settings()
+        client = aioredis.from_url(settings.redis_url, socket_connect_timeout=2)
+        value = await client.get(WORKER_VERSION_KEY)
+        await client.aclose()
+        return value.decode() if value else None
+    except Exception:
+        return None
+
+
 @router.get("/versions", response_model=AdminVersionsResponse)
 async def get_versions(
     _: User = Depends(require_admin),
@@ -1400,6 +1416,7 @@ async def get_versions(
         python=platform.python_version(),
         redis_server=await _redis_server_version(),
         celery=_pkg("celery"),
+        worker=await _worker_version(),
         postgres=pg_version,
         postgres_source=pg_source,
         fastapi=_pkg("fastapi"),

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -9,6 +9,8 @@ from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+from app.celery_app import WORKER_VERSION_KEY
+from app.config import get_settings
 from app.version import VERSION
 
 router = APIRouter(tags=["health"])
@@ -41,9 +43,23 @@ def set_readiness(result: ReadinessResponse) -> None:
     _readiness_cache = result
 
 
+async def _get_worker_version() -> str | None:
+    try:
+        import redis.asyncio as aioredis
+
+        settings = get_settings()
+        client = aioredis.from_url(settings.redis_url, socket_connect_timeout=2)
+        value = await client.get(WORKER_VERSION_KEY)
+        await client.aclose()
+        return value.decode() if value else None
+    except Exception:
+        return None
+
+
 @router.get("/health")
 async def health() -> dict:
-    return {"status": "ok", "version": VERSION}
+    worker_version = await _get_worker_version()
+    return {"status": "ok", "version": VERSION, "worker_version": worker_version}
 
 
 @router.get("/health/ready")

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -55,6 +55,7 @@ export interface AdminVersions {
   python: string;
   redis_server: string;
   celery: string;
+  worker: string | null;
   postgres: string;
   postgres_source: string;
   fastapi: string;

--- a/frontend/src/components/VersionGate.tsx
+++ b/frontend/src/components/VersionGate.tsx
@@ -6,18 +6,28 @@ type Status = "loading" | "ok" | "mismatch" | "unreachable";
 export function VersionGate({ children }: { children: React.ReactNode }) {
   const [status, setStatus] = useState<Status>("loading");
   const [backendVersion, setBackendVersion] = useState("");
+  const [workerVersion, setWorkerVersion] = useState<string | undefined>();
 
   useEffect(() => {
     fetch("/health")
       .then((res) => res.json())
-      .then((data: { version: string }) => {
+      .then((data: { version: string; worker_version?: string | null }) => {
         setBackendVersion(data.version);
-        setStatus(data.version === __APP_VERSION__ ? "ok" : "mismatch");
+        setWorkerVersion(data.worker_version ?? undefined);
+        const apiMismatch = data.version !== __APP_VERSION__;
+        const workerMismatch = !!data.worker_version && data.worker_version !== data.version;
+        setStatus(apiMismatch || workerMismatch ? "mismatch" : "ok");
       })
       .catch(() => setStatus("unreachable"));
   }, []);
 
   if (status === "loading") return null;
   if (status === "ok") return <>{children}</>;
-  return <VersionErrorPage frontendVersion={__APP_VERSION__} backendVersion={backendVersion} />;
+  return (
+    <VersionErrorPage
+      frontendVersion={__APP_VERSION__}
+      backendVersion={backendVersion}
+      workerVersion={workerVersion}
+    />
+  );
 }

--- a/frontend/src/components/layout/VersionFooter.tsx
+++ b/frontend/src/components/layout/VersionFooter.tsx
@@ -4,6 +4,7 @@ import { api } from "@/api/client";
 interface HealthResponse {
   status: string;
   version: string;
+  worker_version?: string | null;
 }
 
 export function VersionBadge() {
@@ -18,6 +19,7 @@ export function VersionBadge() {
     <div className="fixed bottom-3 right-4 z-50 flex items-center gap-2 text-xs bg-muted border border-border rounded px-2 py-1 text-foreground select-none pointer-events-none">
       <span>UI v{__APP_VERSION__}</span>
       {data?.version && <span>API v{data.version}</span>}
+      {data?.worker_version && <span>Worker v{data.worker_version}</span>}
     </div>
   );
 }

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -877,6 +877,7 @@ function VersionsTable() {
     { label: "PostgreSQL", value: `${data.postgres} · ${data.postgres_source}` },
     { label: "Redis", value: data.redis_server },
     { label: "Celery", value: data.celery },
+    { label: "Worker", value: data.worker ?? "not reported" },
   ];
 
   const deps = [

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -874,10 +874,10 @@ function VersionsTable() {
   const versions = [
     { label: "Frontend", value: __APP_VERSION__ },
     { label: "API", value: data.app },
+    { label: "Worker", value: data.worker ?? "not reported" },
     { label: "PostgreSQL", value: `${data.postgres} · ${data.postgres_source}` },
     { label: "Redis", value: data.redis_server },
     { label: "Celery", value: data.celery },
-    { label: "Worker", value: data.worker ?? "not reported" },
   ];
 
   const deps = [

--- a/frontend/src/pages/VersionErrorPage.tsx
+++ b/frontend/src/pages/VersionErrorPage.tsx
@@ -1,9 +1,10 @@
 interface Props {
   frontendVersion: string;
   backendVersion: string;
+  workerVersion?: string;
 }
 
-export function VersionErrorPage({ frontendVersion, backendVersion }: Props) {
+export function VersionErrorPage({ frontendVersion, backendVersion, workerVersion }: Props) {
   return (
     <div className="flex min-h-screen items-center justify-center bg-background">
       <div className="w-full max-w-sm space-y-6 px-4 text-center">
@@ -17,6 +18,7 @@ export function VersionErrorPage({ frontendVersion, backendVersion }: Props) {
         <div className="rounded-md bg-muted px-4 py-3 text-left font-mono text-xs text-muted-foreground space-y-1">
           <div>Frontend: {frontendVersion}</div>
           <div>Backend:&nbsp; {backendVersion || "unreachable"}</div>
+          {workerVersion && <div>Worker:&nbsp;&nbsp; {workerVersion}</div>}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Closes #373.

Worker publishes its VERSION to Redis (`weftmark:worker_version`) via the Celery `worker_ready` signal. The `/health` endpoint reads that key and includes `worker_version` in the response (null until the worker reports in).

**Version badge** (bottom-right of every page): now shows `Worker v{x}` alongside UI and API.

**Startup VersionGate**: if `worker_version` is present and mismatches the API version, blocks with the mismatch error page. Gracefully skips the check if the key is absent (worker still starting).

**Admin → Health tab versions table**: Worker row inserted after API, before PostgreSQL. Shows "not reported" if the worker hasn't started yet.

## Test plan

- [x] `tsc --noEmit` clean, all pre-commit hooks pass
- [x] `/health` returns `worker_version: "0.83.5"` locally
- [ ] Rebuild and verify version badge shows all three
- [ ] Admin health tab shows Worker row in correct position
- [ ] Stop worker, confirm badge still shows UI + API (graceful degradation)
- [ ] Simulate version mismatch — confirm gate blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)