### PR TITLE
chore: add .claude/settings.json with auto-approved command patterns

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,35 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(docker compose *)",
+      "Bash(docker exec *)",
+      "Bash(docker logs *)",
+      "Bash(docker inspect *)",
+      "Bash(docker cp *)",
+      "Bash(docker ps*)",
+      "Bash(docker volume *)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git push *)",
+      "Bash(git pull *)",
+      "Bash(git fetch *)",
+      "Bash(git checkout *)",
+      "Bash(git stash *)",
+      "Bash(git log *)",
+      "Bash(git diff *)",
+      "Bash(git status*)",
+      "Bash(git show *)",
+      "Bash(gh pr *)",
+      "Bash(gh run *)",
+      "Bash(gh issue *)",
+      "Bash(gh release *)",
+      "Bash(conda run *)",
+      "Bash(npx tsc *)",
+      "Bash(npm run *)",
+      "Bash(npm install *)",
+      "Bash(curl -s http://localhost:*)",
+      "Bash(python -c '*)",
+      "Bash(ssh *)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -204,8 +204,10 @@ celerybeat.pid
 # ------------------------------------------------------------
 # AI Agents & Coding Assistants
 # ------------------------------------------------------------
-# Claude Code — entire directory excluded (settings, memory, session state)
-.claude/
+# Claude Code — exclude session state and personal overrides; track settings.json
+.claude/*
+!.claude/settings.json
+.claude/settings.local.json
 
 # Cursor
 .cursor/


### PR DESCRIPTION
## Summary

Adds `.claude/settings.json` so Claude auto-approves bash commands triggered by chat aliases without prompting for confirmation each time.

**Patterns allowed:**
- `docker compose/exec/logs/inspect/cp/ps/volume` — `rbd`, `ulocal`
- `git add/commit/push/pull/fetch/checkout/stash/log/diff/status/show` — `cap`, `reb`
- `gh pr/run/issue/release` — `prd`, `prm`, `rrm`, `rtc`, `li`, `aac`
- `conda run`, `npx tsc`, `npm run/install` — build and test commands
- `curl -s http://localhost:*` — health checks
- `ssh *` — `ussh`

`.gitignore` updated: tracks `settings.json`, gitignores `settings.local.json` for personal overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)