### PR TITLE
fix: harden file upload validation (#320)

### DIFF
--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -1,3 +1,4 @@
+import urllib.parse
 import uuid
 from datetime import datetime
 from typing import Annotated
@@ -16,6 +17,14 @@ from app.services import rendering, storage, wif_linter, wif_modifier, wif_parse
 
 router = APIRouter(prefix="/api/drafts", tags=["drafts"])
 settings = get_settings()
+
+_WIF_MAGIC = b"[WIF]"
+
+
+def _content_disposition(filename: str) -> str:
+    ascii_fallback = "".join(c if c.isascii() and c not in '"\\\r\n' else "_" for c in filename)
+    encoded = urllib.parse.quote(filename, safe="")
+    return f"attachment; filename=\"{ascii_fallback}\"; filename*=UTF-8''{encoded}"
 
 
 # ---------------------------------------------------------------------------
@@ -83,6 +92,8 @@ async def create_draft(
     wif_bytes = await wif_file.read()
     if len(wif_bytes) > settings.max_upload_size:
         raise HTTPException(status_code=413, detail="File too large")
+    if not wif_bytes.lstrip()[:5].upper() == _WIF_MAGIC:
+        raise HTTPException(status_code=400, detail="File does not appear to be a valid WIF file")
 
     lint = wif_linter.lint(wif_bytes)
 
@@ -236,7 +247,7 @@ async def download_wif(
     return Response(
         content=wif_bytes,
         media_type="application/octet-stream",
-        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        headers={"Content-Disposition": _content_disposition(filename)},
     )
 
 
@@ -260,7 +271,7 @@ async def download_wif_modified(
     return Response(
         content=wif_bytes,
         media_type="application/octet-stream",
-        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        headers={"Content-Disposition": _content_disposition(filename)},
     )
 
 

--- a/backend/app/routers/looms.py
+++ b/backend/app/routers/looms.py
@@ -565,7 +565,7 @@ async def upload_version_receipt(
     loom, version = await _get_owned_version(loom_id, version_id, current_user, db)
     data = await file.read()
     if len(data) > MAX_FILE_SIZE:
-        raise HTTPException(status_code=400, detail="File too large (max 20 MB)")
+        raise HTTPException(status_code=400, detail="File too large (max 5 MB)")
     receipt_id = uuid.uuid4()
     ext = _ext(file.content_type or "")
     path = storage.save_version_receipt(loom_id, version_id, receipt_id, ext, data)

--- a/backend/tests/routers/test_drafts.py
+++ b/backend/tests/routers/test_drafts.py
@@ -384,6 +384,23 @@ class TestCreateDraft:
         )
         assert resp.status_code == 401
 
+    async def test_wif_extension_but_non_wif_content_returns_400(self, auth_client: AsyncClient):
+        resp = await auth_client.post(
+            "/api/drafts",
+            files={"wif_file": ("fake.wif", b"not a wif file at all", "application/octet-stream")},
+            data={"name": "Bad Draft"},
+        )
+        assert resp.status_code == 400
+
+    async def test_wif_extension_with_jpeg_content_returns_400(self, auth_client: AsyncClient):
+        jpeg_magic = b"\xff\xd8\xff\xe0" + b"\x00" * 100
+        resp = await auth_client.post(
+            "/api/drafts",
+            files={"wif_file": ("photo.wif", jpeg_magic, "application/octet-stream")},
+            data={"name": "Bad Draft"},
+        )
+        assert resp.status_code == 400
+
 
 # ---------------------------------------------------------------------------
 # GET /api/drafts/{draft_id}/preview
@@ -518,6 +535,18 @@ class TestDownloadWif:
     async def test_unauthenticated_returns_401(self, raw_client: AsyncClient):
         resp = await raw_client.get(f"/api/drafts/{uuid.uuid4()}/wif")
         assert resp.status_code == 401
+
+    async def test_content_disposition_uses_rfc5987_encoding(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User, mock_storage: dict
+    ):
+        mock_storage["drafts/x/original.wif"] = _WIF
+        draft = await _insert_draft(db_session, test_user, wif_path="drafts/x/original.wif")
+        draft.wif_filename = 'my "draft".wif'
+        await db_session.commit()
+        resp = await auth_client.get(f"/api/drafts/{draft.id}/wif")
+        cd = resp.headers.get("content-disposition", "")
+        assert "filename*=UTF-8''" in cd
+        assert "my%20%22draft%22" in cd or "my%22" in cd  # URL-encoded form in filename*
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **WIF magic bytes check** — files with a `.wif` extension but non-WIF content (JPEG, binary, etc.) are now rejected with 400 before they reach the linter or storage. WIF 1.1 files must start with `[WIF]`.
- **RFC 5987 Content-Disposition encoding** — WIF download headers now use the same RFC 5987 pattern already used by `looms.py`, preventing header injection via a crafted `wif_filename`.
- **Looms receipt size error message** — fixes `"max 20 MB"` message (the actual limit is `MAX_FILE_SIZE = 5 MB`).

## Test plan

- [x] `test_wif_extension_but_non_wif_content_returns_400` — binary content with `.wif` name → 400
- [x] `test_wif_extension_with_jpeg_content_returns_400` — JPEG magic bytes with `.wif` name → 400
- [x] `test_content_disposition_uses_rfc5987_encoding` — download header includes `filename*=UTF-8''` and percent-encodes the filename
- [x] Full suite 911 passed

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)