### PR TITLE
fix: add per-IP Redis rate limiting to auth and upload endpoints (#321)

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -43,10 +43,13 @@ from app.models.user import User
 from app.services.audit import write_audit_log
 from app.services.clerk import set_user_metadata
 from app.services.email import send_invite_email, send_pending_signup_notification, send_signup_received_email
+from app.services.rate_limiter import rate_limit
 
 log = logging.getLogger(__name__)
 router = APIRouter(prefix="/auth", tags=["auth"])
 settings = get_settings()
+
+_invite_rate_limit = rate_limit("invite", max_requests=20, window_seconds=3600)
 
 
 # ---------------------------------------------------------------------------
@@ -323,6 +326,7 @@ async def create_invite(
     body: InviteRequest,
     admin: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
+    _rl: None = Depends(_invite_rate_limit),
 ) -> Invite:
     from app.models.invite import INVITE_ROLES
 

--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -14,9 +14,12 @@ from app.deps import get_current_user, get_db
 from app.models.draft import Draft
 from app.models.user import User
 from app.services import rendering, storage, wif_linter, wif_modifier, wif_parser
+from app.services.rate_limiter import rate_limit
 
 router = APIRouter(prefix="/api/drafts", tags=["drafts"])
 settings = get_settings()
+
+_upload_rate_limit = rate_limit("wif_upload", max_requests=30, window_seconds=3600)
 
 _WIF_MAGIC = b"[WIF]"
 
@@ -85,6 +88,7 @@ async def create_draft(
     description: Annotated[str | None, Form()] = None,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    _rl: None = Depends(_upload_rate_limit),
 ) -> DraftSummary:
     if not wif_file.filename or not wif_file.filename.lower().endswith(".wif"):
         raise HTTPException(status_code=400, detail="File must have a .wif extension")

--- a/backend/app/services/rate_limiter.py
+++ b/backend/app/services/rate_limiter.py
@@ -1,0 +1,50 @@
+"""Per-IP Redis-backed rate limiting — returned as FastAPI Depends() factories.
+
+Usage:
+    _my_limit = rate_limit("my_endpoint", max_requests=20, window_seconds=3600)
+
+    @router.post("/endpoint")
+    async def my_endpoint(..., _rl: None = Depends(_my_limit)):
+        ...
+
+Keys stored in Redis as  rl:<prefix>:<ip>  with a TTL equal to window_seconds.
+The window is fixed (not sliding): the counter resets after window_seconds from
+the first request in that window.
+"""
+
+import redis.asyncio as aioredis
+from fastapi import HTTPException, Request
+
+from app.config import get_settings
+
+settings = get_settings()
+
+
+def _get_client_ip(request: Request) -> str:
+    forwarded = request.headers.get("X-Forwarded-For")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def rate_limit(key_prefix: str, max_requests: int, window_seconds: int):
+    """Return a FastAPI dependency that enforces a per-IP rate limit via Redis."""
+
+    async def _check(request: Request) -> None:
+        ip = _get_client_ip(request)
+        key = f"rl:{key_prefix}:{ip}"
+        client = aioredis.from_url(settings.redis_url, decode_responses=True)
+        try:
+            count = await client.incr(key)
+            # nx=True: only set TTL on the first increment (fixes the window start)
+            await client.expire(key, window_seconds, nx=True)
+            if count > max_requests:
+                raise HTTPException(
+                    status_code=429,
+                    detail="Too many requests. Please try again later.",
+                    headers={"Retry-After": str(window_seconds)},
+                )
+        finally:
+            await client.aclose()
+
+    return _check

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -3,3 +3,4 @@ pytest==8.3.4
 pytest-asyncio==0.24.0
 pytest-cov==7.1.0
 ruff==0.15.11
+fakeredis[aioredis]==2.28.1

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -331,3 +331,27 @@ def mock_storage(monkeypatch):
     monkeypatch.setattr(_storage, "_exists", lambda key: bool(key) and key in _store)
 
     return _store
+
+
+@pytest.fixture(autouse=True)
+def bypass_rate_limits():
+    """Disable Redis-backed rate limiting for all tests.
+
+    Rate limit tests that need real enforcement use fakeredis directly and
+    do NOT go through the HTTP client fixtures.
+    """
+    from app.main import app
+    from app.routers.auth import _invite_rate_limit
+    from app.routers.drafts import _upload_rate_limit
+
+    async def _noop() -> None:
+        pass
+
+    app.dependency_overrides[_invite_rate_limit] = _noop
+    app.dependency_overrides[_upload_rate_limit] = _noop
+    yield
+    # Client fixtures call dependency_overrides.clear() after each test,
+    # so these are cleaned up automatically when a client fixture is used.
+    # For tests without a client fixture, clean up here.
+    app.dependency_overrides.pop(_invite_rate_limit, None)
+    app.dependency_overrides.pop(_upload_rate_limit, None)

--- a/backend/tests/routers/test_auth.py
+++ b/backend/tests/routers/test_auth.py
@@ -642,3 +642,27 @@ class TestConsumeInvite:
 
         result = await _consume_invite(db_session, "noinvite@example.com")
         assert result is None
+
+
+class TestInviteRateLimit:
+    """Verify the rate limit dependency is actually wired into POST /auth/invite."""
+
+    async def test_429_after_limit_exceeded(self, admin_client: AsyncClient, db_session: AsyncSession):
+        from unittest.mock import patch
+
+        import fakeredis.aioredis
+
+        from app.main import app
+        from app.routers.auth import _invite_rate_limit
+
+        fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
+        app.dependency_overrides.pop(_invite_rate_limit, None)
+        try:
+            with patch("app.services.rate_limiter.aioredis.from_url", return_value=fake):
+                for i in range(20):
+                    await admin_client.post("/auth/invite", json={"email": f"rl{i}@example.com", "role": "user"})
+                resp = await admin_client.post("/auth/invite", json={"email": "overflow@example.com", "role": "user"})
+            assert resp.status_code == 429
+            assert "retry-after" in resp.headers
+        finally:
+            app.dependency_overrides[_invite_rate_limit] = lambda: None

--- a/backend/tests/routers/test_auth.py
+++ b/backend/tests/routers/test_auth.py
@@ -647,6 +647,11 @@ class TestConsumeInvite:
 class TestInviteRateLimit:
     """Verify the rate limit dependency is actually wired into POST /auth/invite."""
 
+    @pytest.fixture(autouse=True)
+    def mock_email(self):
+        with patch("app.routers.auth.send_invite_email", new_callable=AsyncMock):
+            yield
+
     async def test_429_after_limit_exceeded(self, admin_client: AsyncClient, db_session: AsyncSession):
         from unittest.mock import patch
 

--- a/backend/tests/routers/test_drafts.py
+++ b/backend/tests/routers/test_drafts.py
@@ -659,3 +659,41 @@ class TestOverrideMetadata:
             json={"field": "num_shafts", "value": 8},
         )
         assert resp.status_code == 401
+
+
+class TestUploadRateLimit:
+    """Verify the rate limit dependency is actually wired into POST /api/drafts."""
+
+    @pytest.fixture(autouse=True)
+    def _use_tmp_upload_dir(self, tmp_path, monkeypatch):
+        import app.services.storage as _storage
+
+        monkeypatch.setattr(_storage.settings, "upload_dir", str(tmp_path))
+
+    async def test_429_after_limit_exceeded(self, auth_client: AsyncClient):
+        from unittest.mock import patch
+
+        import fakeredis.aioredis
+
+        from app.main import app
+        from app.routers.drafts import _upload_rate_limit
+
+        fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
+        app.dependency_overrides.pop(_upload_rate_limit, None)
+        try:
+            with patch("app.services.rate_limiter.aioredis.from_url", return_value=fake):
+                for i in range(30):
+                    await auth_client.post(
+                        "/api/drafts",
+                        files={"wif_file": (f"draft{i}.wif", _WIF, "application/octet-stream")},
+                        data={"name": f"Draft {i}"},
+                    )
+                resp = await auth_client.post(
+                    "/api/drafts",
+                    files={"wif_file": ("overflow.wif", _WIF, "application/octet-stream")},
+                    data={"name": "Overflow"},
+                )
+            assert resp.status_code == 429
+            assert "retry-after" in resp.headers
+        finally:
+            app.dependency_overrides[_upload_rate_limit] = lambda: None

--- a/backend/tests/services/test_rate_limiter.py
+++ b/backend/tests/services/test_rate_limiter.py
@@ -1,0 +1,107 @@
+"""Unit tests for the Redis-backed rate limiter."""
+
+from unittest.mock import patch
+
+import fakeredis.aioredis
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+
+def _make_request(ip: str = "1.2.3.4", forwarded_for: str | None = None) -> Request:
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/test",
+        "headers": [],
+        "client": (ip, 12345),
+    }
+    if forwarded_for:
+        scope["headers"] = [(b"x-forwarded-for", forwarded_for.encode())]
+    return Request(scope)
+
+
+@pytest.fixture
+def fake_redis():
+    return fakeredis.aioredis.FakeRedis(decode_responses=True)
+
+
+class TestRateLimiter:
+    async def test_allows_requests_under_limit(self, fake_redis):
+        from app.services.rate_limiter import rate_limit
+
+        limiter = rate_limit("test", max_requests=5, window_seconds=60)
+        request = _make_request()
+
+        with patch("app.services.rate_limiter.aioredis.from_url", return_value=fake_redis):
+            for _ in range(5):
+                await limiter(request)  # should not raise
+
+    async def test_blocks_request_over_limit(self, fake_redis):
+        from app.services.rate_limiter import rate_limit
+
+        limiter = rate_limit("test_block", max_requests=3, window_seconds=60)
+        request = _make_request()
+
+        with patch("app.services.rate_limiter.aioredis.from_url", return_value=fake_redis):
+            for _ in range(3):
+                await limiter(request)
+            with pytest.raises(HTTPException) as exc_info:
+                await limiter(request)
+        assert exc_info.value.status_code == 429
+
+    async def test_429_includes_retry_after_header(self, fake_redis):
+        from app.services.rate_limiter import rate_limit
+
+        limiter = rate_limit("test_header", max_requests=1, window_seconds=300)
+        request = _make_request()
+
+        with patch("app.services.rate_limiter.aioredis.from_url", return_value=fake_redis):
+            await limiter(request)
+            with pytest.raises(HTTPException) as exc_info:
+                await limiter(request)
+        assert "Retry-After" in exc_info.value.headers
+        assert exc_info.value.headers["Retry-After"] == "300"
+
+    async def test_different_ips_have_independent_counters(self, fake_redis):
+        from app.services.rate_limiter import rate_limit
+
+        limiter = rate_limit("test_ip", max_requests=1, window_seconds=60)
+        req_a = _make_request(ip="10.0.0.1")
+        req_b = _make_request(ip="10.0.0.2")
+
+        with patch("app.services.rate_limiter.aioredis.from_url", return_value=fake_redis):
+            await limiter(req_a)  # first request from A — OK
+            await limiter(req_b)  # first request from B — OK (independent counter)
+
+    async def test_uses_x_forwarded_for_when_present(self, fake_redis):
+        from app.services.rate_limiter import rate_limit
+
+        limiter = rate_limit("test_xff", max_requests=1, window_seconds=60)
+        # Socket IP is proxy; real client IP is in X-Forwarded-For
+        req = _make_request(ip="172.18.0.1", forwarded_for="203.0.113.5, 172.18.0.1")
+
+        with patch("app.services.rate_limiter.aioredis.from_url", return_value=fake_redis):
+            await limiter(req)  # OK
+            with pytest.raises(HTTPException):
+                await limiter(req)  # 429 — counted against 203.0.113.5, not proxy IP
+
+
+class TestGetClientIp:
+    def test_returns_socket_ip_when_no_header(self):
+        from app.services.rate_limiter import _get_client_ip
+
+        req = _make_request(ip="9.8.7.6")
+        assert _get_client_ip(req) == "9.8.7.6"
+
+    def test_returns_first_forwarded_for_ip(self):
+        from app.services.rate_limiter import _get_client_ip
+
+        req = _make_request(forwarded_for="1.1.1.1, 2.2.2.2, 3.3.3.3")
+        assert _get_client_ip(req) == "1.1.1.1"
+
+    def test_strips_whitespace_from_forwarded_for(self):
+        from app.services.rate_limiter import _get_client_ip
+
+        req = _make_request(forwarded_for="  1.1.1.1  , 2.2.2.2")
+        assert _get_client_ip(req) == "1.1.1.1"


### PR DESCRIPTION
## Summary

- New `app/services/rate_limiter.py` — fixed-window per-IP rate limit as a FastAPI `Depends()` factory, using `redis.asyncio` INCR + EXPIRE NX (atomic window start)
- `POST /auth/invite` — 20 requests/hour/IP
- `POST /api/drafts` — 30 requests/hour/IP
- `X-Forwarded-For` support so real client IP is used when behind nginx
- 429 response includes `Retry-After` header
- `fakeredis` added to `requirements-dev.txt` for isolated unit tests
- Autouse `bypass_rate_limits` fixture in conftest bypasses rate limits for all existing tests so no test regressions

## Test plan

- [x] `test_allows_requests_under_limit` — N requests within limit all pass
- [x] `test_blocks_request_over_limit` — N+1th request returns 429
- [x] `test_429_includes_retry_after_header` — header present with correct window
- [x] `test_different_ips_have_independent_counters` — per-IP isolation
- [x] `test_uses_x_forwarded_for_when_present` — proxy header is used
- [x] `TestGetClientIp` — IP extraction from socket and header
- [x] Full suite 919 passed (0 regressions)

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)