### PR TITLE
fix: UI copy and layout fixes (#314, #315, #326)

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -216,17 +216,17 @@ export function DashboardPage() {
 
         <div className="mt-3 grid grid-cols-2 gap-3">
           <div className="rounded-lg border p-4 flex items-center gap-3">
-            <AppIcons.projectCompleted className="h-6 w-6 text-muted-foreground shrink-0" strokeWidth={1.75} />
-            <div>
-              <p className="text-2xl font-bold tabular-nums">{completedCount}</p>
-              <p className="text-xs text-muted-foreground">Completed</p>
-            </div>
-          </div>
-          <div className="rounded-lg border p-4 flex items-center gap-3">
             <AppIcons.projectActive className="h-6 w-6 text-muted-foreground shrink-0" strokeWidth={1.75} />
             <div>
               <p className="text-2xl font-bold tabular-nums">{activeProjects.length + planningProjects.length}</p>
               <p className="text-xs text-muted-foreground">Active</p>
+            </div>
+          </div>
+          <div className="rounded-lg border p-4 flex items-center gap-3">
+            <AppIcons.projectCompleted className="h-6 w-6 text-muted-foreground shrink-0" strokeWidth={1.75} />
+            <div>
+              <p className="text-2xl font-bold tabular-nums">{completedCount}</p>
+              <p className="text-xs text-muted-foreground">Completed</p>
             </div>
           </div>
         </div>

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -73,10 +73,10 @@ function ProjectCard({ project, onAssign }: {
               <div className="flex items-center gap-1.5 shrink-0">
                 <button
                   type="button"
-                  aria-label="Preview design"
+                  aria-label="Preview drawdown"
                   onClick={(e) => { e.preventDefault(); setShowPreview(true); }}
                   className="text-muted-foreground hover:text-foreground transition-colors"
-                  title="Preview design"
+                  title="Preview drawdown"
                 >
                   <svg width="13" height="13" viewBox="0 0 12 12" fill="currentColor" aria-hidden>
                     <rect x="0" y="0" width="5" height="5" rx="1" />

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -108,18 +108,18 @@ export function SettingsPage() {
 
   return (
     <div className="mx-auto max-w-2xl px-4 py-8">
+        {(saveSuccess || saveError) && (
+          <div
+            className={`fixed bottom-6 left-1/2 z-50 -translate-x-1/2 rounded-md px-4 py-2 text-sm shadow-lg ${
+              saveSuccess
+                ? "bg-green-500/10 text-green-700 dark:text-green-400"
+                : "bg-destructive/10 text-destructive"
+            }`}
+          >
+            {saveSuccess ? "Saved" : saveError}
+          </div>
+        )}
         <div className="space-y-6">
-            {(saveSuccess || saveError) && (
-              <div
-                className={`rounded-md px-4 py-2 text-sm ${
-                  saveSuccess
-                    ? "bg-green-500/10 text-green-700 dark:text-green-400"
-                    : "bg-destructive/10 text-destructive"
-                }`}
-              >
-                {saveSuccess ? "Saved" : saveError}
-              </div>
-            )}
 
             {/* ── Appearance ── */}
             {activeSection === "appearance" && (


### PR DESCRIPTION
## Summary

Three small UI fixes in one branch:

- **#314** — `ProjectsPage.tsx`: rename `aria-label` and `title` from `"Preview design"` to `"Preview drawdown"` (correct weaving terminology)
- **#315** — `DashboardPage.tsx`: swap Active/Completed card order — Active now renders first (left), Completed second (right)
- **#326** — `SettingsPage.tsx`: move save/error banner from inline (causes layout shift) to `fixed bottom-6 left-1/2` toast — no longer shifts page content when it appears/dismisses

## Test plan

- [x] No remaining instances of "preview design" in codebase
- [x] Dashboard Active card is left, Completed is right
- [x] Settings save banner appears at bottom of viewport without shifting content
- [x] TypeScript clean, ESLint clean

Closes #314
Closes #315
Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)