### PR TITLE
feat: present mode (fullscreen + keep screen on) for project detail page

### DIFF
--- a/frontend/src/hooks/usePresentMode.ts
+++ b/frontend/src/hooks/usePresentMode.ts
@@ -1,0 +1,72 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+
+interface PresentModeResult {
+  isPresent: boolean;
+  isSupported: boolean;
+  toggle: () => Promise<void>;
+}
+
+export function usePresentMode(): PresentModeResult {
+  const [isPresent, setIsPresent] = useState(false);
+  const wakeLockRef = useRef<WakeLockSentinel | null>(null);
+
+  const isSupported =
+    "wakeLock" in navigator &&
+    "requestFullscreen" in document.documentElement;
+
+  const enter = useCallback(async () => {
+    try {
+      await document.documentElement.requestFullscreen();
+    } catch { /* ignore — user may have denied or browser doesn't support */ }
+    try {
+      wakeLockRef.current = await navigator.wakeLock.request("screen");
+    } catch { /* non-critical — screen may still go dark */ }
+    setIsPresent(true);
+  }, []);
+
+  const exit = useCallback(async () => {
+    if (document.fullscreenElement) {
+      try { await document.exitFullscreen(); } catch { /* ignore */ }
+    }
+    if (wakeLockRef.current) {
+      try { await wakeLockRef.current.release(); } catch { /* ignore */ }
+      wakeLockRef.current = null;
+    }
+    setIsPresent(false);
+  }, []);
+
+  const toggle = useCallback(
+    () => (isPresent ? exit() : enter()),
+    [isPresent, enter, exit],
+  );
+
+  // Sync state when user presses Esc to exit fullscreen natively
+  useEffect(() => {
+    const onFullscreenChange = () => {
+      if (!document.fullscreenElement && isPresent) {
+        if (wakeLockRef.current) {
+          wakeLockRef.current.release().catch(() => {});
+          wakeLockRef.current = null;
+        }
+        setIsPresent(false);
+      }
+    };
+    document.addEventListener("fullscreenchange", onFullscreenChange);
+    return () => document.removeEventListener("fullscreenchange", onFullscreenChange);
+  }, [isPresent]);
+
+  // Release everything on unmount
+  useEffect(() => {
+    return () => {
+      if (document.fullscreenElement) {
+        document.exitFullscreen().catch(() => {});
+      }
+      if (wakeLockRef.current) {
+        wakeLockRef.current.release().catch(() => {});
+        wakeLockRef.current = null;
+      }
+    };
+  }, []);
+
+  return { isPresent, isSupported, toggle };
+}

--- a/frontend/src/lib/icons.ts
+++ b/frontend/src/lib/icons.ts
@@ -14,7 +14,9 @@ import {
   LayoutDashboard,
   Layers,
   LogOut,
+  Maximize2,
   Menu,
+  Minimize2,
   Scroll,
   Settings,
   ShieldCheck,
@@ -47,6 +49,8 @@ export const AppIcons = {
   mobileMenu: Menu,
   close: X,
   chevronRight: ChevronRight,
+  presentMode: Maximize2,
+  exitPresentMode: Minimize2,
 
   // ── Landing page features ─────────────────────────────────────────────────
   designLibrary: Layers,

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { AppIcons } from "@/lib/icons";
+import { usePresentMode } from "@/hooks/usePresentMode";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   getProject, getProjectPicks, stepProject, jumpProject, completeProject, abandonProject,
@@ -877,6 +878,8 @@ export function ProjectDetailPage() {
   const [restartConflict, setRestartConflict] = useState<ProjectSummary | null>(null);
   const [localPick, setLocalPick] = useState(1);
 
+  const { isPresent, isSupported: presentModeSupported, toggle: togglePresentMode } = usePresentMode();
+
   const { data: project, isLoading, error } = useQuery({
     queryKey: ["project", id],
     queryFn: () => getProject(id!),
@@ -1146,6 +1149,18 @@ export function ProjectDetailPage() {
           >
             View design
           </button>
+          {presentModeSupported && (
+            <button
+              onClick={togglePresentMode}
+              className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              title={isPresent ? "Exit present mode" : "Present mode — fullscreen + keep screen on"}
+              aria-label={isPresent ? "Exit present mode" : "Enter present mode"}
+            >
+              {isPresent
+                ? <AppIcons.exitPresentMode className="h-4 w-4" />
+                : <AppIcons.presentMode className="h-4 w-4" />}
+            </button>
+          )}
           <span className={`rounded px-2 py-0.5 text-xs font-medium ${badgeClasses}`}>
             {badgeLabel}
           </span>


### PR DESCRIPTION
## Summary

- Adds a `Maximize2` icon button to the `ProjectDetailPage` header
- Clicking it enters fullscreen and acquires a Screen Wake Lock so the display stays on while weaving
- Pressing Esc or clicking the `Minimize2` button exits both cleanly
- Button is hidden on browsers that do not support the Wake Lock API (`"wakeLock" in navigator` check)

## Implementation

- `frontend/src/hooks/usePresentMode.ts` — new hook managing fullscreen + wake lock lifecycle; uses a ref for the sentinel to avoid unnecessary re-renders; syncs state on native Esc exit via `fullscreenchange` event; releases everything on unmount
- `frontend/src/lib/icons.ts` — added `Maximize2` / `Minimize2` as `presentMode` / `exitPresentMode`
- `frontend/src/pages/ProjectDetailPage.tsx` — button wired into page header

Closes #309.

## Test plan

- [ ] Open any active project detail page in Chrome/Edge — present mode button is visible
- [ ] Click button — page goes fullscreen, screen stays on
- [ ] Press Esc — exits fullscreen, button returns to Maximize2
- [ ] Click Minimize2 button — same result
- [ ] Verify button is absent in Firefox/Safari where Wake Lock is unsupported (or present in Safari 16.4+ where it is)
- [ ] Navigate away from page — fullscreen and wake lock are released

🤖 Generated with [Claude Code](https://claude.com/claude-code)