### PR TITLE
fix: present mode visibility, dev banner auto-hide, sidebar logo in rail (#309)

### DIFF
--- a/frontend/src/components/DevBanner.tsx
+++ b/frontend/src/components/DevBanner.tsx
@@ -1,9 +1,34 @@
+import { useState, useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
 const IS_DEV = import.meta.env.VITE_APP_ENV === "dev";
+const DETAIL_PATTERN = /^\/projects\/[^/]+/;
 
 export function DevBanner() {
+  const location = useLocation();
+  const isDetailPage = DETAIL_PATTERN.test(location.pathname);
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const showTimer = setTimeout(() => setVisible(true), 0);
+    if (!isDetailPage) return () => clearTimeout(showTimer);
+    const hideTimer = setTimeout(() => setVisible(false), 2000);
+    return () => {
+      clearTimeout(showTimer);
+      clearTimeout(hideTimer);
+    };
+  }, [location.pathname, isDetailPage]);
+
   if (!IS_DEV) return null;
   return (
-    <div className="w-full bg-amber-400 text-amber-950 text-center text-xs font-semibold py-1.5 px-4 select-none">
+    <div
+      className="w-full bg-amber-400 text-amber-950 text-center text-xs font-semibold py-1.5 px-4 select-none overflow-hidden"
+      style={{
+        maxHeight: visible ? "3rem" : "0",
+        opacity: visible ? 1 : 0,
+        transition: "max-height 0.5s ease, opacity 0.5s ease",
+      }}
+    >
       ⚠️ Development environment — data may be reset at any time
     </div>
   );

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -75,14 +75,16 @@ export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpa
         } ${desktopCollapsed ? "lg:w-14" : "lg:w-60"}`}
       >
         {/* Logo */}
-        <div className={`flex h-16 shrink-0 items-center justify-between border-b border-border ${desktopCollapsed ? "lg:px-2 px-4" : "px-4"}`}>
+        <div className={`shrink-0 border-b border-border flex h-16 items-center justify-between px-4 ${
+          desktopCollapsed ? "lg:flex-col lg:items-center lg:justify-center lg:h-auto lg:px-2 lg:py-3 lg:gap-2" : ""
+        }`}>
           <Link
             to="/home"
-            className="flex items-center gap-2.5"
+            className={`flex items-center gap-2.5 ${desktopCollapsed ? "lg:w-full lg:justify-center" : ""}`}
             onClick={onClose}
             title={desktopCollapsed ? "Dashboard" : undefined}
           >
-            <WeftmarkLogo className="h-6 w-auto text-primary" />
+            <WeftmarkLogo className={`h-6 text-primary ${desktopCollapsed ? "lg:h-auto lg:w-full" : "w-auto"}`} />
             <span className={`text-sm font-semibold tracking-tight text-foreground ${desktopCollapsed ? "lg:hidden" : ""}`} style={{ fontFamily: '"Segoe UI", system-ui, sans-serif' }}>weftmark</span>
           </Link>
           {/* Mobile close button */}
@@ -93,14 +95,14 @@ export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpa
           >
             <AppIcons.close className="h-4 w-4" />
           </button>
-          {/* Desktop expand button — only shown when collapsed */}
+          {/* Desktop expand button — stacks below logo when collapsed */}
           <button
             onClick={onDesktopExpand}
             className={`rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground ${desktopCollapsed ? "hidden lg:flex" : "hidden"}`}
             aria-label="Expand navigation"
             title="Expand navigation"
           >
-            <AppIcons.chevronRight className="h-4 w-4" />
+            <AppIcons.chevronDoubleRight className="h-3.5 w-3.5" />
           </button>
         </div>
 

--- a/frontend/src/components/layout/VersionFooter.tsx
+++ b/frontend/src/components/layout/VersionFooter.tsx
@@ -1,5 +1,9 @@
+import { useState, useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/api/client";
+
+const DETAIL_PATTERN = /^\/projects\/[^/]+/;
 
 interface HealthResponse {
   status: string;
@@ -15,8 +19,27 @@ export function VersionBadge() {
     retry: false,
   });
 
+  const location = useLocation();
+  const isDetailPage = DETAIL_PATTERN.test(location.pathname);
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    // Re-show on every navigation (async to avoid synchronous setState in effect)
+    const showTimer = setTimeout(() => setVisible(true), 0);
+    if (!isDetailPage) return () => clearTimeout(showTimer);
+    // Auto-hide after 2s on project detail pages
+    const hideTimer = setTimeout(() => setVisible(false), 2000);
+    return () => {
+      clearTimeout(showTimer);
+      clearTimeout(hideTimer);
+    };
+  }, [location.pathname, isDetailPage]);
+
   return (
-    <div className="fixed bottom-3 right-4 z-50 flex items-center gap-2 text-xs bg-muted border border-border rounded px-2 py-1 text-foreground select-none pointer-events-none">
+    <div
+      className="fixed bottom-3 right-4 z-50 flex items-center gap-2 text-xs bg-muted border border-border rounded px-2 py-1 text-foreground select-none pointer-events-none"
+      style={{ opacity: visible ? 1 : 0, transition: "opacity 0.5s ease" }}
+    >
       <span>UI v{__APP_VERSION__}</span>
       {data?.version && <span>API v{data.version}</span>}
       {data?.worker_version && <span>Worker v{data.worker_version}</span>}

--- a/frontend/src/hooks/usePresentMode.ts
+++ b/frontend/src/hooks/usePresentMode.ts
@@ -10,9 +10,10 @@ export function usePresentMode(): PresentModeResult {
   const [isPresent, setIsPresent] = useState(false);
   const wakeLockRef = useRef<WakeLockSentinel | null>(null);
 
+  // Show button if either API is available — each is attempted independently
   const isSupported =
-    "wakeLock" in navigator &&
-    "requestFullscreen" in document.documentElement;
+    "requestFullscreen" in document.documentElement ||
+    "wakeLock" in navigator;
 
   const enter = useCallback(async () => {
     try {

--- a/frontend/src/lib/icons.ts
+++ b/frontend/src/lib/icons.ts
@@ -6,6 +6,7 @@ import {
   Activity,
   CheckSquare,
   ChevronRight,
+  ChevronsRight,
   ChevronsUp,
   CircleCheck,
   CircleHelp,
@@ -49,6 +50,7 @@ export const AppIcons = {
   mobileMenu: Menu,
   close: X,
   chevronRight: ChevronRight,
+  chevronDoubleRight: ChevronsRight,
   presentMode: Maximize2,
   exitPresentMode: Minimize2,
 

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1149,10 +1149,13 @@ export function ProjectDetailPage() {
           >
             View design
           </button>
+          <span className={`rounded px-2 py-0.5 text-xs font-medium ${badgeClasses}`}>
+            {badgeLabel}
+          </span>
           {presentModeSupported && (
             <button
               onClick={togglePresentMode}
-              className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              className="ml-3 rounded-md border border-border bg-background px-2.5 py-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
               title={isPresent ? "Exit present mode" : "Present mode — fullscreen + keep screen on"}
               aria-label={isPresent ? "Exit present mode" : "Enter present mode"}
             >
@@ -1161,9 +1164,6 @@ export function ProjectDetailPage() {
                 : <AppIcons.presentMode className="h-4 w-4" />}
             </button>
           )}
-          <span className={`rounded px-2 py-0.5 text-xs font-medium ${badgeClasses}`}>
-            {badgeLabel}
-          </span>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- Show present mode button on Firefox and Chrome Android (`||` instead of `&&` for API detection)
- Reposition present mode button to far right of header with border/bg button styling
- Auto-hide dev banner and version badge after 2s on `/projects/:id` pages (inline style opacity — avoids Tailwind JIT purging the transition classes)
- Sidebar collapses to icon rail on project detail pages; logo fills full rail width at natural aspect ratio; expand button (>>) stacks below logo

## Test plan

- [ ] Navigate to a project detail page — dev banner and version badge should fade out after ~2s
- [ ] Navigate away and back — both should reappear
- [ ] Present mode button visible in Firefox, Chrome, and Chrome for Android
- [ ] Clicking present mode enters fullscreen; Esc exits and syncs state
- [ ] Collapsed sidebar rail shows logo at full rail width, >> expand button below it
- [ ] Expanding the rail restores full sidebar layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)