### PR TITLE
fix: accept WIF files with leading INI comment lines (#395)

### DIFF
--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -22,7 +22,20 @@ settings = get_settings()
 
 _upload_rate_limit = rate_limit("wif_upload", max_requests=30, window_seconds=3600)
 
-_WIF_MAGIC = b"[WIF]"
+
+def _has_wif_header(data: bytes) -> bool:
+    """Return True if data contains a [WIF] section header within the first 20 lines.
+
+    Skips leading INI comment lines (starting with ';') per the WIF spec.
+    Stops at the first non-comment, non-empty line if it isn't [WIF].
+    """
+    for line in data.splitlines()[:20]:
+        stripped = line.strip()
+        if stripped.upper() == b"[WIF]":
+            return True
+        if stripped and not stripped.startswith(b";"):
+            return False
+    return False
 
 
 def _content_disposition(filename: str) -> str:
@@ -99,8 +112,16 @@ async def create_draft(
     wif_bytes = await wif_file.read()
     if len(wif_bytes) > settings.max_upload_size:
         raise HTTPException(status_code=413, detail="File too large")
-    if not wif_bytes.lstrip()[:5].upper() == _WIF_MAGIC:
-        raise HTTPException(status_code=400, detail="File does not appear to be a valid WIF file")
+    if not _has_wif_header(wif_bytes):
+        first_line = wif_bytes.splitlines()[0].decode(errors="replace")[:60] if wif_bytes else ""
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"File does not appear to be a valid WIF file. "
+                f"Expected a [WIF] section header (comment lines starting with ';' are allowed). "
+                f"First line of uploaded file: {first_line!r}"
+            ),
+        )
 
     lint = wif_linter.lint(wif_bytes)
 

--- a/backend/tests/routers/test_drafts.py
+++ b/backend/tests/routers/test_drafts.py
@@ -23,6 +23,48 @@ def _mock_preview_task(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Unit tests for _has_wif_header
+# ---------------------------------------------------------------------------
+
+
+class TestHasWifHeader:
+    def setup_method(self):
+        from app.routers.drafts import _has_wif_header
+
+        self.check = _has_wif_header
+
+    def test_plain_wif_header(self):
+        assert self.check(b"[WIF]\nVersion=1.1\n") is True
+
+    def test_wif_header_case_insensitive(self):
+        assert self.check(b"[wif]\nVersion=1.1\n") is True
+
+    def test_single_comment_then_wif(self):
+        assert self.check(b"; exported by Tempo Weave\r\n[WIF]\r\nVersion=1.1\r\n") is True
+
+    def test_multiple_comments_then_wif(self):
+        assert self.check(b"; line 1\r\n; line 2\r\n[WIF]\r\n") is True
+
+    def test_non_wif_content(self):
+        assert self.check(b"not a wif file") is False
+
+    def test_jpeg_magic(self):
+        assert self.check(b"\xff\xd8\xff\xe0" + b"\x00" * 100) is False
+
+    def test_empty_bytes(self):
+        assert self.check(b"") is False
+
+    def test_only_comments_no_wif(self):
+        assert self.check(b"; just a comment\n; another\n") is False
+
+    def test_wif_after_non_comment_line_rejected(self):
+        assert self.check(b"random line\n[WIF]\n") is False
+
+    def test_whitespace_before_wif(self):
+        assert self.check(b"\r\n\n[WIF]\n") is True
+
+
+# ---------------------------------------------------------------------------
 # WIF fixture — 4-shaft, 4-treadle, coloured warp/weft; renders correctly
 # ---------------------------------------------------------------------------
 
@@ -410,6 +452,27 @@ class TestCreateDraft:
             data={"name": "Bad Draft"},
         )
         assert resp.status_code == 400
+
+    async def test_wif_with_leading_comment_lines_accepted(self, auth_client: AsyncClient, tmp_path, monkeypatch):
+        import app.services.storage as _storage
+
+        monkeypatch.setattr(_storage.settings, "upload_dir", str(tmp_path))
+        tempo_weave_wif = b"; exported by Tempo Weave\r\n" + _WIF
+        resp = await auth_client.post(
+            "/api/drafts",
+            files={"wif_file": ("tempo.wif", tempo_weave_wif, "application/octet-stream")},
+            data={"name": "Tempo Draft"},
+        )
+        assert resp.status_code == 201
+
+    async def test_invalid_wif_error_includes_first_line(self, auth_client: AsyncClient):
+        resp = await auth_client.post(
+            "/api/drafts",
+            files={"wif_file": ("bad.wif", b"CLEARLY_NOT_WIF\nmore content", "application/octet-stream")},
+            data={"name": "Bad Draft"},
+        )
+        assert resp.status_code == 400
+        assert "CLEARLY_NOT_WIF" in resp.json()["detail"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replaces the `lstrip()[:5]` magic byte check with `_has_wif_header()`, which scans the first 20 lines and skips leading `;` comment lines per the WIF/INI spec
- Tempo Weave (and any other software emitting INI comments before `[WIF]`) now uploads successfully
- Error message on rejection now includes the first line of the uploaded file so users can self-diagnose or provide a useful bug report
- 10 unit tests for `_has_wif_header` + 2 new integration tests (leading-comment accepted, error detail exposed)

## Test plan

- [ ] Upload a WIF file exported from Tempo Weave — should succeed (was rejected before)
- [ ] Upload a non-WIF file with a `.wif` extension — should return 400 with the first line in the error detail
- [ ] Existing tests pass (jpeg magic, plain non-WIF content still rejected)

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)