### PR TITLE
feat: S3 orphan file audit in superuser console

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -13,7 +13,7 @@ def _make_celery() -> Celery:
         "weftmark",
         broker=settings.redis_url,
         backend=settings.redis_url,
-        include=["app.tasks.deletion", "app.tasks.preview"],
+        include=["app.tasks.deletion", "app.tasks.preview", "app.tasks.s3_audit"],
     )
     app.conf.update(
         task_serializer="json",

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1601,3 +1601,93 @@ async def backfill_clerk_user(
 
     log.info("backfill clerk_user_id=%s user_id=%s status=%s", clerk_user_id, user.id, result_status)
     return BackfillResponse(status=result_status, user_id=str(user.id), email=email)
+
+
+# ---------------------------------------------------------------------------
+# S3 orphan file audit (superuser only)
+# ---------------------------------------------------------------------------
+
+
+class S3OrphanFile(BaseModel):
+    key: str
+    size: int
+    last_modified: str
+
+
+class S3AuditResult(BaseModel):
+    total_s3_keys: int
+    total_db_paths: int
+    orphaned_count: int
+    orphaned_files: list[S3OrphanFile]
+    not_applicable: bool
+
+
+class S3AuditTaskStatus(BaseModel):
+    status: str  # pending | running | complete | failed
+    result: S3AuditResult | None = None
+    error: str | None = None
+
+
+class S3ScanResponse(BaseModel):
+    task_id: str
+
+
+class S3CleanupRequest(BaseModel):
+    keys: list[str]
+
+
+class S3CleanupResponse(BaseModel):
+    deleted: int
+
+
+@router.post("/s3-audit/scan", response_model=S3ScanResponse, status_code=202)
+async def start_s3_audit_scan(
+    _: User = Depends(require_superuser),
+) -> S3ScanResponse:
+    from app.tasks.s3_audit import run_s3_orphan_scan
+
+    task = run_s3_orphan_scan.delay()
+    log.info("s3_audit_scan_queued task_id=%s", task.id)
+    return S3ScanResponse(task_id=task.id)
+
+
+@router.get("/s3-audit/task/{task_id}", response_model=S3AuditTaskStatus)
+async def get_s3_audit_task(
+    task_id: str,
+    _: User = Depends(require_superuser),
+) -> S3AuditTaskStatus:
+    from celery.result import AsyncResult
+
+    result = AsyncResult(task_id)
+    state = result.state
+    if state in ("PENDING", "RECEIVED"):
+        return S3AuditTaskStatus(status="pending")
+    if state in ("STARTED", "RETRY"):
+        return S3AuditTaskStatus(status="running")
+    if state == "SUCCESS":
+        return S3AuditTaskStatus(status="complete", result=S3AuditResult(**result.result))
+    if state == "FAILURE":
+        return S3AuditTaskStatus(status="failed", error=str(result.result))
+    return S3AuditTaskStatus(status="pending")
+
+
+@router.post("/s3-audit/cleanup", response_model=S3CleanupResponse)
+async def cleanup_s3_orphans(
+    body: S3CleanupRequest,
+    admin: User = Depends(require_superuser),
+) -> S3CleanupResponse:
+    from app.services import storage
+
+    if not body.keys:
+        return S3CleanupResponse(deleted=0)
+
+    deleted = 0
+    for key in body.keys:
+        try:
+            storage._delete(key)
+            deleted += 1
+        except Exception as exc:
+            log.warning("s3_cleanup_error key=%s error=%s", key, exc)
+
+    log.info("s3_cleanup_complete admin_id=%s deleted=%d", admin.id, deleted)
+    return S3CleanupResponse(deleted=deleted)

--- a/backend/app/tasks/s3_audit.py
+++ b/backend/app/tasks/s3_audit.py
@@ -1,0 +1,121 @@
+"""Celery task: S3 orphan file audit.
+
+Scans all keys in the configured S3 bucket, collects all storage paths
+referenced in the database, and returns the difference (orphaned keys).
+Only meaningful when STORAGE_BACKEND=s3; returns not_applicable otherwise.
+"""
+
+import asyncio
+import logging
+
+from celery import Task
+
+from app.celery_app import celery_app
+
+log = logging.getLogger(__name__)
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=0,
+    soft_time_limit=300,
+    time_limit=360,
+    name="app.tasks.s3_audit.run_s3_orphan_scan",
+)
+def run_s3_orphan_scan(self: Task) -> dict:
+    return asyncio.run(_do_scan())
+
+
+async def _do_scan() -> dict:
+    from sqlalchemy import select
+    from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+    from sqlalchemy.orm import sessionmaker
+
+    from app.config import get_settings
+    from app.models.draft import Draft
+    from app.models.loom import Loom, LoomVersionPhoto, LoomVersionReceipt
+    from app.models.project import ProjectPhoto
+    from app.models.yarn import Yarn
+
+    settings = get_settings()
+
+    if settings.storage_backend != "s3":
+        return {
+            "total_s3_keys": 0,
+            "total_db_paths": 0,
+            "orphaned_count": 0,
+            "orphaned_files": [],
+            "not_applicable": True,
+        }
+
+    import boto3
+
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=settings.s3_endpoint_url,
+        aws_access_key_id=settings.s3_access_key_id,
+        aws_secret_access_key=settings.s3_secret_access_key,
+        region_name=settings.s3_region or "auto",
+    )
+
+    s3_files: dict[str, dict] = {}
+    paginator = s3.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=settings.s3_bucket_name):
+        for obj in page.get("Contents", []):
+            s3_files[obj["Key"]] = {
+                "size": obj["Size"],
+                "last_modified": obj["LastModified"].isoformat(),
+            }
+
+    engine = create_async_engine(settings.database_url, echo=False)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    db_paths: set[str] = set()
+    try:
+        async with async_session() as db:
+            drafts = await db.scalars(select(Draft))
+            for d in drafts.all():
+                for p in [d.wif_path, d.preview_path, d.drawdown_preview_path, d.wif_modified_path]:
+                    if p:
+                        db_paths.add(p)
+
+            yarns = await db.scalars(select(Yarn))
+            for y in yarns.all():
+                if y.photo_path:
+                    db_paths.add(y.photo_path)
+
+            looms = await db.scalars(select(Loom))
+            for lm in looms.all():
+                if lm.photo_path:
+                    db_paths.add(lm.photo_path)
+
+            vps = await db.scalars(select(LoomVersionPhoto))
+            for vp in vps.all():
+                if vp.path:
+                    db_paths.add(vp.path)
+
+            vrs = await db.scalars(select(LoomVersionReceipt))
+            for vr in vrs.all():
+                if vr.path:
+                    db_paths.add(vr.path)
+
+            pps = await db.scalars(select(ProjectPhoto))
+            for pp in pps.all():
+                if pp.file_path:
+                    db_paths.add(pp.file_path)
+    finally:
+        await engine.dispose()
+
+    orphaned_keys = set(s3_files.keys()) - db_paths
+    orphaned_files = [
+        {"key": k, "size": s3_files[k]["size"], "last_modified": s3_files[k]["last_modified"]}
+        for k in sorted(orphaned_keys)
+    ]
+
+    return {
+        "total_s3_keys": len(s3_files),
+        "total_db_paths": len(db_paths),
+        "orphaned_count": len(orphaned_files),
+        "orphaned_files": orphaned_files,
+        "not_applicable": False,
+    }

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -224,3 +224,32 @@ export interface ReconcileReport {
 export const getReconcileReport = () => api.get<ReconcileReport>("/api/admin/reconcile");
 export const backfillClerkUser = (clerkUserId: string, role: "user" | "admin" = "user") =>
   api.post<{ status: string; user_id: string; email: string }>(`/api/admin/reconcile/backfill/${clerkUserId}`, { role });
+
+export interface S3OrphanFile {
+  key: string;
+  size: number;
+  last_modified: string;
+}
+
+export interface S3AuditResult {
+  total_s3_keys: number;
+  total_db_paths: number;
+  orphaned_count: number;
+  orphaned_files: S3OrphanFile[];
+  not_applicable: boolean;
+}
+
+export interface S3AuditTaskStatus {
+  status: "pending" | "running" | "complete" | "failed";
+  result?: S3AuditResult;
+  error?: string;
+}
+
+export const startS3AuditScan = () =>
+  api.post<{ task_id: string }>("/api/admin/s3-audit/scan", {});
+
+export const getS3AuditTask = (taskId: string) =>
+  api.get<S3AuditTaskStatus>(`/api/admin/s3-audit/task/${taskId}`);
+
+export const cleanupS3Orphans = (keys: string[]) =>
+  api.post<{ deleted: number }>("/api/admin/s3-audit/cleanup", { keys });

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1542,17 +1542,23 @@ function StorageAuditTab() {
         {scanStatus === "running" && (
           <span className="text-xs text-muted-foreground animate-pulse">Running in background…</span>
         )}
+        {selected.size > 0 && (
+          <>
+            <span className="text-xs text-destructive">
+              {selected.size} file{selected.size !== 1 ? "s" : ""} selected — permanent delete, cannot be undone.
+            </span>
+            <Button variant="destructive" size="sm" onClick={handleCleanup} disabled={cleaning}>
+              {cleaning ? "Deleting…" : "Delete Selected"}
+            </Button>
+          </>
+        )}
+        {cleanupCount !== null && (
+          <span className="text-sm text-green-600 dark:text-green-400">
+            Deleted {cleanupCount} file{cleanupCount !== 1 ? "s" : ""} from S3.
+          </span>
+        )}
+        {error && <span className="text-sm text-destructive">{error}</span>}
       </div>
-
-      {error && (
-        <p className="text-sm text-destructive">{error}</p>
-      )}
-
-      {cleanupCount !== null && (
-        <p className="text-sm text-green-600 dark:text-green-400">
-          Deleted {cleanupCount} file{cleanupCount !== 1 ? "s" : ""} from S3.
-        </p>
-      )}
 
       {result && (
         <div className="space-y-3">
@@ -1571,62 +1577,44 @@ function StorageAuditTab() {
               {result.orphaned_files.length === 0 ? (
                 <p className="text-sm text-muted-foreground">No orphaned files found.</p>
               ) : (
-                <>
-                  <div className="rounded-md border overflow-auto max-h-96">
-                    <table className="w-full text-xs">
-                      <thead className="bg-muted sticky top-0">
-                        <tr>
-                          <th className="p-2 text-left w-8">
+                <div className="rounded-md border overflow-auto max-h-96">
+                  <table className="w-full text-xs">
+                    <thead className="bg-muted sticky top-0">
+                      <tr>
+                        <th className="p-2 text-left w-8">
+                          <input
+                            type="checkbox"
+                            checked={allSelected}
+                            onChange={toggleAll}
+                            className="cursor-pointer"
+                          />
+                        </th>
+                        <th className="p-2 text-left font-medium">Key</th>
+                        <th className="p-2 text-right font-medium">Size</th>
+                        <th className="p-2 text-right font-medium">Last Modified</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {result.orphaned_files.map((f) => (
+                        <tr key={f.key} className="border-t hover:bg-muted/50">
+                          <td className="p-2">
                             <input
                               type="checkbox"
-                              checked={allSelected}
-                              onChange={toggleAll}
+                              checked={selected.has(f.key)}
+                              onChange={() => toggleSelect(f.key)}
                               className="cursor-pointer"
                             />
-                          </th>
-                          <th className="p-2 text-left font-medium">Key</th>
-                          <th className="p-2 text-right font-medium">Size</th>
-                          <th className="p-2 text-right font-medium">Last Modified</th>
+                          </td>
+                          <td className="p-2 font-mono break-all">{f.key}</td>
+                          <td className="p-2 text-right whitespace-nowrap">{formatBytes(f.size)}</td>
+                          <td className="p-2 text-right whitespace-nowrap text-muted-foreground">
+                            {new Date(f.last_modified).toLocaleDateString()}
+                          </td>
                         </tr>
-                      </thead>
-                      <tbody>
-                        {result.orphaned_files.map((f) => (
-                          <tr key={f.key} className="border-t hover:bg-muted/50">
-                            <td className="p-2">
-                              <input
-                                type="checkbox"
-                                checked={selected.has(f.key)}
-                                onChange={() => toggleSelect(f.key)}
-                                className="cursor-pointer"
-                              />
-                            </td>
-                            <td className="p-2 font-mono break-all">{f.key}</td>
-                            <td className="p-2 text-right whitespace-nowrap">{formatBytes(f.size)}</td>
-                            <td className="p-2 text-right whitespace-nowrap text-muted-foreground">
-                              {new Date(f.last_modified).toLocaleDateString()}
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-
-                  {selected.size > 0 && (
-                    <div className="flex items-center gap-3 rounded-md border border-destructive/40 bg-destructive/5 p-3">
-                      <p className="text-sm flex-1 text-destructive">
-                        Permanently delete {selected.size} selected file{selected.size !== 1 ? "s" : ""} from S3? This cannot be undone.
-                      </p>
-                      <Button
-                        variant="destructive"
-                        size="sm"
-                        onClick={handleCleanup}
-                        disabled={cleaning}
-                      >
-                        {cleaning ? "Deleting…" : "Delete Selected"}
-                      </Button>
-                    </div>
-                  )}
-                </>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
               )}
             </>
           )}

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1511,6 +1511,8 @@ function StorageAuditTab() {
 
   async function handleCleanup() {
     if (!selected.size || !result) return;
+    const noun = selected.size === 1 ? "file" : "files";
+    if (!window.confirm(`Permanently delete ${selected.size} ${noun} from S3? This cannot be undone.`)) return;
     setCleaning(true);
     setError(null);
     try {

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -24,6 +24,9 @@ import {
   getAuditLog,
   getReconcileReport,
   backfillClerkUser,
+  startS3AuditScan,
+  getS3AuditTask,
+  cleanupS3Orphans,
   type AdminUser,
   type AdminHealth,
   type AdminDbInfo,
@@ -34,6 +37,7 @@ import {
   type ServicePermCheck,
   type ReconcileReport,
   type WebhookProbeResult,
+  type S3AuditResult,
 } from "@/api/admin";
 import { getHealthDetailed, type ReadinessResponse, type ReadinessService } from "@/api/health";
 import { EulaContent } from "@/components/EulaContent";
@@ -1440,10 +1444,192 @@ function SuperuserTab() {
 }
 
 function StorageAuditTab() {
+  const [scanStatus, setScanStatus] = useState<"idle" | "running" | "complete" | "failed">("idle");
+  const [taskId, setTaskId] = useState<string | null>(null);
+  const [result, setResult] = useState<S3AuditResult | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [cleaning, setCleaning] = useState(false);
+  const [cleanupCount, setCleanupCount] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!taskId || scanStatus !== "running") return;
+    pollRef.current = setInterval(async () => {
+      try {
+        const data = await getS3AuditTask(taskId);
+        if (data.status === "complete" && data.result) {
+          setResult(data.result);
+          setScanStatus("complete");
+          clearInterval(pollRef.current!);
+        } else if (data.status === "failed") {
+          setError(data.error ?? "Scan failed");
+          setScanStatus("failed");
+          clearInterval(pollRef.current!);
+        }
+      } catch {
+        setError("Failed to poll scan status");
+        setScanStatus("failed");
+        clearInterval(pollRef.current!);
+      }
+    }, 2000);
+    return () => { if (pollRef.current) clearInterval(pollRef.current); };
+  }, [taskId, scanStatus]);
+
+  async function startScan() {
+    setScanStatus("running");
+    setResult(null);
+    setSelected(new Set());
+    setCleanupCount(null);
+    setError(null);
+    try {
+      const { task_id } = await startS3AuditScan();
+      setTaskId(task_id);
+    } catch {
+      setScanStatus("failed");
+      setError("Failed to start scan");
+    }
+  }
+
+  function toggleSelect(key: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) { next.delete(key); } else { next.add(key); }
+      return next;
+    });
+  }
+
+  function toggleAll() {
+    if (!result) return;
+    setSelected((prev) =>
+      prev.size === result.orphaned_files.length
+        ? new Set()
+        : new Set(result.orphaned_files.map((f) => f.key))
+    );
+  }
+
+  async function handleCleanup() {
+    if (!selected.size || !result) return;
+    setCleaning(true);
+    setError(null);
+    try {
+      const { deleted } = await cleanupS3Orphans(Array.from(selected));
+      setCleanupCount(deleted);
+      setResult({
+        ...result,
+        orphaned_files: result.orphaned_files.filter((f) => !selected.has(f.key)),
+        orphaned_count: result.orphaned_count - deleted,
+      });
+      setSelected(new Set());
+    } catch {
+      setError("Cleanup failed — check logs");
+    } finally {
+      setCleaning(false);
+    }
+  }
+
+  const allSelected = !!result && selected.size === result.orphaned_files.length && result.orphaned_files.length > 0;
+
   return (
-    <div className="rounded-lg border border-dashed p-8 text-center">
-      <p className="text-sm font-medium text-muted-foreground">Storage Audit</p>
-      <p className="text-xs text-muted-foreground mt-1">Coming soon — per-user S3 storage breakdown.</p>
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        <Button onClick={startScan} disabled={scanStatus === "running"} size="sm">
+          {scanStatus === "running" ? "Scanning…" : "Scan S3 for Orphaned Files"}
+        </Button>
+        {scanStatus === "running" && (
+          <span className="text-xs text-muted-foreground animate-pulse">Running in background…</span>
+        )}
+      </div>
+
+      {error && (
+        <p className="text-sm text-destructive">{error}</p>
+      )}
+
+      {cleanupCount !== null && (
+        <p className="text-sm text-green-600 dark:text-green-400">
+          Deleted {cleanupCount} file{cleanupCount !== 1 ? "s" : ""} from S3.
+        </p>
+      )}
+
+      {result && (
+        <div className="space-y-3">
+          {result.not_applicable ? (
+            <p className="text-sm text-muted-foreground">
+              Storage backend is not S3 — audit not applicable in this environment.
+            </p>
+          ) : (
+            <>
+              <div className="flex gap-6 text-sm">
+                <span><span className="font-medium">{result.total_s3_keys}</span> S3 keys</span>
+                <span><span className="font-medium">{result.total_db_paths}</span> DB-referenced paths</span>
+                <span><span className="font-medium text-amber-600 dark:text-amber-400">{result.orphaned_count}</span> orphaned</span>
+              </div>
+
+              {result.orphaned_files.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No orphaned files found.</p>
+              ) : (
+                <>
+                  <div className="rounded-md border overflow-auto max-h-96">
+                    <table className="w-full text-xs">
+                      <thead className="bg-muted sticky top-0">
+                        <tr>
+                          <th className="p-2 text-left w-8">
+                            <input
+                              type="checkbox"
+                              checked={allSelected}
+                              onChange={toggleAll}
+                              className="cursor-pointer"
+                            />
+                          </th>
+                          <th className="p-2 text-left font-medium">Key</th>
+                          <th className="p-2 text-right font-medium">Size</th>
+                          <th className="p-2 text-right font-medium">Last Modified</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {result.orphaned_files.map((f) => (
+                          <tr key={f.key} className="border-t hover:bg-muted/50">
+                            <td className="p-2">
+                              <input
+                                type="checkbox"
+                                checked={selected.has(f.key)}
+                                onChange={() => toggleSelect(f.key)}
+                                className="cursor-pointer"
+                              />
+                            </td>
+                            <td className="p-2 font-mono break-all">{f.key}</td>
+                            <td className="p-2 text-right whitespace-nowrap">{formatBytes(f.size)}</td>
+                            <td className="p-2 text-right whitespace-nowrap text-muted-foreground">
+                              {new Date(f.last_modified).toLocaleDateString()}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+
+                  {selected.size > 0 && (
+                    <div className="flex items-center gap-3 rounded-md border border-destructive/40 bg-destructive/5 p-3">
+                      <p className="text-sm flex-1 text-destructive">
+                        Permanently delete {selected.size} selected file{selected.size !== 1 ? "s" : ""} from S3? This cannot be undone.
+                      </p>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={handleCleanup}
+                        disabled={cleaning}
+                      >
+                        {cleaning ? "Deleting…" : "Delete Selected"}
+                      </Button>
+                    </div>
+                  )}
+                </>
+              )}
+            </>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds `run_s3_orphan_scan` Celery task that lists all S3 bucket keys, collects all DB-referenced storage paths (drafts, looms, yarn, project photos), and returns the set difference as orphaned files
- Three new superuser-only endpoints: `POST /api/admin/s3-audit/scan` (enqueue), `GET /api/admin/s3-audit/task/{id}` (poll), `POST /api/admin/s3-audit/cleanup` (delete selected keys)
- Replaces the "Storage Audit" placeholder tab in the superuser console with a live UI: scan button, async polling, results table with checkboxes + select-all, and a destructive confirm-and-delete flow

## Test plan
- [ ] Log in as superuser, open Admin > Superuser > Storage tab
- [ ] Click "Scan S3 for Orphaned Files" — status shows "Running in background..."
- [ ] Poll resolves to complete — stats row shows total S3 keys / DB paths / orphaned count
- [ ] Select one or more orphaned files — delete confirmation bar appears
- [ ] Click "Delete Selected" — files removed, table updates
- [ ] Non-S3 environments (local dev) show "not applicable" message after scan
- [ ] Non-superuser admin cannot reach /api/admin/s3-audit/* endpoints (403)

Closes #142

Generated with [Claude Code](https://claude.com/claude-code)