### PR TITLE
feat: admin sidebar nav and full dependency listing

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -110,13 +110,7 @@ class AdminVersionsResponse(BaseModel):
     worker: str | None
     postgres: str
     postgres_source: str
-    fastapi: str
-    sqlalchemy: str
-    alembic: str
-    pyweaving: str
-    pillow: str
-    boto3: str
-    psutil: str
+    backend_packages: dict[str, str]
 
 
 class AdminDbInfoResponse(BaseModel):
@@ -1371,6 +1365,28 @@ def _pkg(name: str) -> str:
         return "unknown"
 
 
+def _all_packages() -> dict[str, str]:
+    """Return all packages listed in requirements.txt with their installed versions."""
+    import re
+
+    req_path = "/app/requirements.txt"
+    try:
+        with open(req_path) as f:
+            lines = f.readlines()
+    except OSError:
+        return {}
+
+    packages: dict[str, str] = {}
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        name = re.split(r"[=<>!~;\s\[]", line)[0].strip()
+        if name:
+            packages[name] = _pkg(name)
+    return dict(sorted(packages.items(), key=lambda kv: kv[0].lower()))
+
+
 async def _redis_server_version() -> str:
     try:
         import redis.asyncio as aioredis
@@ -1419,13 +1435,7 @@ async def get_versions(
         worker=await _worker_version(),
         postgres=pg_version,
         postgres_source=pg_source,
-        fastapi=_pkg("fastapi"),
-        sqlalchemy=_pkg("sqlalchemy"),
-        alembic=_pkg("alembic"),
-        pyweaving=_pkg("pyweaving"),
-        pillow=_pkg("pillow"),
-        boto3=_pkg("boto3"),
-        psutil=_pkg("psutil"),
+        backend_packages=_all_packages(),
     )
 
 

--- a/backend/tests/routers/test_admin.py
+++ b/backend/tests/routers/test_admin.py
@@ -345,10 +345,11 @@ class TestAdminVersions:
         data = (await admin_client.get("/api/admin/versions")).json()
         assert "app" in data
         assert "python" in data
-        assert "fastapi" in data
-        assert "sqlalchemy" in data
-        assert "alembic" in data
-        assert "boto3" in data
+        assert "redis_server" in data
+        assert "celery" in data
+        assert "postgres" in data
+        assert "backend_packages" in data
+        assert isinstance(data["backend_packages"], dict)
 
     async def test_app_version_is_string(self, admin_client: AsyncClient):
         data = (await admin_client.get("/api/admin/versions")).json()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -103,7 +103,8 @@ export default function App() {
                   <Route path="/yarn/:id" element={<AuthRoute><YarnDetailPage /></AuthRoute>} />
                   <Route path="/projects" element={<AuthRoute><ProjectsPage /></AuthRoute>} />
                   <Route path="/projects/:id" element={<AuthRoute><ProjectDetailPage /></AuthRoute>} />
-                  <Route path="/admin" element={<AuthRoute requireAdmin><AdminPage /></AuthRoute>} />
+                  <Route path="/admin" element={<Navigate to="/admin/users" replace />} />
+                  <Route path="/admin/:section" element={<AuthRoute requireAdmin><AdminPage /></AuthRoute>} />
                   <Route path="/settings" element={<Navigate to="/settings/appearance" replace />} />
                   <Route path="/settings/:section" element={<AuthRoute><SettingsPage /></AuthRoute>} />
                   <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -58,13 +58,7 @@ export interface AdminVersions {
   worker: string | null;
   postgres: string;
   postgres_source: string;
-  fastapi: string;
-  sqlalchemy: string;
-  alembic: string;
-  pyweaving: string;
-  pillow: string;
-  boto3: string;
-  psutil: string;
+  backend_packages: Record<string, string>;
 }
 
 export interface AdminDbInfo {

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -26,6 +26,16 @@ const SETTINGS_SECTIONS = [
   { id: "account", label: "Account" },
 ];
 
+const ADMIN_SECTIONS = [
+  { id: "users", label: "Users" },
+  { id: "invites", label: "Invites" },
+  { id: "stats", label: "Stats" },
+  { id: "health", label: "Health" },
+  { id: "services", label: "Services" },
+  { id: "audit", label: "Audit log" },
+  { id: "superuser", label: "Superuser", superuserOnly: true },
+];
+
 interface Props {
   open: boolean;
   onClose: () => void;
@@ -164,7 +174,7 @@ export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpa
 
           {user?.is_admin && (
             <Link
-              to="/admin"
+              to="/admin/users"
               onClick={onClose}
               className={navCls("/admin")}
               title={desktopCollapsed ? "Admin" : undefined}
@@ -172,6 +182,29 @@ export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpa
               <AppIcons.admin className={iconCls("/admin")} strokeWidth={1.75} />
               <span className={desktopCollapsed ? "lg:hidden" : ""}>Admin</span>
             </Link>
+          )}
+
+          {user?.is_admin && isActive("/admin") && !desktopCollapsed && (
+            <div className="ml-3 border-l border-border pl-2 space-y-0.5">
+              {ADMIN_SECTIONS.filter((s) => !s.superuserOnly || user?.is_superuser).map(({ id, label }) => {
+                const href = `/admin/${id}`;
+                const active = location.pathname === href;
+                return (
+                  <Link
+                    key={id}
+                    to={href}
+                    onClick={onClose}
+                    className={`block rounded-md px-2 py-1.5 text-xs transition-colors ${
+                      active
+                        ? "bg-accent/20 text-accent font-medium"
+                        : "text-muted-foreground hover:bg-accent/10 hover:text-foreground"
+                    }`}
+                  >
+                    {label}
+                  </Link>
+                );
+              })}
+            </div>
           )}
 
           <button

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
+import { useParams } from "react-router-dom";
 import { UserDetailModal, type UserDetailTarget } from "@/components/admin/UserDetailModal";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
@@ -70,8 +71,9 @@ function formatUptime(seconds: number): string {
 }
 
 export function AdminPage() {
-  const [tab, setTab] = useState<Tab>("users");
+  const { section = "users" } = useParams<{ section: string }>();
   const { user: currentUser } = useAuth();
+  const tab = section as Tab;
 
   return (
     <div className="p-6 max-w-4xl mx-auto w-full space-y-6">
@@ -81,33 +83,6 @@ export function AdminPage() {
           <span className="text-xs border rounded px-1.5 py-0.5 text-muted-foreground">superuser</span>
         )}
       </div>
-        <div className="flex gap-2 border-b pb-2 flex-wrap">
-          {(["users", "invites", "stats", "health", "services", "audit"] as Tab[]).map((t) => (
-            <button
-              key={t}
-              onClick={() => setTab(t)}
-              className={`px-3 py-1.5 text-sm rounded capitalize ${
-                tab === t
-                  ? "bg-foreground text-background"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-            >
-              {t}
-            </button>
-          ))}
-          {currentUser?.is_superuser && (
-            <button
-              onClick={() => setTab("superuser")}
-              className={`px-3 py-1.5 text-sm rounded capitalize ${
-                tab === "superuser"
-                  ? "bg-foreground text-background"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-            >
-              superuser
-            </button>
-          )}
-        </div>
 
         {tab === "users" && <UsersTab />}
         {tab === "invites" && <InvitesTab />}
@@ -882,29 +857,64 @@ function VersionsTable() {
     { label: "PostgreSQL", value: `${data.postgres} · ${data.postgres_source}` },
     { label: "Redis", value: data.redis_server },
     { label: "Celery", value: data.celery },
+    { label: "Python", value: data.python },
   ];
 
-  const deps = [
-    { label: "Python", value: data.python },
-    { label: "FastAPI", value: data.fastapi },
-    { label: "SQLAlchemy", value: data.sqlalchemy },
-    { label: "Alembic", value: data.alembic },
-    { label: "PyWeaving", value: data.pyweaving },
-    { label: "Pillow", value: data.pillow },
-    { label: "boto3", value: data.boto3 },
-    { label: "psutil", value: data.psutil },
-  ];
+  const backendRows = Object.entries(data.backend_packages).map(([k, v]) => ({ label: k, value: v }));
+  const frontendRows = Object.entries(__FRONTEND_DEPS__).sort(([a], [b]) => a.localeCompare(b)).map(([k, v]) => ({ label: k, value: v }));
+  const devRows = Object.entries(__FRONTEND_DEV_DEPS__).sort(([a], [b]) => a.localeCompare(b)).map(([k, v]) => ({ label: k, value: v }));
 
   return (
     <div className="space-y-4">
       <div>
-        <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">Versions</h2>
+        <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">Runtime</h2>
         <InfoTable rows={versions} />
       </div>
       <div>
-        <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">Dependencies</h2>
-        <InfoTable rows={deps} />
+        <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">Backend packages</h2>
+        <div className="rounded-md border overflow-auto max-h-72">
+          <table className="w-full text-xs">
+            <tbody>
+              {backendRows.map(({ label, value }) => (
+                <tr key={label} className="border-t first:border-t-0">
+                  <td className="px-3 py-1.5 font-mono text-muted-foreground w-1/2">{label}</td>
+                  <td className="px-3 py-1.5 tabular-nums">{value}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </div>
+      <div>
+        <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">Frontend dependencies</h2>
+        <div className="rounded-md border overflow-auto max-h-72">
+          <table className="w-full text-xs">
+            <tbody>
+              {frontendRows.map(({ label, value }) => (
+                <tr key={label} className="border-t first:border-t-0">
+                  <td className="px-3 py-1.5 font-mono text-muted-foreground w-1/2">{label}</td>
+                  <td className="px-3 py-1.5 tabular-nums">{value}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <details className="text-xs">
+        <summary className="cursor-pointer text-muted-foreground hover:text-foreground py-1">Dev dependencies ({devRows.length})</summary>
+        <div className="rounded-md border overflow-auto max-h-60 mt-2">
+          <table className="w-full text-xs">
+            <tbody>
+              {devRows.map(({ label, value }) => (
+                <tr key={label} className="border-t first:border-t-0">
+                  <td className="px-3 py-1.5 font-mono text-muted-foreground w-1/2">{label}</td>
+                  <td className="px-3 py-1.5 tabular-nums">{value}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </details>
     </div>
   );
 }

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,3 +1,5 @@
 /// <reference types="vite/client" />
 
 declare const __APP_VERSION__: string;
+declare const __FRONTEND_DEPS__: Record<string, string>;
+declare const __FRONTEND_DEV_DEPS__: Record<string, string>;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,12 +1,15 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
+import pkg from "./package.json";
 
 export default defineConfig({
   plugins: [react()],
   define: {
     // npm sets npm_package_version from package.json at build time
     __APP_VERSION__: JSON.stringify(process.env.npm_package_version ?? "0.0.0"),
+    __FRONTEND_DEPS__: JSON.stringify(pkg.dependencies ?? {}),
+    __FRONTEND_DEV_DEPS__: JSON.stringify(pkg.devDependencies ?? {}),
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- **#398** — Removes the horizontal tab bar from the admin page. Navigation moves to the sidebar as an indented sub-nav (matching the Settings menu pattern). Tabs become sub-routes (`/admin/:section`); `/admin` redirects to `/admin/users`. Superuser section only shows for `is_superuser` users.
- **#375** — Replaces the hand-curated 8-item backend deps list with a dynamic read of all packages in `requirements.txt` (resolved via `importlib.metadata`). Frontend `dependencies` and `devDependencies` are injected at build time from `package.json` via `vite.config.ts`. The Health tab now shows three scrollable tables: backend packages, frontend deps, and a collapsed dev-deps section.

## Test plan
- [ ] Navigate to Admin — sidebar shows indented sub-nav (Users, Invites, Stats, Health, Services, Audit log)
- [ ] Superuser account also sees Superuser section; regular admin does not
- [ ] Direct URL `/admin` redirects to `/admin/users`
- [ ] Active section highlighted in sidebar
- [ ] Health tab → full backend package list visible (all requirements.txt packages)
- [ ] Frontend deps table shows all production packages; dev deps under collapsed details
- [ ] Sidebar collapses admin sub-nav when desktop rail mode is active (same as settings)

Closes #375, #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)