### PR TITLE
feat: task revocation from worker dashboard history table (#412)

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -63,7 +63,8 @@ def _on_task_failure(task_id=None, exception=None, **kwargs):
     try:
         from app.services.task_history import record_completed
 
-        record_completed(get_settings(), task_id, "failed", error=str(exception))
+        state = "revoked" if type(exception).__name__ == "Revoked" else "failed"
+        record_completed(get_settings(), task_id, state, error=None if state == "revoked" else str(exception))
     except Exception:
         pass
 

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1986,3 +1986,16 @@ async def get_task_history(
         page_size=page_size,
         pages=max(1, math.ceil(total / page_size)),
     )
+
+
+@router.post("/tasks/{task_id}/revoke")
+async def revoke_task(
+    task_id: str,
+    _: User = Depends(require_superuser),
+) -> dict:
+    from app.celery_app import celery_app
+    from app.services.task_history import record_completed
+
+    celery_app.control.revoke(task_id, terminate=True)
+    record_completed(get_settings(), task_id, "revoked")
+    return {"status": "revoked", "task_id": task_id}

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -344,3 +344,6 @@ export interface TaskHistoryResponse {
 
 export const getTaskHistory = (page: number = 1, pageSize: number = 25) =>
   api.get<TaskHistoryResponse>(`/api/admin/task-history?page=${page}&page_size=${pageSize}`);
+
+export const revokeTask = (taskId: string) =>
+  api.post<{ status: string; task_id: string }>(`/api/admin/tasks/${taskId}/revoke`, {});

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -34,6 +34,7 @@ import {
   getWorkerStatus,
   startDebugSleep,
   getTaskHistory,
+  revokeTask,
   type TaskHistoryItem,
   type AdminUser,
   type AdminHealth,
@@ -1988,6 +1989,7 @@ const STATE_CLS: Record<string, string> = {
   running: "text-blue-600 dark:text-blue-400",
   success: "text-green-600 dark:text-green-400",
   failed: "text-destructive",
+  revoked: "text-amber-600 dark:text-amber-400",
 };
 
 function fmtSec(s: number | null): string {
@@ -2006,8 +2008,9 @@ function shortName(name: string): string {
   return parts.length >= 2 ? parts.slice(-2).join(".") : name;
 }
 
-function TaskHistoryRow({ item }: { item: TaskHistoryItem }) {
+function TaskHistoryRow({ item, onRevoke }: { item: TaskHistoryItem; onRevoke: (id: string) => void }) {
   const [expanded, setExpanded] = useState(false);
+  const cancellable = item.state === "queued" || item.state === "running";
   return (
     <>
       <tr
@@ -2022,10 +2025,20 @@ function TaskHistoryRow({ item }: { item: TaskHistoryItem }) {
         <td className="px-3 py-2 tabular-nums text-right">{fmtSec(item.run_seconds)}</td>
         <td className="px-3 py-2 tabular-nums text-right whitespace-nowrap">{fmtTime(item.completed_at)}</td>
         <td className="px-3 py-2 text-muted-foreground">{item.error ? (expanded ? "▲" : "▼ error") : "—"}</td>
+        <td className="px-3 py-2" onClick={(e) => e.stopPropagation()}>
+          {cancellable && (
+            <button
+              className="text-xs text-destructive hover:underline"
+              onClick={() => onRevoke(item.task_id)}
+            >
+              Cancel
+            </button>
+          )}
+        </td>
       </tr>
       {expanded && item.error && (
         <tr className="border-t bg-destructive/5">
-          <td colSpan={8} className="px-3 py-2">
+          <td colSpan={9} className="px-3 py-2">
             <pre className="text-xs font-mono text-destructive whitespace-pre-wrap">{item.error}</pre>
           </td>
         </tr>
@@ -2037,11 +2050,17 @@ function TaskHistoryRow({ item }: { item: TaskHistoryItem }) {
 function TaskHistoryTable() {
   const [page, setPage] = useState(1);
   const PAGE_SIZE = 25;
+  const queryClient = useQueryClient();
 
   const { data, isLoading, refetch } = useQuery({
     queryKey: ["admin", "task-history", page],
     queryFn: () => getTaskHistory(page, PAGE_SIZE),
     refetchInterval: 5_000,
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: revokeTask,
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ["admin", "task-history"] }),
   });
 
   return (
@@ -2078,11 +2097,12 @@ function TaskHistoryTable() {
                   <th className="px-3 py-2 text-right font-medium whitespace-nowrap">Run</th>
                   <th className="px-3 py-2 text-right font-medium whitespace-nowrap">Completed at</th>
                   <th className="px-3 py-2 text-left font-medium">Error</th>
+                  <th className="px-3 py-2 text-left font-medium">Actions</th>
                 </tr>
               </thead>
               <tbody>
                 {data.items.map((item) => (
-                  <TaskHistoryRow key={item.task_id} item={item} />
+                  <TaskHistoryRow key={item.task_id} item={item} onRevoke={(id) => revokeMutation.mutate(id)} />
                 ))}
               </tbody>
             </table>


### PR DESCRIPTION
## Summary

- `POST /api/admin/tasks/{task_id}/revoke` (superuser-only) — sends `control.revoke(terminate=True)` to stop running tasks (SIGTERM) or flag queued ones to be skipped; immediately marks the task `revoked` in Redis
- `_on_task_failure` signal updated to detect `celery.exceptions.Revoked` and record state as `revoked` instead of `failed`
- Task history table gains an **Actions** column with a **Cancel** link on `queued` and `running` rows; clicking invalidates the query for an immediate refresh
- `revoked` state renders in amber — distinct from `failed` (red) to signal intentional cancellation

Closes #412

## Test plan

- [x] Cancel button appears on queued/running rows; absent on success/failed/revoked rows
- [x] Cancel on a running debug-sleep task terminates it mid-run; row transitions to amber `revoked` within one poll cycle
- [x] Cancel on a queued task marks it revoked; task does not execute when the worker picks it up
- [ ] Non-superuser admin receives 403 on `POST /api/admin/tasks/{id}/revoke`

🤖 Generated with [Claude Code](https://claude.com/claude-code)