### PR TITLE
feat: show backend image version on worker dashboard cards (#416)

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -5,6 +5,7 @@ from app.config import get_settings
 from app.version import VERSION
 
 WORKER_VERSION_KEY = "weftmark:worker_version"
+WORKER_VERSION_NODE_PREFIX = "weftmark:worker_version:node:"
 
 
 def _make_celery() -> Celery:
@@ -70,7 +71,7 @@ def _on_task_failure(task_id=None, exception=None, **kwargs):
 
 
 @worker_ready.connect
-def _publish_worker_version(**kwargs):
+def _publish_worker_version(sender=None, **kwargs):
     """Write VERSION to Redis when the worker process finishes startup."""
     try:
         import redis as _redis
@@ -78,6 +79,8 @@ def _publish_worker_version(**kwargs):
         settings = get_settings()
         client = _redis.from_url(settings.redis_url, socket_connect_timeout=2)
         client.set(WORKER_VERSION_KEY, VERSION)
+        if sender is not None:
+            client.set(f"{WORKER_VERSION_NODE_PREFIX}{sender.hostname}", VERSION)
         client.close()
     except Exception:
         pass  # version badge degrades gracefully if Redis is unavailable

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1822,6 +1822,7 @@ class WorkerActiveTask(BaseModel):
 class WorkerInfo(BaseModel):
     name: str
     status: Literal["online", "offline"]
+    version: str | None = None
     concurrency: int | None = None
     completed_tasks: int | None = None
     active_tasks: list[WorkerActiveTask] = []
@@ -1860,13 +1861,20 @@ async def get_worker_status(_: User = Depends(require_superuser)) -> WorkerStatu
     active, reserved, stats = await asyncio.get_event_loop().run_in_executor(None, _inspect)
 
     queues: list[QueueInfo] = []
+    node_versions: dict[str, str] = {}
     try:
         import redis as _redis
+
+        from app.celery_app import WORKER_VERSION_NODE_PREFIX
 
         settings = get_settings()
         client = _redis.from_url(settings.redis_url, socket_connect_timeout=2)
         for q in ["celery"]:
             queues.append(QueueInfo(name=q, depth=client.llen(q)))
+        for name in set(active) | set(reserved) | set(stats):
+            raw = client.get(f"{WORKER_VERSION_NODE_PREFIX}{name}")
+            if raw:
+                node_versions[name] = raw.decode() if isinstance(raw, bytes) else raw
         client.close()
     except Exception as exc:
         log.warning("worker_status_redis_error: %s", exc)
@@ -1894,6 +1902,7 @@ async def get_worker_status(_: User = Depends(require_superuser)) -> WorkerStatu
                 WorkerInfo(
                     name=name,
                     status="online",
+                    version=node_versions.get(name),
                     concurrency=pool.get("max-concurrency"),
                     completed_tasks=sum(total_dict.values()) if total_dict else None,
                     active_tasks=[_task(t) for t in (active.get(name) or [])],

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1837,6 +1837,7 @@ class QueueInfo(BaseModel):
 class WorkerStatus(BaseModel):
     workers: list[WorkerInfo]
     queues: list[QueueInfo]
+    api_version: str
     checked_at: str
 
 
@@ -1910,7 +1911,7 @@ async def get_worker_status(_: User = Depends(require_superuser)) -> WorkerStatu
                 )
             )
 
-    return WorkerStatus(workers=workers, queues=queues, checked_at=checked_at)
+    return WorkerStatus(workers=workers, queues=queues, api_version=VERSION, checked_at=checked_at)
 
 
 class DebugSleepRequest(BaseModel):

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -298,6 +298,7 @@ export interface WorkerActiveTask {
 export interface WorkerInfo {
   name: string;
   status: "online" | "offline";
+  version: string | null;
   concurrency: number | null;
   completed_tasks: number | null;
   active_tasks: WorkerActiveTask[];

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -313,6 +313,7 @@ export interface QueueInfo {
 export interface WorkerStatus {
   workers: WorkerInfo[];
   queues: QueueInfo[];
+  api_version: string;
   checked_at: string;
 }
 

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1830,19 +1830,24 @@ function CveScanTab() {
   );
 }
 
-function WorkerCard({ worker }: { worker: WorkerInfo }) {
+function WorkerCard({ worker, apiVersion }: { worker: WorkerInfo; apiVersion: string }) {
   const isOnline = worker.status === "online";
   const hasActive = worker.active_tasks.length > 0;
   const hasReserved = worker.reserved_tasks.length > 0;
+  const versionMismatch = isOnline && worker.version != null && worker.version !== apiVersion;
 
   return (
-    <div className="border rounded-lg overflow-hidden">
-      <div className="flex items-center gap-3 px-4 py-3 bg-muted/20">
+    <div className={`border rounded-lg overflow-hidden ${versionMismatch ? "border-amber-500/50" : ""}`}>
+      <div className={`flex items-center gap-3 px-4 py-3 ${versionMismatch ? "bg-amber-500/10" : "bg-muted/20"}`}>
         <span className={`w-2 h-2 rounded-full shrink-0 ${isOnline ? "bg-green-500" : "bg-red-500"}`} />
         <span className="text-sm font-mono font-medium flex-1 truncate">{worker.name}</span>
         {isOnline && worker.version && (
-          <span className="text-xs px-2 py-0.5 rounded border border-border text-muted-foreground font-mono">
-            {worker.version}
+          <span className={`text-xs px-2 py-0.5 rounded border font-mono ${
+            versionMismatch
+              ? "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+              : "border-border text-muted-foreground"
+          }`} title={versionMismatch ? `Expected ${apiVersion}` : undefined}>
+            {worker.version}{versionMismatch ? " ⚠" : ""}
           </span>
         )}
         {isOnline && worker.concurrency !== null && (
@@ -1977,7 +1982,7 @@ function WorkersTab() {
             </h3>
             <div className="space-y-3">
               {data.workers.map((w) => (
-                <WorkerCard key={w.name} worker={w} />
+                <WorkerCard key={w.name} worker={w} apiVersion={data.api_version} />
               ))}
             </div>
           </div>

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1840,6 +1840,11 @@ function WorkerCard({ worker }: { worker: WorkerInfo }) {
       <div className="flex items-center gap-3 px-4 py-3 bg-muted/20">
         <span className={`w-2 h-2 rounded-full shrink-0 ${isOnline ? "bg-green-500" : "bg-red-500"}`} />
         <span className="text-sm font-mono font-medium flex-1 truncate">{worker.name}</span>
+        {isOnline && worker.version && (
+          <span className="text-xs px-2 py-0.5 rounded border border-border text-muted-foreground font-mono">
+            {worker.version}
+          </span>
+        )}
         {isOnline && worker.concurrency !== null && (
           <span className={`text-xs px-2 py-0.5 rounded border tabular-nums ${
             worker.active_tasks.length >= worker.concurrency


### PR DESCRIPTION
## Summary

- `worker_ready` signal now writes a per-worker Redis key (`weftmark:worker_version:node:{hostname}`) in addition to the existing global key — lets each worker node advertise its own version independently
- `GET /api/admin/worker-status` looks up the per-node key for each online worker and populates a new `version` field on `WorkerInfo`
- Worker card header renders the version as a small monospace badge (e.g. `v0.94.0`) between the worker name and the slots badge; absent when offline or not yet written

Closes #416

## Test plan

- [x] Worker card shows version badge (e.g. `v0.94.0`) when worker is online
- [x] Both `worker` and `worker2` cards show their respective versions
- [ ] Version badge absent on offline worker card
- [ ] After `rbd`, version badge updates to the new version on next poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)