### PR TITLE
feat: GDPR soft-delete purge task and audit trail hardening (#322, #324)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -217,3 +217,8 @@ CELERY_CONCURRENCY=2
 
 # Enable the second Celery worker by adding "worker02" to COMPOSE_PROFILES (see top of file).
 # Both worker and worker2 use the same CELERY_CONCURRENCY value.
+
+# Number of days after soft-deletion before records are permanently purged.
+# Applies to drafts, looms, projects, and yarn (not users — handled separately).
+# Triggered manually from Admin → Superuser → Maintenance or via a scheduled task.
+SOFT_DELETE_RETENTION_DAYS=365

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -17,6 +17,7 @@ def _make_celery() -> Celery:
         include=[
             "app.tasks.deletion",
             "app.tasks.preview",
+            "app.tasks.purge",
             "app.tasks.s3_audit",
             "app.tasks.cve_scan",
             "app.tasks.debug",

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -111,6 +111,9 @@ class Settings(BaseSettings):
     # Redis / Celery
     redis_url: str = "redis://redis:6379/0"
 
+    # Data retention
+    soft_delete_retention_days: int = 365
+
     # Rendering
     render_max_width: int = 4000
     render_max_height: int = 4000

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -2009,3 +2009,15 @@ async def revoke_task(
     celery_app.control.revoke(task_id, terminate=True)
     record_completed(get_settings(), task_id, "revoked")
     return {"status": "revoked", "task_id": task_id}
+
+
+@router.post("/purge-soft-deleted")
+async def run_purge_soft_deleted(
+    _: User = Depends(require_superuser),
+) -> dict:
+    from app.services.task_history import record_queued
+    from app.tasks.purge import purge_soft_deleted_records
+
+    task = purge_soft_deleted_records.delay()
+    record_queued(get_settings(), task.id, "app.tasks.purge.purge_soft_deleted_records", "maintenance")
+    return {"status": "queued", "task_id": task.id}

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -74,6 +74,7 @@ async def clerk_webhook(request: Request, db: AsyncSession = Depends(get_db)) ->
         event = wh.verify(payload, headers)
     except WebhookVerificationError:
         log.info("webhook_rejected reason=invalid_signature")
+        await write_audit_log(db, event_type="webhook.signature_failed")
         raise HTTPException(status_code=400, detail="Invalid webhook signature")
 
     event_type = event.get("type")
@@ -232,6 +233,7 @@ async def _consume_invite(db: AsyncSession, email: str) -> Invite | None:
         return None
     invite.accepted_at = datetime.now(timezone.utc)
     await db.commit()
+    await write_audit_log(db, event_type="invite.accepted", target_email=email)
     return invite
 
 

--- a/backend/app/tasks/purge.py
+++ b/backend/app/tasks/purge.py
@@ -1,0 +1,160 @@
+"""Celery task: hard-delete soft-deleted records that have exceeded the retention period.
+
+Covers Draft, Loom, Project, and Yarn. User deletion is handled separately
+by run_user_deletion. Storage files associated with purged records are removed
+before the DB rows are deleted.
+
+Dispatched from the admin maintenance panel or by a future scheduled task.
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+
+from celery import Task
+from celery.exceptions import SoftTimeLimitExceeded
+
+from app.celery_app import celery_app
+
+log = logging.getLogger(__name__)
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=0,
+    soft_time_limit=300,
+    time_limit=360,
+    name="app.tasks.purge.purge_soft_deleted_records",
+)
+def purge_soft_deleted_records(self: Task, retention_days: int | None = None) -> dict:
+    from app.config import get_settings
+
+    days = retention_days if retention_days is not None else get_settings().soft_delete_retention_days
+    return asyncio.run(_purge(days))
+
+
+async def _purge(retention_days: int) -> dict:
+    from sqlalchemy import delete, select
+    from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+    from sqlalchemy.orm import sessionmaker
+
+    from app.config import get_settings
+    from app.models.draft import Draft
+    from app.models.loom import Loom, LoomVersion, LoomVersionAccessory, LoomVersionPhoto, LoomVersionReceipt
+    from app.models.project import Project, ProjectPhoto, ProjectStep
+    from app.models.yarn import Skein, Yarn
+    from app.services import storage
+
+    settings = get_settings()
+    cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
+    engine = create_async_engine(settings.database_url, echo=False)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    counts: dict[str, int] = {}
+
+    try:
+        async with async_session() as db:
+            try:
+                # Projects
+                project_ids = list(
+                    await db.scalars(
+                        select(Project.id).where(Project.deleted_at.is_not(None), Project.deleted_at < cutoff)
+                    )
+                )
+                if project_ids:
+                    photos = await db.scalars(select(ProjectPhoto).where(ProjectPhoto.project_id.in_(project_ids)))
+                    for p in photos.all():
+                        _safe_delete(storage, p.file_path)
+                    await db.execute(delete(ProjectStep).where(ProjectStep.project_id.in_(project_ids)))
+                    await db.execute(delete(ProjectPhoto).where(ProjectPhoto.project_id.in_(project_ids)))
+                    await db.execute(delete(Project).where(Project.id.in_(project_ids)))
+                    await db.commit()
+                counts["projects"] = len(project_ids)
+                log.info("purge_soft_deleted projects=%d cutoff=%s", len(project_ids), cutoff.date())
+
+                # Yarn
+                yarn_ids = list(
+                    await db.scalars(select(Yarn.id).where(Yarn.deleted_at.is_not(None), Yarn.deleted_at < cutoff))
+                )
+                if yarn_ids:
+                    yarns = await db.scalars(select(Yarn).where(Yarn.id.in_(yarn_ids)))
+                    for y in yarns.all():
+                        if y.photo_path:
+                            _safe_delete(storage, y.photo_path)
+                    await db.execute(delete(Skein).where(Skein.yarn_id.in_(yarn_ids)))
+                    await db.execute(delete(Yarn).where(Yarn.id.in_(yarn_ids)))
+                    await db.commit()
+                counts["yarn"] = len(yarn_ids)
+                log.info("purge_soft_deleted yarn=%d cutoff=%s", len(yarn_ids), cutoff.date())
+
+                # Looms
+                loom_ids = list(
+                    await db.scalars(select(Loom.id).where(Loom.deleted_at.is_not(None), Loom.deleted_at < cutoff))
+                )
+                if loom_ids:
+                    looms = await db.scalars(select(Loom).where(Loom.id.in_(loom_ids)))
+                    for loom in looms.all():
+                        if loom.photo_path:
+                            _safe_delete(storage, loom.photo_path)
+                    version_ids = list(
+                        await db.scalars(select(LoomVersion.id).where(LoomVersion.loom_id.in_(loom_ids)))
+                    )
+                    if version_ids:
+                        vp = await db.scalars(
+                            select(LoomVersionPhoto).where(LoomVersionPhoto.loom_version_id.in_(version_ids))
+                        )
+                        for p in vp.all():
+                            _safe_delete(storage, p.path)
+                        vr = await db.scalars(
+                            select(LoomVersionReceipt).where(LoomVersionReceipt.loom_version_id.in_(version_ids))
+                        )
+                        for r in vr.all():
+                            _safe_delete(storage, r.path)
+                        await db.execute(
+                            delete(LoomVersionAccessory).where(LoomVersionAccessory.loom_version_id.in_(version_ids))
+                        )
+                        await db.execute(
+                            delete(LoomVersionReceipt).where(LoomVersionReceipt.loom_version_id.in_(version_ids))
+                        )
+                        await db.execute(
+                            delete(LoomVersionPhoto).where(LoomVersionPhoto.loom_version_id.in_(version_ids))
+                        )
+                        await db.execute(delete(LoomVersion).where(LoomVersion.id.in_(version_ids)))
+                    await db.execute(delete(Loom).where(Loom.id.in_(loom_ids)))
+                    await db.commit()
+                counts["looms"] = len(loom_ids)
+                log.info("purge_soft_deleted looms=%d cutoff=%s", len(loom_ids), cutoff.date())
+
+                # Drafts
+                draft_ids = list(
+                    await db.scalars(select(Draft.id).where(Draft.deleted_at.is_not(None), Draft.deleted_at < cutoff))
+                )
+                if draft_ids:
+                    drafts = await db.scalars(select(Draft).where(Draft.id.in_(draft_ids)))
+                    for d in drafts.all():
+                        _safe_delete(storage, d.wif_path)
+                        if d.preview_path:
+                            _safe_delete(storage, d.preview_path)
+                        if d.drawdown_preview_path:
+                            _safe_delete(storage, d.drawdown_preview_path)
+                    await db.execute(delete(Draft).where(Draft.id.in_(draft_ids)))
+                    await db.commit()
+                counts["drafts"] = len(draft_ids)
+                log.info("purge_soft_deleted drafts=%d cutoff=%s", len(draft_ids), cutoff.date())
+
+            except SoftTimeLimitExceeded:
+                log.warning("purge_soft_deleted_stalled reason=soft_time_limit counts_so_far=%s", counts)
+                raise
+
+    finally:
+        await engine.dispose()
+
+    total = sum(counts.values())
+    log.info("purge_soft_deleted_complete total=%d retention_days=%d counts=%s", total, retention_days, counts)
+    return {"retention_days": retention_days, "total": total, **counts}
+
+
+def _safe_delete(storage, path: str) -> None:
+    try:
+        storage._delete(path)
+    except Exception as exc:
+        log.warning("purge_storage_error path=%s error=%s", path, exc)

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -349,3 +349,6 @@ export const getTaskHistory = (page: number = 1, pageSize: number = 25) =>
 
 export const revokeTask = (taskId: string) =>
   api.post<{ status: string; task_id: string }>(`/api/admin/tasks/${taskId}/revoke`, {});
+
+export const runPurgeSoftDeleted = () =>
+  api.post<{ status: string; task_id: string }>("/api/admin/purge-soft-deleted", {});

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -35,6 +35,7 @@ import {
   startDebugSleep,
   getTaskHistory,
   revokeTask,
+  runPurgeSoftDeleted,
   type TaskHistoryItem,
   type AdminUser,
   type AdminHealth,
@@ -1483,7 +1484,7 @@ function EulaTab() {
 // Superuser tab
 // ---------------------------------------------------------------------------
 
-type SuperuserSubTab = "eula" | "storage" | "cve" | "workers" | "deletion" | "reconcile";
+type SuperuserSubTab = "eula" | "storage" | "cve" | "workers" | "deletion" | "reconcile" | "maintenance";
 
 const SUPERUSER_TAB_LABELS: Record<SuperuserSubTab, string> = {
   eula: "EULA",
@@ -1492,6 +1493,7 @@ const SUPERUSER_TAB_LABELS: Record<SuperuserSubTab, string> = {
   workers: "Workers",
   deletion: "Deletion",
   reconcile: "Reconcile",
+  maintenance: "Maintenance",
 };
 
 function SuperuserTab() {
@@ -1500,7 +1502,7 @@ function SuperuserTab() {
   return (
     <div className="space-y-4">
       <div className="flex gap-2 border-b pb-2 flex-wrap">
-        {(["eula", "storage", "cve", "workers", "deletion", "reconcile"] as SuperuserSubTab[]).map((t) => (
+        {(["eula", "storage", "cve", "workers", "deletion", "reconcile", "maintenance"] as SuperuserSubTab[]).map((t) => (
           <button
             key={t}
             onClick={() => setSub(t)}
@@ -1521,6 +1523,7 @@ function SuperuserTab() {
       {sub === "workers" && <WorkersTab />}
       {sub === "deletion" && <DeletionTab />}
       {sub === "reconcile" && <ReconcileTab />}
+      {sub === "maintenance" && <MaintenanceTab />}
     </div>
   );
 }
@@ -2148,6 +2151,48 @@ function DeletionTab() {
     <div className="rounded-lg border border-dashed p-8 text-center">
       <p className="text-sm font-medium text-muted-foreground">Deletion Queue</p>
       <p className="text-xs text-muted-foreground mt-1">Coming soon — in-progress and pending user deletion states.</p>
+    </div>
+  );
+}
+
+function MaintenanceTab() {
+  const queryClient = useQueryClient();
+  const [purging, setPurging] = useState(false);
+
+  function triggerPurge() {
+    setPurging(true);
+    runPurgeSoftDeleted()
+      .then(() => {
+        setPurging(false);
+        queryClient.invalidateQueries({ queryKey: ["admin", "task-history"] });
+      })
+      .catch(() => setPurging(false));
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border p-5 space-y-3">
+        <div>
+          <p className="text-sm font-medium">Purge Soft-Deleted Records</p>
+          <p className="text-xs text-muted-foreground mt-1">
+            Hard-deletes drafts, looms, projects, and yarn that have been soft-deleted for longer than the
+            configured retention period (<code className="font-mono">SOFT_DELETE_RETENTION_DAYS</code>, default 365 days).
+            Associated storage files are removed at the same time. User deletion is handled separately by the
+            deletion cascade task.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <Button
+            size="sm"
+            variant="destructive"
+            disabled={purging}
+            onClick={triggerPurge}
+          >
+            {purging ? "Queuing…" : "Run Purge Now"}
+          </Button>
+          <p className="text-xs text-muted-foreground">Results appear in the Workers → Task History table.</p>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

**#322 — Audit trail hardening**
- `webhook.signature_failed` audit log entry when Clerk webhook HMAC verification fails — previously only logged at INFO, now also in the persistent audit trail
- `invite.accepted` audit log entry when a user signs up via an invite link — the invite lifecycle was logged at creation and revocation but not acceptance

**#324 — GDPR soft-delete purge task**
- New `purge_soft_deleted_records` Celery task — hard-deletes Drafts, Looms, Projects, and Yarn where `deleted_at` is older than `SOFT_DELETE_RETENTION_DAYS` (default 365); deletes associated storage files first
- `SOFT_DELETE_RETENTION_DAYS` setting added to `config.py` and documented in `.env.example`
- `POST /api/admin/purge-soft-deleted` endpoint (superuser-only) dispatches the task and records it in task history
- New **Admin → Superuser → Maintenance** tab with a "Run Purge Now" button; purge results visible in Workers → Task History

Closes #322, #324

## Test plan

- [ ] Trigger a webhook with an invalid signature — `webhook.signature_failed` appears in audit log
- [ ] Accept an invite — `invite.accepted` appears in audit log  
- [ ] Navigate to Admin → Superuser → Maintenance — purge button visible with description
- [ ] Click "Run Purge Now" — task appears in task history as queued → running → success
- [ ] With no eligible records, purge returns `total: 0` and succeeds cleanly
- [ ] Non-superuser admin receives 403 on `POST /api/admin/purge-soft-deleted`

🤖 Generated with [Claude Code](https://claude.com/claude-code)