### PR TITLE
fix: run backend and worker containers as non-root user (#265)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,4 +19,10 @@ COPY VERSION .
 
 RUN sed -i 's/\r$//' entrypoint.sh && chmod +x entrypoint.sh
 
+# Drop to non-root — suppresses Celery SecurityWarning and follows least-privilege.
+# chown covers /app/uploads so the named volume initialises with correct ownership.
+RUN addgroup --system appuser && adduser --system --ingroup appuser appuser \
+    && chown -R appuser:appuser /app
+USER appuser
+
 ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
## Summary

- Adds a `appuser` system user and group to `backend/Dockerfile`
- Transfers ownership of `/app` (including the `uploads` directory) to `appuser`
- Switches to `appuser` via `USER` before the `ENTRYPOINT`
- Applies to both the uvicorn (backend) and Celery worker/worker2 containers since they share the same image

## Effect

- Celery `SecurityWarning` about running as root is eliminated
- Process UID drops from `0` to a system UID (`< 1000`), satisfying least-privilege
- The named `uploads` volume is initialised with `appuser` ownership on first creation, so local-storage writes continue to work in dev

## Notes

- Production uses `STORAGE_BACKEND=s3`, so there are no local filesystem writes in prod — no volume permission concerns there
- Existing dev `uploads` volumes created before this change are root-owned; recreate with `docker volume rm weaving_site_uploads` if local-storage write errors appear after pulling this image

## Test plan

- [ ] `docker compose ... build backend` completes without errors
- [ ] `docker exec weaving_site_backend id` shows `uid != 0`
- [ ] `docker exec weaving_site_worker id` shows `uid != 0`
- [ ] Worker logs no longer show `SecurityWarning: You're running the worker with superuser privileges`
- [ ] Background task (e.g. render preview) completes normally
- [ ] `docker compose ... up -d` health check passes

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)