### PR TITLE
fix: adaptive drawdown scale for oversized designs + surface render errors (#268)

### DIFF
--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -262,7 +262,7 @@ async def get_drawdown(
     wif_bytes = storage.read_file(draft.wif_path)
     try:
         wif_draft = rendering.load_draft(wif_bytes)
-        png, total_rows = rendering.render_drawdown_only(wif_draft)
+        png, total_rows, actual_scale = rendering.render_drawdown_only(wif_draft)
     except HTTPException:
         raise
     except Exception as exc:
@@ -272,7 +272,7 @@ async def get_drawdown(
         content=png,
         media_type="image/png",
         headers={
-            "X-Pixels-Per-Row": str(rendering.DRAWDOWN_SCALE),
+            "X-Pixels-Per-Row": str(actual_scale),
             "X-Total-Rows": str(total_rows),
             "Cache-Control": "public, max-age=31536000, immutable",
             "ETag": f'"{draft_id}"',

--- a/backend/app/services/rendering.py
+++ b/backend/app/services/rendering.py
@@ -91,30 +91,41 @@ def render_drawdown_preview(draft: Draft, max_px: int = 800) -> tuple[bytes, int
     return out.getvalue(), scale
 
 
-def render_drawdown_only(draft: Draft, scale: int = DRAWDOWN_SCALE) -> tuple[bytes, int]:
+def render_drawdown_only(draft: Draft, scale: int = DRAWDOWN_SCALE) -> tuple[bytes, int, int]:
     """Render just the drawdown strip, cropped from the full draft image.
 
-    Returns (png_bytes, total_rows). Pick 1 is at the top of the image (y=0),
-    last pick is at the bottom. Each row is ``scale`` pixels tall.
+    Returns (png_bytes, total_rows, scale_used). Pick 1 is at the top of the image (y=0),
+    last pick is at the bottom. Each row is ``scale_used`` pixels tall.
+
+    Scale is reduced automatically so the output fits within RENDER_MAX_WIDTH/HEIGHT.
+    A 413 is raised only if scale=1 would still exceed the limits.
     """
     margin = 20
     warp_count = len(draft.warp)
     weft_count = len(draft.weft)
-    drawdown_w = warp_count * scale
-    drawdown_h = weft_count * scale
 
-    if drawdown_w <= 0 or drawdown_h <= 0:
+    if warp_count <= 0 or weft_count <= 0:
         raise ValueError("Draft has no drawdown data to render")
 
     _s = get_settings()
-    if drawdown_w > _s.render_max_width or drawdown_h > _s.render_max_height:
+    # Reduce scale to the largest integer that fits within the configured pixel limits.
+    max_scale = min(
+        _s.render_max_width // warp_count,
+        _s.render_max_height // weft_count,
+        scale,
+    )
+    if max_scale < 1:
         raise HTTPException(
             status_code=413,
             detail=(
-                f"Draft dimensions ({drawdown_w}x{drawdown_h}px) exceed the rendering limit "
-                f"({_s.render_max_width}x{_s.render_max_height}px)."
+                f"Draft dimensions ({warp_count}×{weft_count} threads) exceed the rendering limit "
+                f"even at scale=1 ({_s.render_max_width}×{_s.render_max_height}px max)."
             ),
         )
+    scale = max_scale
+
+    drawdown_w = warp_count * scale
+    drawdown_h = weft_count * scale
 
     renderer = ImageRenderer(draft, scale=scale, margin_pixels=margin)
     full_im = renderer.make_pil_image()
@@ -130,4 +141,4 @@ def render_drawdown_only(draft: Draft, scale: int = DRAWDOWN_SCALE) -> tuple[byt
     cropped = cropped.transpose(PILImage.Transpose.FLIP_TOP_BOTTOM)
     out = io.BytesIO()
     cropped.save(out, format="PNG")
-    return out.getvalue(), weft_count
+    return out.getvalue(), weft_count, scale

--- a/backend/tests/services/test_rendering.py
+++ b/backend/tests/services/test_rendering.py
@@ -302,17 +302,22 @@ class TestRenderDrawdownOnly:
     def test_returns_tuple(self):
         draft = load_draft(MINIMAL_WIF)
         result = render_drawdown_only(draft)
-        assert isinstance(result, tuple) and len(result) == 2
+        assert isinstance(result, tuple) and len(result) == 3
 
     def test_first_element_is_png(self):
         draft = load_draft(MINIMAL_WIF)
-        png, _ = render_drawdown_only(draft)
+        png, _, _ = render_drawdown_only(draft)
         assert png[:4] == b"\x89PNG"
 
     def test_second_element_is_weft_count(self):
         draft = load_draft(MINIMAL_WIF)
-        _, total_rows = render_drawdown_only(draft)
+        _, total_rows, _ = render_drawdown_only(draft)
         assert total_rows == len(draft.weft)
+
+    def test_third_element_is_scale_used(self):
+        draft = load_draft(MINIMAL_WIF)
+        _, _, scale_used = render_drawdown_only(draft, scale=10)
+        assert isinstance(scale_used, int) and scale_used == 10
 
     def test_drawdown_scale_constant_is_20(self):
         assert DRAWDOWN_SCALE == 20
@@ -324,15 +329,30 @@ class TestRenderDrawdownOnly:
 
         draft = load_draft(MINIMAL_WIF)
         scale = 10
-        png, total_rows = render_drawdown_only(draft, scale=scale)
+        png, total_rows, scale_used = render_drawdown_only(draft, scale=scale)
         img = Image.open(io.BytesIO(png))
-        assert img.width == len(draft.warp) * scale
-        assert img.height == len(draft.weft) * scale
+        assert img.width == len(draft.warp) * scale_used
+        assert img.height == len(draft.weft) * scale_used
         assert total_rows == len(draft.weft)
+
+    def test_adaptive_scale_reduces_for_large_draft(self, monkeypatch):
+        """Scale is reduced automatically when draft exceeds render limits."""
+        from app.config import Settings
+
+        draft = load_draft(MINIMAL_WIF)
+        # Force a very small render limit so the default scale=20 would exceed it.
+        tiny_settings = Settings(render_max_width=40, render_max_height=40)
+        monkeypatch.setattr("app.services.rendering.get_settings", lambda: tiny_settings)
+        _, _, scale_used = render_drawdown_only(draft)
+        warp = len(draft.warp)
+        weft = len(draft.weft)
+        assert scale_used * warp <= 40
+        assert scale_used * weft <= 40
+        assert scale_used >= 1
 
     def test_eight_shaft_renders(self):
         draft = load_draft(EIGHT_SHAFT_WIF)
-        png, total_rows = render_drawdown_only(draft, scale=4)
+        png, total_rows, _ = render_drawdown_only(draft, scale=4)
         assert png[:4] == b"\x89PNG"
         assert total_rows == len(draft.weft)
 

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -213,6 +213,7 @@ function WeavingPatternView({
   const containerH = useAdaptivePatternHeight();
   const [imgSrc, setImgSrc] = useState<string | null>(null);
   const [pixelsPerRow, setPixelsPerRow] = useState(20);
+  const [loadError, setLoadError] = useState(false);
   const objectUrlRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -221,6 +222,10 @@ function WeavingPatternView({
       const token = await getAuthToken();
       const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
       const res = await fetch(`/api/drafts/${draftId}/drawdown`, { credentials: "include", headers });
+      if (!res.ok) {
+        if (!cancelled) setLoadError(true);
+        return;
+      }
       const ppr = parseInt(res.headers.get("X-Pixels-Per-Row") ?? "20", 10);
       if (!cancelled) setPixelsPerRow(ppr);
       const blob = await res.blob();
@@ -230,7 +235,7 @@ function WeavingPatternView({
       objectUrlRef.current = url;
       setImgSrc(url);
     }
-    load().catch(() => {});
+    load().catch(() => { if (!cancelled) setLoadError(true); });
     return () => {
       cancelled = true;
       if (objectUrlRef.current) {
@@ -240,6 +245,14 @@ function WeavingPatternView({
     };
   }, [draftId]);
 
+  if (loadError) return (
+    <div
+      className="flex items-center justify-center rounded-lg border bg-muted text-muted-foreground text-sm"
+      style={{ height: containerH }}
+    >
+      Pattern preview unavailable for this design.
+    </div>
+  );
   if (!imgSrc) return null;
 
   // Image is flipped: last pick at y=0 (top), pick 1 at bottom.
@@ -372,6 +385,7 @@ function AbandonedDrawdownView({
   totalPicks: number;
 }) {
   const [imgSrc, setImgSrc] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState(false);
   const objectUrlRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -380,6 +394,10 @@ function AbandonedDrawdownView({
       const token = await getAuthToken();
       const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
       const res = await fetch(`/api/drafts/${draftId}/drawdown`, { credentials: "include", headers });
+      if (!res.ok) {
+        if (!cancelled) setLoadError(true);
+        return;
+      }
       const blob = await res.blob();
       if (cancelled) return;
       if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
@@ -387,7 +405,7 @@ function AbandonedDrawdownView({
       objectUrlRef.current = url;
       setImgSrc(url);
     }
-    load().catch(() => {});
+    load().catch(() => { if (!cancelled) setLoadError(true); });
     return () => {
       cancelled = true;
       if (objectUrlRef.current) {
@@ -397,6 +415,11 @@ function AbandonedDrawdownView({
     };
   }, [draftId]);
 
+  if (loadError) return (
+    <div className="flex items-center justify-center rounded-lg border bg-muted text-muted-foreground text-sm p-6">
+      Pattern preview unavailable for this design.
+    </div>
+  );
   if (!imgSrc) return null;
 
   // Image is flipped: row 0 (top) = last pick, row N-1 (bottom) = pick 1.


### PR DESCRIPTION
## Summary

- **Backend:** `render_drawdown_only` now computes the largest integer scale that fits both dimensions within `RENDER_MAX_WIDTH`/`RENDER_MAX_HEIGHT` instead of immediately raising 413. A 413 is only raised if even `scale=1` would still exceed the limits. The function now returns a 3-tuple `(bytes, total_rows, scale_used)` and the live-render path in `drafts.py` sends the actual scale in `X-Pixels-Per-Row` instead of the hardcoded constant.
- **Frontend:** Both `WeavingPatternView` and `AbandonedDrawdownView` check `res.ok` after fetch and set a `loadError` flag on non-2xx. A visible _"Pattern preview unavailable"_ notice replaces the previous silent blank space.

## Before / After

| | Before | After |
|---|---|---|
| 300×456 thread design (6000×9120px at scale=20) | 413 → blank, no user feedback | Renders at scale=13 (3900×5928px, within 4000px limit) |
| Network/server error | Silent blank | "Pattern preview unavailable" notice |
| `X-Pixels-Per-Row` header | Always `20` | Actual scale used |

## Test plan

- [ ] CI passes
- [ ] On dev: open a project backed by a large WIF (>200 warp threads) — drawdown renders instead of going blank
- [ ] On dev: a genuinely too-large design (>4000 warp threads) shows the error notice instead of blank

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)