### PR TITLE
fix: normalise stale Treadles= metadata in liftplan-only WIF files (#266)

### DIFF
--- a/backend/app/services/rendering.py
+++ b/backend/app/services/rendering.py
@@ -35,6 +35,9 @@ DRAWDOWN_SCALE = 20
 
 def load_draft(wif_bytes: bytes) -> Draft:
     """Parse WIF bytes and return a PyWeaving Draft."""
+    from app.services.wif_modifier import zero_treadles_for_liftplan
+
+    wif_bytes = zero_treadles_for_liftplan(wif_bytes)
     with tempfile.NamedTemporaryFile(suffix=".wif", delete=False) as tmp:
         tmp.write(wif_bytes)
         tmp_path = tmp.name

--- a/backend/app/services/wif_modifier.py
+++ b/backend/app/services/wif_modifier.py
@@ -4,6 +4,7 @@ wif_modified_path, never to wif_path).
 
 Currently supports:
   - set_weaving_int: update a single integer key in [WEAVING] (e.g. Treadles, Shafts)
+  - zero_treadles_for_liftplan: normalise liftplan-only files that carry stale Treadles= metadata
 """
 
 from __future__ import annotations
@@ -49,3 +50,24 @@ def set_weaving_int(wif_bytes: bytes, key: str, value: int) -> bytes:
         )
 
     return updated.encode(encoding)
+
+
+def zero_treadles_for_liftplan(wif_bytes: bytes) -> bytes:
+    """Return normalised WIF bytes for files that mix liftplan data with stale treadle metadata.
+
+    Some tools (e.g. TempoWeave Designer) write Treadles=N in [WEAVING] as informational
+    metadata even in pure liftplan files. PyWeaving rejects this combination with an
+    AssertionError. If the file has a [LIFTPLAN] section but no [TREADLING] section,
+    set Treadles=0 so PyWeaving can parse it correctly.
+    """
+    try:
+        text = wif_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        text = wif_bytes.decode("latin-1")
+
+    has_liftplan = bool(re.search(r"(?im)^\[LIFTPLAN\]", text))
+    has_treadling = bool(re.search(r"(?im)^\[TREADLING\]", text))
+
+    if has_liftplan and not has_treadling:
+        return set_weaving_int(wif_bytes, "Treadles", 0)
+    return wif_bytes

--- a/backend/tests/services/test_rendering.py
+++ b/backend/tests/services/test_rendering.py
@@ -11,6 +11,7 @@ A full PyWeaving-compatible WIF requires: [WIF] with Date, [CONTENTS],
 """
 
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -21,6 +22,10 @@ from app.services.rendering import (
     render_full_draft,
     render_full_draft_liftplan,
 )
+
+# Real-world liftplan WIF that declares Treadles=8 as metadata (TempoWeave Designer output).
+_SAMPLES_DIR = Path(__file__).parents[3] / "docs" / "samples"
+_SHADOW_FLOWERS_WIF = _SAMPLES_DIR / "Shadow_flowers~assembly-LP.wif"
 
 # ---------------------------------------------------------------------------
 # Minimal valid WIF fixture
@@ -361,3 +366,28 @@ class TestRenderDrawdownOnly:
         draft.warp = []
         with pytest.raises(ValueError, match="no drawdown data"):
             render_drawdown_only(draft)
+
+
+# ---------------------------------------------------------------------------
+# Real-world liftplan WIF with stale Treadles= metadata (#266)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not _SHADOW_FLOWERS_WIF.exists(),
+    reason="Sample file not present in repo",
+)
+class TestLiftplanTreadles:
+    def test_shadow_flowers_loads_without_assertion_error(self):
+        wif_bytes = _SHADOW_FLOWERS_WIF.read_bytes()
+        draft = load_draft(wif_bytes)
+        assert len(draft.warp) > 0
+        assert len(draft.weft) > 0
+
+    def test_shadow_flowers_drawdown_renders(self):
+        wif_bytes = _SHADOW_FLOWERS_WIF.read_bytes()
+        draft = load_draft(wif_bytes)
+        png, total_rows, scale_used = render_drawdown_only(draft)
+        assert png[:4] == b"\x89PNG"
+        assert total_rows == len(draft.weft)
+        assert scale_used >= 1

--- a/backend/tests/services/test_wif_modifier.py
+++ b/backend/tests/services/test_wif_modifier.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from app.services.wif_modifier import set_weaving_int
+from app.services.wif_modifier import set_weaving_int, zero_treadles_for_liftplan
 
 _MINIMAL_WIF = b"""[WIF]
 Version=1.1
@@ -67,3 +67,76 @@ class TestSetWeavingInt:
         weaving_idx = text.index("[WEAVING]")
         units_idx = text.index("Units=2")
         assert units_idx > weaving_idx
+
+
+_LIFTPLAN_WIF_WITH_TREADLES = b"""[WIF]
+Version=1.1
+Date=June 2025
+Source Program=TempoWeave Designer
+
+[WEAVING]
+Shafts=8
+Treadles=8
+Rising Shed=true
+
+[LIFTPLAN]
+1=1,2,3
+2=4,5,6
+"""
+
+_LIFTPLAN_WIF_NO_TREADLES = b"""[WIF]
+Version=1.1
+Date=June 2025
+Source Program=TempoWeave Designer
+
+[WEAVING]
+Shafts=8
+Treadles=0
+Rising Shed=true
+
+[LIFTPLAN]
+1=1,2,3
+"""
+
+_TREADLE_WIF = b"""[WIF]
+Version=1.1
+Date=June 2025
+Source Program=TestSuite
+
+[WEAVING]
+Shafts=4
+Treadles=4
+Rising Shed=true
+
+[TREADLING]
+1=1
+2=2
+"""
+
+
+class TestZeroTreadlesForLiftplan:
+    def test_zeros_treadles_when_liftplan_without_treadling(self):
+        result = zero_treadles_for_liftplan(_LIFTPLAN_WIF_WITH_TREADLES)
+        assert b"Treadles=0" in result
+        assert b"Treadles=8" not in result
+
+    def test_noop_when_treadles_already_zero(self):
+        result = zero_treadles_for_liftplan(_LIFTPLAN_WIF_NO_TREADLES)
+        assert b"Treadles=0" in result
+
+    def test_noop_when_no_liftplan_section(self):
+        result = zero_treadles_for_liftplan(_TREADLE_WIF)
+        assert result == _TREADLE_WIF
+
+    def test_noop_when_both_liftplan_and_treadling_present(self):
+        both = _LIFTPLAN_WIF_WITH_TREADLES + b"\n[TREADLING]\n1=1\n"
+        result = zero_treadles_for_liftplan(both)
+        assert result == both
+
+    def test_returns_bytes(self):
+        result = zero_treadles_for_liftplan(_LIFTPLAN_WIF_WITH_TREADLES)
+        assert isinstance(result, bytes)
+
+    def test_liftplan_section_preserved(self):
+        result = zero_treadles_for_liftplan(_LIFTPLAN_WIF_WITH_TREADLES)
+        assert b"[LIFTPLAN]" in result


### PR DESCRIPTION
## Summary

TempoWeave Designer (and likely other tools) write `Treadles=N` in `[WEAVING]` as informational metadata even in pure liftplan files. PyWeaving's `WIFReader` asserts that liftplan + non-zero treadle count cannot coexist, crashing preview generation with an `AssertionError` (surfaced as a lint warning and blank preview).

### Approach

Added `zero_treadles_for_liftplan()` to `wif_modifier.py`: if the WIF bytes contain a `[LIFTPLAN]` section but no `[TREADLING]` section, `Treadles=` is set to `0` before PyWeaving parses the file. `load_draft()` in `rendering.py` applies this transparently — all render paths (preview, drawdown, full draft) are covered with no caller changes.

No change to `[TREADLING]`-present files or to the `wif_parser` linting path.

## Test plan

- [ ] CI passes
- [ ] `Shadow_flowers~assembly-LP.wif` preview renders on dev without lint warning
- [ ] Existing treadle-based WIFs unaffected

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)