### PR TITLE
feat: project notes display and inline editing (#274)

### DIFF
--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -91,7 +91,8 @@ class CreateProjectRequest(BaseModel):
 
 
 class RenameProjectRequest(BaseModel):
-    name: str
+    name: str | None = None
+    notes: str | None = None
 
 
 class AssignLoomRequest(BaseModel):
@@ -334,11 +335,16 @@ async def rename_project(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> ProjectDetail:
-    name = body.name.strip()
-    if not name:
-        raise HTTPException(status_code=400, detail="Name cannot be empty")
+    if body.name is None and body.notes is None:
+        raise HTTPException(status_code=400, detail="At least one field (name or notes) must be provided")
     project = await _get_owned_project(project_id, current_user, db)
-    project.name = name
+    if body.name is not None:
+        name = body.name.strip()
+        if not name:
+            raise HTTPException(status_code=400, detail="Name cannot be empty")
+        project.name = name
+    if body.notes is not None:
+        project.notes = body.notes
     await db.commit()
     await db.refresh(project)
     draft = await db.get(Draft, project.draft_id)

--- a/backend/tests/routers/test_projects.py
+++ b/backend/tests/routers/test_projects.py
@@ -835,6 +835,25 @@ class TestRenameProject:
         resp = await client.patch(f"/api/projects/{project.id}", json={"name": "x"})
         assert resp.status_code == 401
 
+    async def test_updates_notes(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        body = (await auth_client.patch(f"/api/projects/{project.id}", json={"notes": "my notes"})).json()
+        assert body["notes"] == "my notes"
+
+    async def test_notes_only_preserves_name(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        original_name = project.name
+        body = (await auth_client.patch(f"/api/projects/{project.id}", json={"notes": "n"})).json()
+        assert body["name"] == original_name
+
+    async def test_no_fields_returns_400(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        resp = await auth_client.patch(f"/api/projects/{project.id}", json={})
+        assert resp.status_code == 400
+
 
 # ---------------------------------------------------------------------------
 # TestDeleteProject

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -148,6 +148,14 @@ export function renameProject(id: string, name: string): Promise<ProjectDetail> 
   });
 }
 
+export function updateProjectNotes(id: string, notes: string | null): Promise<ProjectDetail> {
+  return req(`/api/projects/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ notes }),
+  });
+}
+
 export function restartProject(id: string): Promise<ProjectDetail> {
   return req(`/api/projects/${id}/restart`, { method: "POST" });
 }

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -6,7 +6,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   getProject, getProjectPicks, stepProject, jumpProject, completeProject, abandonProject,
   restartProject, cloneProject, listProjects, deleteProject,
-  renameProject, uploadProjectPhoto, deleteProjectPhoto, projectPhotoUrl,
+  renameProject, updateProjectNotes, uploadProjectPhoto, deleteProjectPhoto, projectPhotoUrl,
   ApiError, PROJECT_TYPE_LABELS, PROJECT_STATUS_LABELS,
   type ProjectSummary, type ProjectPhoto, type PickRow,
 } from "@/api/projects";
@@ -890,6 +890,8 @@ export function ProjectDetailPage() {
   const [showDesignPreview, setShowDesignPreview] = useState(false);
   const [editingName, setEditingName] = useState(false);
   const [nameInput, setNameInput] = useState("");
+  const [editingNotes, setEditingNotes] = useState(false);
+  const [notesInput, setNotesInput] = useState("");
   const [showAssignLoom, setShowAssignLoom] = useState(false);
   const [confirmComplete, setConfirmComplete] = useState(false);
   const [confirmAbandon, setConfirmAbandon] = useState(false);
@@ -1394,6 +1396,42 @@ export function ProjectDetailPage() {
               />
             </CollapsibleSection>
           )}
+
+          <CollapsibleSection title="Notes" defaultOpen={!!project.notes}>
+            {editingNotes ? (
+              <textarea
+                autoFocus
+                className="w-full rounded border border-input bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring resize-none"
+                rows={4}
+                value={notesInput}
+                onChange={(e) => setNotesInput(e.target.value)}
+                onKeyDown={(e) => { if (e.key === "Escape") setEditingNotes(false); }}
+                onBlur={async () => {
+                  const trimmed = notesInput.trim();
+                  const current = project.notes ?? "";
+                  if (trimmed !== current) {
+                    const updated = await updateProjectNotes(id!, trimmed || null);
+                    queryClient.setQueryData<typeof project>(["project", id], (old) =>
+                      old ? { ...updated, photos: old.photos } : updated
+                    );
+                  }
+                  setEditingNotes(false);
+                }}
+              />
+            ) : (
+              <button
+                onClick={() => { setNotesInput(project.notes ?? ""); setEditingNotes(true); }}
+                className="w-full text-left text-sm"
+                title="Click to edit notes"
+              >
+                {project.notes ? (
+                  <p className="whitespace-pre-wrap text-muted-foreground">{project.notes}</p>
+                ) : (
+                  <p className="text-muted-foreground/60 italic">Add notes...</p>
+                )}
+              </button>
+            )}
+          </CollapsibleSection>
 
           <CollapsibleSection title="Details">
             <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">


### PR DESCRIPTION
## Summary

- Extends `PATCH /api/projects/{id}` to accept an optional `notes` field alongside `name` — either can be updated independently; an empty body returns 400
- Adds `updateProjectNotes()` API function in the frontend
- Adds a **Notes** collapsible section to `ProjectDetailPage` with click-to-edit inline textarea (saves on blur, cancels on Escape, sends `null` to clear); section auto-opens when the project already has notes

## Test plan

- [ ] Open a project — Notes section appears collapsed (no notes yet); click it to expand, click inside to edit, type notes, tab/click away → saves and displays the text
- [ ] Re-open the page — Notes section is auto-expanded and shows saved text
- [ ] Edit notes, press Escape — textarea closes without saving
- [ ] Clear all text and blur — notes cleared (shows "Add notes..." placeholder)
- [ ] Rename a project — notes are unaffected
- [ ] `pytest tests/routers/test_projects.py::TestRenameProject` — 8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)