### PR TITLE
perf: optimistic pick-stepping — instant UI response under remote DB latency (#294)

### DIFF
--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -108,6 +108,11 @@ class StepRequest(BaseModel):
     direction: str  # "advance" | "reverse"
 
 
+class StepResponse(BaseModel):
+    current_pick: int
+    total_picks: int
+
+
 class PickRow(BaseModel):
     pick: int
     active: list[int]
@@ -401,13 +406,13 @@ async def assign_loom(
     return _to_detail(project, draft, loom)
 
 
-@router.post("/{project_id}/step", response_model=ProjectDetail)
+@router.post("/{project_id}/step", response_model=StepResponse)
 async def step_project(
     project_id: uuid.UUID,
     body: StepRequest,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-) -> ProjectDetail:
+) -> StepResponse:
     if body.direction not in ("advance", "reverse"):
         raise HTTPException(status_code=400, detail="direction must be 'advance' or 'reverse'")
 
@@ -434,11 +439,8 @@ async def step_project(
     )
     db.add(step)
     await db.commit()
-    await db.refresh(project)
-
-    draft = await db.get(Draft, project.draft_id)
-    loom = await db.get(Loom, project.loom_id) if project.loom_id else None
-    return _to_detail(project, draft, loom)  # type: ignore[arg-type]
+    # current_pick is already updated in-memory; no need to re-fetch draft/loom
+    return StepResponse(current_pick=project.current_pick, total_picks=project.total_picks)
 
 
 @router.post("/{project_id}/jump", response_model=ProjectDetail)

--- a/backend/tests/routers/test_projects.py
+++ b/backend/tests/routers/test_projects.py
@@ -951,6 +951,26 @@ class TestStepProject:
         resp = await client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
         assert resp.status_code == 401
 
+    async def test_response_is_lightweight(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        body = (await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})).json()
+        assert set(body.keys()) == {"current_pick", "total_picks"}
+
+    async def test_logs_step_to_database(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        from sqlalchemy import select
+
+        from app.models.project import ProjectStep
+
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
+        step = await db_session.scalar(select(ProjectStep).where(ProjectStep.project_id == project.id))
+        assert step is not None
+        assert step.event_type == "advance"
+        assert step.from_pick == 1
+        assert step.to_pick == 2
+
 
 # ---------------------------------------------------------------------------
 # TestJumpProject

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -65,6 +65,11 @@ export interface CreateProjectPayload {
   length_unit?: string;
 }
 
+export interface StepResponse {
+  current_pick: number;
+  total_picks: number;
+}
+
 export interface PickRow {
   pick: number;
   active: number[];
@@ -124,7 +129,7 @@ export function createProject(payload: CreateProjectPayload): Promise<ProjectDet
   });
 }
 
-export function stepProject(id: string, direction: "advance" | "reverse"): Promise<ProjectDetail> {
+export function stepProject(id: string, direction: "advance" | "reverse"): Promise<StepResponse> {
   return req(`/api/projects/${id}/step`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -949,17 +949,35 @@ export function ProjectDetailPage() {
   }, [id, stepping, queryClient]);
 
   const handleStep = useCallback(async (direction: "advance" | "reverse") => {
-    if (!id || stepping) return;
-    setStepping(true);
+    if (!id) return;
+    // Read latest cached value so rapid taps each see the up-to-date pick
+    const cached = queryClient.getQueryData<NonNullable<typeof project>>(["project", id]);
+    if (!cached) return;
+    if (direction === "advance" && cached.current_pick > cached.total_picks) return;
+    if (direction === "reverse" && cached.current_pick <= 1) return;
+
+    const prevPick = cached.current_pick;
+    const newPick = direction === "advance" ? prevPick + 1 : prevPick - 1;
+
+    // Instant optimistic update — UI responds before the server replies
+    queryClient.setQueryData<typeof project>(["project", id], (old) =>
+      old ? { ...old, current_pick: newPick } : old
+    );
+
     try {
-      const updated = await stepProject(id, direction);
+      const result = await stepProject(id, direction);
+      // Sync authoritative pick from server
       queryClient.setQueryData<typeof project>(["project", id], (old) =>
-        old ? { ...updated, photos: old.photos } : updated
+        old ? { ...old, current_pick: result.current_pick, total_picks: result.total_picks } : old
       );
-    } finally {
-      setStepping(false);
+    } catch {
+      // Roll back and force a fresh fetch to recover true server state
+      queryClient.setQueryData<typeof project>(["project", id], (old) =>
+        old ? { ...old, current_pick: prevPick } : old
+      );
+      queryClient.invalidateQueries({ queryKey: ["project", id] });
     }
-  }, [id, stepping, queryClient]);
+  }, [id, queryClient]);
 
   const handleLocalStep = useCallback((direction: "advance" | "reverse") => {
     setLocalPick((prev) => {


### PR DESCRIPTION
## Summary

- **Root cause:** `handleStep` set `stepping=true`, blocking all buttons while awaiting a full `ProjectDetail` response (5 DB ops: select + commit + refresh + Draft fetch + Loom fetch) on every single pick press
- **Frontend:** `handleStep` is now optimistic — pick counter updates instantly in the query cache, server request fires in the background, rolls back + force-refetches on failure. Buttons are never disabled during stepping. Keyboard shortcuts (arrow/space) and Bluetooth pedal events get the same improvement
- **Backend:** New `StepResponse { current_pick, total_picks }` — drops `db.refresh`, Draft fetch, and Loom fetch from the step endpoint (2 DB ops instead of 5). Step logging to `ProjectStep` is unchanged

## Test plan

- [x] Open an active project and press advance/reverse rapidly — pick counter updates instantly with no button lockout
- [x] Use keyboard arrows and spacebar — same instant response
- [x] Step to the last pick and try to advance past it — no-ops silently (bounds guard in optimistic handler)
- [x] Step at pick 1 and try to reverse — same
- [x] `pytest tests/routers/test_projects.py::TestStepProject` — 10 tests pass, including `test_response_is_lightweight` and `test_logs_step_to_database`

🤖 Generated with [Claude Code](https://claude.com/claude-code)