### PR TITLE
ux: pre-size drawdown container and show loading skeleton while tiles fetch

### DIFF
--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -292,8 +292,15 @@ function WeavingPatternView({
       Pattern preview unavailable for this design.
     </div>
   );
-  // Render nothing until at least one tile is available.
-  if (Object.keys(tiles).length === 0) return null;
+  // Show a pre-sized skeleton while the first tile is in flight — prevents layout shift.
+  // Mirror the 3-panel flex structure of the loaded state so dimensions don't change on hydration.
+  if (Object.keys(tiles).length === 0) return (
+    <div className="relative flex gap-2" style={{ height: containerH }}>
+      <div className="flex-1 rounded-lg border overflow-hidden relative bg-muted animate-pulse" />
+      <div className="rounded-lg border overflow-hidden relative shrink-0 bg-muted animate-pulse" style={{ width: STEP_PANEL_W }} />
+      <div className="rounded-lg border overflow-hidden relative shrink-0 bg-muted animate-pulse" style={{ width: COLOR_COL_W }} />
+    </div>
+  );
 
   // Image is flipped: last pick at y=0 (top), pick 1 at bottom.
   const flippedIndex = totalPicks - 1 - currentPickIndex;


### PR DESCRIPTION
Closes #429

## Summary

- Replace `return null` in `WeavingPatternView` with a pre-sized 3-panel skeleton that mirrors the loaded state's flex layout (drawdown + step panel + color column)
- Container height is reserved from the first render — no layout shift when the first tile arrives
- Uses `bg-muted` + `animate-pulse`; semantic tokens handle light/dark automatically
- Skeleton width matches the loaded state exactly (same `STEP_PANEL_W` / `COLOR_COL_W` constants) so the flex layout doesn't shift on hydration

## Test plan

- [ ] Open an active project — drawdown area shows a pulsing skeleton at full height immediately, no layout jump when tiles load
- [ ] Verify skeleton uses muted background in both light and dark themes
- [ ] Verify no height or width change when the skeleton transitions to loaded tiles
- [ ] Slow network (DevTools throttle) — skeleton persists for the full fetch duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)