### PR TITLE
fix: default new user theme to 'system' instead of 'light'

### DIFF
--- a/backend/alembic/versions/0003_default_theme_system.py
+++ b/backend/alembic/versions/0003_default_theme_system.py
@@ -1,0 +1,42 @@
+"""Change users.theme column default from 'light' to 'system'.
+
+Revision ID: d5e6f7a8b9c0
+Revises: c4d5e6f7a8b9
+Create Date: 2026-05-07
+
+Changes:
+- users.theme: server default changed from 'light' to 'system'
+
+Existing rows are not modified — we cannot distinguish users who explicitly
+chose light mode from those who received the old default.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d5e6f7a8b9c0"
+down_revision: str | None = "c4d5e6f7a8b9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "users",
+        "theme",
+        existing_type=sa.String(20),
+        server_default="system",
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "users",
+        "theme",
+        existing_type=sa.String(20),
+        server_default="light",
+        existing_nullable=False,
+    )

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -21,7 +21,7 @@ class User(Base, TimestampMixin, SoftDeleteMixin):
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     is_superuser: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
-    theme: Mapped[str] = mapped_column(String(20), default="light", nullable=False)
+    theme: Mapped[str] = mapped_column(String(20), default="system", nullable=False)
     activity_theme: Mapped[str | None] = mapped_column(String(50), nullable=True)
     idle_timeout_minutes: Mapped[int] = mapped_column(Integer, default=30, nullable=False)
     measurement_system: Mapped[str] = mapped_column(String(10), default="metric", nullable=False)

--- a/backend/tests/models/test_user.py
+++ b/backend/tests/models/test_user.py
@@ -27,12 +27,12 @@ class TestUserDefaults:
         await db_session.refresh(user)
         assert user.is_active is True
 
-    async def test_theme_defaults_light(self, db_session: AsyncSession):
+    async def test_theme_defaults_system(self, db_session: AsyncSession):
         user = User(email="u@example.com", display_name="U", oidc_sub="sub-001")
         db_session.add(user)
         await db_session.commit()
         await db_session.refresh(user)
-        assert user.theme == "light"
+        assert user.theme == "system"
 
     async def test_measurement_system_defaults_metric(self, db_session: AsyncSession):
         user = User(email="u@example.com", display_name="U", oidc_sub="sub-001")

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -77,7 +77,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   // Apply theme class to document root
   useEffect(() => {
-    const theme = user?.theme ?? "light";
+    const theme = user?.theme ?? "system";
     if (theme === "system") {
       const mq = window.matchMedia("(prefers-color-scheme: dark)");
       const apply = () => document.documentElement.classList.toggle("dark", mq.matches);


### PR DESCRIPTION
Closes #432

## Summary

- `User.theme` model default changed from `'light'` to `'system'`
- Alembic migration `0003` updates the DB column server default (existing rows left unchanged — can't distinguish users who explicitly chose light from those who received the old default)
- `AuthContext` unauthenticated fallback updated from `?? "light"` to `?? "system"`
- `test_theme_defaults_light` renamed and updated to assert `'system'`

## Test plan

- [ ] Register a new account — page respects OS dark/light preference immediately
- [ ] Existing users on light theme are unaffected
- [ ] `pytest tests/models/test_user.py` passes
- [ ] Migration runs cleanly: `alembic upgrade head`

🤖 Generated with [Claude Code](https://claude.com/claude-code)