### PR TITLE
fix: show spinner and label in drawdown skeleton while tiles load

### DIFF
--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
+import { Loader2 } from "lucide-react";
 import { AppIcons } from "@/lib/icons";
 import { usePresentMode } from "@/hooks/usePresentMode";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -296,7 +297,10 @@ function WeavingPatternView({
   // Mirror the 3-panel flex structure of the loaded state so dimensions don't change on hydration.
   if (Object.keys(tiles).length === 0) return (
     <div className="relative flex gap-2" style={{ height: containerH }}>
-      <div className="flex-1 rounded-lg border overflow-hidden relative bg-muted animate-pulse" />
+      <div className="flex-1 rounded-lg border overflow-hidden relative bg-muted flex flex-col items-center justify-center gap-2">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        <span className="text-xs text-muted-foreground">Loading pattern…</span>
+      </div>
       <div className="rounded-lg border overflow-hidden relative shrink-0 bg-muted animate-pulse" style={{ width: STEP_PANEL_W }} />
       <div className="rounded-lg border overflow-hidden relative shrink-0 bg-muted animate-pulse" style={{ width: COLOR_COL_W }} />
     </div>


### PR DESCRIPTION
Follows up on #430 / closes QA feedback on #429.

## Problem

The `bg-muted animate-pulse` skeleton in `WeavingPatternView` was invisible in light mode — `bg-muted` is barely distinguishable from the page background, so the pre-sized container appeared completely blank with no loading indication.

## Fix

Replace the bare pulsing div with a centered `Loader2` spinner + `"Loading pattern…"` label in the main drawdown panel. The two side panels (step + color column) retain the muted pulse since they're narrow and the spinner would not fit meaningfully.

## Test plan

- [ ] Open an active project on a slow connection (DevTools throttle) — spinner and label visible in the drawdown area while tiles fetch
- [ ] Once first tile loads, spinner disappears and pattern renders with no height change

🤖 Generated with [Claude Code](https://claude.com/claude-code)