### PR TITLE
fix: hide CVE banner when no scan result exists (#439)

### DIFF
--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -92,7 +92,7 @@ function CveBanner() {
     staleTime: 5 * 60_000,
   });
 
-  if (dismissed || !data || data.finding_count === 0) return null;
+  if (dismissed || !data || data.finding_count == null || data.finding_count === 0) return null;
 
   return (
     <div className="flex items-center justify-between gap-3 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm">


### PR DESCRIPTION
Closes #439

## Problem

The CVE banner was showing on every fresh stack startup with "null CVE vulnerabilities found" because `finding_count` is `null` (not `0`) when no Redis scan result exists, and `null === 0` is `false`.

## Fix

One-line change in `CveBanner` — add `data.finding_count == null` to the guard:

```ts
// before
if (dismissed || !data || data.finding_count === 0) return null;
// after
if (dismissed || !data || data.finding_count == null || data.finding_count === 0) return null;
```

## Test plan

- [ ] Fresh stack with no scan result — banner not shown
- [ ] After scan returning 0 findings — banner not shown
- [ ] After scan returning findings > 0 — banner shown correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)