### PR TITLE
feat: superuser scheduled task console (#404)

### DIFF
--- a/backend/alembic/versions/0004_scheduled_tasks.py
+++ b/backend/alembic/versions/0004_scheduled_tasks.py
@@ -1,0 +1,54 @@
+"""Create scheduled_tasks table and seed built-in tasks.
+
+Revision ID: e6f7a8b9c0d1
+Revises: d5e6f7a8b9c0
+Create Date: 2026-05-07
+
+Changes:
+- Creates scheduled_tasks table (name PK, enabled, cron, display_name, description, last_fired_at, updated_at)
+- Seeds the cve_scan task (disabled by default, daily at 02:00 UTC)
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e6f7a8b9c0d1"
+down_revision: str | None = "d5e6f7a8b9c0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "scheduled_tasks",
+        sa.Column("name", sa.String(100), primary_key=True),
+        sa.Column("display_name", sa.String(200), nullable=False),
+        sa.Column("description", sa.String(500), nullable=False, server_default=""),
+        sa.Column("enabled", sa.Boolean, nullable=False, server_default="false"),
+        sa.Column("cron", sa.String(100), nullable=False, server_default="0 2 * * *"),
+        sa.Column("last_fired_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.execute(
+        """
+        INSERT INTO scheduled_tasks (name, display_name, description, enabled, cron)
+        VALUES (
+            'cve_scan',
+            'CVE Scan',
+            'Scans Python dependencies via pip-audit for known vulnerabilities. '
+            'Results are stored and shown in the CVE Scan tab and admin warning banner.',
+            false,
+            '0 2 * * *'
+        )
+        ON CONFLICT (name) DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("scheduled_tasks")

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -21,6 +21,7 @@ def _make_celery() -> Celery:
             "app.tasks.s3_audit",
             "app.tasks.cve_scan",
             "app.tasks.debug",
+            "app.tasks.scheduler",
         ],
     )
     app.conf.update(
@@ -32,6 +33,12 @@ def _make_celery() -> Celery:
         task_track_started=True,
         worker_prefetch_multiplier=1,
         broker_connection_retry_on_startup=True,
+        beat_schedule={
+            "run-scheduled-tasks": {
+                "task": "app.tasks.scheduler.run_scheduled_tasks",
+                "schedule": 60.0,
+            }
+        },
     )
     return app
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -13,6 +13,7 @@ from app.models.loom import (
 )
 from app.models.pending_signup import PendingSignup
 from app.models.project import Project, ProjectPhoto, ProjectStep
+from app.models.scheduled_task import ScheduledTask
 from app.models.seed_run import SeedRun
 from app.models.user import User
 from app.models.user_identity import UserIdentity
@@ -39,4 +40,5 @@ __all__ = [
     "ProjectPhoto",
     "ProjectStep",
     "EulaVersion",
+    "ScheduledTask",
 ]

--- a/backend/app/models/scheduled_task.py
+++ b/backend/app/models/scheduled_task.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class ScheduledTask(Base):
+    __tablename__ = "scheduled_tasks"
+
+    name: Mapped[str] = mapped_column(String(100), primary_key=True)
+    display_name: Mapped[str] = mapped_column(String(200), nullable=False)
+    description: Mapped[str] = mapped_column(String(500), nullable=False, default="")
+    enabled: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    cron: Mapped[str] = mapped_column(String(100), nullable=False, default="0 2 * * *")
+    last_fired_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, default=None)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -2021,3 +2021,142 @@ async def run_purge_soft_deleted(
     task = purge_soft_deleted_records.delay()
     record_queued(get_settings(), task.id, "app.tasks.purge.purge_soft_deleted_records", "maintenance")
     return {"status": "queued", "task_id": task.id}
+
+
+# ---------------------------------------------------------------------------
+# Scheduled tasks (superuser only)
+# ---------------------------------------------------------------------------
+
+
+class ScheduledTaskResponse(BaseModel):
+    name: str
+    display_name: str
+    description: str
+    enabled: bool
+    cron: str
+    next_runs: list[str]
+    last_fired_at: datetime | None
+    updated_at: datetime
+
+
+class PatchScheduledTaskBody(BaseModel):
+    enabled: bool | None = None
+    cron: str | None = None
+
+
+def _next_runs(cron: str, n: int = 3) -> list[str]:
+    from croniter import croniter
+
+    base = datetime.now(timezone.utc)
+    cron_iter = croniter(cron, base)
+    return [cron_iter.get_next(datetime).isoformat() for _ in range(n)]
+
+
+def _validate_cron(cron: str) -> bool:
+    try:
+        from croniter import croniter
+
+        croniter(cron, datetime.now(timezone.utc)).get_next()
+        return True
+    except Exception:
+        return False
+
+
+async def _get_or_seed_scheduled_task(name: str, db: AsyncSession):
+    from app.models.scheduled_task import ScheduledTask
+    from app.tasks.scheduler import REGISTRY
+
+    row = await db.scalar(select(ScheduledTask).where(ScheduledTask.name == name))
+    if row is None and name in REGISTRY:
+        entry = REGISTRY[name]
+        row = ScheduledTask(
+            name=name,
+            display_name=entry["display_name"],
+            description=entry["description"],
+            enabled=False,
+            cron=entry["default_cron"],
+        )
+        db.add(row)
+        await db.flush()
+    return row
+
+
+def _task_to_response(task) -> ScheduledTaskResponse:
+    return ScheduledTaskResponse(
+        name=task.name,
+        display_name=task.display_name,
+        description=task.description,
+        enabled=task.enabled,
+        cron=task.cron,
+        next_runs=_next_runs(task.cron),
+        last_fired_at=task.last_fired_at,
+        updated_at=task.updated_at,
+    )
+
+
+@router.get("/scheduled-tasks")
+async def list_scheduled_tasks(
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_superuser),
+) -> list[ScheduledTaskResponse]:
+    from app.models.scheduled_task import ScheduledTask
+    from app.tasks.scheduler import REGISTRY
+
+    rows = {r.name: r for r in (await db.scalars(select(ScheduledTask))).all()}
+    result = []
+    for name, entry in REGISTRY.items():
+        if name not in rows:
+            row = ScheduledTask(
+                name=name,
+                display_name=entry["display_name"],
+                description=entry["description"],
+                enabled=False,
+                cron=entry["default_cron"],
+            )
+            db.add(row)
+            await db.flush()
+            rows[name] = row
+    await db.commit()
+    for name in REGISTRY:
+        if name in rows:
+            await db.refresh(rows[name])
+            result.append(_task_to_response(rows[name]))
+    return result
+
+
+@router.patch("/scheduled-tasks/{name}")
+async def patch_scheduled_task(
+    name: str,
+    body: PatchScheduledTaskBody,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_superuser),
+) -> ScheduledTaskResponse:
+    from app.models.scheduled_task import ScheduledTask
+    from app.tasks.scheduler import REGISTRY
+
+    if name not in REGISTRY:
+        raise HTTPException(status_code=404, detail="Scheduled task not found")
+
+    row = await db.scalar(select(ScheduledTask).where(ScheduledTask.name == name))
+    if row is None:
+        entry = REGISTRY[name]
+        row = ScheduledTask(
+            name=name,
+            display_name=entry["display_name"],
+            description=entry["description"],
+            enabled=False,
+            cron=entry["default_cron"],
+        )
+        db.add(row)
+        await db.flush()
+
+    if body.cron is not None:
+        if not _validate_cron(body.cron):
+            raise HTTPException(status_code=422, detail="Invalid cron expression")
+        row.cron = body.cron
+    if body.enabled is not None:
+        row.enabled = body.enabled
+
+    await db.commit()
+    await db.refresh(row)
+    return _task_to_response(row)

--- a/backend/app/tasks/scheduler.py
+++ b/backend/app/tasks/scheduler.py
@@ -1,0 +1,86 @@
+"""Celery task: scheduled-task tick.
+
+Runs every 60 seconds via Celery Beat. For each enabled ScheduledTask row,
+checks whether the cron expression matches the current minute and dispatches
+the corresponding Celery task if so.
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from app.celery_app import celery_app
+
+log = logging.getLogger(__name__)
+
+# Public registry: maps slug → metadata used by the admin endpoints.
+REGISTRY: dict[str, dict] = {
+    "cve_scan": {
+        "display_name": "CVE Scan",
+        "description": (
+            "Scans Python dependencies via pip-audit for known vulnerabilities. "
+            "Results are stored and shown in the CVE Scan tab and admin warning banner. "
+            "Scheduled runs skip npm scanning (Python deps only)."
+        ),
+        "default_cron": "0 2 * * *",
+    },
+}
+
+
+def _dispatch_cve_scan(settings):
+    from app.services.task_history import record_queued
+    from app.tasks.cve_scan import run_cve_scan
+
+    task = run_cve_scan.delay({})
+    record_queued(settings, task.id, "app.tasks.cve_scan.run_cve_scan", "scheduled:cve_scan")
+    return task
+
+
+DISPATCH_FNS: dict[str, object] = {
+    "cve_scan": _dispatch_cve_scan,
+}
+
+
+@celery_app.task(
+    name="app.tasks.scheduler.run_scheduled_tasks",
+    max_retries=0,
+    ignore_result=True,
+)
+def run_scheduled_tasks() -> None:
+    from croniter import croniter
+
+    from app.config import get_settings
+
+    settings = get_settings()
+    now = datetime.now(timezone.utc)
+    window_start = now - timedelta(seconds=70)
+
+    try:
+        from sqlalchemy import create_engine, select
+        from sqlalchemy.orm import Session
+
+        from app.models.scheduled_task import ScheduledTask
+
+        engine = create_engine(settings.database_url_sync)
+        with Session(engine) as db:
+            tasks = db.scalars(select(ScheduledTask).where(ScheduledTask.enabled.is_(True))).all()
+            fired = []
+            for task in tasks:
+                try:
+                    cron = croniter(task.cron, window_start)
+                    next_fire = cron.get_next(datetime)
+                    if next_fire <= now:
+                        dispatch_fn = DISPATCH_FNS.get(task.name)
+                        if dispatch_fn:
+                            dispatch_fn(settings)
+                            task.last_fired_at = now
+                            fired.append(task.name)
+                            log.info("scheduled_task_fired name=%s", task.name)
+                        else:
+                            log.warning("scheduled_task_no_dispatch name=%s", task.name)
+                except Exception:
+                    log.exception("scheduled_task_error name=%s", task.name)
+            if fired:
+                db.commit()
+        engine.dispose()
+    except Exception:
+        log.exception("run_scheduled_tasks_error")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,3 +21,4 @@ svix==1.92.2
 boto3==1.38.0
 psutil==6.1.1
 pip-audit
+croniter==3.0.4

--- a/backend/tests/routers/test_admin.py
+++ b/backend/tests/routers/test_admin.py
@@ -1286,3 +1286,115 @@ class TestDeleteUser:
         target = await self._create_target(db_session)
         await superuser_client.post(f"/api/admin/users/{target.id}/delete", json={"confirm": "DELETE USER"})
         mock_deletion_service.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/admin/scheduled-tasks
+# ---------------------------------------------------------------------------
+
+
+class TestListScheduledTasks:
+    async def test_returns_200(self, superuser_client: AsyncClient):
+        resp = await superuser_client.get("/api/admin/scheduled-tasks")
+        assert resp.status_code == 200
+
+    async def test_returns_list(self, superuser_client: AsyncClient):
+        resp = await superuser_client.get("/api/admin/scheduled-tasks")
+        data = resp.json()
+        assert isinstance(data, list)
+
+    async def test_includes_cve_scan(self, superuser_client: AsyncClient):
+        resp = await superuser_client.get("/api/admin/scheduled-tasks")
+        names = [t["name"] for t in resp.json()]
+        assert "cve_scan" in names
+
+    async def test_task_has_required_fields(self, superuser_client: AsyncClient):
+        resp = await superuser_client.get("/api/admin/scheduled-tasks")
+        task = next(t for t in resp.json() if t["name"] == "cve_scan")
+        assert "name" in task
+        assert "display_name" in task
+        assert "description" in task
+        assert "enabled" in task
+        assert "cron" in task
+        assert "next_runs" in task
+
+    async def test_next_runs_has_three_entries(self, superuser_client: AsyncClient):
+        resp = await superuser_client.get("/api/admin/scheduled-tasks")
+        task = next(t for t in resp.json() if t["name"] == "cve_scan")
+        assert len(task["next_runs"]) == 3
+
+    async def test_cve_scan_disabled_by_default(self, superuser_client: AsyncClient):
+        resp = await superuser_client.get("/api/admin/scheduled-tasks")
+        task = next(t for t in resp.json() if t["name"] == "cve_scan")
+        assert task["enabled"] is False
+
+    async def test_non_superuser_returns_403(self, admin_client: AsyncClient):
+        resp = await admin_client.get("/api/admin/scheduled-tasks")
+        assert resp.status_code == 403
+
+    async def test_unauthenticated_returns_401(self, client: AsyncClient):
+        resp = await client.get("/api/admin/scheduled-tasks")
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/admin/scheduled-tasks/{name}
+# ---------------------------------------------------------------------------
+
+
+class TestPatchScheduledTask:
+    async def test_enable_task(self, superuser_client: AsyncClient):
+        resp = await superuser_client.patch("/api/admin/scheduled-tasks/cve_scan", json={"enabled": True})
+        assert resp.status_code == 200
+        assert resp.json()["enabled"] is True
+
+    async def test_disable_task(self, superuser_client: AsyncClient):
+        await superuser_client.patch("/api/admin/scheduled-tasks/cve_scan", json={"enabled": True})
+        resp = await superuser_client.patch("/api/admin/scheduled-tasks/cve_scan", json={"enabled": False})
+        assert resp.status_code == 200
+        assert resp.json()["enabled"] is False
+
+    async def test_update_cron(self, superuser_client: AsyncClient):
+        resp = await superuser_client.patch("/api/admin/scheduled-tasks/cve_scan", json={"cron": "0 6 * * *"})
+        assert resp.status_code == 200
+        assert resp.json()["cron"] == "0 6 * * *"
+
+    async def test_update_persists(self, superuser_client: AsyncClient, db_session: AsyncSession):
+        await superuser_client.patch(
+            "/api/admin/scheduled-tasks/cve_scan",
+            json={"enabled": True, "cron": "0 12 * * 1"},
+        )
+        from sqlalchemy import select
+
+        from app.models.scheduled_task import ScheduledTask
+
+        row = await db_session.scalar(select(ScheduledTask).where(ScheduledTask.name == "cve_scan"))
+        assert row is not None
+        assert row.enabled is True
+        assert row.cron == "0 12 * * 1"
+
+    async def test_invalid_cron_returns_422(self, superuser_client: AsyncClient):
+        resp = await superuser_client.patch("/api/admin/scheduled-tasks/cve_scan", json={"cron": "not a cron"})
+        assert resp.status_code == 422
+
+    async def test_unknown_task_returns_404(self, superuser_client: AsyncClient):
+        resp = await superuser_client.patch("/api/admin/scheduled-tasks/nonexistent_task", json={"enabled": True})
+        assert resp.status_code == 404
+
+    async def test_non_superuser_returns_403(self, admin_client: AsyncClient):
+        resp = await admin_client.patch("/api/admin/scheduled-tasks/cve_scan", json={"enabled": True})
+        assert resp.status_code == 403
+
+    async def test_unauthenticated_returns_401(self, client: AsyncClient):
+        resp = await client.patch("/api/admin/scheduled-tasks/cve_scan", json={"enabled": True})
+        assert resp.status_code == 401
+
+    async def test_response_includes_next_runs(self, superuser_client: AsyncClient):
+        resp = await superuser_client.patch("/api/admin/scheduled-tasks/cve_scan", json={"cron": "0 2 * * *"})
+        assert len(resp.json()["next_runs"]) == 3
+
+    async def test_partial_update_preserves_other_fields(self, superuser_client: AsyncClient):
+        await superuser_client.patch("/api/admin/scheduled-tasks/cve_scan", json={"cron": "0 3 * * *"})
+        resp = await superuser_client.patch("/api/admin/scheduled-tasks/cve_scan", json={"enabled": True})
+        assert resp.json()["cron"] == "0 3 * * *"
+        assert resp.json()["enabled"] is True

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -352,3 +352,20 @@ export const revokeTask = (taskId: string) =>
 
 export const runPurgeSoftDeleted = () =>
   api.post<{ status: string; task_id: string }>("/api/admin/purge-soft-deleted", {});
+
+export interface ScheduledTask {
+  name: string;
+  display_name: string;
+  description: string;
+  enabled: boolean;
+  cron: string;
+  next_runs: string[];
+  last_fired_at: string | null;
+  updated_at: string;
+}
+
+export const listScheduledTasks = () =>
+  api.get<ScheduledTask[]>("/api/admin/scheduled-tasks");
+
+export const patchScheduledTask = (name: string, body: { enabled?: boolean; cron?: string }) =>
+  api.patch<ScheduledTask>(`/api/admin/scheduled-tasks/${name}`, body);

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -36,6 +36,9 @@ import {
   getTaskHistory,
   revokeTask,
   runPurgeSoftDeleted,
+  listScheduledTasks,
+  patchScheduledTask,
+  type ScheduledTask,
   type TaskHistoryItem,
   type AdminUser,
   type AdminHealth,
@@ -1484,7 +1487,7 @@ function EulaTab() {
 // Superuser tab
 // ---------------------------------------------------------------------------
 
-type SuperuserSubTab = "eula" | "storage" | "cve" | "workers" | "deletion" | "reconcile" | "maintenance";
+type SuperuserSubTab = "eula" | "storage" | "cve" | "workers" | "deletion" | "reconcile" | "maintenance" | "schedule";
 
 const SUPERUSER_TAB_LABELS: Record<SuperuserSubTab, string> = {
   eula: "EULA",
@@ -1494,6 +1497,7 @@ const SUPERUSER_TAB_LABELS: Record<SuperuserSubTab, string> = {
   deletion: "Deletion",
   reconcile: "Reconcile",
   maintenance: "Maintenance",
+  schedule: "Scheduled Tasks",
 };
 
 function SuperuserTab() {
@@ -1502,7 +1506,7 @@ function SuperuserTab() {
   return (
     <div className="space-y-4">
       <div className="flex gap-2 border-b pb-2 flex-wrap">
-        {(["eula", "storage", "cve", "workers", "deletion", "reconcile", "maintenance"] as SuperuserSubTab[]).map((t) => (
+        {(["eula", "storage", "cve", "workers", "deletion", "reconcile", "maintenance", "schedule"] as SuperuserSubTab[]).map((t) => (
           <button
             key={t}
             onClick={() => setSub(t)}
@@ -1524,6 +1528,7 @@ function SuperuserTab() {
       {sub === "deletion" && <DeletionTab />}
       {sub === "reconcile" && <ReconcileTab />}
       {sub === "maintenance" && <MaintenanceTab />}
+      {sub === "schedule" && <ScheduledTasksTab />}
     </div>
   );
 }
@@ -2503,5 +2508,149 @@ function AuditLogRow({ entry }: { entry: AuditLogEntry }) {
         </tr>
       )}
     </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Scheduled Tasks tab
+// ---------------------------------------------------------------------------
+
+const CRON_PRESETS = [
+  { label: "Hourly", value: "0 * * * *" },
+  { label: "Daily (2 AM UTC)", value: "0 2 * * *" },
+  { label: "Weekly (Sun 2 AM)", value: "0 2 * * 0" },
+  { label: "Monthly (1st 2 AM)", value: "0 2 1 * *" },
+  { label: "Custom", value: "custom" },
+];
+
+function ScheduledTaskCard({ task, onSaved }: { task: ScheduledTask; onSaved: () => void }) {
+  const [enabled, setEnabled] = useState(task.enabled);
+  const [preset, setPreset] = useState<string>(() => {
+    const match = CRON_PRESETS.find((p) => p.value === task.cron && p.value !== "custom");
+    return match ? match.value : "custom";
+  });
+  const [customCron, setCustomCron] = useState(task.cron);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const effectiveCron = preset === "custom" ? customCron : preset;
+  const isDirty = enabled !== task.enabled || effectiveCron !== task.cron;
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    try {
+      await patchScheduledTask(task.name, { enabled, cron: effectiveCron });
+      onSaved();
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Failed to save";
+      setError(msg.includes("422") ? "Invalid cron expression" : msg);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="border rounded-lg p-4 space-y-3">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="font-medium text-sm">{task.display_name}</p>
+          <p className="text-xs text-muted-foreground mt-0.5">{task.description}</p>
+        </div>
+        <label className="flex items-center gap-2 cursor-pointer shrink-0">
+          <span className="text-xs text-muted-foreground">{enabled ? "Enabled" : "Disabled"}</span>
+          <button
+            role="switch"
+            aria-checked={enabled}
+            onClick={() => setEnabled((v) => !v)}
+            className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+              enabled ? "bg-primary" : "bg-muted"
+            }`}
+          >
+            <span
+              className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                enabled ? "translate-x-4" : "translate-x-0.5"
+              }`}
+            />
+          </button>
+        </label>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-xs text-muted-foreground">Schedule:</span>
+          <select
+            value={preset}
+            onChange={(e) => {
+              setPreset(e.target.value);
+              if (e.target.value !== "custom") setCustomCron(e.target.value);
+            }}
+            className="text-xs border rounded px-2 py-1 bg-background"
+          >
+            {CRON_PRESETS.map((p) => (
+              <option key={p.value} value={p.value}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+          {preset === "custom" && (
+            <input
+              type="text"
+              value={customCron}
+              onChange={(e) => setCustomCron(e.target.value)}
+              placeholder="0 2 * * *"
+              className="text-xs border rounded px-2 py-1 bg-background font-mono w-36"
+            />
+          )}
+        </div>
+
+        {task.next_runs.length > 0 && (
+          <p className="text-xs text-muted-foreground">
+            Next: {task.next_runs.slice(0, 3).map((r) => new Date(r).toLocaleString()).join(" · ")}
+          </p>
+        )}
+        {task.last_fired_at && (
+          <p className="text-xs text-muted-foreground">
+            Last fired: {new Date(task.last_fired_at).toLocaleString()}
+          </p>
+        )}
+      </div>
+
+      {error && <p className="text-xs text-destructive">{error}</p>}
+
+      <Button size="sm" disabled={!isDirty || saving} onClick={save}>
+        {saving ? "Saving…" : "Save"}
+      </Button>
+    </div>
+  );
+}
+
+function ScheduledTasksTab() {
+  const qc = useQueryClient();
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["admin", "scheduled-tasks"],
+    queryFn: listScheduledTasks,
+  });
+
+  if (isLoading) return <p className="text-sm text-muted-foreground">Loading…</p>;
+  if (error) return <p className="text-sm text-destructive">Failed to load scheduled tasks.</p>;
+
+  return (
+    <div className="space-y-4">
+      <p className="text-xs text-muted-foreground">
+        Configure recurring background tasks. Settings are stored in Postgres and survive restarts.
+        The scheduler tick runs every 60 seconds via Celery Beat.
+      </p>
+      {data && data.length === 0 && (
+        <p className="text-sm text-muted-foreground">No scheduled tasks configured.</p>
+      )}
+      {data?.map((task) => (
+        <ScheduledTaskCard
+          key={task.name}
+          task={task}
+          onSaved={() => qc.invalidateQueries({ queryKey: ["admin", "scheduled-tasks"] })}
+        />
+      ))}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- `scheduled_tasks` Postgres table (name PK, `enabled`, `cron`, `last_fired_at`, `updated_at`) + Alembic migration 0004
- Seeds `cve_scan` task (disabled by default, daily at 02:00 UTC)
- `GET /api/admin/scheduled-tasks` and `PATCH /api/admin/scheduled-tasks/{name}` — superuser only; PATCH validates cron with `croniter`, returns 422 on invalid, returns next 3 run times
- `app.tasks.scheduler` Celery Beat tick task (every 60s): reads enabled tasks from DB, dispatches any whose cron window matches the current minute
- `cve_scan` wired as the first registered task; scheduled runs skip npm scanning (Python deps only)
- Scheduled Tasks sub-tab added to AdminPage Superuser section: enable/disable toggle, preset schedule picker (Hourly/Daily/Weekly/Monthly/Custom), custom cron text input, next-3-runs preview, last-fired display, Save button disabled until dirty
- Adds `croniter==3.0.4` to `requirements.txt`
- 18 new DB-backed tests for list and patch endpoints

## Test plan

- [ ] `pytest tests/routers/test_admin.py::TestListScheduledTasks` — 7 tests pass
- [ ] `pytest tests/routers/test_admin.py::TestPatchScheduledTask` — 11 tests pass
- [ ] Deploy to dev; open Admin → Superuser → Scheduled Tasks
- [ ] CVE Scan task visible, disabled by default with `0 2 * * *` schedule
- [ ] Enable toggle + Save persists across page reload
- [ ] Custom cron shows next-3-run preview; invalid cron shows error
- [ ] `tsc` passes; ESLint passes

Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)