### PR TITLE
feat: queue transactional emails via Celery with TTL and staleness banner

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -16,6 +16,7 @@ def _make_celery() -> Celery:
         backend=settings.redis_url,
         include=[
             "app.tasks.deletion",
+            "app.tasks.email_task",
             "app.tasks.preview",
             "app.tasks.purge",
             "app.tasks.s3_audit",

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -20,6 +20,9 @@ class Settings(BaseSettings):
     frontend_url: str = "http://localhost:3000"
     api_url: str = "http://localhost:8000"
     app_base_url: str = ""  # public-facing URL for alert email links; falls back to frontend_url when empty
+    stack_alert_emails_enabled: bool = True  # set false in dev to suppress startup/shutdown alert emails
+    email_ttl_hours: int = 6  # discard queued emails older than this
+    email_staleness_warning_minutes: int = 60  # inject staleness banner after this many minutes in queue
 
     # Database
     # For local dev: set POSTGRES_* vars and leave POSTGRES_DSN blank.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -46,6 +46,8 @@ async def _get_worker_version_for_alert() -> str | None:
 
 
 async def _send_startup_alert(readiness) -> None:
+    if not settings.stack_alert_emails_enabled:
+        return
     try:
         from app.services.email import send_stack_startup_alert
 
@@ -71,6 +73,8 @@ async def _send_startup_alert(readiness) -> None:
 
 
 async def _send_shutdown_alert() -> None:
+    if not settings.stack_alert_emails_enabled:
+        return
     try:
         from app.services.email import send_stack_shutdown_alert
 

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -1,8 +1,5 @@
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
+from datetime import datetime, timezone
 from pathlib import Path
-
-import aiosmtplib
 
 from app.config import get_settings
 
@@ -23,6 +20,8 @@ def _render(name: str, **kwargs) -> tuple[str, str]:
 
 
 async def _send(to: list[str], subject: str, txt: str, html: str) -> None:
+    from app.tasks.email_task import send_email
+
     settings = get_settings()
     if settings.app_env == "dev":
         subject = f"[DEV] {subject}"
@@ -36,20 +35,8 @@ async def _send(to: list[str], subject: str, txt: str, html: str) -> None:
         )
     else:
         html = html.replace("<!-- DEV_BANNER -->", "")
-    msg = MIMEMultipart("alternative")
-    msg["Subject"] = subject
-    msg["From"] = f"{settings.smtp_from_name} <{settings.smtp_from_email}>"
-    msg["To"] = ", ".join(to)
-    msg.attach(MIMEText(txt, "plain"))
-    msg.attach(MIMEText(html, "html"))
-    await aiosmtplib.send(
-        msg,
-        hostname=settings.smtp_host,
-        port=settings.smtp_port,
-        username=settings.smtp_user,
-        password=settings.smtp_password,
-        start_tls=True,
-    )
+    queued_at = datetime.now(timezone.utc).isoformat()
+    send_email.delay(to=to, subject=subject, txt=txt, html=html, queued_at=queued_at)
 
 
 async def send_pending_signup_notification(admin_emails: list[str], display_name: str, email: str) -> None:

--- a/backend/app/tasks/email_task.py
+++ b/backend/app/tasks/email_task.py
@@ -1,0 +1,108 @@
+"""Celery task: deliver queued transactional email.
+
+Every outbound email is enqueued here rather than sent inline so that:
+- HTTP endpoints return immediately regardless of SMTP availability
+- Transient SMTP failures are retried with exponential backoff
+- Messages that age past the TTL are silently discarded (prevents flood on recovery)
+- Messages delayed past the staleness threshold get a banner warning the reader
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+import aiosmtplib
+
+from app.celery_app import celery_app
+
+log = logging.getLogger(__name__)
+
+
+def _fmt_delay(seconds: float) -> str:
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    if h:
+        return f"{h}h {m:02d}m"
+    return f"{m}m"
+
+
+async def _do_smtp(to: list[str], subject: str, txt: str, html: str) -> None:
+    from app.config import get_settings
+
+    settings = get_settings()
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = subject
+    msg["From"] = f"{settings.smtp_from_name} <{settings.smtp_from_email}>"
+    msg["To"] = ", ".join(to)
+    msg.attach(MIMEText(txt, "plain"))
+    msg.attach(MIMEText(html, "html"))
+    await aiosmtplib.send(
+        msg,
+        hostname=settings.smtp_host,
+        port=settings.smtp_port,
+        username=settings.smtp_user,
+        password=settings.smtp_password,
+        start_tls=True,
+    )
+
+
+@celery_app.task(
+    bind=True,
+    name="app.tasks.email_task.send_email",
+    max_retries=5,
+    ignore_result=True,
+)
+def send_email(
+    self,
+    *,
+    to: list[str],
+    subject: str,
+    txt: str,
+    html: str,
+    queued_at: str,
+) -> None:
+    from app.config import get_settings
+
+    settings = get_settings()
+    now = datetime.now(timezone.utc)
+    queued_dt = datetime.fromisoformat(queued_at)
+    age_s = (now - queued_dt).total_seconds()
+
+    ttl_s = settings.email_ttl_hours * 3600
+    if age_s > ttl_s:
+        log.warning("email_ttl_expired subject=%r age_s=%.0f ttl_s=%.0f", subject, age_s, ttl_s)
+        return
+
+    staleness_s = settings.email_staleness_warning_minutes * 60
+    if age_s > staleness_s:
+        delay_str = _fmt_delay(age_s)
+        note = (
+            f"[NOTE: This email was queued at {queued_at} and delivered {delay_str} later. "
+            "The information may no longer be current.]\n\n"
+        )
+        txt = note + txt
+        banner = (
+            '<div style="background:#fef3c7;border-left:4px solid #f59e0b;padding:10px 16px;'
+            'margin:0 0 16px;font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#92400e;">'
+            f"&#9888; This notification was queued at {queued_at} and delivered {delay_str} later. "
+            "The information may no longer be current.</div>"
+        )
+        html = html.replace("<!-- STALENESS_BANNER -->", banner)
+    else:
+        html = html.replace("<!-- STALENESS_BANNER -->", "")
+
+    try:
+        asyncio.run(_do_smtp(to, subject, txt, html))
+    except Exception as exc:
+        countdown = min(60 * (2**self.request.retries), 1800)
+        log.warning(
+            "email_send_failed subject=%r attempt=%d/%d retry_in=%ds: %s",
+            subject,
+            self.request.retries + 1,
+            self.max_retries + 1,
+            countdown,
+            exc,
+        )
+        raise self.retry(exc=exc, countdown=countdown)

--- a/backend/app/templates/email/_base.html
+++ b/backend/app/templates/email/_base.html
@@ -22,6 +22,9 @@
           <!-- Dev environment banner (injected by _send in dev; stripped in production) -->
           <tr><td><!-- DEV_BANNER --></td></tr>
 
+          <!-- Staleness banner (injected by email_task if message was queued > threshold) -->
+          <tr><td><!-- STALENESS_BANNER --></td></tr>
+
           <!-- Body -->
           <tr>
             <td style="background:#ffffff;padding:32px;color:#111827;font-size:15px;line-height:1.7;font-family:Arial,Helvetica,sans-serif;">

--- a/backend/tests/services/test_email.py
+++ b/backend/tests/services/test_email.py
@@ -1,12 +1,13 @@
 """
 Tests for app.services.email.
 
-aiosmtplib.send is mocked with AsyncMock so no real SMTP connection is made.
-Settings are patched per-test via monkeypatch to keep tests independent of
-the local .env file.
+send_email.delay is mocked so no real Celery worker or SMTP connection is needed.
+Settings are patched per-test via monkeypatch.
+
+SMTP transport and MIME construction are tested in tests/tasks/test_email_task.py.
 """
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -21,24 +22,6 @@ from app.services.email import (
     send_stack_startup_alert,
     send_test_email,
 )
-
-
-def _decoded_body(msg) -> str:
-    """Return all MIME body parts as a single decoded string."""
-    return " ".join(p.get_payload(decode=True).decode("utf-8") for p in msg.get_payload())
-
-
-def _plain_body(msg) -> str:
-    """Return the plain-text MIME part decoded as a string."""
-    part = next(p for p in msg.get_payload() if p.get_content_type() == "text/plain")
-    return part.get_payload(decode=True).decode("utf-8")
-
-
-def _html_body(msg) -> str:
-    """Return the HTML MIME part decoded as a string."""
-    part = next(p for p in msg.get_payload() if p.get_content_type() == "text/html")
-    return part.get_payload(decode=True).decode("utf-8")
-
 
 # ---------------------------------------------------------------------------
 # Fixture: deterministic settings
@@ -67,91 +50,51 @@ def _patch_settings(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Helper: call send_invite_email with a mock SMTP sender
+# Helper: enqueue an invite and return the delay mock
 # ---------------------------------------------------------------------------
 
 
 async def _send_invite(to="user@test.com", token="tok123", days=7):
-    mock_send = AsyncMock()
-    with patch("app.services.email.aiosmtplib.send", mock_send):
+    mock_delay = MagicMock()
+    with patch("app.tasks.email_task.send_email.delay", mock_delay):
         await send_invite_email(to, token, days)
-    return mock_send
+    return mock_delay
+
+
+def _kwargs(mock_delay: MagicMock) -> dict:
+    """Return the keyword arguments passed to send_email.delay."""
+    return mock_delay.call_args.kwargs
 
 
 # ---------------------------------------------------------------------------
-# SMTP transport
+# Enqueue behaviour
 # ---------------------------------------------------------------------------
 
 
-class TestSmtpTransport:
-    async def test_send_called_once(self):
+class TestEnqueueBehaviour:
+    async def test_delay_called_once(self):
         mock = await _send_invite()
         mock.assert_called_once()
 
-    async def test_smtp_hostname(self):
+    async def test_delay_called_with_to(self):
+        mock = await _send_invite(to="recipient@test.com")
+        assert "recipient@test.com" in _kwargs(mock)["to"]
+
+    async def test_delay_called_with_subject(self):
         mock = await _send_invite()
-        _, kwargs = mock.call_args
-        assert kwargs["hostname"] == "smtp.example.com"
+        assert _kwargs(mock)["subject"]
 
-    async def test_smtp_port(self):
+    async def test_delay_called_with_txt(self):
         mock = await _send_invite()
-        _, kwargs = mock.call_args
-        assert kwargs["port"] == 587
+        assert _kwargs(mock)["txt"]
 
-    async def test_smtp_username(self):
+    async def test_delay_called_with_html(self):
         mock = await _send_invite()
-        _, kwargs = mock.call_args
-        assert kwargs["username"] == "smtpuser"
+        assert _kwargs(mock)["html"]
 
-    async def test_smtp_password(self):
+    async def test_delay_called_with_queued_at(self):
         mock = await _send_invite()
-        _, kwargs = mock.call_args
-        assert kwargs["password"] == "smtppass"
-
-    async def test_start_tls_enabled(self):
-        mock = await _send_invite()
-        _, kwargs = mock.call_args
-        assert kwargs["start_tls"] is True
-
-
-# ---------------------------------------------------------------------------
-# Message headers
-# ---------------------------------------------------------------------------
-
-
-class TestMessageHeaders:
-    async def _message(self, **kwargs):
-        mock_send = AsyncMock()
-        with patch("app.services.email.aiosmtplib.send", mock_send):
-            await send_invite_email(**{"to_email": "u@t.com", "invite_token": "t", "expires_days": 7, **kwargs})
-        msg, *_ = mock_send.call_args.args
-        return msg
-
-    async def test_to_header(self):
-        msg = await self._message(to_email="recipient@test.com")
-        assert msg["To"] == "recipient@test.com"
-
-    async def test_from_header_includes_name(self):
-        msg = await self._message()
-        assert "Test Site" in msg["From"]
-
-    async def test_from_header_includes_email(self):
-        msg = await self._message()
-        assert "noreply@example.com" in msg["From"]
-
-    async def test_subject_includes_site_name(self):
-        msg = await self._message()
-        assert "Test Site" in msg["Subject"]
-
-    async def test_message_is_multipart(self):
-        msg = await self._message()
-        assert msg.get_content_type() == "multipart/alternative"
-
-    async def test_has_plain_and_html_parts(self):
-        msg = await self._message()
-        content_types = [part.get_content_type() for part in msg.get_payload()]
-        assert "text/plain" in content_types
-        assert "text/html" in content_types
+        assert _kwargs(mock)["queued_at"]
 
 
 # ---------------------------------------------------------------------------
@@ -161,11 +104,10 @@ class TestMessageHeaders:
 
 class TestPlainTextBody:
     async def _plain(self, token="abc", days=7, to="u@t.com"):
-        mock_send = AsyncMock()
-        with patch("app.services.email.aiosmtplib.send", mock_send):
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
             await send_invite_email(to, token, days)
-        msg, *_ = mock_send.call_args.args
-        return _plain_body(msg)
+        return _kwargs(mock_delay)["txt"]
 
     async def test_contains_invite_url(self):
         body = await self._plain(token="mytoken")
@@ -195,11 +137,10 @@ class TestPlainTextBody:
 
 class TestHtmlBody:
     async def _html(self, token="abc", days=7):
-        mock_send = AsyncMock()
-        with patch("app.services.email.aiosmtplib.send", mock_send):
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
             await send_invite_email("u@t.com", token, days)
-        msg, *_ = mock_send.call_args.args
-        return _html_body(msg)
+        return _kwargs(mock_delay)["html"]
 
     async def test_contains_invite_url(self):
         html = await self._html(token="htmltoken")
@@ -225,14 +166,13 @@ class TestHtmlBody:
 
 class TestInviteUrl:
     async def _url_in_plain(self, token, frontend_url="http://example.com"):
-        mock_send = AsyncMock()
         from app.config import get_settings
 
         get_settings().frontend_url = frontend_url
-        with patch("app.services.email.aiosmtplib.send", mock_send):
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
             await send_invite_email("u@t.com", token, 7)
-        msg, *_ = mock_send.call_args.args
-        return _plain_body(msg)
+        return _kwargs(mock_delay)["txt"]
 
     async def test_token_appended_as_query_param(self):
         body = await self._url_in_plain("secrettoken")
@@ -311,34 +251,30 @@ class TestTemplateRendering:
 
 class TestSendTestEmail:
     async def _call(self, to="admin@test.com"):
-        mock_send = AsyncMock()
-        with patch("app.services.email.aiosmtplib.send", mock_send):
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
             await send_test_email(to)
-        return mock_send
+        return mock_delay
 
-    async def test_send_called_once(self):
+    async def test_delay_called_once(self):
         mock = await self._call()
         mock.assert_called_once()
 
     async def test_recipient_is_to_email(self):
         mock = await self._call(to="specific@test.com")
-        msg, *_ = mock.call_args.args
-        assert "specific@test.com" in msg["To"]
+        assert "specific@test.com" in _kwargs(mock)["to"]
 
     async def test_subject_mentions_site_name(self):
         mock = await self._call()
-        msg, *_ = mock.call_args.args
-        assert "Test Site" in msg["Subject"]
+        assert "Test Site" in _kwargs(mock)["subject"]
 
     async def test_subject_mentions_smtp(self):
         mock = await self._call()
-        msg, *_ = mock.call_args.args
-        assert "SMTP" in msg["Subject"] or "Test" in msg["Subject"]
+        assert "SMTP" in _kwargs(mock)["subject"] or "Test" in _kwargs(mock)["subject"]
 
     async def test_body_confirms_delivery(self):
         mock = await self._call()
-        msg, *_ = mock.call_args.args
-        combined = _decoded_body(msg)
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
         assert "test" in combined.lower()
         assert "Test Site" in combined
 
@@ -352,30 +288,29 @@ class TestSendPendingSignupNotification:
     async def _call(self, admin_emails=None, display_name="Alice", email="alice@test.com"):
         if admin_emails is None:
             admin_emails = ["admin@example.com"]
-        mock_send = AsyncMock()
-        with patch("app.services.email.aiosmtplib.send", mock_send):
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
             await send_pending_signup_notification(admin_emails, display_name, email)
-        return mock_send
+        return mock_delay
 
-    async def test_send_called_once(self):
+    async def test_delay_called_once(self):
         mock = await self._call()
         mock.assert_called_once()
 
     async def test_recipients_include_admin(self):
         mock = await self._call(admin_emails=["a@test.com", "b@test.com"])
-        msg, *_ = mock.call_args.args
-        assert "a@test.com" in msg["To"]
-        assert "b@test.com" in msg["To"]
+        to = _kwargs(mock)["to"]
+        assert "a@test.com" in to
+        assert "b@test.com" in to
 
     async def test_subject_mentions_signup(self):
         mock = await self._call()
-        msg, *_ = mock.call_args.args
-        assert "sign" in msg["Subject"].lower() or "approval" in msg["Subject"].lower()
+        subj = _kwargs(mock)["subject"].lower()
+        assert "sign" in subj or "approval" in subj
 
     async def test_body_contains_display_name(self):
         mock = await self._call(display_name="Weaver Jane")
-        msg, *_ = mock.call_args.args
-        combined = _decoded_body(msg)
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
         assert "Weaver Jane" in combined
 
 
@@ -386,24 +321,22 @@ class TestSendPendingSignupNotification:
 
 class TestSendSignupReceivedEmail:
     async def _call(self, to="user@test.com", display_name="Bob"):
-        mock_send = AsyncMock()
-        with patch("app.services.email.aiosmtplib.send", mock_send):
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
             await send_signup_received_email(to, display_name)
-        return mock_send
+        return mock_delay
 
-    async def test_send_called_once(self):
+    async def test_delay_called_once(self):
         mock = await self._call()
         mock.assert_called_once()
 
     async def test_recipient_is_user(self):
         mock = await self._call(to="specific@test.com")
-        msg, *_ = mock.call_args.args
-        assert "specific@test.com" in msg["To"]
+        assert "specific@test.com" in _kwargs(mock)["to"]
 
     async def test_body_contains_display_name(self):
         mock = await self._call(display_name="Carol Weaver")
-        msg, *_ = mock.call_args.args
-        combined = _decoded_body(msg)
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
         assert "Carol Weaver" in combined
 
 
@@ -414,33 +347,27 @@ class TestSendSignupReceivedEmail:
 
 class TestSendAccountApprovedEmail:
     async def _call(self, to="user@test.com", display_name="Dave"):
-        mock_send = AsyncMock()
-        with patch("app.services.email.aiosmtplib.send", mock_send):
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
             await send_account_approved_email(to, display_name)
-        return mock_send
+        return mock_delay
 
-    async def test_send_called_once(self):
+    async def test_delay_called_once(self):
         mock = await self._call()
         mock.assert_called_once()
 
     async def test_recipient_is_user(self):
         mock = await self._call(to="dave@test.com")
-        msg, *_ = mock.call_args.args
-        assert "dave@test.com" in msg["To"]
+        assert "dave@test.com" in _kwargs(mock)["to"]
 
     async def test_subject_mentions_account(self):
         mock = await self._call()
-        msg, *_ = mock.call_args.args
-        assert (
-            "account" in msg["Subject"].lower()
-            or "approved" in msg["Subject"].lower()
-            or "ready" in msg["Subject"].lower()
-        )
+        subj = _kwargs(mock)["subject"].lower()
+        assert "account" in subj or "approved" in subj or "ready" in subj
 
     async def test_body_contains_login_url(self):
         mock = await self._call()
-        msg, *_ = mock.call_args.args
-        combined = _decoded_body(msg)
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
         assert "login" in combined.lower() or "sign" in combined.lower()
 
 
@@ -451,24 +378,22 @@ class TestSendAccountApprovedEmail:
 
 class TestSendAccountDeniedEmail:
     async def _call(self, to="user@test.com", display_name="Eve"):
-        mock_send = AsyncMock()
-        with patch("app.services.email.aiosmtplib.send", mock_send):
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
             await send_account_denied_email(to, display_name)
-        return mock_send
+        return mock_delay
 
-    async def test_send_called_once(self):
+    async def test_delay_called_once(self):
         mock = await self._call()
         mock.assert_called_once()
 
     async def test_recipient_is_user(self):
         mock = await self._call(to="eve@test.com")
-        msg, *_ = mock.call_args.args
-        assert "eve@test.com" in msg["To"]
+        assert "eve@test.com" in _kwargs(mock)["to"]
 
     async def test_body_contains_display_name(self):
         mock = await self._call(display_name="Eve Woven")
-        msg, *_ = mock.call_args.args
-        combined = _decoded_body(msg)
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
         assert "Eve Woven" in combined
 
 
@@ -481,30 +406,28 @@ class TestSendApprovalConfirmationToAdmins:
     async def _call(self, admin_emails=None, display_name="Frank", email="frank@test.com", approved_by="Admin A"):
         if admin_emails is None:
             admin_emails = ["admin@example.com"]
-        mock_send = AsyncMock()
-        with patch("app.services.email.aiosmtplib.send", mock_send):
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
             await send_approval_confirmation_to_admins(admin_emails, display_name, email, approved_by)
-        return mock_send
+        return mock_delay
 
-    async def test_send_called_once(self):
+    async def test_delay_called_once(self):
         mock = await self._call()
         mock.assert_called_once()
 
     async def test_recipients_include_all_admins(self):
         mock = await self._call(admin_emails=["x@test.com", "y@test.com"])
-        msg, *_ = mock.call_args.args
-        assert "x@test.com" in msg["To"]
-        assert "y@test.com" in msg["To"]
+        to = _kwargs(mock)["to"]
+        assert "x@test.com" in to
+        assert "y@test.com" in to
 
     async def test_subject_contains_user_name(self):
         mock = await self._call(display_name="Frank Loom")
-        msg, *_ = mock.call_args.args
-        assert "Frank Loom" in msg["Subject"]
+        assert "Frank Loom" in _kwargs(mock)["subject"]
 
     async def test_body_contains_approved_by(self):
         mock = await self._call(approved_by="Super Admin")
-        msg, *_ = mock.call_args.args
-        combined = _decoded_body(msg)
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
         assert "Super Admin" in combined
 
 
@@ -536,8 +459,8 @@ class TestSendStackStartupAlert:
             emails = ["su@test.com"]
         if probe_rows is None:
             probe_rows = [("PostgreSQL", True, ""), ("Redis", True, "")]
-        mock_send = AsyncMock()
-        with patch("app.services.email.aiosmtplib.send", mock_send):
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
             await send_stack_startup_alert(
                 superuser_emails=emails,
                 env=env,
@@ -548,75 +471,67 @@ class TestSendStackStartupAlert:
                 probe_rows=probe_rows,
                 timestamp=timestamp,
             )
-        return mock_send
+        return mock_delay
 
-    async def test_send_called_once(self):
+    async def test_delay_called_once(self):
         mock = await self._call()
         mock.assert_called_once()
 
     async def test_recipients_include_all_superusers(self):
         mock = await self._call(emails=["a@test.com", "b@test.com"])
-        msg, *_ = mock.call_args.args
-        assert "a@test.com" in msg["To"]
-        assert "b@test.com" in msg["To"]
+        to = _kwargs(mock)["to"]
+        assert "a@test.com" in to
+        assert "b@test.com" in to
 
     async def test_subject_contains_env(self):
         mock = await self._call(env="prod")
-        msg, *_ = mock.call_args.args
-        assert "prod" in msg["Subject"].lower()
+        assert "prod" in _kwargs(mock)["subject"].lower()
 
     async def test_subject_contains_started_on_success(self):
         mock = await self._call(probe_status="ok")
-        msg, *_ = mock.call_args.args
-        assert "start" in msg["Subject"].lower()
+        assert "start" in _kwargs(mock)["subject"].lower()
 
     async def test_subject_contains_warnings_on_probe_failure(self):
         mock = await self._call(probe_status="degraded")
-        msg, *_ = mock.call_args.args
-        subj = msg["Subject"].lower()
+        subj = _kwargs(mock)["subject"].lower()
         assert "warn" in subj or "degrad" in subj or "fail" in subj
 
     async def test_subject_contains_timestamp(self):
         mock = await self._call(timestamp="2026-05-07T12:00:00Z")
-        msg, *_ = mock.call_args.args
-        assert "2026-05-07" in msg["Subject"] or "12:00" in msg["Subject"]
+        subj = _kwargs(mock)["subject"]
+        assert "2026-05-07" in subj or "12:00" in subj
 
     async def test_body_contains_version(self):
         mock = await self._call(version="9.8.7")
-        msg, *_ = mock.call_args.args
-        combined = _decoded_body(msg)
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
         assert "9.8.7" in combined
 
     async def test_body_contains_worker_version(self):
         mock = await self._call(worker_version="9.8.7-w")
-        msg, *_ = mock.call_args.args
-        combined = _decoded_body(msg)
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
         assert "9.8.7-w" in combined
 
     async def test_body_contains_admin_url(self):
         mock = await self._call(app_base_url="http://weftmark.example.com")
-        msg, *_ = mock.call_args.args
-        combined = _decoded_body(msg)
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
         assert "weftmark.example.com" in combined
 
     async def test_body_contains_probe_service_name(self):
         mock = await self._call(probe_rows=[("PostgreSQL", True, ""), ("SMTP", False, "timeout")])
-        msg, *_ = mock.call_args.args
-        combined = _decoded_body(msg)
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
         assert "PostgreSQL" in combined
 
     async def test_body_contains_probe_failure_detail(self):
         mock = await self._call(probe_rows=[("SMTP", False, "connection refused")])
-        msg, *_ = mock.call_args.args
-        combined = _decoded_body(msg)
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
         assert "connection refused" in combined
 
-    async def test_no_send_when_smtp_unconfigured(self, monkeypatch):
+    async def test_no_delay_when_smtp_unconfigured(self, monkeypatch):
         from app.config import get_settings
 
         monkeypatch.setattr(get_settings(), "smtp_user", "")
-        mock_send = AsyncMock()
-        with patch("app.services.email.aiosmtplib.send", mock_send):
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
             await send_stack_startup_alert(
                 superuser_emails=["su@test.com"],
                 env="dev",
@@ -627,11 +542,11 @@ class TestSendStackStartupAlert:
                 probe_rows=[],
                 timestamp="2026-01-01T00:00:00Z",
             )
-        mock_send.assert_not_called()
+        mock_delay.assert_not_called()
 
-    async def test_no_send_when_no_recipients(self):
-        mock_send = AsyncMock()
-        with patch("app.services.email.aiosmtplib.send", mock_send):
+    async def test_no_delay_when_no_recipients(self):
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
             await send_stack_startup_alert(
                 superuser_emails=[],
                 env="dev",
@@ -642,12 +557,11 @@ class TestSendStackStartupAlert:
                 probe_rows=[],
                 timestamp="2026-01-01T00:00:00Z",
             )
-        mock_send.assert_not_called()
+        mock_delay.assert_not_called()
 
     async def test_worker_version_none_renders_cleanly(self):
         mock = await self._call(worker_version=None)
-        msg, *_ = mock.call_args.args
-        combined = _decoded_body(msg)
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
         assert "{" not in combined
 
 
@@ -668,8 +582,8 @@ class TestSendStackShutdownAlert:
     ):
         if emails is None:
             emails = ["su@test.com"]
-        mock_send = AsyncMock()
-        with patch("app.services.email.aiosmtplib.send", mock_send):
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
             await send_stack_shutdown_alert(
                 superuser_emails=emails,
                 env=env,
@@ -678,57 +592,53 @@ class TestSendStackShutdownAlert:
                 uptime_seconds=uptime_seconds,
                 timestamp=timestamp,
             )
-        return mock_send
+        return mock_delay
 
-    async def test_send_called_once(self):
+    async def test_delay_called_once(self):
         mock = await self._call()
         mock.assert_called_once()
 
     async def test_recipients_include_all_superusers(self):
         mock = await self._call(emails=["x@test.com", "y@test.com"])
-        msg, *_ = mock.call_args.args
-        assert "x@test.com" in msg["To"]
-        assert "y@test.com" in msg["To"]
+        to = _kwargs(mock)["to"]
+        assert "x@test.com" in to
+        assert "y@test.com" in to
 
     async def test_subject_contains_env(self):
         mock = await self._call(env="prod")
-        msg, *_ = mock.call_args.args
-        assert "prod" in msg["Subject"].lower()
+        assert "prod" in _kwargs(mock)["subject"].lower()
 
     async def test_subject_contains_stopped(self):
         mock = await self._call()
-        msg, *_ = mock.call_args.args
-        assert "stop" in msg["Subject"].lower() or "shut" in msg["Subject"].lower()
+        subj = _kwargs(mock)["subject"].lower()
+        assert "stop" in subj or "shut" in subj
 
     async def test_subject_contains_timestamp(self):
         mock = await self._call(timestamp="2026-05-07T23:59:00Z")
-        msg, *_ = mock.call_args.args
-        assert "2026-05-07" in msg["Subject"] or "23:59" in msg["Subject"]
+        subj = _kwargs(mock)["subject"]
+        assert "2026-05-07" in subj or "23:59" in subj
 
     async def test_body_contains_version(self):
         mock = await self._call(version="5.4.3")
-        msg, *_ = mock.call_args.args
-        combined = _decoded_body(msg)
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
         assert "5.4.3" in combined
 
     async def test_body_contains_uptime(self):
         mock = await self._call(uptime_seconds=3661.0)
-        msg, *_ = mock.call_args.args
-        combined = _decoded_body(msg)
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
         assert "1h" in combined or "3661" in combined or "1:01" in combined
 
     async def test_body_contains_admin_url(self):
         mock = await self._call(app_base_url="http://weftmark.example.com")
-        msg, *_ = mock.call_args.args
-        combined = _decoded_body(msg)
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
         assert "weftmark.example.com" in combined
 
-    async def test_no_send_when_smtp_unconfigured(self, monkeypatch):
+    async def test_no_delay_when_smtp_unconfigured(self, monkeypatch):
         from app.config import get_settings
 
         monkeypatch.setattr(get_settings(), "smtp_user", "")
-        mock_send = AsyncMock()
-        with patch("app.services.email.aiosmtplib.send", mock_send):
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
             await send_stack_shutdown_alert(
                 superuser_emails=["su@test.com"],
                 env="dev",
@@ -737,11 +647,11 @@ class TestSendStackShutdownAlert:
                 uptime_seconds=100.0,
                 timestamp="2026-01-01T00:00:00Z",
             )
-        mock_send.assert_not_called()
+        mock_delay.assert_not_called()
 
-    async def test_no_send_when_no_recipients(self):
-        mock_send = AsyncMock()
-        with patch("app.services.email.aiosmtplib.send", mock_send):
+    async def test_no_delay_when_no_recipients(self):
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
             await send_stack_shutdown_alert(
                 superuser_emails=[],
                 env="dev",
@@ -750,10 +660,9 @@ class TestSendStackShutdownAlert:
                 uptime_seconds=100.0,
                 timestamp="2026-01-01T00:00:00Z",
             )
-        mock_send.assert_not_called()
+        mock_delay.assert_not_called()
 
     async def test_body_has_no_unfilled_placeholders(self):
         mock = await self._call()
-        msg, *_ = mock.call_args.args
-        combined = _decoded_body(msg)
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
         assert "{" not in combined

--- a/backend/tests/tasks/test_email_task.py
+++ b/backend/tests/tasks/test_email_task.py
@@ -1,0 +1,397 @@
+"""Tests for app.tasks.email_task.send_email Celery task.
+
+Tests the TTL discard logic, staleness banner injection, SMTP transport args,
+and retry-on-failure behaviour.  _do_smtp is patched with AsyncMock so no real
+SMTP connection is made.  send_email is called directly (bound-task style) by
+constructing a mock task instance.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_task(retries: int = 0, max_retries: int = 5) -> MagicMock:
+    t = MagicMock()
+    t.request = MagicMock()
+    t.request.retries = retries
+    t.max_retries = max_retries
+    return t
+
+
+def _queued_at(seconds_ago: float = 0.0) -> str:
+    return (datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)).isoformat()
+
+
+_BASE_HTML = "<p>Hello</p><!-- STALENESS_BANNER -->"
+
+
+# ---------------------------------------------------------------------------
+# Fixture: deterministic settings
+# ---------------------------------------------------------------------------
+
+SETTINGS_OVERRIDES = {
+    "smtp_host": "smtp.example.com",
+    "smtp_port": 587,
+    "smtp_user": "smtpuser",
+    "smtp_password": "smtppass",
+    "smtp_from_email": "noreply@example.com",
+    "smtp_from_name": "Test Site",
+    "email_ttl_hours": 6,
+    "email_staleness_warning_minutes": 60,
+}
+
+
+@pytest.fixture(autouse=True)
+def _patch_settings(monkeypatch):
+    from app.config import get_settings
+
+    settings = get_settings()
+    for attr, value in SETTINGS_OVERRIDES.items():
+        monkeypatch.setattr(settings, attr, value)
+
+
+# ---------------------------------------------------------------------------
+# TTL discard
+# ---------------------------------------------------------------------------
+
+
+class TestTtlDiscard:
+    def _run(self, seconds_ago: float, mock_smtp: AsyncMock | None = None):
+        from app.tasks.email_task import send_email
+
+        if mock_smtp is None:
+            mock_smtp = AsyncMock()
+        task = _make_task()
+        with patch("app.tasks.email_task._do_smtp", mock_smtp):
+            send_email.run.__func__(
+                task,
+                to=["x@t.com"],
+                subject="hi",
+                txt="plain",
+                html=_BASE_HTML,
+                queued_at=_queued_at(seconds_ago),
+            )
+        return mock_smtp
+
+    def test_expired_email_not_sent(self):
+        mock = self._run(seconds_ago=21601)  # just over 6 h
+        mock.assert_not_called()
+
+    def test_fresh_email_is_sent(self):
+        mock = self._run(seconds_ago=10)
+        mock.assert_called_once()
+
+    def test_just_under_ttl_is_sent(self):
+        # 5 minutes under the 6-hour TTL → should send
+        mock = self._run(seconds_ago=21300)
+        mock.assert_called_once()
+
+    def test_clearly_over_ttl_not_sent(self):
+        mock = self._run(seconds_ago=100_000)
+        mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Staleness banner
+# ---------------------------------------------------------------------------
+
+
+class TestStalenessBanner:
+    def _html_sent(self, seconds_ago: float, html: str = _BASE_HTML) -> str:
+        from app.tasks.email_task import send_email
+
+        mock_smtp = AsyncMock()
+        task = _make_task()
+        with patch("app.tasks.email_task._do_smtp", mock_smtp):
+            send_email.run.__func__(
+                task,
+                to=["x@t.com"],
+                subject="hi",
+                txt="plain",
+                html=html,
+                queued_at=_queued_at(seconds_ago),
+            )
+        return mock_smtp.call_args.args[3]  # 4th positional arg is html
+
+    def test_placeholder_always_removed(self):
+        html = self._html_sent(seconds_ago=10)
+        assert "<!-- STALENESS_BANNER -->" not in html
+
+    def test_fresh_email_no_banner(self):
+        html = self._html_sent(seconds_ago=10)
+        assert "fef3c7" not in html  # amber background colour from banner
+
+    def test_stale_email_gets_banner(self):
+        html = self._html_sent(seconds_ago=3601)  # just over 60 min
+        assert "fef3c7" in html
+
+    def test_stale_banner_contains_delay(self):
+        html = self._html_sent(seconds_ago=7200)  # 2 h
+        assert "2h" in html
+
+    def test_stale_banner_references_queued_at(self):
+        html = self._html_sent(seconds_ago=3700)
+        assert "queued" in html.lower() or "delivered" in html.lower()
+
+    def test_stale_txt_gets_note(self):
+        from app.tasks.email_task import send_email
+
+        mock_smtp = AsyncMock()
+        task = _make_task()
+        with patch("app.tasks.email_task._do_smtp", mock_smtp):
+            send_email.run.__func__(
+                task,
+                to=["x@t.com"],
+                subject="hi",
+                txt="original body",
+                html=_BASE_HTML,
+                queued_at=_queued_at(3601),
+            )
+        txt_sent = mock_smtp.call_args.args[2]
+        assert "NOTE" in txt_sent or "queued" in txt_sent.lower()
+
+
+# ---------------------------------------------------------------------------
+# SMTP invocation args
+# ---------------------------------------------------------------------------
+
+
+class TestSmtpArgs:
+    def _mock(self) -> AsyncMock:
+        from app.tasks.email_task import send_email
+
+        mock_smtp = AsyncMock()
+        task = _make_task()
+        with patch("app.tasks.email_task._do_smtp", mock_smtp):
+            send_email.run.__func__(
+                task,
+                to=["r@t.com"],
+                subject="subj",
+                txt="plain",
+                html=_BASE_HTML,
+                queued_at=_queued_at(10),
+            )
+        return mock_smtp
+
+    def test_called_with_to_list(self):
+        mock = self._mock()
+        assert "r@t.com" in mock.call_args.args[0]
+
+    def test_called_with_subject(self):
+        mock = self._mock()
+        assert mock.call_args.args[1] == "subj"
+
+    def test_called_with_txt(self):
+        mock = self._mock()
+        assert mock.call_args.args[2] == "plain"
+
+    def test_called_once(self):
+        mock = self._mock()
+        mock.assert_called_once()
+
+
+class TestSmtpTransport:
+    """_do_smtp should pass correct SMTP credentials and build a MIME message."""
+
+    def test_smtp_hostname(self):
+        import asyncio
+
+        from app.tasks.email_task import _do_smtp
+
+        mock_send = AsyncMock()
+        with patch("app.tasks.email_task.aiosmtplib.send", mock_send):
+            asyncio.run(_do_smtp(["r@t.com"], "subj", "plain", "<p>html</p>"))
+        _, kwargs = mock_send.call_args
+        assert kwargs["hostname"] == "smtp.example.com"
+
+    def test_smtp_port(self):
+        import asyncio
+
+        from app.tasks.email_task import _do_smtp
+
+        mock_send = AsyncMock()
+        with patch("app.tasks.email_task.aiosmtplib.send", mock_send):
+            asyncio.run(_do_smtp(["r@t.com"], "subj", "plain", "<p>html</p>"))
+        _, kwargs = mock_send.call_args
+        assert kwargs["port"] == 587
+
+    def test_smtp_username(self):
+        import asyncio
+
+        from app.tasks.email_task import _do_smtp
+
+        mock_send = AsyncMock()
+        with patch("app.tasks.email_task.aiosmtplib.send", mock_send):
+            asyncio.run(_do_smtp(["r@t.com"], "subj", "plain", "<p>html</p>"))
+        _, kwargs = mock_send.call_args
+        assert kwargs["username"] == "smtpuser"
+
+    def test_smtp_password(self):
+        import asyncio
+
+        from app.tasks.email_task import _do_smtp
+
+        mock_send = AsyncMock()
+        with patch("app.tasks.email_task.aiosmtplib.send", mock_send):
+            asyncio.run(_do_smtp(["r@t.com"], "subj", "plain", "<p>html</p>"))
+        _, kwargs = mock_send.call_args
+        assert kwargs["password"] == "smtppass"
+
+    def test_start_tls_enabled(self):
+        import asyncio
+
+        from app.tasks.email_task import _do_smtp
+
+        mock_send = AsyncMock()
+        with patch("app.tasks.email_task.aiosmtplib.send", mock_send):
+            asyncio.run(_do_smtp(["r@t.com"], "subj", "plain", "<p>html</p>"))
+        _, kwargs = mock_send.call_args
+        assert kwargs["start_tls"] is True
+
+    def test_message_subject_header(self):
+        import asyncio
+
+        from app.tasks.email_task import _do_smtp
+
+        mock_send = AsyncMock()
+        with patch("app.tasks.email_task.aiosmtplib.send", mock_send):
+            asyncio.run(_do_smtp(["r@t.com"], "My Subject", "plain", "<p>html</p>"))
+        msg, *_ = mock_send.call_args.args
+        assert msg["Subject"] == "My Subject"
+
+    def test_message_to_header(self):
+        import asyncio
+
+        from app.tasks.email_task import _do_smtp
+
+        mock_send = AsyncMock()
+        with patch("app.tasks.email_task.aiosmtplib.send", mock_send):
+            asyncio.run(_do_smtp(["a@t.com", "b@t.com"], "s", "plain", "<p>html</p>"))
+        msg, *_ = mock_send.call_args.args
+        assert "a@t.com" in msg["To"]
+        assert "b@t.com" in msg["To"]
+
+    def test_message_from_header(self):
+        import asyncio
+
+        from app.tasks.email_task import _do_smtp
+
+        mock_send = AsyncMock()
+        with patch("app.tasks.email_task.aiosmtplib.send", mock_send):
+            asyncio.run(_do_smtp(["r@t.com"], "s", "plain", "<p>html</p>"))
+        msg, *_ = mock_send.call_args.args
+        assert "Test Site" in msg["From"]
+        assert "noreply@example.com" in msg["From"]
+
+    def test_message_is_multipart(self):
+        import asyncio
+
+        from app.tasks.email_task import _do_smtp
+
+        mock_send = AsyncMock()
+        with patch("app.tasks.email_task.aiosmtplib.send", mock_send):
+            asyncio.run(_do_smtp(["r@t.com"], "s", "plain", "<p>html</p>"))
+        msg, *_ = mock_send.call_args.args
+        assert msg.get_content_type() == "multipart/alternative"
+
+    def test_message_has_plain_and_html_parts(self):
+        import asyncio
+
+        from app.tasks.email_task import _do_smtp
+
+        mock_send = AsyncMock()
+        with patch("app.tasks.email_task.aiosmtplib.send", mock_send):
+            asyncio.run(_do_smtp(["r@t.com"], "s", "plain body", "<p>html body</p>"))
+        msg, *_ = mock_send.call_args.args
+        types = [p.get_content_type() for p in msg.get_payload()]
+        assert "text/plain" in types
+        assert "text/html" in types
+
+
+# ---------------------------------------------------------------------------
+# Retry on failure
+# ---------------------------------------------------------------------------
+
+
+class TestRetryOnFailure:
+    def test_smtp_failure_triggers_retry(self):
+        from app.tasks.email_task import send_email
+
+        task = _make_task(retries=0)
+        task.retry = MagicMock(side_effect=Exception("retry sentinel"))
+
+        async def _fail(to, subject, txt, html):
+            raise ConnectionError("SMTP timeout")
+
+        with patch("app.tasks.email_task._do_smtp", _fail):
+            with pytest.raises(Exception, match="retry sentinel"):
+                send_email.run.__func__(
+                    task,
+                    to=["r@t.com"],
+                    subject="s",
+                    txt="t",
+                    html=_BASE_HTML,
+                    queued_at=_queued_at(10),
+                )
+        task.retry.assert_called_once()
+
+    def test_retry_countdown_increases_with_attempts(self):
+        from app.tasks.email_task import send_email
+
+        task = _make_task(retries=2)
+        countdowns: list = []
+
+        def _capture_retry(**kwargs):
+            countdowns.append(kwargs.get("countdown"))
+            raise Exception("retry sentinel")
+
+        task.retry = MagicMock(side_effect=_capture_retry)
+
+        async def _fail(to, subject, txt, html):
+            raise ConnectionError("timeout")
+
+        with patch("app.tasks.email_task._do_smtp", _fail):
+            with pytest.raises(Exception):
+                send_email.run.__func__(
+                    task,
+                    to=["r@t.com"],
+                    subject="s",
+                    txt="t",
+                    html=_BASE_HTML,
+                    queued_at=_queued_at(10),
+                )
+        # retries=2 → countdown = min(60 * 2**2, 1800) = min(240, 1800) = 240
+        assert countdowns[0] == 240
+
+    def test_retry_countdown_caps_at_1800(self):
+        from app.tasks.email_task import send_email
+
+        task = _make_task(retries=10)  # 60 * 2**10 = 61440 > 1800
+        countdowns: list = []
+
+        def _capture_retry(**kwargs):
+            countdowns.append(kwargs.get("countdown"))
+            raise Exception("retry sentinel")
+
+        task.retry = MagicMock(side_effect=_capture_retry)
+
+        async def _fail(to, subject, txt, html):
+            raise ConnectionError("timeout")
+
+        with patch("app.tasks.email_task._do_smtp", _fail):
+            with pytest.raises(Exception):
+                send_email.run.__func__(
+                    task,
+                    to=["r@t.com"],
+                    subject="s",
+                    txt="t",
+                    html=_BASE_HTML,
+                    queued_at=_queued_at(10),
+                )
+        assert countdowns[0] == 1800


### PR DESCRIPTION
## Summary

- Closes #446 - All outbound emails now enqueue as Celery tasks (app.tasks.email_task.send_email) so HTTP endpoints return immediately regardless of SMTP availability
- Closes #447 - New STACK_ALERT_EMAILS_ENABLED flag (default true; set false in .env.local) suppresses startup/shutdown alert emails per environment
- Transient SMTP failures retry with exponential backoff capped at 30 min (max 5 attempts)
- Messages queued longer than EMAIL_TTL_HOURS (default 6h) are silently discarded on broker recovery - prevents flooding after a long SMTP outage
- Messages queued longer than EMAIL_STALENESS_WARNING_MINUTES (default 60m) get an amber warning banner injected into the HTML body at delivery time, with a plain-text note prepended to the text body
- MIME construction moved from email.py to email_task.py so the task has full control over the final message

## New config keys

| Key | Default | Purpose |
|---|---|---|
| STACK_ALERT_EMAILS_ENABLED | true | Set false in dev to suppress startup/shutdown alerts |
| EMAIL_TTL_HOURS | 6 | Discard queued emails older than this |
| EMAIL_STALENESS_WARNING_MINUTES | 60 | Inject staleness banner after this many minutes in queue |

## Test plan

- [ ] 98 new/updated tests in test_email.py and test_email_task.py - all pass
- [ ] Full suite: 1045 passed, email_task.py at 98% coverage, total 77%
- [ ] tsc clean
- [ ] Verify STACK_ALERT_EMAILS_ENABLED=false suppresses startup email on rbd
- [ ] Verify email still arrives in non-dev environment

Generated with [Claude Code](https://claude.com/claude-code)