### PR TITLE
feat: worker card uptime/memory stats and layout spacing fix

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1863,6 +1863,8 @@ class WorkerInfo(BaseModel):
     version: str | None = None
     concurrency: int | None = None
     completed_tasks: int | None = None
+    uptime: float | None = None
+    memory_mb: float | None = None
     active_tasks: list[WorkerActiveTask] = []
     reserved_tasks: list[WorkerActiveTask] = []
 
@@ -1937,6 +1939,8 @@ async def get_worker_status(_: User = Depends(require_superuser)) -> WorkerStatu
                     time_start=t.get("time_start") if include_time else None,
                 )
 
+            rusage = ws.get("rusage") or {}
+            maxrss_kb = rusage.get("maxrss")
             workers.append(
                 WorkerInfo(
                     name=name,
@@ -1944,6 +1948,8 @@ async def get_worker_status(_: User = Depends(require_superuser)) -> WorkerStatu
                     version=node_versions.get(name),
                     concurrency=pool.get("max-concurrency"),
                     completed_tasks=sum(total_dict.values()) if total_dict else None,
+                    uptime=ws.get("uptime"),
+                    memory_mb=round(maxrss_kb / 1024, 1) if maxrss_kb else None,
                     active_tasks=[_task(t) for t in (active.get(name) or [])],
                     reserved_tasks=[_task(t, include_time=False) for t in (reserved.get(name) or [])],
                 )

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -301,6 +301,8 @@ export interface WorkerInfo {
   version: string | null;
   concurrency: number | null;
   completed_tasks: number | null;
+  uptime: number | null;
+  memory_mb: number | null;
   active_tasks: WorkerActiveTask[];
   reserved_tasks: WorkerActiveTask[];
 }

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1875,14 +1875,22 @@ function WorkerCard({ worker, apiVersion }: { worker: WorkerInfo; apiVersion: st
       </div>
       {isOnline && (
         <div className="divide-y">
-          <div className="grid grid-cols-2 gap-x-4 px-4 py-2.5 text-sm">
-            <div className="flex items-center justify-between">
-              <span className="text-muted-foreground text-xs">Concurrency</span>
+          <div className="grid grid-cols-4 divide-x px-4 py-2.5 text-sm">
+            <div className="flex flex-col gap-0.5 pr-4">
+              <span className="text-xs text-muted-foreground">Concurrency</span>
               <span className="font-medium tabular-nums">{worker.concurrency ?? "—"}</span>
             </div>
-            <div className="flex items-center justify-between">
-              <span className="text-muted-foreground text-xs">Completed</span>
+            <div className="flex flex-col gap-0.5 px-4">
+              <span className="text-xs text-muted-foreground">Completed</span>
               <span className="font-medium tabular-nums">{worker.completed_tasks?.toLocaleString() ?? "—"}</span>
+            </div>
+            <div className="flex flex-col gap-0.5 px-4">
+              <span className="text-xs text-muted-foreground">Uptime</span>
+              <span className="font-medium tabular-nums">{worker.uptime != null ? formatUptime(worker.uptime) : "—"}</span>
+            </div>
+            <div className="flex flex-col gap-0.5 pl-4">
+              <span className="text-xs text-muted-foreground">Memory</span>
+              <span className="font-medium tabular-nums">{worker.memory_mb != null ? `${worker.memory_mb} MB` : "—"}</span>
             </div>
           </div>
           {hasActive && (
@@ -2387,11 +2395,9 @@ function AuditLogTab() {
   const [debouncedQ, setDebouncedQ] = useState<string>("");
 
   useEffect(() => {
-    const t = setTimeout(() => setDebouncedQ(q), 300);
+    const t = setTimeout(() => { setDebouncedQ(q); setPage(1); }, 300);
     return () => clearTimeout(t);
   }, [q]);
-
-  useEffect(() => { setPage(1); }, [eventType, debouncedQ]); // eslint-disable-line react-hooks/set-state-in-effect
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ["audit-log", page, eventType, debouncedQ],
@@ -2405,7 +2411,7 @@ function AuditLogTab() {
       <div className="flex gap-2 flex-wrap">
         <select
           value={eventType}
-          onChange={(e) => setEventType(e.target.value)}
+          onChange={(e) => { setEventType(e.target.value); setPage(1); }}
           className="text-sm border rounded px-2 py-1.5 bg-background"
         >
           <option value="">All events</option>


### PR DESCRIPTION
## Summary

- **Stat layout**: replaces `justify-between` (label ↔ wide gap ↔ value) with stacked label-over-value columns, fixing two visual issues: the artificially wide gap between "Concurrency" and its value, and "3" running visually into "Completed" across the grid gap
- **4-column grid**: adds Uptime and Memory alongside Concurrency and Completed, separated by `divide-x` lines
- **Backend**: exposes `uptime` (seconds, from Celery stats) and `memory_mb` (maxrss ÷ 1024, from rusage) in `WorkerInfo`
- **Bonus fix**: audit log page-reset moved from a synchronous `setState`-in-effect (ESLint `react-hooks/set-state-in-effect`) into the debounce timeout callback and the `eventType` change handler

## Test plan

- [ ] Workers tab: stat row shows 4 columns with divider lines
- [ ] Each column: label on top, value below (no wide gap)
- [ ] Uptime shows human-readable format (e.g. `4h 12m`, `2d 3h`)
- [ ] Memory shows `XX.X MB` for running workers
- [ ] Audit log filter: changing event type or search resets to page 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)