### PR TITLE
fix: EULA current version ordering and export script version comparison

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1320,9 +1320,7 @@ async def get_eula_admin(
     _: User = Depends(require_superuser),
     db: AsyncSession = Depends(get_db),
 ) -> EulaCurrentAdminResponse:
-    row = await db.scalar(
-        select(EulaVersion).order_by(EulaVersion.effective_date.desc(), EulaVersion.id.desc()).limit(1)
-    )
+    row = await db.scalar(select(EulaVersion).order_by(EulaVersion.id.desc()).limit(1))
     if not row:
         raise HTTPException(status_code=404, detail="No EULA version found")
     return EulaCurrentAdminResponse(

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -86,9 +86,7 @@ class UserSettingsResponse(BaseModel):
 
 
 async def get_current_eula_version(db: AsyncSession) -> str:
-    row = await db.scalar(
-        select(EulaVersion).order_by(EulaVersion.effective_date.desc(), EulaVersion.id.desc()).limit(1)
-    )
+    row = await db.scalar(select(EulaVersion).order_by(EulaVersion.id.desc()).limit(1))
     return row.version if row else "0.3"
 
 
@@ -121,9 +119,7 @@ class EulaCurrentResponse(BaseModel):
 
 @eula_router.get("/current", response_model=EulaCurrentResponse)
 async def get_current_eula(db: AsyncSession = Depends(get_db)) -> EulaCurrentResponse:
-    row = await db.scalar(
-        select(EulaVersion).order_by(EulaVersion.effective_date.desc(), EulaVersion.id.desc()).limit(1)
-    )
+    row = await db.scalar(select(EulaVersion).order_by(EulaVersion.id.desc()).limit(1))
     if not row:
         raise HTTPException(status_code=404, detail="No EULA version found")
     return EulaCurrentResponse(version=row.version, body_html=row.body_html, effective_date=row.effective_date)

--- a/tools/export_eula_migration.py
+++ b/tools/export_eula_migration.py
@@ -32,6 +32,8 @@ import textwrap
 from datetime import datetime, timezone
 from pathlib import Path
 
+from packaging.version import Version
+
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
@@ -237,9 +239,22 @@ def main() -> None:
         print(f"Found {len(db_versions)} EULA version(s) in database.")
 
     seeded = _seeded_versions()
-    print(f"Already seeded in migrations: {sorted(seeded) or '(none)'}")
+    seeded_sorted = sorted(seeded, key=lambda v: Version(v))
+    print(f"Already seeded in migrations: {seeded_sorted or '(none)'}")
 
     pending = [v for v in db_versions if v["version"] not in seeded]
+
+    if not pending and args.api_url and seeded:
+        max_seeded = max(seeded, key=lambda v: Version(v))
+        returned = db_versions[0]["version"] if db_versions else None
+        if returned and Version(returned) <= Version(max_seeded):
+            print(
+                f"WARNING: API returned version {returned!r} which is not newer than "
+                f"the latest seeded version {max_seeded!r}.\n"
+                f"This may mean a newer EULA exists in the database with an earlier\n"
+                f"effective_date. Re-run with --db-url to export all versions directly."
+            )
+
     if not pending:
         print("Nothing to do — all database versions are already in migration files.")
         return


### PR DESCRIPTION
## Summary

- **Root cause**: `GET /api/eula/current` ordered by `effective_date DESC, id DESC` — if a new EULA was created with an earlier effective_date than the previous version, the old version was returned as "current", causing `export_eula_migration.py --api-url` to see the old version as already seeded and exit with "Nothing to do"
- **API fix**: changed ordering to `id DESC` in both `get_current_eula` and `get_current_eula_version` — the most recently *created* EULA is always current, effective_date is now purely informational
- **Script fix**: seeded version list now displays in semantic order (`packaging.Version`); warning printed when `--api-url` returns a version ≤ the latest seeded version, with guidance to re-run with `--db-url`

## Test plan

- [ ] Create a new EULA version via admin UI with an effective_date before the previous version — confirm `GET /api/eula/current` returns the new version
- [ ] Run `python tools/export_eula_migration.py --db-url <dsn> --dry-run` — confirm 0.11 appears in pending
- [ ] Seeded versions display in semantic order (0.3, 0.5, 0.9, not 0.11 sorting before 0.9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)