### PR TITLE
fix: install packaging dep in sync-eula workflow

### DIFF
--- a/.github/workflows/sync-eula.yml
+++ b/.github/workflows/sync-eula.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install script dependencies
+        run: pip install packaging
+
       - name: Run export script
         id: export
         run: |


### PR DESCRIPTION
## Summary

The `sync-eula` workflow runs `tools/export_eula_migration.py` but has no install step for its dependencies. The `packaging` module was added to the script in PR #462 (EULA ordering fix) for semantic version comparison, causing the workflow to fail with exit code 1.

Adds a `pip install packaging` step before the export script runs.

## Test plan

- [ ] Re-run `sync-eula` workflow dispatch after merge — should reach the "Nothing to do" or "Written:" step without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)