### PR TITLE
chore: add API probe logging to sync-eula workflow

### DIFF
--- a/.github/workflows/sync-eula.yml
+++ b/.github/workflows/sync-eula.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Install script dependencies
         run: pip install packaging
 
+      - name: Probe API URL
+        run: |
+          echo "HTTP status: $(curl -o /dev/null -sS -w '%{http_code}' --max-time 10 '${{ secrets.EULA_API_URL }}')"
+          curl -fsS --max-time 10 "${{ secrets.EULA_API_URL }}" \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); print('version:', d['version']); print('effective_date:', d['effective_date'])"
+
       - name: Run export script
         id: export
         run: |


### PR DESCRIPTION
Adds a **Probe API URL** step before the export script that logs:
- HTTP status code from `EULA_API_URL`
- Parsed `version` and `effective_date` from the JSON response

Makes it easy to diagnose cases where the secret URL is returning an unexpected version without having to infer from the script's warning output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)