### PR TITLE
chore: move EULA_API_URL from secret to repository variable

### DIFF
--- a/.github/workflows/sync-eula.yml
+++ b/.github/workflows/sync-eula.yml
@@ -32,14 +32,15 @@ jobs:
 
       - name: Probe API URL
         run: |
-          echo "HTTP status: $(curl -o /dev/null -sS -w '%{http_code}' --max-time 10 '${{ secrets.EULA_API_URL }}')"
-          curl -fsS --max-time 10 "${{ secrets.EULA_API_URL }}" \
+          echo "API URL: ${{ vars.EULA_API_URL }}"
+          echo "HTTP status: $(curl -o /dev/null -sS -w '%{http_code}' --max-time 10 '${{ vars.EULA_API_URL }}')"
+          curl -fsS --max-time 10 "${{ vars.EULA_API_URL }}" \
             | python3 -c "import sys,json; d=json.load(sys.stdin); print('version:', d['version']); print('effective_date:', d['effective_date'])"
 
       - name: Run export script
         id: export
         run: |
-          output=$(python tools/export_eula_migration.py --api-url "${{ secrets.EULA_API_URL }}" 2>&1)
+          output=$(python tools/export_eula_migration.py --api-url "${{ vars.EULA_API_URL }}" 2>&1)
           echo "$output"
           written=$(echo "$output" | grep '^Written:' | awk '{print $2}')
           if [ -z "$written" ]; then


### PR DESCRIPTION
Moves `EULA_API_URL` from `secrets` to `vars` context so the value is visible in workflow logs. Also logs the URL explicitly in the Probe API URL step to make diagnosis easy.

**After merging:** delete the old `EULA_API_URL` secret from Settings → Secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)