### PR TITLE
fix: sync-eula --db-url switch and correct Alembic revision IDs

### DIFF
--- a/.github/workflows/sync-eula.yml
+++ b/.github/workflows/sync-eula.yml
@@ -28,19 +28,12 @@ jobs:
           python-version: "3.12"
 
       - name: Install script dependencies
-        run: pip install packaging
-
-      - name: Probe API URL
-        run: |
-          echo "API URL: ${{ vars.EULA_API_URL }}"
-          echo "HTTP status: $(curl -o /dev/null -sS -w '%{http_code}' --max-time 10 '${{ vars.EULA_API_URL }}')"
-          curl -fsS --max-time 10 "${{ vars.EULA_API_URL }}" \
-            | python3 -c "import sys,json; d=json.load(sys.stdin); print('version:', d['version']); print('effective_date:', d['effective_date'])"
+        run: pip install packaging psycopg2-binary
 
       - name: Run export script
         id: export
         run: |
-          output=$(python tools/export_eula_migration.py --api-url "${{ vars.EULA_API_URL }}" 2>&1)
+          output=$(python tools/export_eula_migration.py --db-url "${{ secrets.POSTGRES_DSN_DIRECT }}" 2>&1)
           echo "$output"
           written=$(echo "$output" | grep '^Written:' | awk '{print $2}')
           if [ -z "$written" ]; then

--- a/tools/export_eula_migration.py
+++ b/tools/export_eula_migration.py
@@ -145,14 +145,33 @@ def _seeded_versions() -> set[str]:
 # Migration file generator
 # ---------------------------------------------------------------------------
 
-def _next_revision() -> str:
-    """Return the next four-digit revision number (zero-padded)."""
+def _next_file_prefix() -> str:
+    """Return the next four-digit filename prefix (zero-padded)."""
     existing = [
         int(m.group(1))
         for p in MIGRATIONS_DIR.glob("*.py")
         if (m := re.match(r"^(\d{4})_", p.name))
     ]
     return f"{(max(existing) + 1) if existing else 1:04d}"
+
+
+def _head_revision_id() -> str:
+    """Return the actual revision ID string from the last migration file."""
+    numbered = sorted(
+        p for p in MIGRATIONS_DIR.glob("*.py")
+        if re.match(r"^\d{4}_", p.name)
+    )
+    if not numbered:
+        return "0000"
+    content = numbered[-1].read_text(encoding="utf-8")
+    m = re.search(r'^revision\s*(?::\s*str)?\s*=\s*["\']([^"\']+)["\']', content, re.MULTILINE)
+    return m.group(1) if m else numbered[-1].stem.split("_")[0]
+
+
+def _new_revision_id() -> str:
+    """Generate a random 12-hex-char revision ID matching Alembic's default style."""
+    import secrets
+    return secrets.token_hex(6)
 
 
 def _make_migration(version: dict, revision: str, prev_revision: str) -> str:
@@ -261,20 +280,15 @@ def main() -> None:
 
     print(f"\n{len(pending)} version(s) need a migration: {[v['version'] for v in pending]}\n")
 
-    # Find the current head revision from the last migration file
-    all_revisions = sorted(
-        p.stem.split("_")[0]
-        for p in MIGRATIONS_DIR.glob("*.py")
-        if re.match(r"^\d{4}_", p.name)
-    )
-    prev_revision = all_revisions[-1] if all_revisions else "0000"
+    prev_revision = _head_revision_id()
 
     generated: list[Path] = []
     for version in pending:
-        revision = _next_revision()
+        file_prefix = _next_file_prefix()
+        revision = _new_revision_id()
         content = _make_migration(version, revision, prev_revision)
         slug = re.sub(r"[^a-z0-9]+", "_", version["version"].lower()).strip("_")
-        filename = f"{revision}_eula_version_{slug}.py"
+        filename = f"{file_prefix}_eula_version_{slug}.py"
         out_path = MIGRATIONS_DIR / filename
 
         if args.dry_run:
@@ -285,7 +299,7 @@ def main() -> None:
             print(f"Written: {out_path.relative_to(REPO_ROOT)}")
             generated.append(out_path)
 
-        prev_revision = revision
+        prev_revision = revision  # chain: next migration's down_revision is this one's revision
 
     if generated and not args.dry_run:
         print("\nNext steps:")


### PR DESCRIPTION
## Summary

Two fixes for the `sync-eula` workflow:

- **Switch to `--db-url`**: GitHub Actions runners (Azure AS8075) are blocked by Cloudflare Bot Fight Mode on `weftmark.com`. Reading directly from Neon Postgres bypasses Cloudflare entirely. Requires `POSTGRES_DSN_DIRECT` secret (already added).

- **Fix Alembic revision IDs**: The export script was using filename prefixes (`"0005"`, `"0006"`) as `revision`/`down_revision` values, but existing migrations use 12-char hex IDs. Alembic could not resolve the chain, causing `alembic upgrade head` to fail on the bot-generated PR (#469). Now reads the actual `revision = "..."` from the last file and generates a random hex ID for new migrations.

Also close #469 — that migration file has wrong revision IDs and should be regenerated after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)