### PR TITLE
feat: server events log for admin health panel (#473)

### DIFF
--- a/backend/alembic/versions/0007_server_events.py
+++ b/backend/alembic/versions/0007_server_events.py
@@ -1,0 +1,41 @@
+"""add server_events table
+
+Revision ID: a4b5c6d7e8f9
+Revises: 2385931d5a57
+Create Date: 2026-05-08
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "a4b5c6d7e8f9"
+down_revision = "2385931d5a57"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "server_events",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("event_type", sa.String(length=64), nullable=False),
+        sa.Column("severity", sa.String(length=16), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("ended_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("elapsed_ms", sa.Integer(), nullable=True),
+        sa.Column("app_version", sa.String(length=32), nullable=False, server_default=""),
+        sa.Column("details", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("message", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_server_events_event_type", "server_events", ["event_type"])
+    op.create_index("ix_server_events_started_at", "server_events", ["started_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_server_events_started_at", table_name="server_events")
+    op.drop_index("ix_server_events_event_type", table_name="server_events")
+    op.drop_table("server_events")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -96,6 +96,63 @@ async def _send_shutdown_alert() -> None:
         log.exception("Failed to send shutdown alert email")
 
 
+async def _write_startup_server_event(readiness, boot_started_at: datetime) -> None:
+    try:
+        from app.database import AsyncSessionLocal
+        from app.models.server_event import ServerEvent
+        from app.services.server_events import ET_STARTUP, SEV_ERROR, SEV_INFO, SEV_WARN, close_open_events
+        from app.version import VERSION as _VERSION
+
+        async with AsyncSessionLocal() as db:
+            await close_open_events(db, event_types=[ET_STARTUP])
+            now = datetime.now(timezone.utc)
+            elapsed_ms = int((now - boot_started_at).total_seconds() * 1000)
+            sev = SEV_INFO if readiness.status == "ok" else (SEV_ERROR if readiness.status == "error" else SEV_WARN)
+            failed = [s.name for s in readiness.services if not s.ok]
+            evt = ServerEvent(
+                event_type=ET_STARTUP,
+                severity=sev,
+                status="closed",
+                started_at=boot_started_at,
+                ended_at=now,
+                elapsed_ms=elapsed_ms,
+                app_version=_VERSION,
+                message=f"Started — probe status: {readiness.status}",
+                details={"probe_status": readiness.status, "failed_services": failed},
+            )
+            db.add(evt)
+            await db.commit()
+    except Exception:
+        log.exception("Failed to write startup server event")
+
+
+async def _write_shutdown_server_event() -> None:
+    try:
+        from app.database import AsyncSessionLocal
+        from app.models.server_event import ServerEvent
+        from app.services.server_events import ET_SHUTDOWN, SEV_INFO
+        from app.version import VERSION as _VERSION
+
+        now = datetime.now(timezone.utc)
+        uptime_ms = int((now - start_time).total_seconds() * 1000)
+        async with AsyncSessionLocal() as db:
+            evt = ServerEvent(
+                event_type=ET_SHUTDOWN,
+                severity=SEV_INFO,
+                status="closed",
+                started_at=now,
+                ended_at=now,
+                elapsed_ms=uptime_ms,
+                app_version=_VERSION,
+                message=f"Stopped — {uptime_ms // 1000}s uptime",
+                details={"uptime_ms": uptime_ms},
+            )
+            db.add(evt)
+            await db.commit()
+    except Exception:
+        log.exception("Failed to write shutdown server event")
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     global start_time
@@ -107,12 +164,16 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     set_readiness(readiness)
     start_detailed_refresh()
     asyncio.create_task(_send_startup_alert(readiness))
+    asyncio.create_task(_write_startup_server_event(readiness, start_time))
 
     yield
 
     stop_detailed_refresh()
     try:
-        await asyncio.wait_for(_send_shutdown_alert(), timeout=5.0)
+        await asyncio.wait_for(
+            asyncio.gather(_send_shutdown_alert(), _write_shutdown_server_event(), return_exceptions=True),
+            timeout=5.0,
+        )
     except Exception:
         pass
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -15,6 +15,7 @@ from app.models.pending_signup import PendingSignup
 from app.models.project import Project, ProjectPhoto, ProjectStep
 from app.models.scheduled_task import ScheduledTask
 from app.models.seed_run import SeedRun
+from app.models.server_event import ServerEvent
 from app.models.user import User
 from app.models.user_identity import UserIdentity
 from app.models.yarn import Skein, Yarn
@@ -41,4 +42,5 @@ __all__ = [
     "ProjectStep",
     "EulaVersion",
     "ScheduledTask",
+    "ServerEvent",
 ]

--- a/backend/app/models/server_event.py
+++ b/backend/app/models/server_event.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class ServerEvent(Base):
+    __tablename__ = "server_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    event_type: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    severity: Mapped[str] = mapped_column(String(16), nullable=False)
+    status: Mapped[str] = mapped_column(String(16), nullable=False)
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+    ended_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    elapsed_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    app_version: Mapped[str] = mapped_column(String(32), nullable=False, default="")
+    details: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    message: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -24,6 +24,7 @@ from app.models.invite import Invite
 from app.models.loom import Loom, LoomVersion, LoomVersionPhoto
 from app.models.pending_signup import PendingSignup
 from app.models.project import Project, ProjectPhoto
+from app.models.server_event import ServerEvent
 from app.models.user import User
 from app.models.yarn import Yarn
 from app.services.audit import write_audit_log
@@ -1033,6 +1034,58 @@ async def list_audit_log(
         for r in rows.all()
     ]
     return AuditLogPage(items=items, total=total, page=page, page_size=page_size, pages=pages)
+
+
+# ---------------------------------------------------------------------------
+# Server events log
+# ---------------------------------------------------------------------------
+
+
+class ServerEventResponse(BaseModel):
+    id: int
+    event_type: str
+    severity: str
+    status: str
+    started_at: datetime
+    ended_at: datetime | None
+    elapsed_ms: int | None
+    app_version: str
+    message: str | None
+    details: dict | None
+
+    model_config = {"from_attributes": True}
+
+
+class ServerEventPage(BaseModel):
+    items: list[ServerEventResponse]
+    total: int
+    page: int
+    page_size: int
+    pages: int
+
+
+@router.get("/server-events", response_model=ServerEventPage)
+async def list_server_events(
+    _: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+    page: int = 1,
+    page_size: int = 50,
+    event_type: str | None = None,
+) -> ServerEventPage:
+    stmt = select(ServerEvent)
+    count_stmt = select(func.count()).select_from(ServerEvent)
+
+    if event_type:
+        stmt = stmt.where(ServerEvent.event_type == event_type)
+        count_stmt = count_stmt.where(ServerEvent.event_type == event_type)
+
+    total = await db.scalar(count_stmt) or 0
+    pages = max(1, (total + page_size - 1) // page_size)
+    offset = (page - 1) * page_size
+
+    rows = await db.scalars(stmt.order_by(ServerEvent.started_at.desc()).offset(offset).limit(page_size))
+    items = [ServerEventResponse.model_validate(r) for r in rows.all()]
+    return ServerEventPage(items=items, total=total, page=page, page_size=page_size, pages=pages)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -44,6 +44,7 @@ _HEALTH_ALERT_COOLDOWN_S = 3600  # re-alert at most once per hour if status stay
 
 # Superuser email cache — refreshed when DB is healthy; used as fallback when DB is down
 _superuser_email_cache: list[str] = []
+_open_health_event_id: int | None = None
 
 
 def set_readiness(result: ReadinessResponse) -> None:
@@ -270,6 +271,60 @@ async def _dispatch_health_alert(result: ReadinessResponse, is_recovery: bool) -
         log.exception("Failed to send health alert email")
 
 
+async def _record_health_transition(prev_status: str | None, result: ReadinessResponse) -> None:
+    """Write or close a ServerEvent row to capture health status transitions.
+
+    Silently skips on any DB error — the events log is best-effort.
+    """
+    global _open_health_event_id
+    new_status = result.status
+    if prev_status == new_status:
+        return
+    try:
+        from app.database import AsyncSessionLocal
+        from app.services.server_events import (
+            ET_HEALTH_DEGRADED,
+            ET_HEALTH_ERROR,
+            SEV_ERROR,
+            SEV_WARN,
+            STATUS_OPEN,
+            close_event,
+            write_event,
+        )
+
+        async with AsyncSessionLocal() as db:
+            # Close any open health event when recovering
+            if new_status == "ok" and _open_health_event_id is not None:
+                from sqlalchemy import select
+
+                from app.models.server_event import ServerEvent
+
+                evt = await db.scalar(select(ServerEvent).where(ServerEvent.id == _open_health_event_id))
+                if evt and evt.status == STATUS_OPEN:
+                    await close_event(db, evt)
+                    await db.commit()
+                _open_health_event_id = None
+                return
+
+            # Open a new event when health goes bad
+            if new_status in ("degraded", "error"):
+                failed = [s.name for s in result.services if not s.ok]
+                et = ET_HEALTH_ERROR if new_status == "error" else ET_HEALTH_DEGRADED
+                sev = SEV_ERROR if new_status == "error" else SEV_WARN
+                evt = await write_event(
+                    db,
+                    event_type=et,
+                    severity=sev,
+                    message=f"Services failing: {', '.join(failed)}" if failed else "Health probe failure",
+                    details={"failed_services": failed, "probe_status": new_status},
+                )
+                await db.commit()
+                await db.refresh(evt)
+                _open_health_event_id = evt.id
+    except Exception:
+        log.debug("Could not record health transition event", exc_info=True)
+
+
 async def _detailed_refresh_loop() -> None:
     global _detailed_cache, _last_alert_status, _last_alert_at
     while True:
@@ -279,6 +334,7 @@ async def _detailed_refresh_loop() -> None:
             postgres_ok = any(s.name == "PostgreSQL" and s.ok for s in result.services)
             if postgres_ok:
                 await _refresh_superuser_email_cache()
+            await _record_health_transition(_last_alert_status, result)
             new_status = result.status
             now = datetime.now(timezone.utc)
             prev_status = _last_alert_status

--- a/backend/app/services/server_events.py
+++ b/backend/app/services/server_events.py
@@ -1,0 +1,91 @@
+"""Helpers for writing and closing ServerEvent rows."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.server_event import ServerEvent
+from app.version import VERSION
+
+# ── event_type constants ──────────────────────────────────────────────────────
+ET_STARTUP = "stack.startup"
+ET_SHUTDOWN = "stack.shutdown"
+ET_HEALTH_DEGRADED = "health.degraded"
+ET_HEALTH_ERROR = "health.error"
+ET_HEALTH_CHECK = "health.check"
+
+# ── severity constants ────────────────────────────────────────────────────────
+SEV_INFO = "info"
+SEV_WARN = "warn"
+SEV_ERROR = "error"
+
+# ── status constants ──────────────────────────────────────────────────────────
+STATUS_OPEN = "open"
+STATUS_CLOSED = "closed"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+async def write_event(
+    db: AsyncSession,
+    event_type: str,
+    severity: str,
+    status: str = STATUS_OPEN,
+    message: str | None = None,
+    details: dict | None = None,
+    started_at: datetime | None = None,
+) -> ServerEvent:
+    evt = ServerEvent(
+        event_type=event_type,
+        severity=severity,
+        status=status,
+        started_at=started_at or _now(),
+        app_version=VERSION,
+        message=message,
+        details=details,
+    )
+    db.add(evt)
+    await db.flush()
+    return evt
+
+
+async def close_event(db: AsyncSession, event: ServerEvent) -> None:
+    now = _now()
+    event.ended_at = now
+    elapsed = now - event.started_at
+    event.elapsed_ms = int(elapsed.total_seconds() * 1000)
+    event.status = STATUS_CLOSED
+    await db.flush()
+
+
+async def close_open_events(db: AsyncSession, event_types: list[str] | None = None) -> int:
+    """Close any open events matching the given types (all open types if None).
+
+    Returns the number of events closed. Called at startup to clean up
+    events left open by an unclean shutdown.
+    """
+    stmt = select(ServerEvent).where(ServerEvent.status == STATUS_OPEN)
+    if event_types:
+        stmt = stmt.where(ServerEvent.event_type.in_(event_types))
+    result = await db.execute(stmt)
+    events = result.scalars().all()
+    for evt in events:
+        await close_event(db, evt)
+    return len(events)
+
+
+async def get_open_event(db: AsyncSession, event_type: str) -> ServerEvent | None:
+    """Return the most recent open event of the given type, or None."""
+    stmt = (
+        select(ServerEvent)
+        .where(ServerEvent.event_type == event_type, ServerEvent.status == STATUS_OPEN)
+        .order_by(ServerEvent.started_at.desc())
+        .limit(1)
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()

--- a/backend/app/tasks/maintenance.py
+++ b/backend/app/tasks/maintenance.py
@@ -171,3 +171,165 @@ def retry_failed_previews(self, limit: int = 50) -> dict:
         engine.dispose()
     log.info("retry_failed_previews retried=%d limit=%d", retried, limit)
     return {"retried": retried}
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=0,
+    name="app.tasks.maintenance.daily_health_check",
+)
+def daily_health_check(self) -> dict:
+    import asyncio
+
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import Session
+
+    from app.config import get_settings
+    from app.models.server_event import ServerEvent
+    from app.version import VERSION
+
+    settings = get_settings()
+    ts = datetime.now(timezone.utc)
+
+    async def _run():
+        from app.database import AsyncSessionLocal
+        from app.routers.admin import _probe_clerk, _probe_postgres, _probe_s3, _probe_smtp
+        from app.routers.health import ReadinessResponse, ReadinessService, _build_readiness_from_results
+        from app.services.clerk_webhook_probe import run_webhook_probe
+
+        try:
+            async with AsyncSessionLocal() as db:
+                results, webhook_result = await asyncio.gather(
+                    asyncio.gather(
+                        _probe_postgres(db),
+                        _probe_s3(),
+                        _probe_clerk(),
+                        _probe_smtp(),
+                        return_exceptions=True,
+                    ),
+                    run_webhook_probe(),
+                )
+        except Exception as exc:
+            return ReadinessResponse(
+                status="error",
+                services=[ReadinessService(name="postgres", ok=False, critical=True, message=str(exc)[:120])],
+                checked_at=ts.isoformat(),
+            )
+        return _build_readiness_from_results(results, webhook_result, checked_at=ts.isoformat())
+
+    result = asyncio.run(_run())
+    probe_rows = [(s.name, s.ok, s.detail) for s in result.services]
+    failed = [s.name for s in result.services if not s.ok]
+    sev = "error" if result.status == "error" else ("warn" if result.status == "degraded" else "info")
+
+    engine = create_engine(settings.database_url_sync)
+    try:
+        with Session(engine) as db:
+            evt = ServerEvent(
+                event_type="health.check",
+                severity=sev,
+                status="closed",
+                started_at=ts,
+                ended_at=datetime.now(timezone.utc),
+                app_version=VERSION,
+                message=f"Daily health check — {result.status}",
+                details={"probe_status": result.status, "failed_services": failed},
+            )
+            evt.elapsed_ms = int((evt.ended_at - evt.started_at).total_seconds() * 1000)
+            db.add(evt)
+            db.commit()
+    finally:
+        engine.dispose()
+
+    if result.status != "ok":
+        try:
+            from sqlalchemy import select
+
+            email_engine = create_engine(settings.database_url_sync)
+            try:
+                with Session(email_engine) as db:
+                    from app.models.user import User
+
+                    emails = [
+                        r
+                        for r in db.scalars(
+                            select(User.email).where(User.is_superuser.is_(True), User.is_active.is_(True))
+                        ).all()
+                        if r
+                    ]
+            finally:
+                email_engine.dispose()
+            if emails:
+                import asyncio as _asyncio
+
+                from app.services.email import send_health_degraded_alert
+
+                _asyncio.run(
+                    send_health_degraded_alert(
+                        superuser_emails=emails,
+                        env=settings.app_env,
+                        app_base_url=settings.app_base_url or settings.frontend_url,
+                        version=VERSION,
+                        probe_rows=probe_rows,
+                        status=result.status,
+                        timestamp=ts.isoformat(),
+                    )
+                )
+        except Exception:
+            log.exception("daily_health_check: failed to send degraded alert email")
+
+    log.info("daily_health_check status=%s failed=%s", result.status, failed)
+    return {"status": result.status, "failed_services": failed}
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=0,
+    name="app.tasks.maintenance.prune_server_event_log",
+)
+def prune_server_event_log(self, max_age_days: int = 28, max_entries: int = 1000) -> dict:
+    from sqlalchemy import create_engine, text
+    from sqlalchemy.orm import Session
+
+    from app.config import get_settings
+
+    settings = get_settings()
+    cutoff = datetime.now(timezone.utc) - timedelta(days=max_age_days)
+    deleted_age = 0
+    deleted_overflow = 0
+
+    engine = create_engine(settings.database_url_sync)
+    try:
+        with Session(engine) as db:
+            result = db.execute(
+                text("DELETE FROM server_events WHERE started_at < :cutoff"),
+                {"cutoff": cutoff},
+            )
+            db.commit()
+            deleted_age = result.rowcount
+
+            count_result = db.execute(text("SELECT COUNT(*) FROM server_events"))
+            total = count_result.scalar() or 0
+            if total > max_entries:
+                overflow = total - max_entries
+                result2 = db.execute(
+                    text(
+                        "DELETE FROM server_events WHERE id IN ("
+                        "  SELECT id FROM server_events ORDER BY started_at ASC LIMIT :overflow"
+                        ")"
+                    ),
+                    {"overflow": overflow},
+                )
+                db.commit()
+                deleted_overflow = result2.rowcount
+    finally:
+        engine.dispose()
+
+    log.info(
+        "prune_server_event_log deleted_age=%d deleted_overflow=%d max_age_days=%d max_entries=%d",
+        deleted_age,
+        deleted_overflow,
+        max_age_days,
+        max_entries,
+    )
+    return {"deleted_age": deleted_age, "deleted_overflow": deleted_overflow}

--- a/backend/app/tasks/scheduler.py
+++ b/backend/app/tasks/scheduler.py
@@ -79,6 +79,24 @@ REGISTRY: dict[str, dict] = {
         "default_cron": "0 5 * * *",
         "default_config": {"limit": 50},
     },
+    "daily_health_check": {
+        "display_name": "Daily Health Check",
+        "description": (
+            "Runs all service probes once daily and writes the result to the server events log. "
+            "Sends a health degraded alert email if any probe is failing."
+        ),
+        "default_cron": "0 2 * * *",
+        "default_config": {},
+    },
+    "server_event_log_pruning": {
+        "display_name": "Server Event Log Pruning",
+        "description": (
+            "Removes server event log entries older than the configured age limit "
+            "and trims the table when it exceeds the maximum entry count."
+        ),
+        "default_cron": "30 2 * * *",
+        "default_config": {"max_age_days": 28, "max_entries": 1000},
+    },
 }
 
 
@@ -153,6 +171,27 @@ def _dispatch_preview_retry(settings, task=None):
     return t
 
 
+def _dispatch_daily_health_check(settings, task=None):
+    from app.services.task_history import record_queued
+    from app.tasks.maintenance import daily_health_check
+
+    t = daily_health_check.delay()
+    record_queued(settings, t.id, "app.tasks.maintenance.daily_health_check", "scheduled:daily_health_check")
+    return t
+
+
+def _dispatch_server_event_log_pruning(settings, task=None):
+    from app.services.task_history import record_queued
+    from app.tasks.maintenance import prune_server_event_log
+
+    cfg = (task.config or {}) if task else {}
+    max_age_days = int(cfg.get("max_age_days", 28))
+    max_entries = int(cfg.get("max_entries", 1000))
+    t = prune_server_event_log.delay(max_age_days=max_age_days, max_entries=max_entries)
+    record_queued(settings, t.id, "app.tasks.maintenance.prune_server_event_log", "scheduled:server_event_log_pruning")
+    return t
+
+
 DISPATCH_FNS: dict[str, object] = {
     "cve_scan": _dispatch_cve_scan,
     "s3_audit": _dispatch_s3_audit,
@@ -161,6 +200,8 @@ DISPATCH_FNS: dict[str, object] = {
     "audit_log_pruning": _dispatch_audit_log_pruning,
     "heartbeat": _dispatch_heartbeat,
     "preview_retry": _dispatch_preview_retry,
+    "daily_health_check": _dispatch_daily_health_check,
+    "server_event_log_pruning": _dispatch_server_event_log_pruning,
 }
 
 

--- a/backend/tests/routers/test_server_events.py
+++ b/backend/tests/routers/test_server_events.py
@@ -1,0 +1,152 @@
+"""Tests for GET /api/admin/server-events endpoint."""
+
+from datetime import datetime, timezone
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.server_event import ServerEvent
+
+
+def _make_event(
+    event_type: str = "stack.startup",
+    severity: str = "info",
+    status: str = "closed",
+    message: str | None = None,
+    app_version: str = "1.0.0",
+    started_at: datetime | None = None,
+) -> ServerEvent:
+    return ServerEvent(
+        event_type=event_type,
+        severity=severity,
+        status=status,
+        started_at=started_at or datetime.now(timezone.utc),
+        app_version=app_version,
+        message=message,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /api/admin/server-events
+# ---------------------------------------------------------------------------
+
+
+class TestListServerEvents:
+    async def test_returns_200_admin(self, admin_client: AsyncClient):
+        resp = await admin_client.get("/api/admin/server-events")
+        assert resp.status_code == 200
+
+    async def test_returns_page_shape(self, admin_client: AsyncClient):
+        resp = await admin_client.get("/api/admin/server-events")
+        data = resp.json()
+        assert "items" in data
+        assert "total" in data
+        assert "page" in data
+        assert "page_size" in data
+        assert "pages" in data
+
+    async def test_requires_auth(self, client: AsyncClient):
+        resp = await client.get("/api/admin/server-events")
+        assert resp.status_code in (401, 403)
+
+    async def test_requires_admin(self, auth_client: AsyncClient):
+        resp = await auth_client.get("/api/admin/server-events")
+        assert resp.status_code in (401, 403)
+
+    async def test_returns_seeded_events(self, admin_client: AsyncClient, db_session: AsyncSession):
+        db_session.add(_make_event("stack.startup", message="Test startup"))
+        db_session.add(_make_event("health.check", message="Test check"))
+        await db_session.commit()
+
+        resp = await admin_client.get("/api/admin/server-events")
+        data = resp.json()
+        assert data["total"] >= 2
+        assert len(data["items"]) >= 2
+
+    async def test_event_fields_present(self, admin_client: AsyncClient, db_session: AsyncSession):
+        db_session.add(_make_event("stack.startup", severity="info", status="closed", message="Boot"))
+        await db_session.commit()
+
+        resp = await admin_client.get("/api/admin/server-events")
+        item = resp.json()["items"][0]
+        assert "id" in item
+        assert "event_type" in item
+        assert "severity" in item
+        assert "status" in item
+        assert "started_at" in item
+        assert "ended_at" in item
+        assert "elapsed_ms" in item
+        assert "app_version" in item
+        assert "message" in item
+
+    async def test_ordered_newest_first(self, admin_client: AsyncClient, db_session: AsyncSession):
+        from datetime import timedelta
+
+        now = datetime.now(timezone.utc)
+        db_session.add(_make_event(started_at=now - timedelta(hours=2)))
+        db_session.add(_make_event(started_at=now - timedelta(hours=1)))
+        db_session.add(_make_event(started_at=now))
+        await db_session.commit()
+
+        resp = await admin_client.get("/api/admin/server-events")
+        items = resp.json()["items"]
+        times = [item["started_at"] for item in items]
+        assert times == sorted(times, reverse=True)
+
+    async def test_filter_by_event_type(self, admin_client: AsyncClient, db_session: AsyncSession):
+        db_session.add(_make_event("stack.startup"))
+        db_session.add(_make_event("health.check"))
+        db_session.add(_make_event("health.check"))
+        await db_session.commit()
+
+        resp = await admin_client.get("/api/admin/server-events?event_type=health.check")
+        data = resp.json()
+        assert all(item["event_type"] == "health.check" for item in data["items"])
+
+    async def test_filter_event_type_excludes_others(self, admin_client: AsyncClient, db_session: AsyncSession):
+        db_session.add(_make_event("stack.startup"))
+        db_session.add(_make_event("stack.shutdown"))
+        await db_session.commit()
+
+        resp = await admin_client.get("/api/admin/server-events?event_type=stack.startup")
+        data = resp.json()
+        assert all(item["event_type"] == "stack.startup" for item in data["items"])
+
+    async def test_pagination_page_size(self, admin_client: AsyncClient, db_session: AsyncSession):
+        for _ in range(5):
+            db_session.add(_make_event())
+        await db_session.commit()
+
+        resp = await admin_client.get("/api/admin/server-events?page_size=3")
+        data = resp.json()
+        assert len(data["items"]) <= 3
+
+    async def test_pagination_page_2(self, admin_client: AsyncClient, db_session: AsyncSession):
+        from datetime import timedelta
+
+        now = datetime.now(timezone.utc)
+        for i in range(5):
+            db_session.add(_make_event(started_at=now - timedelta(minutes=i)))
+        await db_session.commit()
+
+        resp1 = await admin_client.get("/api/admin/server-events?page=1&page_size=3")
+        resp2 = await admin_client.get("/api/admin/server-events?page=2&page_size=3")
+        ids1 = {item["id"] for item in resp1.json()["items"]}
+        ids2 = {item["id"] for item in resp2.json()["items"]}
+        assert ids1.isdisjoint(ids2)
+
+    async def test_total_reflects_filter(self, admin_client: AsyncClient, db_session: AsyncSession):
+        db_session.add(_make_event("stack.startup"))
+        db_session.add(_make_event("stack.startup"))
+        db_session.add(_make_event("health.check"))
+        await db_session.commit()
+
+        resp_all = await admin_client.get("/api/admin/server-events")
+        resp_filtered = await admin_client.get("/api/admin/server-events?event_type=stack.startup")
+        assert resp_filtered.json()["total"] < resp_all.json()["total"]
+
+    async def test_empty_result_when_no_events(self, admin_client: AsyncClient):
+        resp = await admin_client.get("/api/admin/server-events?event_type=nonexistent.type")
+        data = resp.json()
+        assert data["total"] == 0
+        assert data["items"] == []

--- a/backend/tests/services/test_server_events.py
+++ b/backend/tests/services/test_server_events.py
@@ -1,0 +1,142 @@
+"""Tests for app.services.server_events helpers."""
+
+from datetime import datetime, timezone
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.server_events import (
+    ET_HEALTH_CHECK,
+    ET_SHUTDOWN,
+    ET_STARTUP,
+    SEV_INFO,
+    STATUS_CLOSED,
+    STATUS_OPEN,
+    close_event,
+    close_open_events,
+    get_open_event,
+    write_event,
+)
+
+
+class TestWriteEvent:
+    async def test_write_creates_row(self, db_session: AsyncSession):
+        evt = await write_event(db_session, event_type=ET_STARTUP, severity=SEV_INFO)
+        await db_session.commit()
+        assert evt.id is not None
+
+    async def test_write_defaults_to_open(self, db_session: AsyncSession):
+        evt = await write_event(db_session, event_type=ET_STARTUP, severity=SEV_INFO)
+        await db_session.commit()
+        assert evt.status == STATUS_OPEN
+
+    async def test_write_accepts_closed_status(self, db_session: AsyncSession):
+        evt = await write_event(db_session, event_type=ET_STARTUP, severity=SEV_INFO, status=STATUS_CLOSED)
+        await db_session.commit()
+        assert evt.status == STATUS_CLOSED
+
+    async def test_write_persists_message(self, db_session: AsyncSession):
+        evt = await write_event(db_session, event_type=ET_HEALTH_CHECK, severity=SEV_INFO, message="Daily check")
+        await db_session.commit()
+        assert evt.message == "Daily check"
+
+    async def test_write_persists_details(self, db_session: AsyncSession):
+        evt = await write_event(
+            db_session,
+            event_type=ET_HEALTH_CHECK,
+            severity=SEV_INFO,
+            details={"probe_status": "ok"},
+        )
+        await db_session.commit()
+        assert evt.details == {"probe_status": "ok"}
+
+    async def test_write_sets_app_version(self, db_session: AsyncSession):
+        evt = await write_event(db_session, event_type=ET_STARTUP, severity=SEV_INFO)
+        await db_session.commit()
+        assert evt.app_version  # non-empty string
+
+    async def test_write_accepts_custom_started_at(self, db_session: AsyncSession):
+        ts = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        evt = await write_event(db_session, event_type=ET_STARTUP, severity=SEV_INFO, started_at=ts)
+        await db_session.commit()
+        assert evt.started_at == ts
+
+
+class TestCloseEvent:
+    async def test_close_sets_ended_at(self, db_session: AsyncSession):
+        evt = await write_event(db_session, event_type=ET_STARTUP, severity=SEV_INFO)
+        await db_session.flush()
+        await close_event(db_session, evt)
+        await db_session.commit()
+        assert evt.ended_at is not None
+
+    async def test_close_sets_status_closed(self, db_session: AsyncSession):
+        evt = await write_event(db_session, event_type=ET_STARTUP, severity=SEV_INFO)
+        await db_session.flush()
+        await close_event(db_session, evt)
+        await db_session.commit()
+        assert evt.status == STATUS_CLOSED
+
+    async def test_close_computes_elapsed_ms(self, db_session: AsyncSession):
+        evt = await write_event(db_session, event_type=ET_STARTUP, severity=SEV_INFO)
+        await db_session.flush()
+        await close_event(db_session, evt)
+        await db_session.commit()
+        assert evt.elapsed_ms is not None
+        assert evt.elapsed_ms >= 0
+
+
+class TestCloseOpenEvents:
+    async def test_closes_all_open_events(self, db_session: AsyncSession):
+        await write_event(db_session, event_type=ET_STARTUP, severity=SEV_INFO)
+        await write_event(db_session, event_type=ET_HEALTH_CHECK, severity=SEV_INFO)
+        await db_session.flush()
+
+        closed_count = await close_open_events(db_session)
+        await db_session.commit()
+        assert closed_count == 2
+
+    async def test_skips_already_closed_events(self, db_session: AsyncSession):
+        await write_event(db_session, event_type=ET_STARTUP, severity=SEV_INFO, status=STATUS_CLOSED)
+        await write_event(db_session, event_type=ET_HEALTH_CHECK, severity=SEV_INFO)
+        await db_session.flush()
+
+        closed_count = await close_open_events(db_session)
+        await db_session.commit()
+        assert closed_count == 1
+
+    async def test_filter_by_event_type(self, db_session: AsyncSession):
+        await write_event(db_session, event_type=ET_STARTUP, severity=SEV_INFO)
+        await write_event(db_session, event_type=ET_HEALTH_CHECK, severity=SEV_INFO)
+        await db_session.flush()
+
+        closed_count = await close_open_events(db_session, event_types=[ET_STARTUP])
+        await db_session.commit()
+        assert closed_count == 1
+
+    async def test_returns_zero_when_none_open(self, db_session: AsyncSession):
+        closed_count = await close_open_events(db_session)
+        assert closed_count == 0
+
+
+class TestGetOpenEvent:
+    async def test_returns_open_event(self, db_session: AsyncSession):
+        evt = await write_event(db_session, event_type=ET_STARTUP, severity=SEV_INFO)
+        await db_session.flush()
+
+        found = await get_open_event(db_session, ET_STARTUP)
+        assert found is not None
+        assert found.id == evt.id
+
+    async def test_returns_none_when_no_open_event(self, db_session: AsyncSession):
+        await write_event(db_session, event_type=ET_STARTUP, severity=SEV_INFO, status=STATUS_CLOSED)
+        await db_session.flush()
+
+        found = await get_open_event(db_session, ET_STARTUP)
+        assert found is None
+
+    async def test_returns_none_for_different_type(self, db_session: AsyncSession):
+        await write_event(db_session, event_type=ET_STARTUP, severity=SEV_INFO)
+        await db_session.flush()
+
+        found = await get_open_event(db_session, ET_SHUTDOWN)
+        assert found is None

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -374,3 +374,33 @@ export const patchScheduledTask = (
   name: string,
   body: { enabled?: boolean; cron?: string; config?: Record<string, unknown> },
 ) => api.patch<ScheduledTask>(`/api/admin/scheduled-tasks/${name}`, body);
+
+export interface ServerEvent {
+  id: number;
+  event_type: string;
+  severity: "info" | "warn" | "error";
+  status: "open" | "closed";
+  started_at: string;
+  ended_at: string | null;
+  elapsed_ms: number | null;
+  app_version: string;
+  message: string | null;
+  details: Record<string, unknown> | null;
+}
+
+export interface ServerEventPage {
+  items: ServerEvent[];
+  total: number;
+  page: number;
+  page_size: number;
+  pages: number;
+}
+
+export const getServerEvents = (params: { page?: number; page_size?: number; event_type?: string } = {}) => {
+  const qs = new URLSearchParams();
+  if (params.page) qs.set("page", String(params.page));
+  if (params.page_size) qs.set("page_size", String(params.page_size));
+  if (params.event_type) qs.set("event_type", params.event_type);
+  const query = qs.toString();
+  return api.get<ServerEventPage>(`/api/admin/server-events${query ? `?${query}` : ""}`);
+};

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -38,6 +38,7 @@ import {
   runPurgeSoftDeleted,
   listScheduledTasks,
   patchScheduledTask,
+  getServerEvents,
   type ScheduledTask,
   type TaskHistoryItem,
   type AdminUser,
@@ -55,6 +56,7 @@ import {
   type CveFinding,
   type WorkerStatus,
   type WorkerInfo,
+  type ServerEvent,
 } from "@/api/admin";
 import { getHealthDetailed, type ReadinessResponse, type ReadinessService } from "@/api/health";
 import { EulaContent } from "@/components/EulaContent";
@@ -1233,6 +1235,131 @@ function ServicesTab() {
       )}
 
       <DbInfoPanel />
+      <ServerEventsPanel />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Server events panel (inside ServicesTab)
+// ---------------------------------------------------------------------------
+
+const SERVER_EVENT_TYPES = [
+  "stack.startup",
+  "stack.shutdown",
+  "health.degraded",
+  "health.error",
+  "health.check",
+];
+
+function severityBadge(severity: ServerEvent["severity"]) {
+  if (severity === "error") return <span className="px-1.5 py-0.5 rounded text-xs bg-destructive/15 text-destructive font-medium">error</span>;
+  if (severity === "warn") return <span className="px-1.5 py-0.5 rounded text-xs bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300 font-medium">warn</span>;
+  return <span className="px-1.5 py-0.5 rounded text-xs bg-muted text-muted-foreground font-medium">info</span>;
+}
+
+function formatElapsed(ms: number | null) {
+  if (ms === null) return "—";
+  if (ms < 1000) return `${ms}ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  const rem = Math.round(s % 60);
+  return `${m}m ${rem}s`;
+}
+
+function ServerEventsPanel() {
+  const [page, setPage] = useState(1);
+  const [eventType, setEventType] = useState("");
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["server-events", page, eventType],
+    queryFn: () => getServerEvents({ page, page_size: 25, event_type: eventType || undefined }),
+    refetchInterval: 60_000,
+  });
+
+  return (
+    <div className="space-y-3 pt-2">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold">Server Events Log</h3>
+        <div className="flex items-center gap-2">
+          <select
+            value={eventType}
+            onChange={(e) => { setEventType(e.target.value); setPage(1); }}
+            className="text-xs border rounded px-2 py-1 bg-background"
+          >
+            <option value="">All types</option>
+            {SERVER_EVENT_TYPES.map((t) => (
+              <option key={t} value={t}>{t}</option>
+            ))}
+          </select>
+          {data && (
+            <span className="text-xs text-muted-foreground">
+              {data.total.toLocaleString()} event{data.total !== 1 ? "s" : ""}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {isLoading && <p className="text-xs text-muted-foreground">Loading…</p>}
+      {isError && <p className="text-xs text-destructive">Failed to load server events.</p>}
+
+      {data && data.items.length === 0 && (
+        <p className="text-xs text-muted-foreground">No events recorded yet.</p>
+      )}
+
+      {data && data.items.length > 0 && (
+        <div className="rounded-lg border overflow-hidden">
+          <table className="w-full text-xs">
+            <thead className="bg-muted/50 text-muted-foreground">
+              <tr>
+                <th className="text-left px-3 py-2">Time</th>
+                <th className="text-left px-3 py-2">Type</th>
+                <th className="text-left px-3 py-2">Severity</th>
+                <th className="text-left px-3 py-2">Status</th>
+                <th className="text-left px-3 py-2">Elapsed</th>
+                <th className="text-left px-3 py-2">Version</th>
+                <th className="text-left px-3 py-2">Message</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {data.items.map((evt) => (
+                <tr key={evt.id} className="hover:bg-muted/30">
+                  <td className="px-3 py-2 whitespace-nowrap text-muted-foreground font-mono">
+                    {new Date(evt.started_at).toLocaleString()}
+                  </td>
+                  <td className="px-3 py-2 font-mono">{evt.event_type}</td>
+                  <td className="px-3 py-2">{severityBadge(evt.severity)}</td>
+                  <td className="px-3 py-2 text-muted-foreground">{evt.status}</td>
+                  <td className="px-3 py-2 font-mono whitespace-nowrap">{formatElapsed(evt.elapsed_ms)}</td>
+                  <td className="px-3 py-2 font-mono text-muted-foreground">{evt.app_version}</td>
+                  <td className="px-3 py-2 text-muted-foreground max-w-xs truncate">{evt.message ?? "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {data && data.pages > 1 && (
+        <div className="flex items-center gap-2 justify-center text-xs">
+          <button
+            disabled={page <= 1}
+            onClick={() => setPage((p) => p - 1)}
+            className="px-2 py-1 border rounded disabled:opacity-40"
+          >
+            ←
+          </button>
+          <span className="text-muted-foreground">Page {data.page} of {data.pages}</span>
+          <button
+            disabled={page >= data.pages}
+            onClick={() => setPage((p) => p + 1)}
+            className="px-2 py-1 border rounded disabled:opacity-40"
+          >
+            →
+          </button>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds a persistent `server_events` table tracking stack lifecycle and health transitions, visible in the admin **Services** tab as a paginated, filterable log
- Stack startup and shutdown events are written from the FastAPI lifespan; health degradation/recovery events are written by the 30s probe loop on status transitions
- Two new scheduled tasks: `daily_health_check` (2am, runs probes + logs result + emails superusers if degraded) and `server_event_log_pruning` (2:30am, enforces 28-day/1000-entry limits)

## Changes

- `ServerEvent` SQLAlchemy model + Alembic migration `0007`
- `app/services/server_events.py` — `write_event`, `close_event`, `close_open_events`, `get_open_event`
- `GET /api/admin/server-events` — paginated, filterable by `event_type`
- `app/routers/health.py` — `_record_health_transition` in the refresh loop; alert dispatch helpers (merges #472 intent onto this branch)
- `app/main.py` — startup + shutdown event writes in lifespan
- `app/tasks/maintenance.py` — `daily_health_check`, `prune_server_event_log`
- `app/tasks/scheduler.py` — both new tasks registered
- Frontend `ServerEventsPanel` in Services tab (type filter, pagination, 60s auto-refresh)
- 28 tests (11 endpoint, 17 service unit)

## Test plan

- [ ] Services tab shows Server Events Log panel with type filter and pagination
- [ ] `stack.startup` event appears after `rbd`
- [ ] `health.degraded` event appears when a critical probe fails; closes when recovered
- [ ] `stack.shutdown` event written on clean container stop
- [ ] Daily Health Check and Server Event Log Pruning appear in Scheduled Tasks tab
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)