### PR TITLE
fix: offload blocking I/O and CPU-bound rendering to thread pool (#155)

### DIFF
--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -1,3 +1,4 @@
+import asyncio
 import urllib.parse
 import uuid
 from datetime import datetime
@@ -150,16 +151,7 @@ async def create_draft(
     db.add(draft)
     await db.flush()  # get draft.id without committing
 
-    draft.wif_path = storage.save_wif(draft.id, wif_file.filename, wif_bytes)
-
-    # Render preview if parseable
-    if lint.is_parseable and not lint.errors:
-        try:
-            wif_draft = rendering.load_draft(wif_bytes)
-            png = rendering.render_full_draft(wif_draft)
-            draft.preview_path = storage.save_preview(draft.id, png)
-        except Exception as exc:
-            draft.lint_warnings = list(draft.lint_warnings) + [f"Preview rendering failed: {exc}"]
+    draft.wif_path = await storage.asave_wif(draft.id, wif_file.filename, wif_bytes)
 
     await db.commit()
     await db.refresh(draft)
@@ -217,9 +209,9 @@ async def get_preview(
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     draft = await _get_owned_draft(draft_id, current_user, db)
-    if not storage.preview_exists(draft.preview_path):
+    if not await storage.afile_exists(draft.preview_path):
         raise HTTPException(status_code=404, detail="Preview not available")
-    png = storage.read_preview(draft.preview_path)  # type: ignore[arg-type]
+    png = await storage.aread_file(draft.preview_path)  # type: ignore[arg-type]
     return Response(content=png, media_type="image/png")
 
 
@@ -242,13 +234,14 @@ async def get_drawdown(
     if start_row is not None or row_count is not None:
         if not draft.wif_path:
             raise HTTPException(status_code=404, detail="No WIF file for this draft")
-        if not storage.file_exists(draft.wif_path):
+        if not await storage.afile_exists(draft.wif_path):
             raise HTTPException(status_code=404, detail="WIF file not found in storage")
-        wif_bytes = storage.read_file(draft.wif_path)
+        wif_bytes = await storage.aread_file(draft.wif_path)
         try:
-            wif_draft = rendering.load_draft(wif_bytes)
-            png, total_rows, actual_start, actual_row_count, actual_scale = rendering.render_drawdown_tile(
-                wif_draft, start_row=start_row or 0, row_count=row_count
+            _sr = start_row or 0
+            _rc = row_count
+            png, total_rows, actual_start, actual_row_count, actual_scale = await asyncio.to_thread(
+                lambda: rendering.render_drawdown_tile(rendering.load_draft(wif_bytes), start_row=_sr, row_count=_rc)
             )
         except HTTPException:
             raise
@@ -267,8 +260,8 @@ async def get_drawdown(
         )
 
     # Non-tiled: serve pre-generated cached preview if available
-    if draft.drawdown_preview_path and storage.file_exists(draft.drawdown_preview_path):
-        png = storage.read_drawdown_preview(draft.drawdown_preview_path)
+    if draft.drawdown_preview_path and await storage.afile_exists(draft.drawdown_preview_path):
+        png = await storage.aread_drawdown_preview(draft.drawdown_preview_path)
         scale = draft.drawdown_preview_scale or rendering.DRAWDOWN_SCALE
         total_rows = draft.weft_threads or 0
         return Response(
@@ -286,13 +279,14 @@ async def get_drawdown(
     if not draft.wif_path:
         raise HTTPException(status_code=404, detail="No WIF file for this draft")
 
-    if not storage.file_exists(draft.wif_path):
+    if not await storage.afile_exists(draft.wif_path):
         raise HTTPException(status_code=404, detail="WIF file not found in storage")
 
-    wif_bytes = storage.read_file(draft.wif_path)
+    wif_bytes = await storage.aread_file(draft.wif_path)
     try:
-        wif_draft = rendering.load_draft(wif_bytes)
-        png, total_rows, actual_scale = rendering.render_drawdown_only(wif_draft)
+        png, total_rows, actual_scale = await asyncio.to_thread(
+            lambda: rendering.render_drawdown_only(rendering.load_draft(wif_bytes))
+        )
     except HTTPException:
         raise
     except Exception as exc:
@@ -322,9 +316,9 @@ async def download_wif(
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     draft = await _get_owned_draft(draft_id, current_user, db)
-    if not draft.wif_path or not storage.file_exists(draft.wif_path):
+    if not draft.wif_path or not await storage.afile_exists(draft.wif_path):
         raise HTTPException(status_code=404, detail="WIF file not available for this draft")
-    wif_bytes = storage.read_file(draft.wif_path)
+    wif_bytes = await storage.aread_file(draft.wif_path)
     filename = draft.wif_filename or "draft.wif"
     return Response(
         content=wif_bytes,
@@ -345,9 +339,9 @@ async def download_wif_modified(
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     draft = await _get_owned_draft(draft_id, current_user, db)
-    if not draft.wif_modified_path or not storage.file_exists(draft.wif_modified_path):
+    if not draft.wif_modified_path or not await storage.afile_exists(draft.wif_modified_path):
         raise HTTPException(status_code=404, detail="No modified WIF file for this draft")
-    wif_bytes = storage.read_file(draft.wif_modified_path)
+    wif_bytes = await storage.aread_file(draft.wif_modified_path)
     base = (draft.wif_filename or "draft.wif").rsplit(".", 1)[0]
     filename = f"{base}-modified.wif"
     return Response(
@@ -392,16 +386,16 @@ async def generate_liftplan(
         raise HTTPException(status_code=400, detail="WIF file has no [TIEUP] section — cannot compute lift plan")
 
     # Read from modified file if one exists (to chain onto prior modifications)
-    has_mod = draft.wif_modified_path and storage.file_exists(draft.wif_modified_path)
+    has_mod = draft.wif_modified_path and await storage.afile_exists(draft.wif_modified_path)
     source_path = draft.wif_modified_path if has_mod else draft.wif_path
-    wif_bytes = storage.read_file(source_path)
+    wif_bytes = await storage.aread_file(source_path)
     try:
-        updated_bytes = wif_parser.compute_liftplan(wif_bytes)
+        updated_bytes = await asyncio.to_thread(wif_parser.compute_liftplan, wif_bytes)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
     modified_filename = draft.wif_filename.rsplit(".", 1)[0] + "-modified.wif"
-    draft.wif_modified_path = storage.save_wif(draft.id, modified_filename, updated_bytes)
+    draft.wif_modified_path = await storage.asave_wif(draft.id, modified_filename, updated_bytes)
     draft.has_liftplan = True
     draft.liftplan_generated = True
 

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -1,3 +1,4 @@
+import asyncio
 import mimetypes
 import uuid
 from datetime import datetime, timezone
@@ -147,7 +148,7 @@ async def _check_loom_conflict(
         raise HTTPException(status_code=409, detail="This loom already has an active project")
 
 
-def _wif_path_for_project(draft: Draft, project_type: str) -> str:
+async def _wif_path_for_project(draft: Draft, project_type: str) -> str:
     """Return the correct WIF path for a project type.
 
     For lift projects, prefer the liftplan-augmented file when available so
@@ -155,7 +156,7 @@ def _wif_path_for_project(draft: Draft, project_type: str) -> str:
     the case where the liftplan was embedded in the original WIF by the user's
     design software).
     """
-    if project_type == "lift" and draft.wif_modified_path and storage.file_exists(draft.wif_modified_path):
+    if project_type == "lift" and draft.wif_modified_path and await storage.afile_exists(draft.wif_modified_path):
         return draft.wif_modified_path
     return draft.wif_path
 
@@ -244,9 +245,9 @@ async def create_project(
         raise HTTPException(status_code=400, detail="WIF file has no [LIFTPLAN] section")
 
     # Parse pick count from WIF
-    wif_bytes = storage.read_file(_wif_path_for_project(draft, body.project_type))
+    wif_bytes = await storage.aread_file(await _wif_path_for_project(draft, body.project_type))
     try:
-        pick_data = wif_parser.parse_picks(wif_bytes, body.project_type)
+        pick_data = await asyncio.to_thread(wif_parser.parse_picks, wif_bytes, body.project_type)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
@@ -598,7 +599,7 @@ async def upload_project_photo(
     await check_storage_quota(current_user.id, db, incoming_bytes=len(data))
 
     photo_id = uuid.uuid4()
-    file_path = storage.save_project_photo(project.id, photo_id, ".jpg", data)
+    file_path = await storage.asave_project_photo(project.id, photo_id, ".jpg", data)
 
     max_order_result = await db.scalars(
         select(ProjectPhoto.display_order)
@@ -633,9 +634,9 @@ async def get_project_photo(
     photo = await db.scalar(
         select(ProjectPhoto).where(ProjectPhoto.id == photo_id, ProjectPhoto.project_id == project_id)
     )
-    if photo is None or not storage.file_exists(photo.file_path):
+    if photo is None or not await storage.afile_exists(photo.file_path):
         raise HTTPException(status_code=404, detail="Photo not found")
-    data = storage.read_file(photo.file_path)
+    data = await storage.aread_file(photo.file_path)
     ct = mimetypes.guess_type(photo.file_path)[0] or "application/octet-stream"
     return Response(content=data, media_type=ct)
 
@@ -653,7 +654,7 @@ async def delete_project_photo(
     )
     if photo is None:
         raise HTTPException(status_code=404, detail="Photo not found")
-    storage.delete_project_photo(photo.file_path)
+    await storage.adelete_project_photo(photo.file_path)
     await db.delete(photo)
     await db.commit()
 
@@ -669,9 +670,9 @@ async def get_picks(
     if draft is None:
         raise HTTPException(status_code=404, detail="Draft not found")
 
-    wif_bytes = storage.read_file(_wif_path_for_project(draft, project.project_type))
+    wif_bytes = await storage.aread_file(await _wif_path_for_project(draft, project.project_type))
     try:
-        pick_data = wif_parser.parse_picks(wif_bytes, project.project_type)
+        pick_data = await asyncio.to_thread(wif_parser.parse_picks, wif_bytes, project.project_type)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -13,6 +13,7 @@ and returned via Content-Disposition headers — not embedded in storage keys.
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from pathlib import Path
 
@@ -204,3 +205,78 @@ def copy_file(old_key: str, new_key: str) -> str:
     """Copy a stored file to a new key. Used by migrations."""
     data = _get(old_key)
     return _put(new_key, data)
+
+
+# ---------------------------------------------------------------------------
+# Async wrappers for use in FastAPI async handlers
+# All storage primitives (boto3, pathlib) are synchronous blocking I/O.
+# These wrappers offload to a thread pool so the event loop is not blocked.
+# ---------------------------------------------------------------------------
+
+
+async def aread_file(path: str) -> bytes:
+    return await asyncio.to_thread(_get, path)
+
+
+async def afile_exists(path: str | None) -> bool:
+    return await asyncio.to_thread(_exists, path)
+
+
+async def asave_wif(draft_id: uuid.UUID, filename: str, data: bytes) -> str:
+    return await asyncio.to_thread(save_wif, draft_id, filename, data)
+
+
+async def asave_preview(draft_id: uuid.UUID, data: bytes) -> str:
+    return await asyncio.to_thread(save_preview, draft_id, data)
+
+
+async def asave_drawdown_preview(data: bytes) -> str:
+    return await asyncio.to_thread(save_drawdown_preview, data)
+
+
+async def aread_drawdown_preview(path: str) -> bytes:
+    return await asyncio.to_thread(read_drawdown_preview, path)
+
+
+async def asave_project_photo(project_id: uuid.UUID, photo_id: uuid.UUID, ext: str, data: bytes) -> str:
+    return await asyncio.to_thread(save_project_photo, project_id, photo_id, ext, data)
+
+
+async def adelete_project_photo(path: str) -> None:
+    await asyncio.to_thread(delete_project_photo, path)
+
+
+async def asave_loom_photo(loom_id: uuid.UUID, ext: str, data: bytes) -> str:
+    return await asyncio.to_thread(save_loom_photo, loom_id, ext, data)
+
+
+async def adelete_loom_photo(photo_path: str) -> None:
+    await asyncio.to_thread(delete_loom_photo, photo_path)
+
+
+async def asave_version_photo(
+    loom_id: uuid.UUID, version_id: uuid.UUID, photo_id: uuid.UUID, ext: str, data: bytes
+) -> str:
+    return await asyncio.to_thread(save_version_photo, loom_id, version_id, photo_id, ext, data)
+
+
+async def adelete_version_photo(path: str) -> None:
+    await asyncio.to_thread(delete_version_photo, path)
+
+
+async def asave_version_receipt(
+    loom_id: uuid.UUID, version_id: uuid.UUID, receipt_id: uuid.UUID, ext: str, data: bytes
+) -> str:
+    return await asyncio.to_thread(save_version_receipt, loom_id, version_id, receipt_id, ext, data)
+
+
+async def adelete_version_receipt(path: str) -> None:
+    await asyncio.to_thread(delete_version_receipt, path)
+
+
+async def asave_yarn_photo(yarn_id: uuid.UUID, ext: str, data: bytes) -> str:
+    return await asyncio.to_thread(save_yarn_photo, yarn_id, ext, data)
+
+
+async def adelete_yarn_photo(photo_path: str) -> None:
+    await asyncio.to_thread(delete_yarn_photo, photo_path)

--- a/backend/app/tasks/preview.py
+++ b/backend/app/tasks/preview.py
@@ -46,6 +46,16 @@ async def _generate_preview(task: Task, draft_id: uuid.UUID) -> None:
             try:
                 wif_bytes = storage.read_file(draft.wif_path)
                 wif_draft = rendering.load_draft(wif_bytes)
+
+                # Full color preview (threading + tie-up + drawdown) if not yet generated
+                if not draft.preview_path:
+                    try:
+                        png_full = rendering.render_full_draft(wif_draft)
+                        draft.preview_path = storage.save_preview(draft.id, png_full)
+                    except Exception as exc:
+                        log.warning("preview_task_full_failed draft_id=%s error=%s", draft_id, exc)
+
+                # Reduced drawdown preview for the project screen
                 png, scale = rendering.render_drawdown_preview(wif_draft, settings.drawdown_preview_max_px)
                 preview_path = storage.save_drawdown_preview(png)
                 draft.drawdown_preview_path = preview_path

--- a/backend/tests/services/test_storage.py
+++ b/backend/tests/services/test_storage.py
@@ -409,3 +409,47 @@ class TestS3Paths:
         monkeypatch.setattr("boto3.client", mock_boto3_client)
         storage._s3()
         mock_boto3_client.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Async wrappers (asyncio.to_thread round-trips)
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncWrappers:
+    async def test_asave_wif_and_aread_file_round_trip(self):
+        pid = _pid()
+        key = await storage.asave_wif(pid, "test.wif", b"WIF DATA")
+        assert await storage.aread_file(key) == b"WIF DATA"
+
+    async def test_afile_exists_true_after_save(self):
+        pid = _pid()
+        key = await storage.asave_wif(pid, "test.wif", b"data")
+        assert await storage.afile_exists(key) is True
+
+    async def test_afile_exists_false_for_missing(self):
+        assert await storage.afile_exists("no/such/file.wif") is False
+
+    async def test_afile_exists_false_for_none(self):
+        assert await storage.afile_exists(None) is False
+
+    async def test_asave_project_photo_and_read_round_trip(self):
+        pid, phid = _pid(), _pid()
+        key = await storage.asave_project_photo(pid, phid, ".jpg", b"JPEG DATA")
+        assert await storage.aread_file(key) == b"JPEG DATA"
+
+    async def test_adelete_project_photo_removes_file(self):
+        pid, phid = _pid(), _pid()
+        key = await storage.asave_project_photo(pid, phid, ".jpg", b"data")
+        await storage.adelete_project_photo(key)
+        assert await storage.afile_exists(key) is False
+
+    async def test_aread_drawdown_preview_round_trip(self):
+        data = b"\x89PNG\r\n\x1a\n"
+        key = storage.save_drawdown_preview(data)
+        assert await storage.aread_drawdown_preview(key) == data
+
+    async def test_asave_drawdown_preview_round_trip(self):
+        data = b"\x89PNG\r\n\x1a\n"
+        key = await storage.asave_drawdown_preview(data)
+        assert storage.read_drawdown_preview(key) == data


### PR DESCRIPTION
## Summary

- All synchronous boto3/filesystem and CPU-bound WIF parsing/rendering calls that were blocking the FastAPI event loop are now offloaded via `asyncio.to_thread()` or async storage wrappers
- `create_draft()` no longer does inline `render_full_draft` — the Celery preview task now generates both the full color preview and the drawdown preview, so the upload response is fast regardless of WIF complexity
- `_wif_path_for_project()` converted to `async def` so it can call `afile_exists` without blocking

**Files changed:**
- `storage.py` — 14 new async wrappers (`aread_file`, `afile_exists`, `asave_wif`, `asave/adelete` for project/loom/yarn photos, drawdown preview read/write)
- `drafts.py` — `create_draft`, `get_drawdown`, `generate_liftplan`, download endpoints all use async storage + `asyncio.to_thread` for render/parse calls
- `projects.py` — `create_project`, `get_picks`, photo upload/get/delete use async storage + `asyncio.to_thread` for `parse_picks`
- `preview.py` — Celery task now also generates `preview_path` (full color) if not yet set
- `test_storage.py` — 8 new async round-trip tests for the new async wrappers

## Test plan

- [ ] 264 tests pass locally (`test_drafts.py`, `test_projects.py`, `test_storage.py`)
- [ ] Upload a WIF draft — confirm response is fast and preview appears shortly after (via Celery task)
- [ ] Generate liftplan on a draft — confirm success and preview regenerates
- [ ] Open a project and view the picks — confirm treadle/lift picks load correctly
- [ ] Upload a project photo, view it, delete it
- [ ] Download WIF and modified WIF files

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)