### PR TITLE
fix: horizontal scroll on server events log table

### DIFF
--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1309,7 +1309,7 @@ function ServerEventsPanel() {
       )}
 
       {data && data.items.length > 0 && (
-        <div className="rounded-lg border overflow-hidden">
+        <div className="rounded-lg border overflow-hidden overflow-x-auto">
           <table className="w-full text-xs">
             <thead className="bg-muted/50 text-muted-foreground">
               <tr>


### PR DESCRIPTION
## Summary

- Adds `overflow-x-auto` to the server events table wrapper so it scrolls horizontally on narrow screens instead of overflowing the panel

## Test plan

- [ ] Narrow the admin panel / browser window — server events table scrolls horizontally rather than overflowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)