### PR TITLE
fix: suppress boot-time health.degraded false positive from Clerk Webhook

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -162,7 +162,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     readiness = await run_startup_probes()
     set_readiness(readiness)
-    start_detailed_refresh()
+    start_detailed_refresh(initial_status=readiness.status)
     asyncio.create_task(_send_startup_alert(readiness))
     asyncio.create_task(_write_startup_server_event(readiness, start_time))
 

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -327,6 +327,7 @@ async def _record_health_transition(prev_status: str | None, result: ReadinessRe
 
 async def _detailed_refresh_loop() -> None:
     global _detailed_cache, _last_alert_status, _last_alert_at
+    await asyncio.sleep(DETAILED_REFRESH_INTERVAL_S)  # skip transient startup failures
     while True:
         try:
             result = await _run_detailed_probes()
@@ -374,9 +375,11 @@ async def _detailed_refresh_loop() -> None:
         await asyncio.sleep(DETAILED_REFRESH_INTERVAL_S)
 
 
-def start_detailed_refresh() -> None:
+def start_detailed_refresh(initial_status: str | None = None) -> None:
     """Create the background refresh task. Call from lifespan after startup."""
-    global _detailed_task
+    global _detailed_task, _last_alert_status
+    if initial_status is not None:
+        _last_alert_status = initial_status
     _detailed_task = asyncio.create_task(_detailed_refresh_loop())
 
 


### PR DESCRIPTION
## Summary

- Adds a 30-second initial sleep to `_detailed_refresh_loop` before the first probe fires, so transient Clerk Webhook failures immediately after startup are never recorded as health events
- Seeds `_last_alert_status` in `start_detailed_refresh()` from the startup probe result so the first detailed cycle uses proper transition logic instead of the special-case `prev_status is None` branch

**Root cause:** `_detailed_refresh_loop` had no delay before its first iteration, so it fired ~3 seconds after startup and caught the Clerk Webhook in a transient failure state. This opened a `health.degraded` ServerEvent that self-closed 31.5 seconds later — creating noise in the events log on every boot.

**Before:** boot → 3s → webhook fails → `health.degraded` opens → 31.5s → webhook recovers → event closes  
**After:** boot → 30s → webhook recovered → no event recorded

## Test plan

- [ ] Rebuild and redeploy on dev; confirm no `health.degraded` event appears in Server Events Log on boot
- [ ] Verify `/health/detailed` returns `"ok"` within ~35s of startup

Closes #155 (health false positive follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)