### PR TITLE
feat: storage quota progress bar in admin user detail modal

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -35,6 +35,7 @@ from app.services.email import (
     send_approval_confirmation_to_admins,
     send_test_email,
 )
+from app.services.storage_quota import MAX_USER_STORAGE_BYTES
 from app.version import VERSION
 
 log = logging.getLogger(__name__)
@@ -52,6 +53,7 @@ class AdminUserCounts(BaseModel):
     projects_completed: int
     looms: int
     storage_bytes: int
+    storage_quota_bytes: int
 
 
 class AdminUserResponse(BaseModel):
@@ -483,6 +485,7 @@ async def list_users(
                 projects_completed=project_completed.get(u.id, 0),
                 looms=loom_counts.get(u.id, 0),
                 storage_bytes=storage_bytes.get(u.id, 0),
+                storage_quota_bytes=MAX_USER_STORAGE_BYTES,
             ),
         )
         for u in users
@@ -594,6 +597,7 @@ async def patch_user(
             projects_completed=proj_completed,
             looms=looms,
             storage_bytes=int(project_storage) + int(loom_storage),
+            storage_quota_bytes=MAX_USER_STORAGE_BYTES,
         ),
     )
 
@@ -642,7 +646,14 @@ async def ban_user(
         deletion_state=user.deletion_state,
         deletion_initiated_at=user.deletion_initiated_at,
         clerk_errored=user.clerk_errored,
-        counts=AdminUserCounts(drafts=0, projects_active=0, projects_completed=0, looms=0, storage_bytes=0),
+        counts=AdminUserCounts(
+            drafts=0,
+            projects_active=0,
+            projects_completed=0,
+            looms=0,
+            storage_bytes=0,
+            storage_quota_bytes=MAX_USER_STORAGE_BYTES,
+        ),
     )
 
 
@@ -681,7 +692,14 @@ async def unban_user(
         deletion_state=user.deletion_state,
         deletion_initiated_at=user.deletion_initiated_at,
         clerk_errored=user.clerk_errored,
-        counts=AdminUserCounts(drafts=0, projects_active=0, projects_completed=0, looms=0, storage_bytes=0),
+        counts=AdminUserCounts(
+            drafts=0,
+            projects_active=0,
+            projects_completed=0,
+            looms=0,
+            storage_bytes=0,
+            storage_quota_bytes=MAX_USER_STORAGE_BYTES,
+        ),
     )
 
 

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -6,6 +6,7 @@ export interface AdminUserCounts {
   projects_completed: number;
   looms: number;
   storage_bytes: number;
+  storage_quota_bytes: number;
 }
 
 export interface AdminUser {

--- a/frontend/src/components/admin/UserDetailModal.tsx
+++ b/frontend/src/components/admin/UserDetailModal.tsx
@@ -305,7 +305,29 @@ export function UserDetailModal({ target, onClose }: Props) {
           <div className="space-y-1.5">
             <InfoRow label="Joined">{formatDate(u.created_at)}</InfoRow>
             <InfoRow label="Last login">{formatRelative(u.last_active_at)}</InfoRow>
-            <InfoRow label="Storage">{formatBytes(u.counts.storage_bytes)}</InfoRow>
+            {/* Storage quota */}
+            <div className="flex gap-4 text-sm">
+              <span className="w-28 shrink-0 text-muted-foreground">Storage</span>
+              <div className="flex-1">
+                {(() => {
+                  const used = u.counts.storage_bytes;
+                  const quota = u.counts.storage_quota_bytes;
+                  const pct = Math.min(Math.round((used / quota) * 100), 100);
+                  const barColor = pct >= 90 ? "bg-red-500" : pct >= 75 ? "bg-amber-500" : "bg-primary";
+                  return (
+                    <>
+                      <div className="flex justify-between mb-1">
+                        <span>{formatBytes(used)}</span>
+                        <span className="text-muted-foreground">{formatBytes(quota)} · {pct}%</span>
+                      </div>
+                      <div className="h-1.5 w-full rounded-full bg-muted overflow-hidden">
+                        <div className={`h-full rounded-full ${barColor}`} style={{ width: `${pct}%` }} />
+                      </div>
+                    </>
+                  );
+                })()}
+              </div>
+            </div>
             <InfoRow label="Drafts">{u.counts.drafts}</InfoRow>
             <InfoRow label="Projects">
               {u.counts.projects_active} active, {u.counts.projects_completed} completed


### PR DESCRIPTION
## Summary

- Adds `storage_quota_bytes` to the `AdminUserCounts` backend schema, populated from `MAX_USER_STORAGE_BYTES` (500 MB) in `storage_quota.py`
- Replaces the plain "Storage: 160 KB" `InfoRow` in `UserDetailModal` with a compact quota progress bar showing used / total and a colour-coded fill (green → amber ≥75% → red ≥90%), matching the style on the user-facing dashboard

## Test plan

- [ ] Open Admin → Users → click any user: confirm "Storage" row now shows used / 524 MB and a filled bar
- [ ] For a user with no uploads: bar shows 0 KB / 524 MB at 0%
- [ ] Bar colour: green at low usage, amber at ≥75%, red at ≥90%

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)