### PR TITLE
feat: SMTP health check — TCP probe + circuit-breaker backoff

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -831,7 +831,7 @@ def _smtp_conn_meta(settings: "Settings") -> dict[str, str]:
 
 
 async def _probe_smtp() -> ServiceCheckResult:
-    import aiosmtplib
+    from app.services import smtp_health
 
     settings = get_settings()
     checks: list[ServicePermCheck] = []
@@ -859,33 +859,8 @@ async def _probe_smtp() -> ServiceCheckResult:
         ServicePermCheck(name="config", status="ok", message=f"{settings.smtp_host}:{settings.smtp_port} configured")
     )
 
-    # start_tls=True mirrors aiosmtplib.send() — connect() handles STARTTLS automatically
-    smtp = aiosmtplib.SMTP(hostname=settings.smtp_host, port=settings.smtp_port, start_tls=True, timeout=5)
-
-    try:
-        await asyncio.wait_for(smtp.connect(), timeout=5.0)
-        checks.append(
-            ServicePermCheck(
-                name="connect", status="ok", message=f"TCP connected to {settings.smtp_host}:{settings.smtp_port}"
-            )
-        )
-        checks.append(ServicePermCheck(name="starttls", status="ok", message="STARTTLS negotiated"))
-    except (asyncio.TimeoutError, Exception) as exc:
-        msg = "Timed out after 5 s" if isinstance(exc, asyncio.TimeoutError) else str(exc)[:120]
-        checks.append(ServicePermCheck(name="connect", status="error", message=msg))
-        return _make_result("SMTP", checks, meta=meta)
-
-    try:
-        await asyncio.wait_for(smtp.login(settings.smtp_user, settings.smtp_password), timeout=5.0)
-        checks.append(ServicePermCheck(name="auth", status="ok", message=f"Authenticated as {settings.smtp_user}"))
-    except (asyncio.TimeoutError, Exception) as exc:
-        msg = "Timed out after 5 s" if isinstance(exc, asyncio.TimeoutError) else str(exc)[:120]
-        checks.append(ServicePermCheck(name="auth", status="error", message=msg))
-    finally:
-        try:
-            await smtp.quit()
-        except Exception:
-            pass
+    ok, msg = await smtp_health.check(settings.smtp_host, settings.smtp_port)
+    checks.append(ServicePermCheck(name="tcp", status="ok" if ok else "error", message=msg))
 
     return _make_result("SMTP", checks, meta=meta)
 

--- a/backend/app/services/smtp_health.py
+++ b/backend/app/services/smtp_health.py
@@ -1,0 +1,83 @@
+"""
+Lightweight SMTP health check: bare TCP probe with a circuit-breaker backoff.
+
+Replaces the full aiosmtplib auth session that previously ran every 30 s,
+consuming a real SMTP2Go login slot each cycle.  A TCP connection verifies
+reachability without triggering rate-limits or auth quotas.
+
+Circuit-breaker behaviour:
+- First failure → enters backoff; subsequent calls return cached failure for
+  BACKOFF_SECONDS without opening another socket.
+- First success after backoff → resets to normal; every call probes live.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+log = logging.getLogger(__name__)
+
+TCP_TIMEOUT_S: float = 5.0
+BACKOFF_SECONDS: int = 300  # 5 minutes between retries after a failure
+
+# Module-level circuit-breaker state (single asyncio event loop — no lock needed)
+_last_ok: bool | None = None
+_last_message: str = ""
+_last_checked_at: datetime | None = None
+_in_backoff: bool = False
+
+
+async def _tcp_probe(host: str, port: int) -> tuple[bool, str]:
+    """Open a bare TCP connection to host:port and immediately close it."""
+    try:
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(host, port),
+            timeout=TCP_TIMEOUT_S,
+        )
+        writer.close()
+        await writer.wait_closed()
+        return True, f"TCP connected to {host}:{port}"
+    except asyncio.TimeoutError:
+        return False, f"TCP connection timed out after {TCP_TIMEOUT_S:.0f} s"
+    except OSError as exc:
+        return False, str(exc)[:120]
+    except Exception as exc:  # pragma: no cover
+        return False, str(exc)[:120]
+
+
+async def check(host: str, port: int) -> tuple[bool, str]:
+    """Return ``(ok, message)`` for SMTP TCP reachability.
+
+    After a failure the cached result is returned for BACKOFF_SECONDS to
+    avoid hammering the relay.  A success resets the circuit immediately.
+    """
+    global _last_ok, _last_message, _last_checked_at, _in_backoff
+
+    now = datetime.now(timezone.utc)
+
+    if _in_backoff and _last_checked_at is not None:
+        elapsed = (now - _last_checked_at).total_seconds()
+        remaining = int(BACKOFF_SECONDS - elapsed)
+        if remaining > 0:
+            log.debug("smtp_health: backoff active, %ds remaining", remaining)
+            return False, f"{_last_message} (cached — retry in {remaining}s)"
+
+    ok, msg = await _tcp_probe(host, port)
+
+    _last_ok = ok
+    _last_message = msg
+    _last_checked_at = now
+    _in_backoff = not ok
+
+    return ok, msg
+
+
+def reset() -> None:
+    """Reset circuit-breaker state. Intended for tests."""
+    global _last_ok, _last_message, _last_checked_at, _in_backoff
+    _last_ok = None
+    _last_message = ""
+    _last_checked_at = None
+    _in_backoff = False

--- a/backend/tests/services/test_smtp_health.py
+++ b/backend/tests/services/test_smtp_health.py
@@ -1,0 +1,180 @@
+"""Tests for app.services.smtp_health — TCP probe and circuit-breaker logic."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import app.services.smtp_health as smtp_health
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    """Reset circuit-breaker state before every test."""
+    smtp_health.reset()
+    yield
+    smtp_health.reset()
+
+
+# ---------------------------------------------------------------------------
+# TCP probe unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestTcpProbe:
+    async def test_success_returns_true_and_message(self):
+        mock_reader = MagicMock()
+        mock_writer = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+
+        with patch("asyncio.open_connection", return_value=(mock_reader, mock_writer)):
+            ok, msg = await smtp_health._tcp_probe("smtp.example.com", 587)
+
+        assert ok is True
+        assert "smtp.example.com" in msg
+        assert "587" in msg
+
+    async def test_timeout_returns_false(self):
+        with patch("asyncio.open_connection", side_effect=asyncio.TimeoutError):
+            ok, msg = await smtp_health._tcp_probe("smtp.example.com", 587)
+
+        assert ok is False
+        assert "timed out" in msg.lower()
+
+    async def test_oserror_returns_false(self):
+        with patch("asyncio.open_connection", side_effect=OSError("Connection refused")):
+            ok, msg = await smtp_health._tcp_probe("smtp.example.com", 587)
+
+        assert ok is False
+        assert "Connection refused" in msg
+
+    async def test_writer_closed_on_success(self):
+        mock_reader = MagicMock()
+        mock_writer = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+
+        with patch("asyncio.open_connection", return_value=(mock_reader, mock_writer)):
+            await smtp_health._tcp_probe("smtp.example.com", 587)
+
+        mock_writer.close.assert_called_once()
+        mock_writer.wait_closed.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Circuit-breaker logic via check()
+# ---------------------------------------------------------------------------
+
+
+class TestCircuitBreaker:
+    async def test_success_returns_ok(self):
+        mock_reader = MagicMock()
+        mock_writer = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+
+        with patch("asyncio.open_connection", return_value=(mock_reader, mock_writer)):
+            ok, msg = await smtp_health.check("smtp.example.com", 587)
+
+        assert ok is True
+
+    async def test_failure_sets_backoff(self):
+        with patch("asyncio.open_connection", side_effect=OSError("refused")):
+            ok, _ = await smtp_health.check("smtp.example.com", 587)
+
+        assert ok is False
+        assert smtp_health._in_backoff is True
+
+    async def test_backoff_returns_cached_without_probing(self):
+        # First call — fail, enter backoff
+        with patch("asyncio.open_connection", side_effect=OSError("refused")):
+            await smtp_health.check("smtp.example.com", 587)
+
+        # Second call — should NOT open a new connection
+        with patch("asyncio.open_connection", side_effect=AssertionError("should not probe")) as mock_conn:
+            ok, msg = await smtp_health.check("smtp.example.com", 587)
+            mock_conn.assert_not_called()
+
+        assert ok is False
+        assert "cached" in msg
+
+    async def test_backoff_retries_after_window(self):
+        # First call — fail, enter backoff
+        with patch("asyncio.open_connection", side_effect=OSError("refused")):
+            await smtp_health.check("smtp.example.com", 587)
+
+        # Wind the clock past BACKOFF_SECONDS
+        past = datetime.now(timezone.utc) - timedelta(seconds=smtp_health.BACKOFF_SECONDS + 1)
+        smtp_health._last_checked_at = past
+
+        # Second call — should attempt a fresh probe (and succeed this time)
+        mock_reader = MagicMock()
+        mock_writer = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+
+        with patch("asyncio.open_connection", return_value=(mock_reader, mock_writer)):
+            ok, msg = await smtp_health.check("smtp.example.com", 587)
+
+        assert ok is True
+        assert "cached" not in msg
+
+    async def test_success_resets_backoff(self):
+        # Enter backoff
+        with patch("asyncio.open_connection", side_effect=OSError("refused")):
+            await smtp_health.check("smtp.example.com", 587)
+
+        assert smtp_health._in_backoff is True
+
+        # Expire backoff window and probe successfully
+        smtp_health._last_checked_at = datetime.now(timezone.utc) - timedelta(seconds=smtp_health.BACKOFF_SECONDS + 1)
+        mock_reader = MagicMock()
+        mock_writer = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+
+        with patch("asyncio.open_connection", return_value=(mock_reader, mock_writer)):
+            ok, _ = await smtp_health.check("smtp.example.com", 587)
+
+        assert ok is True
+        assert smtp_health._in_backoff is False
+
+    async def test_no_backoff_on_first_call_without_prior_failure(self):
+        """Fresh state: first call always probes live even if _in_backoff were somehow True."""
+        smtp_health.reset()
+        assert smtp_health._in_backoff is False
+        assert smtp_health._last_checked_at is None
+
+        mock_reader = MagicMock()
+        mock_writer = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+
+        with patch("asyncio.open_connection", return_value=(mock_reader, mock_writer)):
+            ok, _ = await smtp_health.check("smtp.example.com", 587)
+
+        assert ok is True
+
+    async def test_cached_message_includes_retry_countdown(self):
+        with patch("asyncio.open_connection", side_effect=OSError("refused")):
+            await smtp_health.check("smtp.example.com", 587)
+
+        _, msg = await smtp_health.check("smtp.example.com", 587)
+        assert "retry in" in msg
+        assert "cached" in msg
+
+
+# ---------------------------------------------------------------------------
+# reset() helper
+# ---------------------------------------------------------------------------
+
+
+class TestReset:
+    async def test_reset_clears_state(self):
+        with patch("asyncio.open_connection", side_effect=OSError("refused")):
+            await smtp_health.check("smtp.example.com", 587)
+
+        smtp_health.reset()
+
+        assert smtp_health._last_ok is None
+        assert smtp_health._last_message == ""
+        assert smtp_health._last_checked_at is None
+        assert smtp_health._in_backoff is False


### PR DESCRIPTION
## Summary

Replaces the full `aiosmtplib` authenticated SMTP session that ran every 30 s with a lightweight TCP probe backed by a 5-minute circuit-breaker.

**Before:** every 30 s → TCP connect → STARTTLS → `AUTH LOGIN` → `QUIT`  = 120 real SMTP2Go logins per hour around the clock. Risk: auth rate-limiting / IP ban on the sending relay.

**After:** `asyncio.open_connection(host, port)` + immediate close. Verifies the relay port is listening without any auth overhead. After a failure, cached result is returned for 5 minutes (no socket opens). Resets on first success after the backoff window.

## Changes

- **`app/services/smtp_health.py`** (new): `_tcp_probe()` opens a bare TCP socket; `check()` wraps it with circuit-breaker state; `reset()` for test isolation
- **`app/routers/admin.py`**: `_probe_smtp()` calls `smtp_health.check()` instead of `aiosmtplib` — checks reported as `tcp` instead of `connect/starttls/auth`
- **`tests/services/test_smtp_health.py`** (new): 12 tests — TCP probe success/timeout/OSError, circuit-breaker backoff window, cache expiry, recovery, reset. `smtp_health.py` at 100% coverage.

## Tradeoff

The probe no longer validates credentials — only reachability. Credential failures are surfaced by actual email sends, not the health check. This is the right tradeoff for a 30 s polling probe.

## Test plan

- [ ] `_detailed` health endpoint shows SMTP `tcp` check (not `connect/starttls/auth`) after deploy
- [ ] Confirm no SMTP2Go login events appear in relay logs every 30 s after deploy

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)