### PR TITLE
feat: absolute last login + EULA details in admin user modal

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -71,6 +71,8 @@ class AdminUserResponse(BaseModel):
     deletion_state: str | None
     deletion_initiated_at: datetime | None
     clerk_errored: bool
+    eula_accepted_version: str | None
+    eula_accepted_at: datetime | None
     counts: AdminUserCounts
 
     model_config = {"from_attributes": False}
@@ -479,6 +481,8 @@ async def list_users(
             deletion_state=u.deletion_state,
             deletion_initiated_at=u.deletion_initiated_at,
             clerk_errored=u.clerk_errored,
+            eula_accepted_version=u.eula_accepted_version,
+            eula_accepted_at=u.eula_accepted_at,
             counts=AdminUserCounts(
                 drafts=draft_counts.get(u.id, 0),
                 projects_active=project_active.get(u.id, 0),
@@ -591,6 +595,8 @@ async def patch_user(
         deletion_state=user.deletion_state,
         deletion_initiated_at=user.deletion_initiated_at,
         clerk_errored=user.clerk_errored,
+        eula_accepted_version=user.eula_accepted_version,
+        eula_accepted_at=user.eula_accepted_at,
         counts=AdminUserCounts(
             drafts=drafts,
             projects_active=proj_active,
@@ -646,6 +652,8 @@ async def ban_user(
         deletion_state=user.deletion_state,
         deletion_initiated_at=user.deletion_initiated_at,
         clerk_errored=user.clerk_errored,
+        eula_accepted_version=user.eula_accepted_version,
+        eula_accepted_at=user.eula_accepted_at,
         counts=AdminUserCounts(
             drafts=0,
             projects_active=0,
@@ -692,6 +700,8 @@ async def unban_user(
         deletion_state=user.deletion_state,
         deletion_initiated_at=user.deletion_initiated_at,
         clerk_errored=user.clerk_errored,
+        eula_accepted_version=user.eula_accepted_version,
+        eula_accepted_at=user.eula_accepted_at,
         counts=AdminUserCounts(
             drafts=0,
             projects_active=0,

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -24,6 +24,8 @@ export interface AdminUser {
   last_active_at: string | null;
   approved_by_name: string | null;
   approved_by_email: string | null;
+  eula_accepted_version: string | null;
+  eula_accepted_at: string | null;
   counts: AdminUserCounts;
 }
 

--- a/frontend/src/components/admin/UserDetailModal.tsx
+++ b/frontend/src/components/admin/UserDetailModal.tsx
@@ -91,15 +91,15 @@ function formatDate(iso: string) {
   });
 }
 
-function formatRelative(iso: string | null) {
+function formatDateTime(iso: string | null) {
   if (!iso) return "Never";
-  const diff = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(diff / 60_000);
-  if (mins < 2) return "Just now";
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
+  return new Date(iso).toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
 }
 
 export function UserDetailModal({ target, onClose }: Props) {
@@ -304,7 +304,7 @@ export function UserDetailModal({ target, onClose }: Props) {
           {/* Info */}
           <div className="space-y-1.5">
             <InfoRow label="Joined">{formatDate(u.created_at)}</InfoRow>
-            <InfoRow label="Last login">{formatRelative(u.last_active_at)}</InfoRow>
+            <InfoRow label="Last login">{formatDateTime(u.last_active_at)}</InfoRow>
             {/* Storage quota */}
             <div className="flex gap-4 text-sm">
               <span className="w-28 shrink-0 text-muted-foreground">Storage</span>
@@ -339,6 +339,11 @@ export function UserDetailModal({ target, onClose }: Props) {
                 {u.approved_by_email ? ` (${u.approved_by_email})` : ""}
               </InfoRow>
             )}
+            <InfoRow label="EULA">
+              {u.eula_accepted_version
+                ? `v${u.eula_accepted_version} · ${formatDateTime(u.eula_accepted_at)}`
+                : <span className="text-muted-foreground">Not accepted</span>}
+            </InfoRow>
           </div>
 
           {/* Actions */}


### PR DESCRIPTION
## Summary

- **Last login** — replaces relative "Just now / 3d ago" with a locale-formatted absolute date+time (e.g. "May 8, 2026, 9:41 PM") via a new `formatDateTime()` helper. Exact timestamps are required for support and audit use cases.
- **EULA row** — new row below "Approved by" showing accepted EULA version and acceptance date+time (e.g. `v0.9 · May 3, 2026, 2:14 PM`), or "Not accepted" if the user hasn't accepted yet. Data comes directly from `user.eula_accepted_version` / `user.eula_accepted_at` — no audit log query.

## Changes

- **`backend/app/routers/admin.py`**: `AdminUserResponse` gains `eula_accepted_version: str | None` and `eula_accepted_at: datetime | None`; all 4 construction sites updated
- **`frontend/src/api/admin.ts`**: `AdminUser` interface updated with both new fields
- **`frontend/src/components/admin/UserDetailModal.tsx`**: `formatRelative` replaced by `formatDateTime`; EULA row added

## Test plan

- [ ] Open Admin → Users → click any user: Last Login shows absolute date+time, not relative
- [ ] User who has accepted EULA: row shows `v<version> · <date time>`
- [ ] User who has not accepted EULA: row shows "Not accepted" in muted text

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)