### PR TITLE
feat: green Mark Complete and Confirm buttons on project completion

### DIFF
--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -10,6 +10,8 @@ const buttonVariants = cva(
         default: "bg-primary text-primary-foreground shadow hover:bg-primary/90",
         destructive:
           "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        success:
+          "bg-green-600 text-white shadow-sm hover:bg-green-700",
         outline:
           "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
         secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1457,11 +1457,11 @@ export function ProjectDetailPage() {
               {isActiveTracking && (
                 <div className="mt-6">
                   {!confirmComplete ? (
-                    <Button onClick={() => setConfirmComplete(true)}>Mark complete</Button>
+                    <Button variant="success" onClick={() => setConfirmComplete(true)}>Mark complete</Button>
                   ) : (
                     <div className="flex items-center justify-center gap-2">
                       <span className="text-sm">Mark this project as completed?</span>
-                      <Button size="sm" onClick={handleComplete} disabled={actionLoading}>Confirm</Button>
+                      <Button size="sm" variant="success" onClick={handleComplete} disabled={actionLoading}>Confirm</Button>
                       <Button size="sm" variant="outline" onClick={() => setConfirmComplete(false)} disabled={actionLoading}>Cancel</Button>
                     </div>
                   )}
@@ -1643,7 +1643,7 @@ export function ProjectDetailPage() {
               <div className="flex flex-wrap gap-2">
                 {!confirmComplete && !confirmAbandon && (
                   <>
-                    <Button variant="outline" size="sm" onClick={() => setConfirmComplete(true)}>
+                    <Button variant="success" size="sm" onClick={() => setConfirmComplete(true)}>
                       Mark complete
                     </Button>
                     <Button variant="outline" size="sm" onClick={() => setConfirmAbandon(true)}>
@@ -1654,7 +1654,7 @@ export function ProjectDetailPage() {
                 {confirmComplete && (
                   <div className="flex items-center gap-2">
                     <span className="text-sm">Mark this project as completed?</span>
-                    <Button size="sm" onClick={handleComplete} disabled={actionLoading}>Confirm</Button>
+                    <Button size="sm" variant="success" onClick={handleComplete} disabled={actionLoading}>Confirm</Button>
                     <Button size="sm" variant="outline" onClick={() => setConfirmComplete(false)} disabled={actionLoading}>Cancel</Button>
                   </div>
                 )}


### PR DESCRIPTION
## Summary

- Adds a `success` variant to the shared `Button` component (`bg-green-600 text-white hover:bg-green-700`)
- Applies it to the **Mark complete** trigger button and **Confirm** button in both the completion banner (shown when all picks are recorded) and the Actions collapsible section on `ProjectDetailPage`

## Test plan

- [ ] Navigate to a project with all picks recorded — "Mark complete" button is green
- [ ] Click it — confirmation inline shows green "Confirm" button
- [ ] In the Actions section — "Mark complete" is green, "Abandon" remains outline, confirm is green
- [ ] Dark mode: green buttons remain legible

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)