### PR TITLE
feat: audit log entry on render limit exceeded (#270)

### DIFF
--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -15,6 +15,7 @@ from app.deps import get_current_user, get_db
 from app.models.draft import Draft
 from app.models.user import User
 from app.services import rendering, storage, wif_linter, wif_modifier, wif_parser
+from app.services.audit import write_audit_log
 from app.services.rate_limiter import rate_limit
 from app.tasks.preview import generate_drawdown_preview
 
@@ -243,7 +244,22 @@ async def get_drawdown(
             png, total_rows, actual_start, actual_row_count, actual_scale = await asyncio.to_thread(
                 lambda: rendering.render_drawdown_tile(rendering.load_draft(wif_bytes), start_row=_sr, row_count=_rc)
             )
-        except HTTPException:
+        except HTTPException as exc:
+            if exc.status_code == 413:
+                await write_audit_log(
+                    db,
+                    event_type="render.limit_exceeded",
+                    actor=current_user,
+                    details={
+                        "draft_id": str(draft_id),
+                        "warp_threads": draft.warp_threads,
+                        "weft_threads": draft.weft_threads,
+                        "render_max_width": settings.render_max_width,
+                        "render_max_height": settings.render_max_height,
+                        "mode": "tile",
+                    },
+                )
+                await db.commit()
             raise
         except Exception as exc:
             raise HTTPException(status_code=500, detail=f"Drawdown rendering failed: {exc}")
@@ -287,7 +303,22 @@ async def get_drawdown(
         png, total_rows, actual_scale = await asyncio.to_thread(
             lambda: rendering.render_drawdown_only(rendering.load_draft(wif_bytes))
         )
-    except HTTPException:
+    except HTTPException as exc:
+        if exc.status_code == 413:
+            await write_audit_log(
+                db,
+                event_type="render.limit_exceeded",
+                actor=current_user,
+                details={
+                    "draft_id": str(draft_id),
+                    "warp_threads": draft.warp_threads,
+                    "weft_threads": draft.weft_threads,
+                    "render_max_width": settings.render_max_width,
+                    "render_max_height": settings.render_max_height,
+                    "mode": "full",
+                },
+            )
+            await db.commit()
         raise
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Drawdown rendering failed: {exc}")

--- a/backend/tests/routers/test_drafts.py
+++ b/backend/tests/routers/test_drafts.py
@@ -5,10 +5,13 @@ import uuid
 from unittest.mock import MagicMock
 
 import pytest
+from fastapi import HTTPException
 from httpx import AsyncClient
 from PIL import Image
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.audit_log import AuditLog
 from app.models.draft import Draft
 from app.models.user import User
 from app.services import rendering
@@ -369,6 +372,29 @@ class TestGetDrawdown:
 
         assert resp.headers.get("ETag") == f'"{draft.id}"'
 
+    async def test_413_writes_audit_log(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+    ):
+        draft = await self._draft_with_wif(db_session, test_user)
+
+        def _raise_413(*_a, **_kw):
+            raise HTTPException(status_code=413, detail="too big")
+
+        monkeypatch.setattr(rendering, "render_drawdown_only", _raise_413)
+
+        resp = await auth_client.get(f"/api/drafts/{draft.id}/drawdown")
+
+        assert resp.status_code == 413
+        entry = await db_session.scalar(
+            select(AuditLog).where(
+                AuditLog.actor_email == test_user.email,
+                AuditLog.event_type == "render.limit_exceeded",
+            )
+        )
+        assert entry is not None
+        assert entry.details["draft_id"] == str(draft.id)
+        assert entry.details["mode"] == "full"
+
 
 # ---------------------------------------------------------------------------
 # GET /{draft_id}/drawdown?start_row=&row_count=  (tiled)
@@ -449,6 +475,29 @@ class TestGetDrawdownTile:
         draft = await self._draft_with_wif(db_session, test_user)
         resp = await client.get(f"/api/drafts/{draft.id}/drawdown?start_row=0&row_count=2")
         assert resp.status_code == 401
+
+    async def test_413_writes_audit_log(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User, monkeypatch: pytest.MonkeyPatch
+    ):
+        draft = await self._draft_with_wif(db_session, test_user)
+
+        def _raise_413(*_a, **_kw):
+            raise HTTPException(status_code=413, detail="too wide")
+
+        monkeypatch.setattr(rendering, "render_drawdown_tile", _raise_413)
+
+        resp = await auth_client.get(f"/api/drafts/{draft.id}/drawdown?start_row=0&row_count=2")
+
+        assert resp.status_code == 413
+        entry = await db_session.scalar(
+            select(AuditLog).where(
+                AuditLog.actor_email == test_user.email,
+                AuditLog.event_type == "render.limit_exceeded",
+            )
+        )
+        assert entry is not None
+        assert entry.details["draft_id"] == str(draft.id)
+        assert entry.details["mode"] == "tile"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- When a drawdown request triggers a 413 (draft too large to render even at scale=1), write a `render.limit_exceeded` entry to the admin audit log
- Covers both paths: full render (`render_drawdown_only`) and tiled render (`render_drawdown_tile`)
- Audit entry includes: `draft_id`, `warp_threads`, `weft_threads`, `render_max_width`, `render_max_height`, `mode` (`"full"` or `"tile"`)
- Non-413 HTTP exceptions are still re-raised transparently with no audit write

## Changes

- `backend/app/routers/drafts.py` — add `write_audit_log` call in both `except HTTPException` blocks inside `get_drawdown`
- `backend/tests/routers/test_drafts.py` — two new tests (`TestGetDrawdown::test_413_writes_audit_log`, `TestGetDrawdownTile::test_413_writes_audit_log`) that monkeypatch the rendering functions to raise 413 and assert an audit entry is created

## Test plan

- [ ] CI pytest passes (tests require DB so local skip is expected)
- [ ] Trigger a real 413 in dev by setting `RENDER_MAX_WIDTH=1` temporarily — audit log entry should appear in admin panel

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)