### PR TITLE
feat: credential expiry tracking and alerting (#261)

### DIFF
--- a/backend/alembic/versions/0008_credential_expiry.py
+++ b/backend/alembic/versions/0008_credential_expiry.py
@@ -1,0 +1,43 @@
+"""add credential_expiry table
+
+Revision ID: b1c2d3e4f5a6
+Revises: a4b5c6d7e8f9
+Create Date: 2026-05-09
+
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "b1c2d3e4f5a6"
+down_revision = "a4b5c6d7e8f9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "credential_expiry",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("name", sa.String(200), nullable=False),
+        sa.Column("resource", sa.String(50), nullable=False),
+        sa.Column("expires_on", sa.Date(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("last_alerted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "updated_by_user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index("ix_credential_expiry_expires_on", "credential_expiry", ["expires_on"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_credential_expiry_expires_on", table_name="credential_expiry")
+    op.drop_table("credential_expiry")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,6 +1,7 @@
 from app.models.alembic_meta import AlembicMeta
 from app.models.audit_log import AuditLog
 from app.models.base import Base
+from app.models.credential_expiry import CredentialExpiry
 from app.models.draft import Draft
 from app.models.eula_version import EulaVersion
 from app.models.invite import Invite
@@ -24,6 +25,7 @@ __all__ = [
     "Base",
     "AlembicMeta",
     "AuditLog",
+    "CredentialExpiry",
     "User",
     "UserIdentity",
     "Invite",

--- a/backend/app/models/credential_expiry.py
+++ b/backend/app/models/credential_expiry.py
@@ -1,0 +1,28 @@
+import uuid
+from datetime import date, datetime
+
+from sqlalchemy import Date, DateTime, ForeignKey, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+RESOURCE_CHOICES = frozenset({"smtp", "s3", "clerk", "postgres", "app"})
+
+
+class CredentialExpiry(Base):
+    __tablename__ = "credential_expiry"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    resource: Mapped[str] = mapped_column(String(50), nullable=False)
+    expires_on: Mapped[date | None] = mapped_column(Date, nullable=True, index=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_alerted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    updated_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -5,7 +5,7 @@ import math
 import platform
 import time
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import Literal
 
 import httpx
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import Settings, get_settings
 from app.deps import get_db, require_admin, require_superuser
 from app.models.audit_log import AuditLog
+from app.models.credential_expiry import RESOURCE_CHOICES, CredentialExpiry
 from app.models.draft import Draft
 from app.models.eula_version import EulaVersion
 from app.models.invite import Invite
@@ -2266,3 +2267,124 @@ async def patch_scheduled_task(
     await db.commit()
     await db.refresh(row)
     return _task_to_response(row)
+
+
+# ---------------------------------------------------------------------------
+# Credential expiry
+# ---------------------------------------------------------------------------
+
+
+class CredentialExpiryResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    resource: str
+    expires_on: date | None
+    notes: str | None
+    last_alerted_at: datetime | None
+    updated_by_user_id: uuid.UUID | None
+    created_at: datetime
+    updated_at: datetime
+    days_remaining: int | None
+
+    model_config = {"from_attributes": False}
+
+
+class CreateCredentialBody(BaseModel):
+    name: str
+    resource: str
+    expires_on: date | None = None
+    notes: str | None = None
+
+
+class PatchCredentialBody(BaseModel):
+    name: str | None = None
+    resource: str | None = None
+    expires_on: date | None = None
+    notes: str | None = None
+
+
+def _credential_to_response(cred: CredentialExpiry) -> CredentialExpiryResponse:
+    days_remaining: int | None = None
+    if cred.expires_on is not None:
+        days_remaining = (cred.expires_on - datetime.now(timezone.utc).date()).days
+    return CredentialExpiryResponse(
+        id=cred.id,
+        name=cred.name,
+        resource=cred.resource,
+        expires_on=cred.expires_on,
+        notes=cred.notes,
+        last_alerted_at=cred.last_alerted_at,
+        updated_by_user_id=cred.updated_by_user_id,
+        created_at=cred.created_at,
+        updated_at=cred.updated_at,
+        days_remaining=days_remaining,
+    )
+
+
+@router.get("/credentials", response_model=list[CredentialExpiryResponse])
+async def list_credentials(
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_admin),
+) -> list[CredentialExpiryResponse]:
+    rows = await db.scalars(select(CredentialExpiry).order_by(CredentialExpiry.expires_on.asc().nulls_last()))
+    return [_credential_to_response(r) for r in rows.all()]
+
+
+@router.post("/credentials", response_model=CredentialExpiryResponse, status_code=201)
+async def create_credential(
+    body: CreateCredentialBody,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_superuser),
+) -> CredentialExpiryResponse:
+    if body.resource not in RESOURCE_CHOICES:
+        raise HTTPException(status_code=422, detail=f"Invalid resource. Must be one of: {sorted(RESOURCE_CHOICES)}")
+    cred = CredentialExpiry(
+        name=body.name.strip(),
+        resource=body.resource,
+        expires_on=body.expires_on,
+        notes=body.notes,
+        updated_by_user_id=current_user.id,
+    )
+    db.add(cred)
+    await db.commit()
+    await db.refresh(cred)
+    return _credential_to_response(cred)
+
+
+@router.patch("/credentials/{credential_id}", response_model=CredentialExpiryResponse)
+async def patch_credential(
+    credential_id: uuid.UUID,
+    body: PatchCredentialBody,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_superuser),
+) -> CredentialExpiryResponse:
+    cred = await db.scalar(select(CredentialExpiry).where(CredentialExpiry.id == credential_id))
+    if cred is None:
+        raise HTTPException(status_code=404, detail="Credential not found")
+    if body.resource is not None and body.resource not in RESOURCE_CHOICES:
+        raise HTTPException(status_code=422, detail=f"Invalid resource. Must be one of: {sorted(RESOURCE_CHOICES)}")
+    if body.name is not None:
+        cred.name = body.name.strip()
+    if body.resource is not None:
+        cred.resource = body.resource
+    if body.expires_on is not None:
+        cred.expires_on = body.expires_on
+    if body.notes is not None:
+        cred.notes = body.notes
+    cred.updated_by_user_id = current_user.id
+    await db.commit()
+    await db.refresh(cred)
+    return _credential_to_response(cred)
+
+
+@router.delete("/credentials/{credential_id}", status_code=204)
+async def delete_credential(
+    credential_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_superuser),
+) -> None:
+    cred = await db.scalar(select(CredentialExpiry).where(CredentialExpiry.id == credential_id))
+    if cred is None:
+        raise HTTPException(status_code=404, detail="Credential not found")
+    await db.delete(cred)
+    await db.commit()

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -294,6 +294,54 @@ async def send_test_email(to_email: str) -> None:
     await _send([to_email], f"{settings.app_name} — SMTP Test", txt, html)
 
 
+async def send_credential_expiring_superuser(
+    superuser_emails: list[str],
+    credential_name: str,
+    resource: str,
+    days_remaining: int,
+    expires_on: str,
+) -> None:
+    settings = get_settings()
+    if not settings.smtp_user or not superuser_emails:
+        return
+    days_plural = "" if days_remaining == 1 else "s"
+    admin_url = f"{settings.frontend_url}/admin/credentials"
+    txt, html = _render(
+        "credential_expiring_superuser",
+        credential_name=credential_name,
+        resource=resource,
+        days_remaining=days_remaining,
+        days_plural=days_plural,
+        expires_on=expires_on,
+        admin_url=admin_url,
+    )
+    subject = f"Action required: {credential_name} expires in {days_remaining} day{days_plural}"
+    await _send(superuser_emails, subject, txt, html)
+
+
+async def send_credential_expiring_admin(
+    admin_emails: list[str],
+    credential_name: str,
+    resource: str,
+    days_remaining: int,
+    expires_on: str,
+) -> None:
+    settings = get_settings()
+    if not settings.smtp_user or not admin_emails:
+        return
+    days_plural = "" if days_remaining == 1 else "s"
+    txt, html = _render(
+        "credential_expiring_admin",
+        credential_name=credential_name,
+        resource=resource,
+        days_remaining=days_remaining,
+        days_plural=days_plural,
+        expires_on=expires_on,
+    )
+    subject = f"Notice: {credential_name} expires in {days_remaining} day{days_plural}"
+    await _send(admin_emails, subject, txt, html)
+
+
 async def send_invite_email(
     to_email: str, invite_token: str, expires_days: int, admin_name: str = "A weftmark admin"
 ) -> None:

--- a/backend/app/tasks/maintenance.py
+++ b/backend/app/tasks/maintenance.py
@@ -403,16 +403,20 @@ def check_credential_expiry(self) -> dict:
                 display_days = max(days_remaining, 0)
 
                 try:
-                    asyncio.run(
-                        _send_credential_alerts(
-                            superuser_emails=superuser_emails,
-                            admin_emails=admin_emails,
-                            credential_name=cred.name,
-                            resource=cred.resource,
-                            days_remaining=display_days,
-                            expires_on=expires_on_str,
-                        )
-                    )
+                    import concurrent.futures
+
+                    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                        pool.submit(
+                            asyncio.run,
+                            _send_credential_alerts(
+                                superuser_emails=superuser_emails,
+                                admin_emails=admin_emails,
+                                credential_name=cred.name,
+                                resource=cred.resource,
+                                days_remaining=display_days,
+                                expires_on=expires_on_str,
+                            ),
+                        ).result()
                     cred.last_alerted_at = now
                     alerted += 1
                 except Exception:

--- a/backend/app/tasks/maintenance.py
+++ b/backend/app/tasks/maintenance.py
@@ -333,3 +333,119 @@ def prune_server_event_log(self, max_age_days: int = 28, max_entries: int = 1000
         max_entries,
     )
     return {"deleted_age": deleted_age, "deleted_overflow": deleted_overflow}
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=0,
+    name="app.tasks.maintenance.check_credential_expiry",
+)
+def check_credential_expiry(self) -> dict:
+    import asyncio
+
+    from sqlalchemy import create_engine, select
+    from sqlalchemy.orm import Session
+
+    from app.config import get_settings
+    from app.models.credential_expiry import CredentialExpiry
+    from app.models.user import User
+
+    settings = get_settings()
+    today = datetime.now(timezone.utc).date()
+    now = datetime.now(timezone.utc)
+    alerted = 0
+    skipped = 0
+
+    engine = create_engine(settings.database_url_sync)
+    try:
+        with Session(engine) as db:
+            credentials = db.scalars(select(CredentialExpiry).where(CredentialExpiry.expires_on.isnot(None))).all()
+
+            superuser_emails = [
+                r
+                for r in db.scalars(
+                    select(User.email).where(User.is_superuser.is_(True), User.is_active.is_(True))
+                ).all()
+                if r
+            ]
+            admin_emails = [
+                r
+                for r in db.scalars(
+                    select(User.email).where(
+                        User.is_admin.is_(True),
+                        User.is_superuser.is_(False),
+                        User.is_active.is_(True),
+                    )
+                ).all()
+                if r
+            ]
+
+            for cred in credentials:
+                days_remaining = (cred.expires_on - today).days
+
+                if days_remaining > 30:
+                    skipped += 1
+                    continue
+
+                # Determine required send interval
+                if days_remaining <= 7:
+                    interval_hours = 24
+                else:
+                    interval_hours = 24 * 7
+
+                if cred.last_alerted_at is not None:
+                    elapsed_hours = (now - cred.last_alerted_at).total_seconds() / 3600
+                    if elapsed_hours < interval_hours:
+                        skipped += 1
+                        continue
+
+                expires_on_str = cred.expires_on.strftime("%B %d, %Y")
+                display_days = max(days_remaining, 0)
+
+                try:
+                    asyncio.run(
+                        _send_credential_alerts(
+                            superuser_emails=superuser_emails,
+                            admin_emails=admin_emails,
+                            credential_name=cred.name,
+                            resource=cred.resource,
+                            days_remaining=display_days,
+                            expires_on=expires_on_str,
+                        )
+                    )
+                    cred.last_alerted_at = now
+                    alerted += 1
+                except Exception:
+                    log.exception("check_credential_expiry: failed to send alerts for credential id=%s", cred.id)
+            db.commit()
+    finally:
+        engine.dispose()
+
+    log.info("check_credential_expiry alerted=%d skipped=%d", alerted, skipped)
+    return {"alerted": alerted, "skipped": skipped}
+
+
+async def _send_credential_alerts(
+    superuser_emails: list[str],
+    admin_emails: list[str],
+    credential_name: str,
+    resource: str,
+    days_remaining: int,
+    expires_on: str,
+) -> None:
+    from app.services.email import send_credential_expiring_admin, send_credential_expiring_superuser
+
+    await send_credential_expiring_superuser(
+        superuser_emails=superuser_emails,
+        credential_name=credential_name,
+        resource=resource,
+        days_remaining=days_remaining,
+        expires_on=expires_on,
+    )
+    await send_credential_expiring_admin(
+        admin_emails=admin_emails,
+        credential_name=credential_name,
+        resource=resource,
+        days_remaining=days_remaining,
+        expires_on=expires_on,
+    )

--- a/backend/app/tasks/scheduler.py
+++ b/backend/app/tasks/scheduler.py
@@ -97,6 +97,16 @@ REGISTRY: dict[str, dict] = {
         "default_cron": "30 2 * * *",
         "default_config": {"max_age_days": 28, "max_entries": 1000},
     },
+    "credential_expiry_check": {
+        "display_name": "Credential Expiry Check",
+        "description": (
+            "Checks all tracked credentials for upcoming expiration and sends alert emails. "
+            "Superusers receive an action-required email; admins receive a notice-only email. "
+            "Weekly alerts start 30 days before expiration; daily alerts begin 7 days before."
+        ),
+        "default_cron": "0 8 * * *",
+        "default_config": {},
+    },
 }
 
 
@@ -192,6 +202,15 @@ def _dispatch_server_event_log_pruning(settings, task=None):
     return t
 
 
+def _dispatch_credential_expiry_check(settings, task=None):
+    from app.services.task_history import record_queued
+    from app.tasks.maintenance import check_credential_expiry
+
+    t = check_credential_expiry.delay()
+    record_queued(settings, t.id, "app.tasks.maintenance.check_credential_expiry", "scheduled:credential_expiry_check")
+    return t
+
+
 DISPATCH_FNS: dict[str, object] = {
     "cve_scan": _dispatch_cve_scan,
     "s3_audit": _dispatch_s3_audit,
@@ -202,6 +221,7 @@ DISPATCH_FNS: dict[str, object] = {
     "preview_retry": _dispatch_preview_retry,
     "daily_health_check": _dispatch_daily_health_check,
     "server_event_log_pruning": _dispatch_server_event_log_pruning,
+    "credential_expiry_check": _dispatch_credential_expiry_check,
 }
 
 

--- a/backend/tests/tasks/test_maintenance.py
+++ b/backend/tests/tasks/test_maintenance.py
@@ -7,7 +7,7 @@ DB-dependent tests seed data async then verify the sync task reads it correctly.
 
 import uuid
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -393,8 +393,7 @@ class TestCheckCredentialExpiry:
         _cred(db_session, expires_in_days=25, last_alerted_hours_ago=None)
         await db_session.commit()
 
-        with patch("app.tasks.maintenance._send_credential_alerts") as mock_send:
-            mock_send.return_value = None
+        with patch("app.tasks.maintenance._send_credential_alerts", new_callable=AsyncMock):
             result = check_credential_expiry.run.__func__(_make_task())
 
         assert result["alerted"] >= 1
@@ -406,8 +405,7 @@ class TestCheckCredentialExpiry:
         _cred(db_session, expires_in_days=5, last_alerted_hours_ago=None)
         await db_session.commit()
 
-        with patch("app.tasks.maintenance._send_credential_alerts") as mock_send:
-            mock_send.return_value = None
+        with patch("app.tasks.maintenance._send_credential_alerts", new_callable=AsyncMock):
             result = check_credential_expiry.run.__func__(_make_task())
 
         assert result["alerted"] >= 1
@@ -446,8 +444,7 @@ class TestCheckCredentialExpiry:
         _cred(db_session, expires_in_days=-5, last_alerted_hours_ago=None)
         await db_session.commit()
 
-        with patch("app.tasks.maintenance._send_credential_alerts") as mock_send:
-            mock_send.return_value = None
+        with patch("app.tasks.maintenance._send_credential_alerts", new_callable=AsyncMock):
             result = check_credential_expiry.run.__func__(_make_task())
 
         assert result["alerted"] >= 1
@@ -459,8 +456,7 @@ class TestCheckCredentialExpiry:
         cred = _cred(db_session, expires_in_days=5, last_alerted_hours_ago=None)
         await db_session.commit()
 
-        with patch("app.tasks.maintenance._send_credential_alerts") as mock_send:
-            mock_send.return_value = None
+        with patch("app.tasks.maintenance._send_credential_alerts", new_callable=AsyncMock):
             check_credential_expiry.run.__func__(_make_task())
 
         await db_session.refresh(cred)

--- a/backend/tests/tasks/test_maintenance.py
+++ b/backend/tests/tasks/test_maintenance.py
@@ -314,7 +314,7 @@ class TestRetryFailedPreviews:
     @pytest.mark.asyncio
     async def test_skips_soft_deleted_drafts(self, db_session, test_user):
         from app.models.draft import Draft
-        from app.tasks.maintenance import retry_failed_previews
+        from app.tasks.maintenance import retry_failed_previews  # noqa: F811
 
         deleted = Draft(
             id=uuid.uuid4(),
@@ -335,3 +335,146 @@ class TestRetryFailedPreviews:
 
         mock_preview.delay.assert_not_called()
         assert result["retried"] == 0
+
+
+# ---------------------------------------------------------------------------
+# check_credential_expiry
+# ---------------------------------------------------------------------------
+
+
+def _cred(db, *, expires_in_days: int | None, last_alerted_hours_ago: float | None = None):
+    from datetime import date, timedelta
+
+    from app.models.credential_expiry import CredentialExpiry
+
+    now = datetime.now(timezone.utc)
+    expires_on = (date.today() + timedelta(days=expires_in_days)) if expires_in_days is not None else None
+    last_alerted_at = (now - timedelta(hours=last_alerted_hours_ago)) if last_alerted_hours_ago is not None else None
+    c = CredentialExpiry(
+        id=uuid.uuid4(),
+        name="Test Cred",
+        resource="smtp",
+        expires_on=expires_on,
+        last_alerted_at=last_alerted_at,
+    )
+    db.add(c)
+    return c
+
+
+class TestCheckCredentialExpiry:
+    @pytest.mark.asyncio
+    async def test_no_credentials_returns_zero(self, db_session):
+        from app.tasks.maintenance import check_credential_expiry
+
+        with patch("app.tasks.maintenance._send_credential_alerts") as mock_send:
+            result = check_credential_expiry.run.__func__(_make_task())
+
+        assert result["alerted"] == 0
+        mock_send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_credential_beyond_30_days_skipped(self, db_session):
+        from app.tasks.maintenance import check_credential_expiry
+
+        _cred(db_session, expires_in_days=60)
+        await db_session.commit()
+
+        with patch("app.tasks.maintenance._send_credential_alerts") as mock_send:
+            result = check_credential_expiry.run.__func__(_make_task())
+
+        assert result["alerted"] == 0
+        assert result["skipped"] >= 1
+        mock_send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_credential_at_25_days_alerts_first_time(self, db_session):
+        from app.tasks.maintenance import check_credential_expiry
+
+        _cred(db_session, expires_in_days=25, last_alerted_hours_ago=None)
+        await db_session.commit()
+
+        with patch("app.tasks.maintenance._send_credential_alerts") as mock_send:
+            mock_send.return_value = None
+            result = check_credential_expiry.run.__func__(_make_task())
+
+        assert result["alerted"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_credential_at_5_days_alerts(self, db_session):
+        from app.tasks.maintenance import check_credential_expiry
+
+        _cred(db_session, expires_in_days=5, last_alerted_hours_ago=None)
+        await db_session.commit()
+
+        with patch("app.tasks.maintenance._send_credential_alerts") as mock_send:
+            mock_send.return_value = None
+            result = check_credential_expiry.run.__func__(_make_task())
+
+        assert result["alerted"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_weekly_dedup_skips_within_7_days(self, db_session):
+        from app.tasks.maintenance import check_credential_expiry
+
+        _cred(db_session, expires_in_days=20, last_alerted_hours_ago=72)
+        await db_session.commit()
+
+        with patch("app.tasks.maintenance._send_credential_alerts") as mock_send:
+            result = check_credential_expiry.run.__func__(_make_task())
+
+        assert result["alerted"] == 0
+        assert result["skipped"] >= 1
+        mock_send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_daily_dedup_skips_within_24h(self, db_session):
+        from app.tasks.maintenance import check_credential_expiry
+
+        _cred(db_session, expires_in_days=3, last_alerted_hours_ago=12)
+        await db_session.commit()
+
+        with patch("app.tasks.maintenance._send_credential_alerts") as mock_send:
+            result = check_credential_expiry.run.__func__(_make_task())
+
+        assert result["alerted"] == 0
+        mock_send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_overdue_credential_alerts(self, db_session):
+        from app.tasks.maintenance import check_credential_expiry
+
+        _cred(db_session, expires_in_days=-5, last_alerted_hours_ago=None)
+        await db_session.commit()
+
+        with patch("app.tasks.maintenance._send_credential_alerts") as mock_send:
+            mock_send.return_value = None
+            result = check_credential_expiry.run.__func__(_make_task())
+
+        assert result["alerted"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_last_alerted_at_updated_after_alert(self, db_session):
+        from app.tasks.maintenance import check_credential_expiry
+
+        cred = _cred(db_session, expires_in_days=5, last_alerted_hours_ago=None)
+        await db_session.commit()
+
+        with patch("app.tasks.maintenance._send_credential_alerts") as mock_send:
+            mock_send.return_value = None
+            check_credential_expiry.run.__func__(_make_task())
+
+        await db_session.refresh(cred)
+        assert cred.last_alerted_at is not None
+
+    @pytest.mark.asyncio
+    async def test_no_expiry_credential_skipped(self, db_session):
+        from app.tasks.maintenance import check_credential_expiry
+
+        _cred(db_session, expires_in_days=None)
+        await db_session.commit()
+
+        with patch("app.tasks.maintenance._send_credential_alerts") as mock_send:
+            result = check_credential_expiry.run.__func__(_make_task())
+
+        assert result["alerted"] == 0
+        mock_send.assert_not_called()

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -407,3 +407,34 @@ export const getServerEvents = (params: { page?: number; page_size?: number; eve
   const query = qs.toString();
   return api.get<ServerEventPage>(`/api/admin/server-events${query ? `?${query}` : ""}`);
 };
+
+export type CredentialResource = "smtp" | "s3" | "clerk" | "postgres" | "app";
+
+export interface CredentialExpiry {
+  id: string;
+  name: string;
+  resource: CredentialResource;
+  expires_on: string | null;
+  notes: string | null;
+  last_alerted_at: string | null;
+  updated_by_user_id: string | null;
+  created_at: string;
+  updated_at: string;
+  days_remaining: number | null;
+}
+
+export const listCredentials = () => api.get<CredentialExpiry[]>("/api/admin/credentials");
+
+export const createCredential = (body: {
+  name: string;
+  resource: CredentialResource;
+  expires_on?: string | null;
+  notes?: string | null;
+}) => api.post<CredentialExpiry>("/api/admin/credentials", body);
+
+export const patchCredential = (
+  id: string,
+  body: { name?: string; resource?: CredentialResource; expires_on?: string | null; notes?: string | null },
+) => api.patch<CredentialExpiry>(`/api/admin/credentials/${id}`, body);
+
+export const deleteCredential = (id: string) => api.delete<void>(`/api/admin/credentials/${id}`);

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -34,6 +34,7 @@ const ADMIN_SECTIONS = [
   { id: "services", label: "Services" },
   { id: "deps", label: "Dependencies" },
   { id: "audit", label: "Audit log" },
+  { id: "credentials", label: "Credentials" },
   { id: "superuser", label: "Superuser", superuserOnly: true },
 ];
 

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -39,6 +39,12 @@ import {
   listScheduledTasks,
   patchScheduledTask,
   getServerEvents,
+  listCredentials,
+  createCredential,
+  patchCredential,
+  deleteCredential,
+  type CredentialExpiry,
+  type CredentialResource,
   type ScheduledTask,
   type TaskHistoryItem,
   type AdminUser,
@@ -63,7 +69,7 @@ import { EulaContent } from "@/components/EulaContent";
 import { CopyEmail } from "@/components/admin/CopyEmail";
 import { formatBytes } from "@/lib/image-utils";
 
-type Tab = "users" | "invites" | "stats" | "health" | "services" | "deps" | "audit" | "superuser";
+type Tab = "users" | "invites" | "stats" | "health" | "services" | "deps" | "audit" | "credentials" | "superuser";
 
 function formatLastActive(iso: string | null): string {
   if (!iso) return "Never";
@@ -150,6 +156,7 @@ export function AdminPage() {
       {tab === "services" && <ServicesTab />}
       {tab === "deps" && <DepsTab />}
       {tab === "audit" && <AuditLogTab />}
+      {tab === "credentials" && <CredentialsTab />}
       {tab === "superuser" && <SuperuserTab />}
     </div>
   );
@@ -1606,6 +1613,222 @@ function EulaTab() {
           </Button>
         )}
       </form>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Credentials tab
+// ---------------------------------------------------------------------------
+
+const RESOURCE_LABELS: Record<CredentialResource, string> = {
+  smtp: "SMTP",
+  s3: "S3 / R2",
+  clerk: "Clerk",
+  postgres: "PostgreSQL",
+  app: "App Secret",
+};
+
+const RESOURCE_OPTIONS: CredentialResource[] = ["smtp", "s3", "clerk", "postgres", "app"];
+
+function credentialStatus(daysRemaining: number | null): { label: string; cls: string } {
+  if (daysRemaining === null) return { label: "No expiry", cls: "bg-muted text-muted-foreground" };
+  if (daysRemaining < 0) return { label: "Expired", cls: "bg-destructive/10 text-destructive" };
+  if (daysRemaining <= 7) return { label: "Critical", cls: "bg-destructive/10 text-destructive" };
+  if (daysRemaining <= 30) return { label: "Warning", cls: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300" };
+  return { label: "OK", cls: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300" };
+}
+
+function CredentialsTab() {
+  const { user: currentUser } = useAuth();
+  const queryClient = useQueryClient();
+  const isSuperuser = currentUser?.is_superuser ?? false;
+
+  const { data: credentials = [], isLoading } = useQuery({
+    queryKey: ["admin", "credentials"],
+    queryFn: listCredentials,
+  });
+
+  const [editing, setEditing] = useState<CredentialExpiry | null>(null);
+  const [adding, setAdding] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<CredentialExpiry | null>(null);
+  const [formName, setFormName] = useState("");
+  const [formResource, setFormResource] = useState<CredentialResource>("smtp");
+  const [formExpiry, setFormExpiry] = useState("");
+  const [formNotes, setFormNotes] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function openAdd() {
+    setFormName(""); setFormResource("smtp"); setFormExpiry(""); setFormNotes("");
+    setError(null); setAdding(true);
+  }
+
+  function openEdit(c: CredentialExpiry) {
+    setFormName(c.name);
+    setFormResource(c.resource);
+    setFormExpiry(c.expires_on ?? "");
+    setFormNotes(c.notes ?? "");
+    setError(null);
+    setEditing(c);
+  }
+
+  function closeForm() { setAdding(false); setEditing(null); setError(null); }
+
+  async function handleSave() {
+    if (!formName.trim()) { setError("Name is required"); return; }
+    setSaving(true); setError(null);
+    try {
+      const body = {
+        name: formName.trim(),
+        resource: formResource,
+        expires_on: formExpiry || null,
+        notes: formNotes.trim() || null,
+      };
+      if (adding) {
+        await createCredential(body);
+      } else if (editing) {
+        await patchCredential(editing.id, body);
+      }
+      queryClient.invalidateQueries({ queryKey: ["admin", "credentials"] });
+      closeForm();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      await deleteCredential(deleteTarget.id);
+      queryClient.invalidateQueries({ queryKey: ["admin", "credentials"] });
+      setDeleteTarget(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to delete");
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  const sorted = [...credentials].sort((a, b) => {
+    if (a.days_remaining === null && b.days_remaining === null) return 0;
+    if (a.days_remaining === null) return 1;
+    if (b.days_remaining === null) return -1;
+    return a.days_remaining - b.days_remaining;
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-base font-semibold">Managed credentials</h2>
+          <p className="text-xs text-muted-foreground mt-0.5">Track expiration dates for secrets and service credentials.</p>
+        </div>
+        {isSuperuser && (
+          <Button size="sm" onClick={openAdd}>Add credential</Button>
+        )}
+      </div>
+
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : sorted.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No credentials tracked yet.</p>
+      ) : (
+        <div className="rounded-md border border-border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-muted">
+              <tr>
+                <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">Name</th>
+                <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">Service</th>
+                <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">Expires</th>
+                <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">Status</th>
+                {isSuperuser && <th className="px-3 py-2" />}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {sorted.map((c) => {
+                const { label, cls } = credentialStatus(c.days_remaining);
+                return (
+                  <tr key={c.id} className="hover:bg-muted/50">
+                    <td className="px-3 py-2.5 font-medium">{c.name}</td>
+                    <td className="px-3 py-2.5 text-muted-foreground">{RESOURCE_LABELS[c.resource]}</td>
+                    <td className="px-3 py-2.5 text-muted-foreground">
+                      {c.expires_on
+                        ? <>
+                            {new Date(c.expires_on).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })}
+                            {c.days_remaining !== null && (
+                              <span className="ml-1.5 text-xs text-muted-foreground">
+                                ({c.days_remaining < 0 ? `${Math.abs(c.days_remaining)}d ago` : `${c.days_remaining}d`})
+                              </span>
+                            )}
+                          </>
+                        : <span className="text-muted-foreground">Never</span>}
+                    </td>
+                    <td className="px-3 py-2.5">
+                      <span className={`inline-block rounded px-1.5 py-0.5 text-xs font-medium ${cls}`}>{label}</span>
+                    </td>
+                    {isSuperuser && (
+                      <td className="px-3 py-2.5 text-right">
+                        <button className="text-xs text-muted-foreground hover:text-foreground mr-3" onClick={() => openEdit(c)}>Edit</button>
+                        <button className="text-xs text-destructive hover:text-destructive/80" onClick={() => setDeleteTarget(c)}>Delete</button>
+                      </td>
+                    )}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {(adding || editing) && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-md rounded-lg border bg-background shadow-lg p-6 space-y-4">
+            <h3 className="font-semibold">{adding ? "Add credential" : "Edit credential"}</h3>
+            <div>
+              <label className="mb-1 block text-sm font-medium">Name <span className="text-destructive">*</span></label>
+              <input className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring" value={formName} onChange={(e) => setFormName(e.target.value)} placeholder="Clerk Secret Key" />
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium">Service</label>
+              <select className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring" value={formResource} onChange={(e) => setFormResource(e.target.value as CredentialResource)}>
+                {RESOURCE_OPTIONS.map((r) => <option key={r} value={r}>{RESOURCE_LABELS[r]}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium">Expiration date <span className="text-muted-foreground font-normal">(optional)</span></label>
+              <input type="date" className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring" value={formExpiry} onChange={(e) => setFormExpiry(e.target.value)} />
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium">Notes <span className="text-muted-foreground font-normal">(optional)</span></label>
+              <textarea className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring" rows={2} value={formNotes} onChange={(e) => setFormNotes(e.target.value)} placeholder="Rotation instructions, link to vault, etc." />
+            </div>
+            {error && <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</p>}
+            <div className="flex justify-end gap-2 pt-1">
+              <Button type="button" variant="outline" onClick={closeForm} disabled={saving}>Cancel</Button>
+              <Button onClick={handleSave} disabled={saving}>{saving ? "Saving…" : "Save"}</Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {deleteTarget && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-sm rounded-lg border bg-background shadow-lg p-6 space-y-4">
+            <h3 className="font-semibold">Delete credential?</h3>
+            <p className="text-sm text-muted-foreground">This will permanently remove <strong>{deleteTarget.name}</strong> from the tracking list.</p>
+            {error && <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</p>}
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setDeleteTarget(null)} disabled={deleting}>Cancel</Button>
+              <Button variant="destructive" onClick={handleDelete} disabled={deleting}>{deleting ? "Deleting…" : "Delete"}</Button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- New `credential_expiry` table + Alembic migration (`0008`) to track expiration dates for SMTP, S3/R2, Clerk, PostgreSQL, and app secrets
- Admin panel **Credentials** tab (sidebar + route `/admin/credentials`): admins read-only, superusers can add/edit/delete
- Daily Celery task `check_credential_expiry` (08:00 UTC) scans entries and sends alerts: superusers get action-required email, admins get notice-only email
- Alert cadence: weekly starting 30 days before expiration, daily from 7 days out, daily when overdue; 24h/7d deduplication via `last_alerted_at`
- Two new email functions using the existing `credential_expiring_superuser` / `credential_expiring_admin` templates (templates were already in the repo)
- Scheduler registry entry `credential_expiry_check` — enabled/configurable via Scheduled Tasks admin tab
- 9 pytest tests covering all cadences, deduplication, overdue alerting, and `last_alerted_at` update

## Files changed

| Area | Files |
|------|-------|
| Model | `backend/app/models/credential_expiry.py` (new), `__init__.py` |
| Migration | `backend/alembic/versions/0008_credential_expiry.py` (new) |
| Email | `backend/app/services/email.py` — two new send functions |
| Task | `backend/app/tasks/maintenance.py` — `check_credential_expiry` + `_send_credential_alerts` |
| Scheduler | `backend/app/tasks/scheduler.py` — REGISTRY + DISPATCH_FNS entry |
| Router | `backend/app/routers/admin.py` — 4 CRUD endpoints + 3 Pydantic schemas |
| Tests | `backend/tests/tasks/test_maintenance.py` — `TestCheckCredentialExpiry` (9 tests) |
| Frontend API | `frontend/src/api/admin.ts` — types + 4 API functions |
| Frontend UI | `frontend/src/pages/AdminPage.tsx` — `CredentialsTab` component |
| Nav | `frontend/src/components/layout/Sidebar.tsx` — Credentials sidebar entry |

## Test plan

- [ ] CI pytest passes (DB tests skip locally, run in CI)
- [ ] `tsc --noEmit` clean ✓ (confirmed locally)
- [ ] Navigate to `/admin/credentials` — table shows (empty state or seeded entries)
- [ ] As superuser: add a credential expiring in 5 days → verify status badge shows "Critical"
- [ ] As superuser: edit/delete credential
- [ ] As non-superuser admin: confirm write buttons are hidden
- [ ] Trigger task manually via Maintenance tab → confirm `last_alerted_at` updates

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)