### PR TITLE
feat: project view settings drawer and version number preference (#299, #300)

### DIFF
--- a/backend/alembic/versions/0009_user_show_version_numbers.py
+++ b/backend/alembic/versions/0009_user_show_version_numbers.py
@@ -1,0 +1,27 @@
+"""add show_version_numbers to users
+
+Revision ID: c2d3e4f5a6b7
+Revises: b1c2d3e4f5a6
+Create Date: 2026-05-09
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "c2d3e4f5a6b7"
+down_revision = "b1c2d3e4f5a6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("show_version_numbers", sa.Boolean(), nullable=False, server_default="true"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "show_version_numbers")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -35,3 +35,4 @@ class User(Base, TimestampMixin, SoftDeleteMixin):
     deletion_state: Mapped[str | None] = mapped_column(String(20), nullable=True, default=None)
     deletion_initiated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, default=None)
     clerk_errored: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    show_version_numbers: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -54,6 +54,7 @@ class UserSettingsUpdate(BaseModel):
     idle_timeout_minutes: int | None = None
     measurement_system: str | None = None
     ai_training_consent: bool | None = None
+    show_version_numbers: bool | None = None
 
 
 class EulaAcceptRequest(BaseModel):
@@ -74,6 +75,7 @@ class UserSettingsResponse(BaseModel):
     idle_timeout_minutes: int
     measurement_system: str
     ai_training_consent: bool
+    show_version_numbers: bool
     eula_accepted_version: str | None
     current_eula_version: str
 
@@ -101,6 +103,7 @@ def _to_response(user: User, current_eula_version: str) -> UserSettingsResponse:
         idle_timeout_minutes=user.idle_timeout_minutes,
         measurement_system=user.measurement_system,
         ai_training_consent=user.ai_training_consent,
+        show_version_numbers=user.show_version_numbers,
         eula_accepted_version=user.eula_accepted_version,
         current_eula_version=current_eula_version,
     )
@@ -177,6 +180,9 @@ async def update_settings(
                 detail=f"measurement_system must be one of {sorted(_VALID_MEASUREMENT_SYSTEMS)}",
             )
         current_user.measurement_system = body.measurement_system
+
+    if body.show_version_numbers is not None:
+        current_user.show_version_numbers = body.show_version_numbers
 
     if body.ai_training_consent is not None:
         current_user.ai_training_consent = body.ai_training_consent

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -102,6 +102,21 @@ class TestUpdateSettings:
         assert resp.status_code == 200
         assert resp.json()["ai_training_consent"] is False
 
+    async def test_show_version_numbers_defaults_true(self, auth_client: AsyncClient):
+        resp = await auth_client.get("/api/users/me")
+        assert resp.status_code == 200
+        assert resp.json()["show_version_numbers"] is True
+
+    async def test_update_show_version_numbers_false(self, auth_client: AsyncClient):
+        resp = await auth_client.patch("/api/users/me", json={"show_version_numbers": False})
+        assert resp.status_code == 200
+        assert resp.json()["show_version_numbers"] is False
+
+    async def test_update_show_version_numbers_true(self, auth_client: AsyncClient):
+        resp = await auth_client.patch("/api/users/me", json={"show_version_numbers": True})
+        assert resp.status_code == 200
+        assert resp.json()["show_version_numbers"] is True
+
     async def test_empty_display_name_returns_422(self, auth_client: AsyncClient):
         resp = await auth_client.patch("/api/users/me", json={"display_name": "   "})
         assert resp.status_code == 422

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -18,6 +18,7 @@ export interface UserSettingsUpdate {
   idle_timeout_minutes?: number;
   measurement_system?: string;
   ai_training_consent?: boolean;
+  show_version_numbers?: boolean;
 }
 
 export async function updateSettings(body: UserSettingsUpdate): Promise<User> {

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -3,6 +3,7 @@ import { useLocation } from "react-router-dom";
 import { AppIcons } from "@/lib/icons";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { VersionBadge } from "@/components/layout/VersionFooter";
+import { useAuth } from "@/hooks/useAuth";
 import type { ReactNode } from "react";
 
 const DETAIL_PATTERN = /^\/projects\/[^/]+/;
@@ -12,6 +13,7 @@ interface Props {
 }
 
 export function AppLayout({ children }: Props) {
+  const { user } = useAuth();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   // Track which detail path the user manually expanded the sidebar on.
   // Collapse whenever on a detail page unless this matches the current path.
@@ -47,7 +49,7 @@ export function AppLayout({ children }: Props) {
         </main>
       </div>
 
-      <VersionBadge />
+      {(user?.show_version_numbers ?? true) && <VersionBadge />}
     </div>
   );
 }

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -14,6 +14,7 @@ export interface User {
   idle_timeout_minutes: number;
   measurement_system: string;
   ai_training_consent: boolean;
+  show_version_numbers: boolean;
   eula_accepted_version: string | null;
   current_eula_version: string;
   storage_used_bytes: number;

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1020,8 +1020,22 @@ export function ProjectDetailPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [stepping, setStepping] = useState(false);
-  const [colorMode, setColorMode] = useState<ColorMode>("strip");
-  const [showWeftColor, setShowWeftColor] = useState(true);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [colorMode, setColorMode] = useState<ColorMode>(
+    () => (localStorage.getItem("proj-view:colorMode") as ColorMode) ?? "strip"
+  );
+  const [showWeftColor, setShowWeftColor] = useState(
+    () => localStorage.getItem("proj-view:showWeftColor") !== "false"
+  );
+  const [showDrawdown, setShowDrawdown] = useState(
+    () => localStorage.getItem("proj-view:showDrawdown") !== "false"
+  );
+  const [showPickDisplay, setShowPickDisplay] = useState(
+    () => localStorage.getItem("proj-view:showPickDisplay") !== "false"
+  );
+  const [showProgress, setShowProgress] = useState(
+    () => localStorage.getItem("proj-view:showProgress") !== "false"
+  );
   const [showDesignPreview, setShowDesignPreview] = useState(false);
   const [editingName, setEditingName] = useState(false);
   const [nameInput, setNameInput] = useState("");
@@ -1339,6 +1353,14 @@ export function ProjectDetailPage() {
           >
             View design
           </button>
+          <button
+            onClick={() => setSettingsOpen(true)}
+            className="rounded-md border border-border bg-background px-2.5 py-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            title="View settings"
+            aria-label="Open view settings"
+          >
+            <AppIcons.settings className="h-4 w-4" />
+          </button>
           <span className={`rounded px-2 py-0.5 text-xs font-medium ${badgeClasses}`}>
             {badgeLabel}
           </span>
@@ -1405,49 +1427,15 @@ export function ProjectDetailPage() {
           </div>
         )}
 
-        {/* Progress bar + color controls — same row to save vertical space */}
-        {(!isPlanning && !isCompleted) || (picksData?.has_weft_colors && !isFinished && !isCompleted) ? (
-          <div className="mx-auto max-w-2xl px-8 pt-6 flex items-center gap-4">
-            {!isPlanning && !isCompleted && (
-              <div className="flex-1">
-                <ProgressBar current={project.current_pick} total={project.total_picks} />
-              </div>
-            )}
-            {picksData?.has_weft_colors && !isFinished && !isCompleted && (
-              <div className="shrink-0 flex items-center gap-3">
-                <label className="flex items-center gap-2 cursor-pointer select-none">
-                  <span className="text-sm text-muted-foreground">Weft</span>
-                  <button
-                    role="switch"
-                    aria-checked={showWeftColor}
-                    onClick={() => setShowWeftColor((v) => !v)}
-                    className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 ${showWeftColor ? "bg-primary" : "bg-muted"}`}
-                  >
-                    <span className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform ${showWeftColor ? "translate-x-4" : "translate-x-1"}`} />
-                  </button>
-                </label>
-                <div className="inline-flex rounded-md border border-input overflow-hidden text-sm">
-                  {(["theme", "strip", "filled"] as ColorMode[]).map((mode) => (
-                    <button
-                      key={mode}
-                      onClick={() => setColorMode(mode)}
-                      className={`px-2.5 py-1 capitalize transition-colors ${
-                        colorMode === mode
-                          ? "bg-primary text-primary-foreground"
-                          : "bg-background text-muted-foreground hover:bg-muted"
-                      }`}
-                    >
-                      {mode}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            )}
+        {/* Progress bar */}
+        {showProgress && !isPlanning && !isCompleted && (
+          <div className="mx-auto max-w-2xl px-8 pt-6">
+            <ProgressBar current={project.current_pick} total={project.total_picks} />
           </div>
-        ) : null}
+        )}
 
         {/* Pick instruction — stays compact */}
-        {!isCompleted && <div className="mx-auto max-w-2xl px-8 pt-4">
+        {!isCompleted && showPickDisplay && <div className="mx-auto max-w-2xl px-8 pt-4">
           {isFinished ? (
             <div className="mx-auto max-w-lg rounded-lg border border-dashed p-10 text-center">
               <p className="text-lg font-medium">All {project.total_picks} picks complete!</p>
@@ -1484,7 +1472,7 @@ export function ProjectDetailPage() {
         </div>}
 
         {/* Pattern view — wider on large screens to show more warp threads */}
-        {picksData && !isFinished && !isCompleted && !isAbandoned && (
+        {showDrawdown && picksData && !isFinished && !isCompleted && !isAbandoned && (
           <div className="mx-auto w-full max-w-2xl lg:max-w-5xl xl:max-w-7xl px-8 pb-4 pt-4">
             <WeavingPatternView
               draftId={project.draft_id}
@@ -1794,6 +1782,75 @@ export function ProjectDetailPage() {
           }}
           onClose={() => setShowAssignLoom(false)}
         />
+      )}
+
+      {/* View settings drawer */}
+      {settingsOpen && (
+        <>
+          <div
+            className="fixed inset-0 z-40 bg-black/40"
+            onClick={() => setSettingsOpen(false)}
+          />
+          <div className="fixed inset-y-0 right-0 z-50 flex w-72 flex-col border-l border-border bg-card shadow-xl">
+            <div className="flex items-center justify-between border-b border-border px-4 py-3">
+              <span className="text-sm font-semibold">View settings</span>
+              <button
+                onClick={() => setSettingsOpen(false)}
+                className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                aria-label="Close settings"
+              >
+                <AppIcons.close className="h-4 w-4" />
+              </button>
+            </div>
+
+            <div className="flex-1 overflow-y-auto px-4 py-4 space-y-6">
+              {/* Show/hide toggles */}
+              <div className="space-y-3">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Show / hide</p>
+                {([
+                  { label: "Progress bar", value: showProgress, key: "proj-view:showProgress", setter: setShowProgress },
+                  { label: "Pick instruction", value: showPickDisplay, key: "proj-view:showPickDisplay", setter: setShowPickDisplay },
+                  { label: "Drawdown pattern", value: showDrawdown, key: "proj-view:showDrawdown", setter: setShowDrawdown },
+                  { label: "Weft color", value: showWeftColor, key: "proj-view:showWeftColor", setter: setShowWeftColor },
+                ] as { label: string; value: boolean; key: string; setter: (v: boolean) => void }[]).map(({ label, value, key, setter }) => (
+                  <div key={label} className="flex items-center justify-between">
+                    <span className="text-sm">{label}</span>
+                    <button
+                      role="switch"
+                      aria-checked={value}
+                      onClick={() => { setter(!value); localStorage.setItem(key, String(!value)); }}
+                      className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-ring ${value ? "bg-primary" : "bg-input"}`}
+                    >
+                      <span className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform ${value ? "translate-x-4" : "translate-x-1"}`} />
+                    </button>
+                  </div>
+                ))}
+              </div>
+
+              {/* Color mode selector */}
+              {picksData?.has_weft_colors && (
+                <div className="space-y-2">
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Color mode</p>
+                  <div className="inline-flex rounded-md border border-input overflow-hidden text-sm w-full">
+                    {(["theme", "strip", "filled"] as ColorMode[]).map((mode) => (
+                      <button
+                        key={mode}
+                        onClick={() => { setColorMode(mode); localStorage.setItem("proj-view:colorMode", mode); }}
+                        className={`flex-1 px-2.5 py-1.5 capitalize transition-colors ${
+                          colorMode === mode
+                            ? "bg-primary text-primary-foreground"
+                            : "bg-background text-muted-foreground hover:bg-muted"
+                        }`}
+                      >
+                        {mode}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </>
       )}
     </div>
   );

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -33,6 +33,7 @@ export function SettingsPage() {
   const [displayName, setDisplayName] = useState(user?.display_name ?? "");
   const [theme, setTheme] = useState(user?.theme ?? "light");
   const [activityTheme, setActivityTheme] = useState(user?.activity_theme ?? "default");
+  const [showVersionNumbers, setShowVersionNumbers] = useState(user?.show_version_numbers ?? true);
   const [idleTimeout, setIdleTimeout] = useState(user?.idle_timeout_minutes ?? 30);
   const [measurementSystem, setMeasurementSystem] = useState(user?.measurement_system ?? "metric");
   const [dataConsent, setDataConsent] = useState(user?.ai_training_consent ?? false);
@@ -160,6 +161,33 @@ export function SettingsPage() {
                   </select>
                   <p className="text-xs text-muted-foreground mt-1">
                     Controls the visual density of the pick-by-pick tracker.
+                  </p>
+                </Field>
+
+                <Field label="Show version numbers">
+                  <div className="flex items-center gap-3">
+                    <button
+                      role="switch"
+                      aria-checked={showVersionNumbers}
+                      onClick={() => {
+                        const next = !showVersionNumbers;
+                        setShowVersionNumbers(next);
+                        save({ show_version_numbers: next });
+                      }}
+                      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+                        showVersionNumbers ? "bg-primary" : "bg-input"
+                      }`}
+                    >
+                      <span
+                        className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                          showVersionNumbers ? "translate-x-6" : "translate-x-1"
+                        }`}
+                      />
+                    </button>
+                    <span className="text-sm">{showVersionNumbers ? "Visible" : "Hidden"}</span>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Show or hide the UI, API, and worker version badge in the bottom-right corner.
                   </p>
                 </Field>
               </Section>


### PR DESCRIPTION
## Summary

- **#299** — Project detail page settings drawer: gear icon button opens a slide-out panel with show/hide toggles for progress bar, pick instruction, drawdown pattern, and weft color. Color mode selector moved into the drawer. All state persisted to localStorage.
- **#300** — User preference to show/hide version numbers: new `show_version_numbers` boolean on the User model (default `true`), exposed in Settings → Appearance. Alembic migration 0009 included.

## Test plan

- [ ] Open a project detail page — gear icon appears in header toolbar next to "View design"
- [ ] Clicking gear opens a drawer from the right with a dark backdrop
- [ ] Each show/hide toggle collapses the corresponding section immediately
- [ ] State survives page reload (localStorage)
- [ ] Color mode selector in drawer changes pick/pattern colors
- [ ] Settings → Appearance → "Show version numbers" toggle hides/shows the version badge
- [ ] `pytest tests/routers/test_users.py::TestUpdateSettings` — 3 new show_version_numbers tests pass
- [ ] tsc clean (no type errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)