### PR TITLE
feat: weekly admin digest email (#411)

### DIFF
--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -349,3 +349,95 @@ async def send_invite_email(
     invite_url = f"{settings.frontend_url}/register?token={invite_token}"
     txt, html = _render("invite", invite_url=invite_url, expires_days=expires_days, admin_name=admin_name)
     await _send([to_email], f"{admin_name} has invited you to join {settings.app_name}", txt, html)
+
+
+def _digest_cve_txt(finding_count: int | None, scanned_at: str | None) -> str:
+    if finding_count is None:
+        return "No scan data available"
+    s = "" if finding_count == 1 else "s"
+    line = f"{finding_count} finding{s}"
+    if scanned_at:
+        line += f" (scanned {scanned_at[:10]})"
+    return line
+
+
+def _digest_cve_html(finding_count: int | None, scanned_at: str | None) -> str:
+    if finding_count is None:
+        return '<span style="color:#6b7280;">No scan data available</span>'
+    color = "#dc2626" if finding_count > 0 else "#16a34a"
+    s = "" if finding_count == 1 else "s"
+    html = f'<strong style="color:{color};">{finding_count}</strong>'
+    if scanned_at:
+        html += f' <span style="color:#6b7280;">finding{s} &mdash; scanned {scanned_at[:10]}</span>'
+    return html
+
+
+def _digest_s3_txt(orphaned_count: int | None, scanned_at: str | None) -> str:
+    if orphaned_count is None:
+        return "No scan data available"
+    s = "" if orphaned_count == 1 else "s"
+    line = f"{orphaned_count} orphaned file{s}"
+    if scanned_at:
+        line += f" (scanned {scanned_at[:10]})"
+    return line
+
+
+def _digest_s3_html(orphaned_count: int | None, scanned_at: str | None) -> str:
+    if orphaned_count is None:
+        return '<span style="color:#6b7280;">No scan data available</span>'
+    color = "#dc2626" if orphaned_count > 0 else "#16a34a"
+    s = "" if orphaned_count == 1 else "s"
+    html = f'<strong style="color:{color};">{orphaned_count}</strong>'
+    if scanned_at:
+        html += f' <span style="color:#6b7280;">orphaned file{s} &mdash; scanned {scanned_at[:10]}</span>'
+    return html
+
+
+async def send_admin_digest_email(
+    admin_emails: list[str],
+    week_start: str,
+    week_end: str,
+    new_users: int,
+    pending_signups: int,
+    new_drafts: int,
+    new_projects: int,
+    new_looms: int,
+    storage_str: str,
+    storage_delta_str: str | None,
+    cve_finding_count: int | None,
+    cve_scanned_at: str | None,
+    s3_orphaned_count: int | None,
+    s3_scanned_at: str | None,
+) -> None:
+    settings = get_settings()
+    if not settings.smtp_user or not admin_emails:
+        return
+    admin_url = f"{settings.frontend_url}/admin"
+
+    delta_txt = storage_delta_str if storage_delta_str is not None else "—"
+    delta_html = (
+        storage_delta_str
+        if storage_delta_str is not None
+        else '<em style="color:#6b7280;">First run — no prior baseline</em>'
+    )
+
+    txt, html = _render(
+        "admin_digest",
+        week_start=week_start,
+        week_end=week_end,
+        new_users=new_users,
+        pending_signups=pending_signups,
+        new_drafts=new_drafts,
+        new_projects=new_projects,
+        new_looms=new_looms,
+        storage_str=storage_str,
+        delta_txt=delta_txt,
+        delta_html=delta_html,
+        cve_txt=_digest_cve_txt(cve_finding_count, cve_scanned_at),
+        cve_html=_digest_cve_html(cve_finding_count, cve_scanned_at),
+        s3_txt=_digest_s3_txt(s3_orphaned_count, s3_scanned_at),
+        s3_html=_digest_s3_html(s3_orphaned_count, s3_scanned_at),
+        admin_url=admin_url,
+    )
+    subject = f"{settings.app_name} — Weekly Admin Digest ({week_start} – {week_end})"
+    await _send(admin_emails, subject, txt, html)

--- a/backend/app/tasks/maintenance.py
+++ b/backend/app/tasks/maintenance.py
@@ -6,6 +6,7 @@ Covers:
 - prune_audit_log            — delete old audit log entries (security events exempt)
 - worker_heartbeat           — no-op liveness signal
 - retry_failed_previews      — re-dispatch preview generation for drafts missing drawdown previews
+- send_admin_digest          — weekly digest email to all active admins
 """
 
 import logging
@@ -452,4 +453,212 @@ async def _send_credential_alerts(
         resource=resource,
         days_remaining=days_remaining,
         expires_on=expires_on,
+    )
+
+
+DIGEST_STATE_KEY = "weftmark:admin_digest:last_sent"
+
+
+def _fmt_bytes(b: int) -> str:
+    if b >= 1_073_741_824:
+        return f"{b / 1_073_741_824:.1f} GB"
+    if b >= 1_048_576:
+        return f"{b / 1_048_576:.1f} MB"
+    if b >= 1024:
+        return f"{b / 1024:.1f} KB"
+    return f"{b} B"
+
+
+def _fmt_delta(b: int) -> str:
+    sign = "+" if b >= 0 else "-"
+    return f"{sign}{_fmt_bytes(abs(b))}"
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=0,
+    name="app.tasks.maintenance.send_admin_digest",
+)
+def send_admin_digest(self) -> dict:
+    import asyncio
+    import concurrent.futures
+    import json
+
+    from sqlalchemy import create_engine, func, select
+    from sqlalchemy.orm import Session
+
+    from app.config import get_settings
+    from app.models.draft import Draft
+    from app.models.loom import Loom, LoomVersionPhoto
+    from app.models.pending_signup import PendingSignup
+    from app.models.project import Project, ProjectPhoto
+    from app.models.user import User
+
+    settings = get_settings()
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=7)
+
+    engine = create_engine(settings.database_url_sync)
+    try:
+        with Session(engine) as db:
+            admin_emails = [
+                r
+                for r in db.scalars(
+                    select(User.email).where(
+                        User.is_admin.is_(True),
+                        User.is_active.is_(True),
+                        User.deleted_at.is_(None),
+                    )
+                ).all()
+                if r
+            ]
+
+            if not admin_emails:
+                return {"sent": 0}
+
+            new_users = (
+                db.scalar(
+                    select(func.count()).select_from(User).where(User.deleted_at.is_(None), User.created_at >= cutoff)
+                )
+                or 0
+            )
+
+            pending_signups = db.scalar(select(func.count()).select_from(PendingSignup)) or 0
+
+            new_drafts = (
+                db.scalar(
+                    select(func.count())
+                    .select_from(Draft)
+                    .where(Draft.deleted_at.is_(None), Draft.created_at >= cutoff)
+                )
+                or 0
+            )
+
+            new_projects = (
+                db.scalar(
+                    select(func.count())
+                    .select_from(Project)
+                    .where(Project.deleted_at.is_(None), Project.created_at >= cutoff)
+                )
+                or 0
+            )
+
+            new_looms = (
+                db.scalar(
+                    select(func.count()).select_from(Loom).where(Loom.deleted_at.is_(None), Loom.created_at >= cutoff)
+                )
+                or 0
+            )
+
+            project_storage = db.scalar(select(func.coalesce(func.sum(ProjectPhoto.file_size_bytes), 0))) or 0
+            loom_storage = db.scalar(select(func.coalesce(func.sum(LoomVersionPhoto.file_size_bytes), 0))) or 0
+            total_storage_bytes = int(project_storage) + int(loom_storage)
+    finally:
+        engine.dispose()
+
+    cve_finding_count: int | None = None
+    cve_scanned_at: str | None = None
+    s3_orphaned_count: int | None = None
+    s3_scanned_at: str | None = None
+    storage_delta_bytes: int | None = None
+
+    try:
+        import redis as _redis
+
+        from app.tasks.cve_scan import CVE_SUMMARY_KEY
+        from app.tasks.s3_audit import S3_AUDIT_SUMMARY_KEY
+
+        client = _redis.from_url(settings.redis_url, socket_connect_timeout=2)
+
+        raw_cve = client.get(CVE_SUMMARY_KEY)
+        if raw_cve:
+            data = json.loads(raw_cve)
+            cve_finding_count = data.get("finding_count")
+            cve_scanned_at = data.get("scanned_at")
+
+        raw_s3 = client.get(S3_AUDIT_SUMMARY_KEY)
+        if raw_s3:
+            data = json.loads(raw_s3)
+            if not data.get("not_applicable"):
+                s3_orphaned_count = data.get("orphaned_count")
+                s3_scanned_at = data.get("scanned_at")
+
+        raw_last = client.get(DIGEST_STATE_KEY)
+        if raw_last:
+            prev = json.loads(raw_last)
+            prev_bytes = prev.get("storage_bytes")
+            if prev_bytes is not None:
+                storage_delta_bytes = total_storage_bytes - int(prev_bytes)
+
+        client.set(
+            DIGEST_STATE_KEY,
+            json.dumps({"sent_at": now.isoformat(), "storage_bytes": total_storage_bytes}),
+        )
+        client.close()
+    except Exception:
+        log.warning("send_admin_digest: Redis state read/write failed", exc_info=True)
+
+    week_start = (now - timedelta(days=7)).strftime("%b %d, %Y")
+    week_end = now.strftime("%b %d, %Y")
+    storage_str = _fmt_bytes(total_storage_bytes)
+    storage_delta_str = _fmt_delta(storage_delta_bytes) if storage_delta_bytes is not None else None
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        pool.submit(
+            asyncio.run,
+            _send_admin_digest_email(
+                admin_emails=admin_emails,
+                week_start=week_start,
+                week_end=week_end,
+                new_users=new_users,
+                pending_signups=pending_signups,
+                new_drafts=new_drafts,
+                new_projects=new_projects,
+                new_looms=new_looms,
+                storage_str=storage_str,
+                storage_delta_str=storage_delta_str,
+                cve_finding_count=cve_finding_count,
+                cve_scanned_at=cve_scanned_at,
+                s3_orphaned_count=s3_orphaned_count,
+                s3_scanned_at=s3_scanned_at,
+            ),
+        ).result()
+
+    log.info("send_admin_digest sent=%d", len(admin_emails))
+    return {"sent": len(admin_emails)}
+
+
+async def _send_admin_digest_email(
+    admin_emails: list[str],
+    week_start: str,
+    week_end: str,
+    new_users: int,
+    pending_signups: int,
+    new_drafts: int,
+    new_projects: int,
+    new_looms: int,
+    storage_str: str,
+    storage_delta_str: str | None,
+    cve_finding_count: int | None,
+    cve_scanned_at: str | None,
+    s3_orphaned_count: int | None,
+    s3_scanned_at: str | None,
+) -> None:
+    from app.services.email import send_admin_digest_email as _send
+
+    await _send(
+        admin_emails=admin_emails,
+        week_start=week_start,
+        week_end=week_end,
+        new_users=new_users,
+        pending_signups=pending_signups,
+        new_drafts=new_drafts,
+        new_projects=new_projects,
+        new_looms=new_looms,
+        storage_str=storage_str,
+        storage_delta_str=storage_delta_str,
+        cve_finding_count=cve_finding_count,
+        cve_scanned_at=cve_scanned_at,
+        s3_orphaned_count=s3_orphaned_count,
+        s3_scanned_at=s3_scanned_at,
     )

--- a/backend/app/tasks/scheduler.py
+++ b/backend/app/tasks/scheduler.py
@@ -107,6 +107,16 @@ REGISTRY: dict[str, dict] = {
         "default_cron": "0 8 * * *",
         "default_config": {},
     },
+    "admin_digest": {
+        "display_name": "Weekly Admin Digest",
+        "description": (
+            "Sends a weekly summary email to all active admin users covering new signups, "
+            "pending approvals, platform activity, storage usage, and security status. "
+            "Disabled by default — enable to start receiving weekly digests."
+        ),
+        "default_cron": "0 8 * * 1",
+        "default_config": {},
+    },
 }
 
 
@@ -211,6 +221,15 @@ def _dispatch_credential_expiry_check(settings, task=None):
     return t
 
 
+def _dispatch_admin_digest(settings, task=None):
+    from app.services.task_history import record_queued
+    from app.tasks.maintenance import send_admin_digest
+
+    t = send_admin_digest.delay()
+    record_queued(settings, t.id, "app.tasks.maintenance.send_admin_digest", "scheduled:admin_digest")
+    return t
+
+
 DISPATCH_FNS: dict[str, object] = {
     "cve_scan": _dispatch_cve_scan,
     "s3_audit": _dispatch_s3_audit,
@@ -222,6 +241,7 @@ DISPATCH_FNS: dict[str, object] = {
     "daily_health_check": _dispatch_daily_health_check,
     "server_event_log_pruning": _dispatch_server_event_log_pruning,
     "credential_expiry_check": _dispatch_credential_expiry_check,
+    "admin_digest": _dispatch_admin_digest,
 }
 
 

--- a/backend/app/templates/email/admin_digest.html
+++ b/backend/app/templates/email/admin_digest.html
@@ -1,0 +1,64 @@
+<div style="background:#eff6ff;border-left:4px solid #1d4ed8;padding:12px 16px;margin:0 0 20px;border-radius:0 4px 4px 0;">
+  <p style="margin:0;color:#1e40af;font-weight:bold;font-size:15px;">Weekly Admin Digest</p>
+  <p style="margin:4px 0 0;color:#1e40af;font-size:13px;">{week_start} &mdash; {week_end}</p>
+</div>
+
+<p style="margin:0 0 8px;font-size:14px;font-weight:bold;color:#111827;">Users</p>
+<table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;margin:0 0 20px;background:#f9fafb;border-radius:6px;overflow:hidden;">
+  <tr>
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;width:220px;">Approved this week</td>
+    <td style="padding:10px 16px;font-size:14px;font-weight:bold;">{new_users}</td>
+  </tr>
+  <tr style="background:#f3f4f6;">
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;">Pending approval</td>
+    <td style="padding:10px 16px;font-size:14px;font-weight:bold;">{pending_signups}</td>
+  </tr>
+</table>
+
+<p style="margin:0 0 8px;font-size:14px;font-weight:bold;color:#111827;">Platform Activity (last 7 days)</p>
+<table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;margin:0 0 20px;background:#f9fafb;border-radius:6px;overflow:hidden;">
+  <tr>
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;width:220px;">Drafts created</td>
+    <td style="padding:10px 16px;font-size:14px;font-weight:bold;">{new_drafts}</td>
+  </tr>
+  <tr style="background:#f3f4f6;">
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;">Projects started</td>
+    <td style="padding:10px 16px;font-size:14px;font-weight:bold;">{new_projects}</td>
+  </tr>
+  <tr>
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;">Looms added</td>
+    <td style="padding:10px 16px;font-size:14px;font-weight:bold;">{new_looms}</td>
+  </tr>
+</table>
+
+<p style="margin:0 0 8px;font-size:14px;font-weight:bold;color:#111827;">Storage</p>
+<table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;margin:0 0 20px;background:#f9fafb;border-radius:6px;overflow:hidden;">
+  <tr>
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;width:220px;">Total used</td>
+    <td style="padding:10px 16px;font-size:14px;font-weight:bold;">{storage_str}</td>
+  </tr>
+  <tr style="background:#f3f4f6;">
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;">Change since last digest</td>
+    <td style="padding:10px 16px;font-size:14px;">{delta_html}</td>
+  </tr>
+</table>
+
+<p style="margin:0 0 8px;font-size:14px;font-weight:bold;color:#111827;">Security</p>
+<table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;margin:0 0 20px;background:#f9fafb;border-radius:6px;overflow:hidden;">
+  <tr>
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;width:220px;">CVE findings</td>
+    <td style="padding:10px 16px;font-size:14px;">{cve_html}</td>
+  </tr>
+  <tr style="background:#f3f4f6;">
+    <td style="padding:10px 16px;color:#6b7280;font-size:14px;white-space:nowrap;">S3 orphaned files</td>
+    <td style="padding:10px 16px;font-size:14px;">{s3_html}</td>
+  </tr>
+</table>
+
+<table cellpadding="0" cellspacing="0" role="presentation" style="margin-top:20px;">
+  <tr>
+    <td style="background:#1d3557;border-radius:6px;">
+      <a href="{admin_url}" style="display:inline-block;padding:12px 28px;color:#ffffff;font-weight:bold;text-decoration:none;font-size:15px;font-family:Arial,Helvetica,sans-serif;">View Admin Dashboard</a>
+    </td>
+  </tr>
+</table>

--- a/backend/app/templates/email/admin_digest.txt
+++ b/backend/app/templates/email/admin_digest.txt
@@ -1,0 +1,22 @@
+WEEKLY ADMIN DIGEST
+{week_start} – {week_end}
+========================================
+
+USERS
+  Approved this week:    {new_users}
+  Pending approval:      {pending_signups}
+
+PLATFORM ACTIVITY (LAST 7 DAYS)
+  Drafts created:        {new_drafts}
+  Projects started:      {new_projects}
+  Looms added:           {new_looms}
+
+STORAGE
+  Total used:            {storage_str}
+  Change since last:     {delta_txt}
+
+SECURITY
+  CVE findings:          {cve_txt}
+  S3 orphaned files:     {s3_txt}
+
+View the admin dashboard: {admin_url}

--- a/backend/tests/tasks/test_maintenance.py
+++ b/backend/tests/tasks/test_maintenance.py
@@ -474,3 +474,102 @@ class TestCheckCredentialExpiry:
 
         assert result["alerted"] == 0
         mock_send.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# send_admin_digest
+# ---------------------------------------------------------------------------
+
+
+def _make_admin(db, *, is_admin: bool = True, is_active: bool = True):
+    from app.models.user import User
+
+    u = User(
+        id=uuid.uuid4(),
+        email=f"admin-{uuid.uuid4().hex[:8]}@example.test",
+        display_name="Admin User",
+        is_admin=is_admin,
+        is_active=is_active,
+    )
+    db.add(u)
+    return u
+
+
+class TestSendAdminDigest:
+    @pytest.mark.asyncio
+    async def test_no_admins_returns_zero(self, db_session):
+        from app.tasks.maintenance import send_admin_digest
+
+        with patch("app.tasks.maintenance._send_admin_digest_email", new_callable=AsyncMock) as mock_send:
+            with patch("redis.from_url") as mock_redis:
+                mock_redis.return_value.get.return_value = None
+                result = send_admin_digest.run.__func__(_make_task())
+
+        assert result["sent"] == 0
+        mock_send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sends_email_to_active_admins(self, db_session):
+        from app.tasks.maintenance import send_admin_digest
+
+        _make_admin(db_session)
+        await db_session.commit()
+
+        with patch("app.tasks.maintenance._send_admin_digest_email", new_callable=AsyncMock) as mock_send:
+            with patch("redis.from_url") as mock_redis:
+                mock_redis.return_value.get.return_value = None
+                result = send_admin_digest.run.__func__(_make_task())
+
+        assert result["sent"] == 1
+        mock_send.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_inactive_admin_excluded(self, db_session):
+        from app.tasks.maintenance import send_admin_digest
+
+        _make_admin(db_session, is_active=False)
+        await db_session.commit()
+
+        with patch("app.tasks.maintenance._send_admin_digest_email", new_callable=AsyncMock) as mock_send:
+            with patch("redis.from_url") as mock_redis:
+                mock_redis.return_value.get.return_value = None
+                result = send_admin_digest.run.__func__(_make_task())
+
+        assert result["sent"] == 0
+        mock_send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_redis_failure_still_sends_email(self, db_session):
+        from app.tasks.maintenance import send_admin_digest
+
+        _make_admin(db_session)
+        await db_session.commit()
+
+        with patch("app.tasks.maintenance._send_admin_digest_email", new_callable=AsyncMock) as mock_send:
+            with patch("redis.from_url", side_effect=Exception("Redis unavailable")):
+                result = send_admin_digest.run.__func__(_make_task())
+
+        assert result["sent"] == 1
+        mock_send.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_storage_delta_computed_from_prior_run(self, db_session):
+        import json
+
+        from app.tasks.maintenance import DIGEST_STATE_KEY, send_admin_digest
+
+        _make_admin(db_session)
+        await db_session.commit()
+
+        prior_state = json.dumps({"sent_at": "2026-01-01T08:00:00+00:00", "storage_bytes": 1_048_576})
+
+        with patch("app.tasks.maintenance._send_admin_digest_email", new_callable=AsyncMock) as mock_send:
+            mock_client = MagicMock()
+            mock_client.get.side_effect = lambda key: prior_state.encode() if key == DIGEST_STATE_KEY else None
+            with patch("redis.from_url", return_value=mock_client):
+                result = send_admin_digest.run.__func__(_make_task())
+
+        assert result["sent"] == 1
+        call_kwargs = mock_send.call_args.kwargs
+        # storage_delta_str should be set (non-None) since prior baseline exists
+        assert call_kwargs["storage_delta_str"] is not None


### PR DESCRIPTION
## Summary

- Adds `send_admin_digest` Celery task: queries DB for all active admin emails, gathers 7-day platform stats, reads CVE/S3 summaries from Redis, and sends a weekly digest email
- Registered in the scheduler as `admin_digest` (default: Mondays 08:00 UTC, **disabled by default**)
- Redis key `weftmark:admin_digest:last_sent` stores prior-week storage baseline for week-over-week delta
- Email content: new signups, pending approvals, drafts/projects/looms created, storage used + delta, CVE findings, S3 orphan count
- HTML + plain-text template pair (`admin_digest.html` / `admin_digest.txt`)
- 5 tests: no-admin guard (returns `{"sent": 0}`), happy path, inactive admin exclusion, Redis failure graceful fallback, delta calculation from prior run

## Test plan

- [ ] Merge and deploy; navigate to Admin → Scheduled Tasks — verify `Weekly Admin Digest` appears in the list
- [ ] Enable the task and trigger it manually via the Run Now button
- [ ] Confirm digest email received at admin address with all 6 sections populated
- [ ] Run again after storage changes; confirm delta reflects the difference
- [ ] Disable Redis temporarily (or simulate); confirm task still completes and email still sends (no delta row)
- [ ] Verify `{"sent": N}` in task history result matches number of active admins

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)