### PR TITLE
feat: project screen loom treadle count and trailing-unused toggle (#298)

### DIFF
--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -75,6 +75,8 @@ class ProjectDetail(ProjectSummary):
     draft_effective_num_shafts: int | None
     draft_metadata_overrides: dict | None
     loom_name: str | None
+    loom_num_treadles: int | None = None
+    loom_num_shafts: int | None = None
     photos: list[ProjectPhotoSchema] = []
 
 
@@ -182,7 +184,11 @@ async def _get_owned_project(
 
 
 def _to_detail(
-    project: Project, draft: Draft, loom: Loom | None, photos: list[ProjectPhoto] | None = None
+    project: Project,
+    draft: Draft,
+    loom: Loom | None,
+    photos: list[ProjectPhoto] | None = None,
+    loom_version: LoomVersion | None = None,
 ) -> ProjectDetail:
     return ProjectDetail(
         id=project.id,
@@ -210,6 +216,8 @@ def _to_detail(
         draft_effective_num_shafts=draft.effective_num_shafts,
         draft_metadata_overrides=draft.metadata_overrides,
         loom_name=f"{loom.manufacturer} {loom.model_name}" if loom else None,
+        loom_num_treadles=loom_version.num_treadles if loom_version else None,
+        loom_num_shafts=loom_version.num_shafts if loom_version else None,
         photos=[ProjectPhotoSchema.model_validate(p) for p in (photos or [])],
     )
 
@@ -338,7 +346,8 @@ async def get_project(
         raise HTTPException(status_code=404, detail="Project not found")
     draft = await db.get(Draft, project.draft_id)
     loom = await db.get(Loom, project.loom_id) if project.loom_id else None
-    return _to_detail(project, draft, loom, photos=list(project.photos))  # type: ignore[arg-type]
+    loom_version = await db.get(LoomVersion, project.loom_version_id) if project.loom_version_id else None
+    return _to_detail(project, draft, loom, photos=list(project.photos), loom_version=loom_version)  # type: ignore[arg-type]
 
 
 @router.patch("/{project_id}", response_model=ProjectDetail)
@@ -411,7 +420,8 @@ async def assign_loom(
     await db.commit()
     await db.refresh(project)
     draft = await db.get(Draft, project.draft_id)
-    return _to_detail(project, draft, loom)
+    loom_version = await db.get(LoomVersion, project.loom_version_id) if project.loom_version_id else None
+    return _to_detail(project, draft, loom, loom_version=loom_version)
 
 
 @router.post("/{project_id}/step", response_model=StepResponse)

--- a/backend/tests/routers/test_projects.py
+++ b/backend/tests/routers/test_projects.py
@@ -762,6 +762,37 @@ class TestGetProject:
         resp = await client.get(f"/api/projects/{project.id}")
         assert resp.status_code == 401
 
+    async def test_loom_num_treadles_null_without_loom(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        body = (await auth_client.get(f"/api/projects/{project.id}")).json()
+        assert body["loom_num_treadles"] is None
+        assert body["loom_num_shafts"] is None
+
+    async def test_loom_num_treadles_populated_with_loom_version(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        loom, version = await _insert_loom(db_session, test_user)
+        project = Project(
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            loom_id=loom.id,
+            loom_version_id=version.id,
+            name="Test project",
+            project_type="treadle",
+            status="active",
+            current_pick=1,
+            total_picks=2,
+        )
+        db_session.add(project)
+        await db_session.commit()
+        body = (await auth_client.get(f"/api/projects/{project.id}")).json()
+        assert body["loom_num_treadles"] == version.num_treadles
+        assert body["loom_num_shafts"] == version.num_shafts
+
 
 # ---------------------------------------------------------------------------
 # TestListProjects
@@ -1163,6 +1194,21 @@ class TestAssignLoom:
             )
         ).json()
         assert body["loom_version_id"] == str(version.id)
+
+    async def test_assign_loom_version_returns_loom_counts(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        loom, version = await _insert_loom(db_session, test_user)
+        body = (
+            await auth_client.post(
+                f"/api/projects/{project.id}/assign-loom",
+                json={"loom_id": str(loom.id), "loom_version_id": str(version.id)},
+            )
+        ).json()
+        assert body["loom_num_treadles"] == version.num_treadles
+        assert body["loom_num_shafts"] == version.num_shafts
 
     async def test_wrong_version_for_loom_returns_400(
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -49,6 +49,8 @@ export interface ProjectDetail extends ProjectSummary {
   draft_effective_num_shafts: number | null;
   draft_metadata_overrides: Record<string, { original: number | null; override: number }> | null;
   loom_name: string | null;
+  loom_num_treadles: number | null;
+  loom_num_shafts: number | null;
   photos: ProjectPhoto[];
 }
 

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -96,12 +96,14 @@ function DesignPreviewModal({ draftId, onClose }: { draftId: string; onClose: ()
 function PickDisplay({
   pick,
   totalCount,
+  dimAbove,
   projectType,
   colorMode,
   showWeftColor,
 }: {
   pick: PickRow;
   totalCount: number;
+  dimAbove: number;
   projectType: string;
   colorMode: ColorMode;
   showWeftColor: boolean;
@@ -128,6 +130,7 @@ function PickDisplay({
         >
           {Array.from({ length: count }, (_, i) => i + 1).map((n) => {
             const active = pick.active.includes(n);
+            const trailing = dimAbove > 0 && n > dimAbove;
             if (colorMode !== "theme" && active && weftHex) {
               if (colorMode === "filled") {
                 const fg = contrastColor(weftHex);
@@ -154,7 +157,9 @@ function PickDisplay({
                 className={`rounded-md border-2 flex items-center justify-center text-xs font-bold ${
                   active
                     ? "bg-primary border-primary text-primary-foreground"
-                    : "border-muted bg-muted/30 text-muted-foreground"
+                    : trailing
+                      ? "border-muted/40 bg-muted/10 text-muted-foreground/30"
+                      : "border-muted bg-muted/30 text-muted-foreground"
                 }`}>
                 {n}
               </div>
@@ -1036,6 +1041,9 @@ export function ProjectDetailPage() {
   const [showProgress, setShowProgress] = useState(
     () => localStorage.getItem("proj-view:showProgress") !== "false"
   );
+  const [hideTrailingUnused, setHideTrailingUnused] = useState(
+    () => localStorage.getItem("proj-view:hideTrailingUnused") === "true"
+  );
   const [showDesignPreview, setShowDesignPreview] = useState(false);
   const [editingName, setEditingName] = useState(false);
   const [nameInput, setNameInput] = useState("");
@@ -1264,11 +1272,25 @@ export function ProjectDetailPage() {
 
   const displayPick = isPlanning ? localPick : project.current_pick;
   const currentPickIndex = displayPick - 1;
+
+  const loomCount = project.project_type === "lift"
+    ? (project.loom_num_shafts ?? null)
+    : (project.loom_num_treadles ?? null);
   const declaredCount = project.project_type === "lift"
     ? (project.draft_num_shafts ?? 0)
     : (project.draft_num_treadles ?? 0);
   const maxFromPicks = picksData ? Math.max(0, ...picksData.picks.flatMap((p) => p.active)) : 0;
-  const maxActive = declaredCount > 0 ? declaredCount : maxFromPicks;
+  // When a loom is assigned, use its treadle/shaft count; otherwise fall back to draft declared count.
+  const maxActive = (loomCount !== null && loomCount > 0)
+    ? loomCount
+    : (declaredCount > 0 ? declaredCount : maxFromPicks);
+
+  // Highest treadle/shaft index actually used in any pick across the full sequence.
+  const maxUsed = picksData ? Math.max(0, ...picksData.picks.flatMap((p) => p.active)) : 0;
+  // Count of trailing unused boxes (never used in any pick, counting from the top).
+  const trailingUnused = maxActive > maxUsed ? maxActive - maxUsed : 0;
+  // Effective box count shown: when hiding trailing, shrink to maxUsed.
+  const displayCount = hideTrailingUnused && trailingUnused > 0 ? maxUsed : maxActive;
 
   const isFinished = displayPick > project.total_picks;
   const isActiveTracking = project.status === "active" && !isPlanning;
@@ -1459,7 +1481,8 @@ export function ProjectDetailPage() {
           ) : picksData ? (
             <PickDisplay
               pick={picksData.picks[currentPickIndex]}
-              totalCount={maxActive}
+              totalCount={displayCount}
+              dimAbove={hideTrailingUnused ? 0 : trailingUnused > 0 ? maxUsed : 0}
               projectType={project.project_type}
               colorMode={colorMode}
               showWeftColor={showWeftColor}
@@ -1479,7 +1502,7 @@ export function ProjectDetailPage() {
               currentPickIndex={currentPickIndex}
               totalPicks={project.total_picks}
               picks={picksData.picks}
-              maxActive={maxActive}
+              maxActive={displayCount}
             />
           </div>
         )}
@@ -1826,6 +1849,31 @@ export function ProjectDetailPage() {
                   </div>
                 ))}
               </div>
+
+              {/* Trailing unused toggle — only shown when there are trailing boxes */}
+              {trailingUnused > 0 && (
+                <div className="space-y-1.5">
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Treadle display</p>
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <span className="text-sm">Hide trailing unused</span>
+                      <p className="text-xs text-muted-foreground">{trailingUnused} never-used trailing {trailingUnused === 1 ? "box" : "boxes"}</p>
+                    </div>
+                    <button
+                      role="switch"
+                      aria-checked={hideTrailingUnused}
+                      onClick={() => {
+                        const next = !hideTrailingUnused;
+                        setHideTrailingUnused(next);
+                        localStorage.setItem("proj-view:hideTrailingUnused", String(next));
+                      }}
+                      className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-ring ${hideTrailingUnused ? "bg-primary" : "bg-input"}`}
+                    >
+                      <span className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform ${hideTrailingUnused ? "translate-x-4" : "translate-x-1"}`} />
+                    </button>
+                  </div>
+                </div>
+              )}
 
               {/* Color mode selector */}
               {picksData?.has_weft_colors && (


### PR DESCRIPTION
## Summary

- **Loom count takes precedence**: when a loom version is assigned, the pick instruction box count uses `loom_version.num_treadles` (treadle projects) or `loom_version.num_shafts` (lift projects) instead of the WIF-declared count. Falls back to draft count when no loom is attached.
- **Trailing unused boxes are dimmed**: boxes beyond the highest index used in any pick across the full sequence render at reduced opacity, distinguishing unused capacity from active treadles.
- **"Hide trailing unused" toggle**: appears in the view settings drawer only when trailing unused boxes exist. Shrinks the box count to the highest actually-used index. State persisted in `localStorage` per browser.
- **Backend**: `ProjectDetail` response now includes `loom_num_treadles` and `loom_num_shafts`, populated by loading `LoomVersion` in `get_project` and `assign_loom` endpoints.
- **3 new tests**: null when no loom, populated when loom version is set, assign-loom response includes counts.

## Test plan

- [ ] Open a project with no loom assigned — box count matches WIF treadle count, no trailing-unused toggle in settings
- [ ] Assign a 10-treadle loom to a 6-treadle design — pick display shows 10 boxes; trailing 4 are dimmed
- [ ] Open settings drawer — "Hide trailing unused" toggle appears with "4 never-used trailing boxes"
- [ ] Toggle on — display collapses to 6 boxes; toggle off — expands back to 10
- [ ] Reload page — toggle preference is remembered
- [ ] Open a project where all loom treadles are used — no toggle appears in settings drawer
- [ ] Lift project with a loom assigned — shaft count from loom version is used

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)