### PR TITLE
fix: resolve pkg_resources crash from setuptools>=80 breaking OTel startup

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -53,10 +53,6 @@ if _settings.otel_exporter_otlp_endpoint:
 
     configure_telemetry(_settings)
 
-    from opentelemetry.instrumentation.celery import CeleryInstrumentor
-
-    CeleryInstrumentor().instrument()
-
 
 @task_prerun.connect
 def _on_task_prerun(task_id=None, **kwargs):

--- a/backend/app/telemetry.py
+++ b/backend/app/telemetry.py
@@ -68,9 +68,12 @@ def configure_telemetry(settings) -> None:
         set_logger_provider(logger_provider)
 
         # Auto-instrumentors (S3/httpx covered by botocore + httpx instrumentors)
+        from opentelemetry.instrumentation.celery import CeleryInstrumentor
+
         SQLAlchemyInstrumentor().instrument()
         HTTPXClientInstrumentor().instrument()
         BotocoreInstrumentor().instrument()
+        CeleryInstrumentor().instrument()
         # Bridge Python log records to OTel without overriding our JSON formatter
         LoggingInstrumentor().instrument(set_logging_format=False)
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,6 +22,7 @@ boto3==1.38.0
 psutil==6.1.1
 pip-audit
 croniter==3.0.4
+setuptools<80
 opentelemetry-api==1.27.0
 opentelemetry-sdk==1.27.0
 opentelemetry-exporter-otlp-proto-http==1.27.0


### PR DESCRIPTION
## Summary

- `opentelemetry-instrumentation==0.48b0` imports from `pkg_resources`, which was separated from `setuptools` in v80.0 — pin `setuptools<80` to keep it available
- Move `CeleryInstrumentor` import from `celery_app.py` (module-level, unprotected) into `configure_telemetry()` in `telemetry.py` where it is wrapped in the existing `try/except` — any future instrumentation import failure now degrades gracefully instead of crashing the process

**Root cause:** dev stack containers running with `OTEL_EXPORTER_OTLP_ENDPOINT` set hit the unprotected `from opentelemetry.instrumentation.celery import CeleryInstrumentor` at module load, which triggered the `pkg_resources` import inside the OTel package, which failed on `setuptools==82.0.1`.

## Test plan

- [ ] CI passes
- [ ] Dev stack starts cleanly after `ddev`
- [ ] Backend logs show `OpenTelemetry configured` on startup (when endpoint is set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)