### PR TITLE
fix: use _log_exporter path for OTel 1.27.0 log exporter

### DIFF
--- a/backend/app/telemetry.py
+++ b/backend/app/telemetry.py
@@ -24,7 +24,7 @@ def configure_telemetry(settings) -> None:
     try:
         from opentelemetry import metrics, trace
         from opentelemetry._logs import set_logger_provider
-        from opentelemetry.exporter.otlp.proto.http.log_exporter import OTLPLogExporter
+        from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
         from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
         from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
         from opentelemetry.instrumentation.botocore import BotocoreInstrumentor


### PR DESCRIPTION
## Summary

- The OTLP log exporter is still experimental in SDK 1.27.0 and lives at `opentelemetry.exporter.otlp.proto.http._log_exporter` — the non-underscored path (`log_exporter`) was added in a later release
- Caught in dev stack logs: `ModuleNotFoundError: No module named 'opentelemetry.exporter.otlp.proto.http.log_exporter'` (OTel fell back gracefully, stack stayed up)

## Test plan

- [ ] CI passes
- [ ] After `ddev`, backend logs show `OpenTelemetry configured` on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)