### PR TITLE
fix: configure logging before router imports to preserve OTel startup log

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,12 +10,17 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.config import get_settings
 from app.logging_config import configure_logging
 from app.middleware import SecurityHeadersMiddleware
-from app.routers import admin, auth, dev, drafts, health, logs, looms, projects, system, users, yarn
-from app.telemetry import configure_telemetry
 from app.version import VERSION
 
+# Configure logging before router imports — routers pull in celery_app which
+# calls configure_telemetry(), and that confirmation log would be silently
+# dropped if no handlers are set up yet.
 settings = get_settings()
 configure_logging(settings.log_level)
+
+from app.routers import admin, auth, dev, drafts, health, logs, looms, projects, system, users, yarn  # noqa: E402
+from app.telemetry import configure_telemetry  # noqa: E402
+
 configure_telemetry(settings)
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

- Router imports transitively pull in `celery_app`, which calls `configure_telemetry()` at module level
- If logging handlers aren't set up yet when that happens, the `"OpenTelemetry configured"` INFO log is silently dropped by Python's `lastResort` handler (WARNING-only)
- `_configured = True` is already set by that point, so the explicit `configure_telemetry()` call in `main.py` becomes a no-op — and the confirmation log is never emitted
- Fix: move `configure_logging()` call before the router imports so JSON handlers are ready when telemetry initialises

The OTel providers themselves were initialising correctly (metrics confirmed flowing to Prometheus via `http_server_duration_milliseconds_count{job="weftmark-api"}`), but the startup log was always missing.

## Test plan

- [ ] Deploy to dev and confirm `"OpenTelemetry configured"` appears in backend startup logs
- [ ] Confirm `http_server_duration_milliseconds` continues to appear in Prometheus with `job="weftmark-api"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)