### PR TITLE
fix: add LoggingHandler to export Python logs to OTel/Loki pipeline

### DIFF
--- a/backend/app/telemetry.py
+++ b/backend/app/telemetry.py
@@ -63,9 +63,13 @@ def configure_telemetry(settings) -> None:
         metrics.set_meter_provider(meter_provider)
 
         # Logs — bridge Python logging → OTel log pipeline → Loki
+        from opentelemetry.sdk._logs import LoggingHandler
+
         logger_provider = LoggerProvider(resource=resource)
         logger_provider.add_log_record_processor(BatchLogRecordProcessor(OTLPLogExporter()))
         set_logger_provider(logger_provider)
+        # Attach OTel handler to root logger so all Python log records are exported
+        logging.getLogger().addHandler(LoggingHandler(logger_provider=logger_provider))
 
         # Auto-instrumentors (S3/httpx covered by botocore + httpx instrumentors)
         from opentelemetry.instrumentation.celery import CeleryInstrumentor
@@ -74,7 +78,7 @@ def configure_telemetry(settings) -> None:
         HTTPXClientInstrumentor().instrument()
         BotocoreInstrumentor().instrument()
         CeleryInstrumentor().instrument()
-        # Bridge Python log records to OTel without overriding our JSON formatter
+        # Inject OTel trace context into Python log records (trace_id, span_id fields)
         LoggingInstrumentor().instrument(set_logging_format=False)
 
         _configured = True


### PR DESCRIPTION
## Summary

- `LoggingInstrumentor().instrument()` only injects OTel trace context fields (`otelTraceID`, `otelSpanID`, etc.) into Python log records — it does **not** export them to the OTel log pipeline
- The `LoggerProvider` + `OTLPLogExporter` were being set up but nothing was actually sending records to them — Loki was receiving zero logs
- Fix: attach `LoggingHandler(logger_provider=...)` to the root Python logger, which bridges all log records through the OTLP batch exporter to the collector → Loki

## Test plan

- [ ] Deploy to dev and confirm Loki receives log streams from `weftmark-api` / `weftmark-worker`
- [ ] Verify traces (Tempo) and metrics (Prometheus) still flowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)