### PR TITLE
fix: restore OTel LoggingHandler in Celery workers/beat (#503)

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -1,7 +1,11 @@
+import logging
+
 from celery import Celery
+from celery.signals import setup_logging as celery_setup_logging
 from celery.signals import task_failure, task_postrun, task_prerun, worker_ready
 
 from app.config import get_settings
+from app.logging_config import configure_logging
 from app.version import VERSION
 
 WORKER_VERSION_KEY = "weftmark:worker_version"
@@ -52,6 +56,24 @@ if _settings.otel_exporter_otlp_endpoint:
     from app.telemetry import configure_telemetry
 
     configure_telemetry(_settings)
+
+
+@celery_setup_logging.connect
+def _configure_worker_logging(**kwargs):
+    # Connecting to this signal suppresses Celery's own root-logger hijacking.
+    # We replicate what main.py does: JSON StreamHandler first, then re-attach
+    # the OTel LoggingHandler (configure_logging() clears root handlers, which
+    # would otherwise strip the handler added by configure_telemetry()).
+    settings = get_settings()
+    configure_logging(settings.log_level)
+    if settings.otel_exporter_otlp_endpoint:
+        try:
+            from opentelemetry._logs import get_logger_provider
+            from opentelemetry.sdk._logs import LoggingHandler
+
+            logging.getLogger().addHandler(LoggingHandler(logger_provider=get_logger_provider()))
+        except Exception:
+            pass
 
 
 @task_prerun.connect


### PR DESCRIPTION
## Summary

- Closes #503
- Connects to Celery's `setup_logging` signal in `celery_app.py` so Celery skips its own root-logger hijacking entirely
- The signal handler calls `configure_logging()` (JSON StreamHandler) then re-attaches `LoggingHandler` via `get_logger_provider()` — the provider was already set by the module-level `configure_telemetry()` call
- Without this, worker/beat log records were never reaching Loki; traces and metrics were unaffected

## Root cause

`configure_telemetry()` adds `LoggingHandler` to the root logger at module import time. Celery's `worker_hijack_root_logger = True` (default) then strips all root handlers when the worker process starts, before any tasks run. The new signal handler fires at exactly that moment and Celery's hijack never executes when the signal is connected.

## Test plan

- [ ] Deploy to dev; confirm `weftmark-worker` and `weftmark-beat` log streams appear in Loki with `service_name` label
- [ ] Confirm worker logs are JSON-formatted in `docker logs weftmark-dev_worker`
- [ ] Confirm traces still flowing to Tempo from worker tasks
- [ ] Confirm CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)