### PR TITLE
fix: suppress opentelemetry.attributes WARNING noise in Celery workers (#509)

### DIFF
--- a/backend/app/logging_config.py
+++ b/backend/app/logging_config.py
@@ -88,3 +88,8 @@ def configure_logging(log_level: str) -> None:
         logger.addHandler(handler)
         logger.setLevel(level)
         logger.propagate = False
+
+    # CeleryInstrumentor emits a WARNING for every task when Celery attaches a
+    # dict extra to log records — the SDK skips the attribute safely, so this
+    # is pure noise.  Raise to ERROR to keep Loki clean.
+    logging.getLogger("opentelemetry.attributes").setLevel(logging.ERROR)


### PR DESCRIPTION
## Summary

- Closes #509
- Raises the `opentelemetry.attributes` logger to `ERROR` in `configure_logging()` 
- `CeleryInstrumentor` emits a `WARNING` on every task receive and completion because Celery's task trace logger attaches a `data` dict as an extra field — the OTel SDK rejects dicts as span attributes but handles it gracefully (skips the attribute). The warning is pure noise with no data loss.
- One-line fix in `logging_config.py` so it applies to both the API process and Celery workers uniformly

## Test plan

- [ ] Deploy to dev; confirm `WARNING opentelemetry.attributes: Invalid type dict` no longer appears in worker logs
- [ ] Confirm tasks still execute and traces still appear in Tempo
- [ ] Confirm CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)