### PR TITLE
fix: Celery task outcome counters — succeeded/failed/retried/revoked (#517)

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -2,7 +2,7 @@ import logging
 
 from celery import Celery
 from celery.signals import setup_logging as celery_setup_logging
-from celery.signals import task_failure, task_postrun, task_prerun, worker_ready
+from celery.signals import task_failure, task_postrun, task_prerun, task_retry, worker_ready
 
 from app.config import get_settings
 from app.logging_config import configure_logging
@@ -87,7 +87,8 @@ def _on_task_prerun(task_id=None, **kwargs):
 
 
 @task_postrun.connect
-def _on_task_postrun(task_id=None, state=None, **kwargs):
+def _on_task_postrun(task_id=None, state=None, sender=None, **kwargs):
+    task_name = sender.name if sender is not None else "unknown"
     if state == "SUCCESS":
         try:
             from app.services.task_history import record_completed
@@ -95,15 +96,39 @@ def _on_task_postrun(task_id=None, state=None, **kwargs):
             record_completed(get_settings(), task_id, "success")
         except Exception:
             pass
+        try:
+            from app.metrics import celery_tasks_total
+
+            celery_tasks_total.add(1, {"state": "succeeded", "task": task_name})
+        except Exception:
+            pass
 
 
 @task_failure.connect
-def _on_task_failure(task_id=None, exception=None, **kwargs):
+def _on_task_failure(task_id=None, exception=None, sender=None, **kwargs):
+    task_name = sender.name if sender is not None else "unknown"
+    outcome = "revoked" if type(exception).__name__ == "Revoked" else "failed"
     try:
         from app.services.task_history import record_completed
 
-        state = "revoked" if type(exception).__name__ == "Revoked" else "failed"
-        record_completed(get_settings(), task_id, state, error=None if state == "revoked" else str(exception))
+        record_completed(get_settings(), task_id, outcome, error=None if outcome == "revoked" else str(exception))
+    except Exception:
+        pass
+    try:
+        from app.metrics import celery_tasks_total
+
+        celery_tasks_total.add(1, {"state": outcome, "task": task_name})
+    except Exception:
+        pass
+
+
+@task_retry.connect
+def _on_task_retry(sender=None, **kwargs):
+    task_name = sender.name if sender is not None else "unknown"
+    try:
+        from app.metrics import celery_tasks_total
+
+        celery_tasks_total.add(1, {"state": "retried", "task": task_name})
     except Exception:
         pass
 

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -31,3 +31,9 @@ logins_total = _meter.create_counter(
     description="User logins via Clerk session.created webhook",
     unit="1",
 )
+
+celery_tasks_total = _meter.create_counter(
+    "weftmark.celery.tasks",
+    description="Celery task executions by outcome (succeeded/failed/retried/revoked)",
+    unit="1",
+)

--- a/backend/tests/services/test_celery_metrics.py
+++ b/backend/tests/services/test_celery_metrics.py
@@ -1,0 +1,129 @@
+"""Tests for Celery task outcome counters (app/celery_app.py signal handlers).
+
+Calls the signal handler functions directly with a mock sender and patches
+app.metrics.celery_tasks_total with an InMemoryMetricReader-backed counter
+so assertions work without a live OTel Collector or Celery broker.
+"""
+
+import pytest
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+import app.celery_app as ca
+import app.metrics as bm
+
+
+def _make_provider():
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(metric_readers=[reader])
+    return provider, reader
+
+
+def _get_data_points(reader: InMemoryMetricReader, metric_name: str) -> list:
+    points = []
+    metrics_data = reader.get_metrics_data()
+    if metrics_data is None:
+        return points
+    for rm in metrics_data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for m in sm.metrics:
+                if m.name == metric_name:
+                    for dp in m.data.data_points:
+                        points.append(dp)
+    return points
+
+
+class _MockTask:
+    """Minimal Celery task stub — only .name is needed."""
+
+    def __init__(self, name: str):
+        self.name = name
+
+
+@pytest.fixture
+def patched_celery_metrics():
+    provider, reader = _make_provider()
+    meter = provider.get_meter("weftmark.business")
+    original = bm.celery_tasks_total
+    bm.celery_tasks_total = meter.create_counter("weftmark.celery.tasks", unit="1")
+    yield reader
+    bm.celery_tasks_total = original
+    provider.shutdown()
+
+
+class TestCeleryTasksSucceeded:
+    def test_success_increments_counter(self, patched_celery_metrics):
+        sender = _MockTask("app.tasks.preview.render_preview")
+        ca._on_task_postrun(task_id="t1", state="SUCCESS", sender=sender)
+
+        points = _get_data_points(patched_celery_metrics, "weftmark.celery.tasks")
+        assert len(points) == 1
+        assert points[0].value == 1
+        assert points[0].attributes == {"state": "succeeded", "task": "app.tasks.preview.render_preview"}
+
+    def test_non_success_state_does_not_increment(self, patched_celery_metrics):
+        sender = _MockTask("app.tasks.preview.render_preview")
+        ca._on_task_postrun(task_id="t1", state="FAILURE", sender=sender)
+
+        points = _get_data_points(patched_celery_metrics, "weftmark.celery.tasks")
+        assert len(points) == 0
+
+    def test_multiple_successes_accumulate_by_task(self, patched_celery_metrics):
+        ca._on_task_postrun(task_id="t1", state="SUCCESS", sender=_MockTask("app.tasks.preview.render_preview"))
+        ca._on_task_postrun(task_id="t2", state="SUCCESS", sender=_MockTask("app.tasks.preview.render_preview"))
+        ca._on_task_postrun(task_id="t3", state="SUCCESS", sender=_MockTask("app.tasks.email_task.send_email"))
+
+        points = _get_data_points(patched_celery_metrics, "weftmark.celery.tasks")
+        by_task = {p.attributes["task"]: p.value for p in points}
+        assert by_task["app.tasks.preview.render_preview"] == 2
+        assert by_task["app.tasks.email_task.send_email"] == 1
+
+
+class TestCeleryTasksFailed:
+    def test_failure_increments_counter(self, patched_celery_metrics):
+        sender = _MockTask("app.tasks.maintenance.cleanup")
+
+        class _Err(Exception):
+            pass
+
+        ca._on_task_failure(task_id="t1", exception=_Err("boom"), sender=sender)
+
+        points = _get_data_points(patched_celery_metrics, "weftmark.celery.tasks")
+        assert len(points) == 1
+        assert points[0].attributes == {"state": "failed", "task": "app.tasks.maintenance.cleanup"}
+
+    def test_revoked_task_uses_revoked_state(self, patched_celery_metrics):
+        sender = _MockTask("app.tasks.deletion.delete_user")
+
+        class Revoked(Exception):
+            pass
+
+        ca._on_task_failure(task_id="t1", exception=Revoked(), sender=sender)
+
+        points = _get_data_points(patched_celery_metrics, "weftmark.celery.tasks")
+        assert points[0].attributes["state"] == "revoked"
+
+    def test_none_sender_uses_unknown_task(self, patched_celery_metrics):
+        ca._on_task_failure(task_id="t1", exception=Exception("x"), sender=None)
+
+        points = _get_data_points(patched_celery_metrics, "weftmark.celery.tasks")
+        assert points[0].attributes["task"] == "unknown"
+
+
+class TestCeleryTasksRetried:
+    def test_retry_increments_counter(self, patched_celery_metrics):
+        sender = _MockTask("app.tasks.email_task.send_email")
+        ca._on_task_retry(sender=sender)
+
+        points = _get_data_points(patched_celery_metrics, "weftmark.celery.tasks")
+        assert len(points) == 1
+        assert points[0].attributes == {"state": "retried", "task": "app.tasks.email_task.send_email"}
+
+    def test_multiple_retries_accumulate(self, patched_celery_metrics):
+        sender = _MockTask("app.tasks.email_task.send_email")
+        ca._on_task_retry(sender=sender)
+        ca._on_task_retry(sender=sender)
+        ca._on_task_retry(sender=sender)
+
+        points = _get_data_points(patched_celery_metrics, "weftmark.celery.tasks")
+        assert points[0].value == 3


### PR DESCRIPTION
## Summary

- **Root cause**: `CeleryInstrumentor` only emits one metric instrument — `flower.task.runtime.seconds` (histogram). It produces spans/traces but zero success/failure counters, leaving the worker failure panel in Grafana empty.
- Adds `weftmark.celery.tasks` counter in `app/metrics.py` with `state` (succeeded/failed/retried/revoked) and `task` (full task module path) attributes
- Wires counter into existing `task_postrun` and `task_failure` signal handlers in `celery_app.py`, and adds a new `task_retry` handler for the retry signal
- Adds 8 tests in `tests/services/test_celery_metrics.py` using `InMemoryMetricReader`; all pass

Closes #517.

## Grafana query (after container rebuild)

```promql
sum by (state) (rate(weftmark_celery_tasks_total[5m]))
```

## Test plan

- [x] `pytest tests/services/test_celery_metrics.py` — 8/8 pass
- [x] `ruff check` clean
- [ ] Full CI suite via `ci-dev-pr.yml`
- [ ] After rebuild: run a task (e.g. trigger a preview render) and confirm `weftmark_celery_tasks_total{state="succeeded"}` appears in Prometheus

🤖 Generated with [Claude Code](https://claude.com/claude-code)