### PR TITLE
feat: SQLAlchemy pool metrics via OTel observable gauges (#516)

### DIFF
--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from opentelemetry import metrics
+from opentelemetry.metrics import Observation
 
 _meter = metrics.get_meter("weftmark.business")
 
@@ -37,3 +40,33 @@ celery_tasks_total = _meter.create_counter(
     description="Celery task executions by outcome (succeeded/failed/retried/revoked)",
     unit="1",
 )
+
+
+def register_pool_metrics(engine) -> None:
+    """Register SQLAlchemy pool observable gauges. Call once after MeterProvider is set."""
+    pool = engine.sync_engine.pool
+
+    _meter.create_observable_gauge(
+        "weftmark.db.pool.size",
+        callbacks=[lambda _: [Observation(pool.size())]],
+        description="SQLAlchemy connection pool configured size",
+        unit="connections",
+    )
+    _meter.create_observable_gauge(
+        "weftmark.db.pool.checked_out",
+        callbacks=[lambda _: [Observation(pool.checkedout())]],
+        description="Connections currently checked out (in use by queries)",
+        unit="connections",
+    )
+    _meter.create_observable_gauge(
+        "weftmark.db.pool.checked_in",
+        callbacks=[lambda _: [Observation(pool.checkedin())]],
+        description="Connections currently idle in the pool",
+        unit="connections",
+    )
+    _meter.create_observable_gauge(
+        "weftmark.db.pool.overflow",
+        callbacks=[lambda _: [Observation(pool.overflow())]],
+        description="Overflow connections above pool_size (negative means unused capacity)",
+        unit="connections",
+    )

--- a/backend/app/telemetry.py
+++ b/backend/app/telemetry.py
@@ -81,6 +81,12 @@ def configure_telemetry(settings) -> None:
         # Inject OTel trace context into Python log records (trace_id, span_id fields)
         LoggingInstrumentor().instrument(set_logging_format=False)
 
+        # Pool gauges — import after provider is set so ProxyMeter is upgraded
+        from app.database import engine as _db_engine
+        from app.metrics import register_pool_metrics
+
+        register_pool_metrics(_db_engine)
+
         _configured = True
         log.info("OpenTelemetry configured", extra={"otlp_endpoint": settings.otel_exporter_otlp_endpoint})
 

--- a/backend/tests/services/test_pool_metrics.py
+++ b/backend/tests/services/test_pool_metrics.py
@@ -1,0 +1,121 @@
+"""Tests for SQLAlchemy pool observable gauges (app/metrics.py).
+
+Uses a mock engine/pool so no real database connection is required.
+Patches _meter with an InMemoryMetricReader-backed provider to assert
+that each gauge callback reports the correct pool stat.
+"""
+
+import pytest
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+import app.metrics as bm
+
+
+def _make_provider():
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(metric_readers=[reader])
+    return provider, reader
+
+
+def _get_gauge_value(reader: InMemoryMetricReader, metric_name: str) -> int | None:
+    metrics_data = reader.get_metrics_data()
+    if metrics_data is None:
+        return None
+    for rm in metrics_data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for m in sm.metrics:
+                if m.name == metric_name:
+                    points = list(m.data.data_points)
+                    if points:
+                        return points[0].value
+    return None
+
+
+class _MockPool:
+    def __init__(self, size=5, checkedout=2, checkedin=3, overflow=-3):
+        self._size = size
+        self._checkedout = checkedout
+        self._checkedin = checkedin
+        self._overflow = overflow
+
+    def size(self):
+        return self._size
+
+    def checkedout(self):
+        return self._checkedout
+
+    def checkedin(self):
+        return self._checkedin
+
+    def overflow(self):
+        return self._overflow
+
+
+class _MockEngine:
+    def __init__(self, pool: _MockPool):
+        class _SyncEngine:
+            pass
+
+        self.sync_engine = _SyncEngine()
+        self.sync_engine.pool = pool
+
+
+@pytest.fixture
+def pool_metrics_reader():
+    provider, reader = _make_provider()
+    original_meter = bm._meter
+    bm._meter = provider.get_meter("weftmark.business")
+    yield reader
+    bm._meter = original_meter
+    provider.shutdown()
+
+
+class TestPoolSizeGauge:
+    def test_reports_configured_pool_size(self, pool_metrics_reader):
+        engine = _MockEngine(_MockPool(size=5))
+        bm.register_pool_metrics(engine)
+
+        assert _get_gauge_value(pool_metrics_reader, "weftmark.db.pool.size") == 5
+
+    def test_reflects_different_pool_size(self, pool_metrics_reader):
+        engine = _MockEngine(_MockPool(size=10))
+        bm.register_pool_metrics(engine)
+
+        assert _get_gauge_value(pool_metrics_reader, "weftmark.db.pool.size") == 10
+
+
+class TestPoolCheckedOutGauge:
+    def test_reports_checked_out_connections(self, pool_metrics_reader):
+        engine = _MockEngine(_MockPool(checkedout=3))
+        bm.register_pool_metrics(engine)
+
+        assert _get_gauge_value(pool_metrics_reader, "weftmark.db.pool.checked_out") == 3
+
+    def test_zero_when_no_active_queries(self, pool_metrics_reader):
+        engine = _MockEngine(_MockPool(checkedout=0))
+        bm.register_pool_metrics(engine)
+
+        assert _get_gauge_value(pool_metrics_reader, "weftmark.db.pool.checked_out") == 0
+
+
+class TestPoolCheckedInGauge:
+    def test_reports_idle_connections(self, pool_metrics_reader):
+        engine = _MockEngine(_MockPool(checkedin=4))
+        bm.register_pool_metrics(engine)
+
+        assert _get_gauge_value(pool_metrics_reader, "weftmark.db.pool.checked_in") == 4
+
+
+class TestPoolOverflowGauge:
+    def test_negative_overflow_means_unused_capacity(self, pool_metrics_reader):
+        engine = _MockEngine(_MockPool(size=5, checkedout=0, overflow=-5))
+        bm.register_pool_metrics(engine)
+
+        assert _get_gauge_value(pool_metrics_reader, "weftmark.db.pool.overflow") == -5
+
+    def test_positive_overflow_means_pool_exhausted(self, pool_metrics_reader):
+        engine = _MockEngine(_MockPool(size=5, checkedout=7, overflow=2))
+        bm.register_pool_metrics(engine)
+
+        assert _get_gauge_value(pool_metrics_reader, "weftmark.db.pool.overflow") == 2


### PR DESCRIPTION
## Summary

- **Root cause of gap**: `SQLAlchemyInstrumentor().instrument()` called without `engine=` only wraps future `create_engine` calls — our engine is created at module import time before telemetry is configured, so the built-in `db.client.connections.usage` UpDownCounter is never populated. Additionally, the event-based UpDownCounter drifts on restart (same problem as active sessions).
- Adds `register_pool_metrics(engine)` to `app/metrics.py` — creates four OTel observable gauges that **poll** `engine.sync_engine.pool` at each collection interval, always reflecting current state
- Called from `configure_telemetry()` after `set_meter_provider()` so the ProxyMeter is fully upgraded before gauge registration
- Adds 7 tests in `tests/services/test_pool_metrics.py` using mock pool objects and `InMemoryMetricReader`

Closes #516.

## Gauges emitted

| Metric | Description |
|--------|-------------|
| `weftmark.db.pool.size` | Configured pool size (default: 5) |
| `weftmark.db.pool.checked_out` | Connections in use by active queries |
| `weftmark.db.pool.checked_in` | Idle connections available in pool |
| `weftmark.db.pool.overflow` | Overflow above pool_size (negative = unused capacity) |

## Grafana query (after container rebuild)

```promql
weftmark_db_pool_checked_out{job="weftmark-api"}
weftmark_db_pool_overflow{job="weftmark-api"}
```

## Test plan

- [x] `pytest tests/services/test_pool_metrics.py` — 7/7 pass
- [x] `ruff check` clean
- [ ] Full CI suite via `ci-dev-pr.yml`
- [ ] After rebuild: confirm all four `weftmark_db_pool_*` metrics appear in Prometheus

🤖 Generated with [Claude Code](https://claude.com/claude-code)