### PR TITLE
feat: add Geomap panel to business-metrics dashboard

### DIFF
--- a/docs/grafana/business-metrics.json
+++ b/docs/grafana/business-metrics.json
@@ -21,6 +21,7 @@
     {"type": "datasource", "id": "loki", "name": "Loki", "version": "1.0.0"},
     {"type": "panel", "id": "timeseries", "name": "Time series", "version": ""},
     {"type": "panel", "id": "stat", "name": "Stat", "version": ""},
+    {"type": "panel", "id": "geomap", "name": "Geomap", "version": ""},
     {"type": "panel", "id": "logs", "name": "Logs", "version": ""}
   ],
   "annotations": {
@@ -558,8 +559,73 @@
       "type": "timeseries"
     },
     {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "continuous-GrYlRd"},
+          "custom": {
+            "hideFrom": {"legend": false, "tooltip": false, "viz": false}
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 10},
+              {"color": "red", "value": 100}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 12, "w": 24, "x": 0, "y": 32},
+      "id": 16,
+      "options": {
+        "basemap": {"config": {}, "name": "Basemap", "type": "default"},
+        "controls": {
+          "mouseWheelZoom": false,
+          "showAttribution": true,
+          "showDebug": false,
+          "showMeasure": false,
+          "showScale": false,
+          "showZoom": true
+        },
+        "layers": [
+          {
+            "config": {
+              "showLegend": true,
+              "style": {
+                "color": {"field": "Value", "mode": "continuous-GrYlRd"},
+                "opacity": 0.7,
+                "size": {"field": "Value", "fixed": 5, "max": 25, "min": 3, "mode": "field"},
+                "symbol": {"fixed": "img/icons/marker/circle.svg", "mode": "fixed"}
+              }
+            },
+            "location": {"lookup": "country", "mode": "lookup"},
+            "name": "Logins",
+            "tooltip": true,
+            "type": "markers"
+          }
+        ],
+        "tooltip": {"mode": "details"},
+        "view": {"allLayers": true, "id": "zero", "lat": 30, "lon": 10, "zoom": 1}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (country) (increase(weftmark_user_logins_total{deployment_environment=~\"$env\", country!=\"\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{country}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Login Geography Map",
+      "type": "geomap"
+    },
+    {
       "datasource": {"type": "loki", "uid": "${loki}"},
-      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 32},
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 44},
       "id": 15,
       "options": {
         "dedupStrategy": "none",


### PR DESCRIPTION
## Summary

Missed from PR #529 — pushed after merge.

Adds a world map panel (`geomap` type) to the business-metrics dashboard showing login volume by country as sized circles, using `increase(weftmark_user_logins_total{...}[$__range])` and Grafana's built-in ISO-3166 country code lookup.

## Test plan
- [ ] Import updated `docs/grafana/business-metrics.json` into Grafana
- [ ] Verify Geomap panel renders with country circles after logins with geo data

🤖 Generated with [Claude Code](https://claude.com/claude-code)