### PR TITLE
fix: remove invalid LogQL escape in Auth/Webhook Events panel

### DIFF
--- a/docs/grafana/business-metrics.json
+++ b/docs/grafana/business-metrics.json
@@ -1115,7 +1115,7 @@
             "type": "loki",
             "uid": "${loki}"
           },
-          "expr": "{service_name=\"weftmark-api\", deployment_environment=~\"$env\"} | json | message=~\"session\\.created|session\\.ended|user\\.created|signup|login|eula|role_change|geo_country_mismatch\"",
+          "expr": "{service_name=\"weftmark-api\", deployment_environment=~\"$env\"} | json | message=~\"session.created|session.ended|user.created|signup|login|eula|role_change|geo_country_mismatch\"",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
## Summary

- Fixes 500 error on the Business Metrics dashboard "Auth / Webhook Events" log panel
- `\.` is not a valid escape sequence in LogQL double-quoted strings (Go string rules); unescaped `.` is correct for these message patterns

## Test plan

- [ ] Re-import `docs/grafana/business-metrics.json` and confirm the Auth/Webhook Events panel loads without a 500 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)