### PR TITLE
fix: correct Loki log query patterns and scope env dropdown (#539)

### DIFF
--- a/docs/grafana/api-overview.json
+++ b/docs/grafana/api-overview.json
@@ -119,14 +119,14 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(deployment_environment)",
+        "definition": "label_values(weftmark_users_total_ratio, deployment_environment)",
         "hide": 0,
         "includeAll": true,
         "multi": false,
         "name": "env",
         "options": [],
         "query": {
-          "query": "label_values(deployment_environment)",
+          "query": "label_values(weftmark_users_total_ratio, deployment_environment)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -771,7 +771,7 @@
             "type": "loki",
             "uid": "${loki}"
           },
-          "expr": "{service_name=\"weftmark-api\", deployment_environment=~\"$env\"} | json | level=`ERROR` or level=`CRITICAL`",
+          "expr": "{service_name=\"weftmark-api\", deployment_environment=~\"$env\", level=\"ERROR\"}",
           "refId": "A"
         }
       ],

--- a/docs/grafana/business-metrics.json
+++ b/docs/grafana/business-metrics.json
@@ -120,14 +120,14 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(deployment_environment)",
+        "definition": "label_values(weftmark_users_total_ratio, deployment_environment)",
         "hide": 0,
         "includeAll": true,
         "multi": false,
         "name": "env",
         "options": [],
         "query": {
-          "query": "label_values(deployment_environment)",
+          "query": "label_values(weftmark_users_total_ratio, deployment_environment)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/docs/grafana/infrastructure.json
+++ b/docs/grafana/infrastructure.json
@@ -89,14 +89,14 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(deployment_environment)",
+        "definition": "label_values(weftmark_users_total_ratio, deployment_environment)",
         "hide": 0,
         "includeAll": true,
         "multi": false,
         "name": "env",
         "options": [],
         "query": {
-          "query": "label_values(deployment_environment)",
+          "query": "label_values(weftmark_users_total_ratio, deployment_environment)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/docs/grafana/traces-explorer.json
+++ b/docs/grafana/traces-explorer.json
@@ -151,14 +151,14 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(deployment_environment)",
+        "definition": "label_values(weftmark_users_total_ratio, deployment_environment)",
         "hide": 0,
         "includeAll": true,
         "multi": false,
         "name": "env",
         "options": [],
         "query": {
-          "query": "label_values(deployment_environment)",
+          "query": "label_values(weftmark_users_total_ratio, deployment_environment)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/docs/grafana/worker-overview.json
+++ b/docs/grafana/worker-overview.json
@@ -120,14 +120,14 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(deployment_environment)",
+        "definition": "label_values(weftmark_users_total_ratio, deployment_environment)",
         "hide": 0,
         "includeAll": true,
         "multi": false,
         "name": "env",
         "options": [],
         "query": {
-          "query": "label_values(deployment_environment)",
+          "query": "label_values(weftmark_users_total_ratio, deployment_environment)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -585,7 +585,7 @@
             "type": "loki",
             "uid": "${loki}"
           },
-          "expr": "{service_name=~\"weftmark-worker|weftmark-beat\", deployment_environment=~\"$env\"} | json | level=`ERROR` or level=`CRITICAL`",
+          "expr": "{service_name=~\"weftmark-worker|weftmark-beat\", deployment_environment=~\"$env\", level=\"ERROR\"}",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
## Summary

Fixes three concrete defects found in the observability pipeline audit (#539):

- **Loki level filter**: Replace `| json | level=\`ERROR\`` post-filter with `level="ERROR"` in the stream selector on api-overview and worker-overview log panels. `level` is a Loki stream label (indexed), not a field in the OTLP log body JSON — the old pattern silently matched all log levels. Also drops `CRITICAL` (no values; OTel FATAL maps to `detected_level=fatal`).
- **Env dropdown scoping**: All five dashboards' `env` template variable now queries `label_values(weftmark_users_total_ratio, deployment_environment)` instead of unscoped `label_values(deployment_environment)`. The dropdown auto-populates only from environments that have metric data — no hardcoded option values.
- **Out-of-band** (gitignored / separate repo):
  - Local `observability-local/otelcol-config.yaml`: replaced legacy `loki` push exporter with `otlp_http/loki` (OTLP native, matches remote)
  - Local `observability-local/grafana/provisioning/datasources/datasources.yaml`: derived field updated to `matcherType: label` + `matcherRegex: otelTraceID`
  - Remote Komodo `datasources.yaml`: same derived field fix committed directly to `weftmark/komodo` repo (commit `06ad400`)

## Test plan

- [ ] All automated checks pass (see issue #539 verification checklist)
- [ ] `grep -r '| json | level=' docs/grafana/` exits non-zero (no matches)
- [ ] `grep 'matcherType' observability-local/grafana/provisioning/datasources/datasources.yaml` shows `matcherType: label`
- [ ] `grep 'loki/api/v1/push' observability-local/otelcol-config.yaml` exits non-zero (removed)
- [ ] Env dropdown in each dashboard shows only environments with live data; no hardcoded values
- [ ] Error log panels (api-overview, worker-overview) show only ERROR entries after generating an error log

🤖 Generated with [Claude Code](https://claude.com/claude-code)