### PR TITLE
feat: move Save into header row of scheduled task cards

### DIFF
--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -2913,23 +2913,29 @@ function ScheduledTaskCard({ task, onSaved }: { task: ScheduledTask; onSaved: ()
           <p className="font-medium text-sm">{task.display_name}</p>
           <p className="text-xs text-muted-foreground mt-0.5">{task.description}</p>
         </div>
-        <label className="flex items-center gap-2 cursor-pointer shrink-0">
-          <span className="text-xs text-muted-foreground">{enabled ? "Enabled" : "Disabled"}</span>
-          <button
-            role="switch"
-            aria-checked={enabled}
-            onClick={() => setEnabled((v) => !v)}
-            className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
-              enabled ? "bg-primary" : "bg-muted"
-            }`}
-          >
-            <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
-                enabled ? "translate-x-4" : "translate-x-0.5"
+        <div className="flex items-center gap-2 shrink-0">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <span className="text-xs text-muted-foreground">{enabled ? "Enabled" : "Disabled"}</span>
+            <button
+              role="switch"
+              aria-checked={enabled}
+              onClick={() => setEnabled((v) => !v)}
+              className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+                enabled ? "bg-primary" : "bg-muted"
               }`}
-            />
-          </button>
-        </label>
+            >
+              <span
+                className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                  enabled ? "translate-x-4" : "translate-x-0.5"
+                }`}
+              />
+            </button>
+          </label>
+          {error && <p className="text-xs text-destructive">{error}</p>}
+          <Button size="sm" disabled={!isDirty || saving} onClick={save}>
+            {saving ? "Saving…" : "Save"}
+          </Button>
+        </div>
       </div>
 
       <div className="space-y-1.5">
@@ -2970,13 +2976,6 @@ function ScheduledTaskCard({ task, onSaved }: { task: ScheduledTask; onSaved: ()
             Last fired: {new Date(task.last_fired_at).toLocaleString()}
           </p>
         )}
-      </div>
-
-      <div className="flex items-center justify-end gap-2">
-        {error && <p className="text-xs text-destructive">{error}</p>}
-        <Button size="sm" disabled={!isDirty || saving} onClick={save}>
-          {saving ? "Saving…" : "Save"}
-        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Removes the dedicated bottom action row from each scheduled task card
- Save button now sits inline in the header: **title/description → Enabled toggle → Save**
- Reduces each card's height by one row; error message (if any) appears between the toggle and Save

## Test plan
- [ ] Verify Save button appears to the right of the Enabled toggle in each task card
- [ ] Confirm Save is disabled when no changes are made and enabled after toggling enabled or changing schedule
- [ ] Confirm error message renders inline between toggle and Save on invalid cron input
- [ ] Check layout at narrow viewport widths for wrapping issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)