### PR TITLE
fix: add SVG favicon (#549)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>weftmark</title>
     <script src="/env-config.js"></script>
   </head>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#1e293b"/>
+  <g transform="translate(2, 11) scale(0.14)">
+    <ellipse cx="100" cy="36" rx="90" ry="30" fill="#d97706"/>
+    <polyline
+      points="55,24 75,50 100,34 125,50 145,24"
+      fill="none"
+      stroke="white"
+      stroke-width="5.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

- Adds `frontend/public/favicon.svg` — slate-800 rounded square with the weftmark ellipse+waveform logo in amber, adapted from `WeftmarkLogo.tsx`
- Adds `<link rel="icon" type="image/svg+xml" href="/favicon.svg">` to `index.html`

**Root cause:** `index.html` had no `<link rel="icon">`, so browsers fell back to requesting `/favicon.ico`. nginx's `try_files` SPA catch-all served `index.html` for that request, returning `content-type: text/html` — which browsers silently ignore as a favicon, leaving the tab blank.

## Test plan
- [ ] Browser tab shows the weftmark favicon (slate square with amber waveform)
- [ ] No `/favicon.ico` request in DevTools network tab (browser uses the linked SVG instead)
- [ ] Favicon displays correctly in bookmarks and pinned tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)