### PR TITLE
feat: trigger drawdown tile prerender eagerly on upload and project create

### DIFF
--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -158,11 +158,12 @@ async def create_draft(
     await db.commit()
     await db.refresh(draft)
     if draft.wif_path:
-        task = generate_drawdown_preview.delay(str(draft.id))
         from app.config import get_settings
         from app.services.task_history import record_queued
 
+        task = generate_drawdown_preview.delay(str(draft.id))
         record_queued(get_settings(), task.id, "app.tasks.preview.generate_drawdown_preview", "preview")
+        prerender_drawdown_tiles.delay(str(draft.id))
     return DraftSummary.from_draft(draft)
 
 

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -20,6 +20,7 @@ from app.services import storage, wif_parser
 from app.services.images import resize_to_jpeg
 from app.services.storage_quota import check_storage_quota
 from app.tasks.preview import generate_drawdown_preview
+from app.tasks.tiles import prerender_drawdown_tiles
 
 ALLOWED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/webp", "image/heic", "image/heif"}
 MAX_PROJECT_PHOTOS = 10
@@ -314,6 +315,7 @@ async def create_project(
     await db.refresh(project)
     if draft.drawdown_preview_path is None:
         generate_drawdown_preview.delay(str(draft.id))
+    prerender_drawdown_tiles.delay(str(draft.id))
     return _to_detail(project, draft, loom)
 
 

--- a/backend/tests/routers/test_projects.py
+++ b/backend/tests/routers/test_projects.py
@@ -23,6 +23,14 @@ def _mock_preview_task(monkeypatch):
     return mock
 
 
+@pytest.fixture(autouse=True)
+def _mock_tile_task(monkeypatch):
+    """Prevent prerender_drawdown_tiles.delay() from connecting to Celery in tests."""
+    mock = MagicMock()
+    monkeypatch.setattr("app.routers.projects.prerender_drawdown_tiles", mock)
+    return mock
+
+
 # ---------------------------------------------------------------------------
 # Minimal WIF bytes used for all tests (has both treadling and liftplan)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `prerender_drawdown_tiles` now fires immediately on WIF upload (`create_draft`) and on project creation (`create_project`)
- Ensures tiles are warm in R2 before the user ever opens the drawdown viewer — eliminates the ~4s cold render on first project open
- On-demand lazy trigger (on first standard tile request) is kept as a fallback

## Why

Previously tiles were only queued when the drawdown viewer fired its first tile request. A user who uploads a draft and immediately starts their project would still hit the slow on-demand render on first load. Since preview generation already fires eagerly on upload/project-create, tile prerender follows the same pattern.

## Test plan
- [ ] Upload a WIF → verify `tiles.prerender_drawdown_tiles` appears in task history
- [ ] Create a project → verify `tiles.prerender_drawdown_tiles` appears in task history
- [ ] Open project drawdown viewer after tiles are pre-rendered → tiles load instantly from R2

Generated with [Claude Code](https://claude.com/claude-code)