### PR TITLE
fix: record prerender_drawdown_tiles in admin task history (#556)

### DIFF
--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -163,7 +163,8 @@ async def create_draft(
 
         task = generate_drawdown_preview.delay(str(draft.id))
         record_queued(get_settings(), task.id, "app.tasks.preview.generate_drawdown_preview", "preview")
-        prerender_drawdown_tiles.delay(str(draft.id))
+        tile_task = prerender_drawdown_tiles.delay(str(draft.id))
+        record_queued(get_settings(), tile_task.id, "app.tasks.tiles.prerender_drawdown_tiles", "preview")
     return DraftSummary.from_draft(draft)
 
 
@@ -299,7 +300,10 @@ async def get_drawdown(
 
         # Trigger background tile pre-render on standard cache miss
         if _sr % tile_row_count == 0 and _rc == tile_row_count:
-            prerender_drawdown_tiles.apply_async(args=[str(draft_id)])
+            from app.services.task_history import record_queued
+
+            tile_task = prerender_drawdown_tiles.apply_async(args=[str(draft_id)])
+            record_queued(settings, tile_task.id, "app.tasks.tiles.prerender_drawdown_tiles", "preview")
 
         return Response(
             content=png,

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -315,7 +315,11 @@ async def create_project(
     await db.refresh(project)
     if draft.drawdown_preview_path is None:
         generate_drawdown_preview.delay(str(draft.id))
-    prerender_drawdown_tiles.delay(str(draft.id))
+    from app.config import get_settings
+    from app.services.task_history import record_queued
+
+    tile_task = prerender_drawdown_tiles.delay(str(draft.id))
+    record_queued(get_settings(), tile_task.id, "app.tasks.tiles.prerender_drawdown_tiles", "preview")
     return _to_detail(project, draft, loom)
 
 


### PR DESCRIPTION
## Summary

Adds `record_queued()` after every `prerender_drawdown_tiles` dispatch so the task appears in the admin Task History console.

Three sites patched:
- `routers/drafts.py` — on WIF upload
- `routers/projects.py` — on project creation  
- `routers/drafts.py` — on-miss lazy trigger in `get_drawdown`

Partially addresses #556 (task history visibility). The duplicate-fire issue remains open.

## Test plan
- [ ] Upload a draft → `tiles.prerender_drawdown_tiles` appears in Task History
- [ ] Create a project → `tiles.prerender_drawdown_tiles` appears in Task History
- [ ] Open project drawdown viewer (cache miss) → lazy trigger also appears in Task History

Generated with [Claude Code](https://claude.com/claude-code)