### PR TITLE
fix: skip lazy tile prerender when t0 already exists (#556)

### DIFF
--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -298,12 +298,14 @@ async def get_drawdown(
         except Exception as exc:
             raise HTTPException(status_code=500, detail=f"Drawdown rendering failed: {exc}")
 
-        # Trigger background tile pre-render on standard cache miss
+        # Trigger background tile pre-render on standard cache miss, but only if
+        # t0 doesn't exist yet — avoids double-fire when eager prerender already ran.
         if _sr % tile_row_count == 0 and _rc == tile_row_count:
-            from app.services.task_history import record_queued
+            if not await storage.adrawdown_tile_exists(draft_id, expected_scale, 0):
+                from app.services.task_history import record_queued
 
-            tile_task = prerender_drawdown_tiles.apply_async(args=[str(draft_id)])
-            record_queued(settings, tile_task.id, "app.tasks.tiles.prerender_drawdown_tiles", "preview")
+                tile_task = prerender_drawdown_tiles.apply_async(args=[str(draft_id)])
+                record_queued(settings, tile_task.id, "app.tasks.tiles.prerender_drawdown_tiles", "preview")
 
         return Response(
             content=png,

--- a/backend/tests/routers/test_drafts.py
+++ b/backend/tests/routers/test_drafts.py
@@ -589,6 +589,31 @@ class TestGetDrawdownTileCache:
         await auth_client.get(f"/api/drafts/{draft.id}/drawdown?start_row=0&row_count={tile_row_count}")
         _mock_tile_task.apply_async.assert_called_once_with(args=[str(draft.id)])
 
+    async def test_cache_miss_skips_task_when_t0_exists(
+        self,
+        auth_client: AsyncClient,
+        db_session: AsyncSession,
+        test_user: User,
+        _mock_tile_task: MagicMock,
+    ):
+        """When t0 already exists (eager prerender ran), lazy trigger must not re-queue."""
+        import app.services.storage as storage
+        from app.config import get_settings
+        from app.services.rendering import DRAWDOWN_SCALE
+
+        draft = await self._draft_with_wif_and_dimensions(db_session, test_user)
+        settings = get_settings()
+        tile_row_count = settings.tile_row_count
+        expected_scale = min(settings.render_max_width // draft.warp_threads, DRAWDOWN_SCALE)
+
+        # Pre-save t0 (simulates completed eager prerender) but not the requested tile
+        storage.save_drawdown_tile(draft.id, expected_scale, 0, self._TILE_PNG)
+
+        # Request tile at row 100 — cache miss, but t0 exists so no new task
+        resp = await auth_client.get(f"/api/drafts/{draft.id}/drawdown?start_row=100&row_count={tile_row_count}")
+        assert resp.status_code == 200
+        _mock_tile_task.apply_async.assert_not_called()
+
     async def test_non_standard_request_skips_cache_and_task(
         self,
         auth_client: AsyncClient,


### PR DESCRIPTION
## Summary
- Guards the on-miss Celery dispatch in `get_drawdown` with an existence check on tile `t0`
- If `t0` already exists (eager prerender ran on WIF upload or project creation), the lazy trigger is skipped
- Prevents the duplicate `tiles.prerender_drawdown_tiles` task visible in Task History when opening a project shortly after uploading a WIF

## Test plan
- [ ] `TestGetDrawdownTileCache::test_cache_miss_skips_task_when_t0_exists` — new test: pre-save `t0`, request tile at row 100, assert no task queued
- [ ] Existing `test_cache_miss_triggers_prerender_task` still passes (no `t0` → task fires)
- [ ] Deploy to dev, upload WIF, open project → Task History shows exactly one `tiles.prerender_drawdown_tiles`

Closes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)