### PR TITLE
feat: hide unused shafts/treadles + compact pick display for wide looms (#563)

### DIFF
--- a/backend/alembic/versions/0010_hide_unused_shafts_treadles.py
+++ b/backend/alembic/versions/0010_hide_unused_shafts_treadles.py
@@ -1,0 +1,32 @@
+"""add hide_unused_shafts_treadles to users and projects
+
+Revision ID: d3e4f5a6b7c8
+Revises: c2d3e4f5a6b7
+Create Date: 2026-05-10
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "d3e4f5a6b7c8"
+down_revision = "c2d3e4f5a6b7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("hide_unused_shafts_treadles", sa.Boolean(), nullable=False, server_default="false"),
+    )
+    op.add_column(
+        "projects",
+        sa.Column("hide_unused_shafts_treadles", sa.Boolean(), nullable=False, server_default="false"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "hide_unused_shafts_treadles")
+    op.drop_column("projects", "hide_unused_shafts_treadles")

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from decimal import Decimal
 
-from sqlalchemy import DateTime, ForeignKey, Integer, Numeric, String, Text
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, Numeric, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -56,6 +56,7 @@ class Project(Base, TimestampMixin, SoftDeleteMixin):
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     abandoned_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hide_unused_shafts_treadles: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
 
     steps: Mapped[list["ProjectStep"]] = relationship(
         "ProjectStep", back_populates="project", order_by="ProjectStep.created_at"

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -36,3 +36,4 @@ class User(Base, TimestampMixin, SoftDeleteMixin):
     deletion_initiated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, default=None)
     clerk_errored: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     show_version_numbers: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    hide_unused_shafts_treadles: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)

--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -229,10 +229,14 @@ async def get_drawdown(
     draft_id: uuid.UUID,
     start_row: int | None = Query(None, ge=0),
     row_count: int | None = Query(None, ge=1),
+    hide_unused_shafts_treadles: bool = Query(False),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     draft = await _get_owned_draft(draft_id, current_user, db)
+
+    effective_shafts = draft.effective_num_shafts if hide_unused_shafts_treadles else None
+    effective_treadles = draft.effective_num_treadles if hide_unused_shafts_treadles else None
 
     # Tiled request: check pre-rendered tile cache first, then render on-demand
     if start_row is not None or row_count is not None:
@@ -276,7 +280,13 @@ async def get_drawdown(
         wif_bytes = await storage.aread_file(draft.wif_path)
         try:
             png, total_rows, actual_start, actual_row_count, actual_scale = await asyncio.to_thread(
-                lambda: rendering.render_drawdown_tile(rendering.load_draft(wif_bytes), start_row=_sr, row_count=_rc)
+                lambda: rendering.render_drawdown_tile(
+                    rendering.load_draft(wif_bytes),
+                    start_row=_sr,
+                    row_count=_rc,
+                    effective_shafts=effective_shafts,
+                    effective_treadles=effective_treadles,
+                )
             )
         except HTTPException as exc:
             if exc.status_code == 413:
@@ -345,7 +355,11 @@ async def get_drawdown(
     wif_bytes = await storage.aread_file(draft.wif_path)
     try:
         png, total_rows, actual_scale = await asyncio.to_thread(
-            lambda: rendering.render_drawdown_only(rendering.load_draft(wif_bytes))
+            lambda: rendering.render_drawdown_only(
+                rendering.load_draft(wif_bytes),
+                effective_shafts=effective_shafts,
+                effective_treadles=effective_treadles,
+            )
         )
     except HTTPException as exc:
         if exc.status_code == 413:

--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -258,7 +258,8 @@ async def get_drawdown(
             expected_scale = rendering.DRAWDOWN_SCALE
 
         if (
-            warp_count > 0
+            not hide_unused_shafts_treadles
+            and warp_count > 0
             and _sr % tile_row_count == 0
             and _rc == tile_row_count
             and await storage.adrawdown_tile_exists(draft_id, expected_scale, _sr)

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -187,6 +187,18 @@ async def _get_owned_project(
     return project
 
 
+async def _resolve_loom_version(project: Project, db: AsyncSession) -> LoomVersion | None:
+    """Return the project's loom version, falling back to the loom's only version when loom_version_id is unset."""
+    if project.loom_version_id:
+        return await db.get(LoomVersion, project.loom_version_id)
+    if project.loom_id:
+        versions = await db.scalars(select(LoomVersion).where(LoomVersion.loom_id == project.loom_id))
+        all_versions = versions.all()
+        if len(all_versions) == 1:
+            return all_versions[0]
+    return None
+
+
 def _to_detail(
     project: Project,
     draft: Draft,
@@ -359,7 +371,7 @@ async def get_project(
         raise HTTPException(status_code=404, detail="Project not found")
     draft = await db.get(Draft, project.draft_id)
     loom = await db.get(Loom, project.loom_id) if project.loom_id else None
-    loom_version = await db.get(LoomVersion, project.loom_version_id) if project.loom_version_id else None
+    loom_version = await _resolve_loom_version(project, db)
     if draft is not None and draft.drawdown_preview_path is None:
         generate_drawdown_preview.delay(str(draft.id))
     return _to_detail(project, draft, loom, photos=list(project.photos), loom_version=loom_version)  # type: ignore[arg-type]
@@ -388,7 +400,8 @@ async def rename_project(
     await db.refresh(project)
     draft = await db.get(Draft, project.draft_id)
     loom = await db.get(Loom, project.loom_id) if project.loom_id else None
-    return _to_detail(project, draft, loom)  # type: ignore[arg-type]
+    loom_version = await _resolve_loom_version(project, db)
+    return _to_detail(project, draft, loom, loom_version=loom_version)  # type: ignore[arg-type]
 
 
 @router.post("/{project_id}/assign-loom", response_model=ProjectDetail)
@@ -437,7 +450,7 @@ async def assign_loom(
     await db.commit()
     await db.refresh(project)
     draft = await db.get(Draft, project.draft_id)
-    loom_version = await db.get(LoomVersion, project.loom_version_id) if project.loom_version_id else None
+    loom_version = await _resolve_loom_version(project, db)
     return _to_detail(project, draft, loom, loom_version=loom_version)
 
 

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -60,6 +60,7 @@ class ProjectSummary(BaseModel):
     completed_at: datetime | None
     abandoned_at: datetime | None
     created_at: datetime
+    hide_unused_shafts_treadles: bool
 
     model_config = {"from_attributes": True}
 
@@ -98,6 +99,7 @@ class CreateProjectRequest(BaseModel):
 class RenameProjectRequest(BaseModel):
     name: str | None = None
     notes: str | None = None
+    hide_unused_shafts_treadles: bool | None = None
 
 
 class AssignLoomRequest(BaseModel):
@@ -211,6 +213,7 @@ def _to_detail(
         abandoned_at=project.abandoned_at,
         notes=project.notes,
         created_at=project.created_at,
+        hide_unused_shafts_treadles=project.hide_unused_shafts_treadles,
         draft_name=draft.name,
         draft_num_shafts=draft.num_shafts,
         draft_num_treadles=draft.num_treadles,
@@ -309,6 +312,7 @@ async def create_project(
         waste_between_items=body.waste_between_items,
         warp_waste_allowance=body.warp_waste_allowance,
         length_unit=body.length_unit,
+        hide_unused_shafts_treadles=current_user.hide_unused_shafts_treadles,
     )
     db.add(project)
     await db.commit()
@@ -368,8 +372,8 @@ async def rename_project(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> ProjectDetail:
-    if body.name is None and body.notes is None:
-        raise HTTPException(status_code=400, detail="At least one field (name or notes) must be provided")
+    if body.name is None and body.notes is None and body.hide_unused_shafts_treadles is None:
+        raise HTTPException(status_code=400, detail="At least one field must be provided")
     project = await _get_owned_project(project_id, current_user, db)
     if body.name is not None:
         name = body.name.strip()
@@ -378,6 +382,8 @@ async def rename_project(
         project.name = name
     if body.notes is not None:
         project.notes = body.notes
+    if body.hide_unused_shafts_treadles is not None:
+        project.hide_unused_shafts_treadles = body.hide_unused_shafts_treadles
     await db.commit()
     await db.refresh(project)
     draft = await db.get(Draft, project.draft_id)

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -56,6 +56,7 @@ class UserSettingsUpdate(BaseModel):
     measurement_system: str | None = None
     ai_training_consent: bool | None = None
     show_version_numbers: bool | None = None
+    hide_unused_shafts_treadles: bool | None = None
 
 
 class EulaAcceptRequest(BaseModel):
@@ -77,6 +78,7 @@ class UserSettingsResponse(BaseModel):
     measurement_system: str
     ai_training_consent: bool
     show_version_numbers: bool
+    hide_unused_shafts_treadles: bool
     eula_accepted_version: str | None
     current_eula_version: str
 
@@ -105,6 +107,7 @@ def _to_response(user: User, current_eula_version: str) -> UserSettingsResponse:
         measurement_system=user.measurement_system,
         ai_training_consent=user.ai_training_consent,
         show_version_numbers=user.show_version_numbers,
+        hide_unused_shafts_treadles=user.hide_unused_shafts_treadles,
         eula_accepted_version=user.eula_accepted_version,
         current_eula_version=current_eula_version,
     )
@@ -184,6 +187,9 @@ async def update_settings(
 
     if body.show_version_numbers is not None:
         current_user.show_version_numbers = body.show_version_numbers
+
+    if body.hide_unused_shafts_treadles is not None:
+        current_user.hide_unused_shafts_treadles = body.hide_unused_shafts_treadles
 
     if body.ai_training_consent is not None:
         current_user.ai_training_consent = body.ai_training_consent

--- a/backend/app/services/rendering.py
+++ b/backend/app/services/rendering.py
@@ -99,6 +99,27 @@ def render_full_draft_liftplan(draft: Draft, scale: int = 10) -> bytes:
     return out.getvalue()
 
 
+def clip_draft_to_effective(draft: Draft, effective_shafts: int | None, effective_treadles: int | None) -> Draft:
+    """Slice draft.shafts and draft.treadles to their effective counts.
+
+    Modifies the draft in-place and returns it. Caller should pass a copy if
+    the original object is reused.
+    """
+    if effective_shafts and effective_shafts < len(draft.shafts):
+        draft.shafts = draft.shafts[:effective_shafts]
+        for thread in draft.warp:
+            thread.shaft = [s for s in thread.shaft if s in draft.shafts]
+        if hasattr(draft, "tieup") and draft.tieup:
+            draft.tieup = {k: v for k, v in draft.tieup.items() if k in draft.shafts}
+    if effective_treadles and effective_treadles < len(draft.treadles):
+        draft.treadles = draft.treadles[:effective_treadles]
+        for thread in draft.weft:
+            thread.treadles = [t for t in thread.treadles if t in draft.treadles]
+        if hasattr(draft, "tieup") and draft.tieup:
+            draft.tieup = {k: {t: v for t, v in row.items() if t in draft.treadles} for k, row in draft.tieup.items()}
+    return draft
+
+
 def render_drawdown_preview(draft: Draft, max_px: int = 800) -> tuple[bytes, int]:
     """Render a reduced-size drawdown for caching.
 
@@ -138,6 +159,8 @@ def render_drawdown_tile(
     start_row: int = 0,
     row_count: int | None = None,
     scale: int = DRAWDOWN_SCALE,
+    effective_shafts: int | None = None,
+    effective_treadles: int | None = None,
 ) -> tuple[bytes, int, int, int, int]:
     """Render a horizontal strip (tile) of the drawdown.
 
@@ -148,6 +171,9 @@ def render_drawdown_tile(
 
     Returns (png_bytes, total_rows, actual_start_row, actual_row_count, scale_used).
     """
+    if effective_shafts is not None or effective_treadles is not None:
+        draft = clip_draft_to_effective(draft, effective_shafts, effective_treadles)
+
     margin = 20
     warp_count = len(draft.warp)
     weft_count = len(draft.weft)
@@ -201,7 +227,12 @@ def render_drawdown_tile(
     return out.getvalue(), weft_count, actual_start, actual_row_count, scale
 
 
-def render_drawdown_only(draft: Draft, scale: int = DRAWDOWN_SCALE) -> tuple[bytes, int, int]:
+def render_drawdown_only(
+    draft: Draft,
+    scale: int = DRAWDOWN_SCALE,
+    effective_shafts: int | None = None,
+    effective_treadles: int | None = None,
+) -> tuple[bytes, int, int]:
     """Render just the drawdown strip, cropped from the full draft image.
 
     Returns (png_bytes, total_rows, scale_used). Pick 1 is at the top of the image (y=0),
@@ -210,6 +241,9 @@ def render_drawdown_only(draft: Draft, scale: int = DRAWDOWN_SCALE) -> tuple[byt
     Scale is reduced automatically so the output fits within RENDER_MAX_WIDTH/HEIGHT.
     A 413 is raised only if scale=1 would still exceed the limits.
     """
+    if effective_shafts is not None or effective_treadles is not None:
+        draft = clip_draft_to_effective(draft, effective_shafts, effective_treadles)
+
     margin = 20
     warp_count = len(draft.warp)
     weft_count = len(draft.weft)

--- a/backend/app/services/wif_parser.py
+++ b/backend/app/services/wif_parser.py
@@ -87,6 +87,15 @@ def parse_picks(wif_bytes: bytes, project_type: str) -> PickData:
         scale = _color_scale(config)
         colors = _color_table(config, scale)
 
+        # Global default weft color from [WEFT] Color= key (palette index)
+        default_weft_color: str | None = None
+        if config.has_section("WEFT"):
+            try:
+                default_idx = int(config.get("WEFT", "Color").split(",")[0].strip())
+                default_weft_color = colors.get(default_idx)
+            except Exception:
+                pass
+
         weft_color_map: dict[int, int] = {}
         if config.has_section("WEFT COLORS"):
             for k, v in config.items("WEFT COLORS"):
@@ -97,7 +106,7 @@ def parse_picks(wif_bytes: bytes, project_type: str) -> PickData:
                     continue
 
         weft_colors: list[str | None] = [
-            colors.get(weft_color_map[i]) if i in weft_color_map else None for i in range(1, max_pick + 1)
+            colors.get(weft_color_map[i]) if i in weft_color_map else default_weft_color for i in range(1, max_pick + 1)
         ]
 
         result = PickData(project_type=project_type, total_picks=max_pick, picks=picks, weft_colors=weft_colors)

--- a/backend/tests/routers/test_projects.py
+++ b/backend/tests/routers/test_projects.py
@@ -1022,6 +1022,97 @@ class TestRenameProject:
         resp = await auth_client.patch(f"/api/projects/{project.id}", json={})
         assert resp.status_code == 400
 
+    async def test_sets_hide_unused_shafts_treadles(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        body = (
+            await auth_client.patch(f"/api/projects/{project.id}", json={"hide_unused_shafts_treadles": True})
+        ).json()
+        assert body["hide_unused_shafts_treadles"] is True
+
+    async def test_clears_hide_unused_shafts_treadles(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        await auth_client.patch(f"/api/projects/{project.id}", json={"hide_unused_shafts_treadles": True})
+        body = (
+            await auth_client.patch(f"/api/projects/{project.id}", json={"hide_unused_shafts_treadles": False})
+        ).json()
+        assert body["hide_unused_shafts_treadles"] is False
+
+
+# ---------------------------------------------------------------------------
+# TestHideUnusedShaftsTreadlesInheritance
+# ---------------------------------------------------------------------------
+
+
+class TestHideUnusedShaftsTreadlesInheritance:
+    async def test_project_inherits_user_default_off(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        """New project inherits hide_unused_shafts_treadles=False (user default)."""
+        import app.services.storage as storage
+
+        draft_id = uuid.uuid4()
+        wif_key = storage.save_wif(draft_id, "test.wif", _WIF)
+        draft = Draft(
+            id=draft_id,
+            owner_id=test_user.id,
+            name="Draft",
+            wif_filename="test.wif",
+            wif_path=wif_key,
+            has_treadling=True,
+            num_shafts=4,
+            num_treadles=4,
+            warp_threads=4,
+            weft_threads=4,
+        )
+        db_session.add(draft)
+        await db_session.commit()
+
+        resp = await auth_client.post(
+            "/api/projects",
+            json={"name": "P", "draft_id": str(draft_id), "project_type": "treadle"},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["hide_unused_shafts_treadles"] is False
+
+    async def test_project_inherits_user_default_on(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        """New project inherits hide_unused_shafts_treadles=True when user default is on."""
+        import app.services.storage as storage
+
+        test_user.hide_unused_shafts_treadles = True
+        await db_session.commit()
+
+        draft_id = uuid.uuid4()
+        wif_key = storage.save_wif(draft_id, "test.wif", _WIF)
+        draft = Draft(
+            id=draft_id,
+            owner_id=test_user.id,
+            name="Draft",
+            wif_filename="test.wif",
+            wif_path=wif_key,
+            has_treadling=True,
+            num_shafts=4,
+            num_treadles=4,
+            warp_threads=4,
+            weft_threads=4,
+        )
+        db_session.add(draft)
+        await db_session.commit()
+
+        resp = await auth_client.post(
+            "/api/projects",
+            json={"name": "P", "draft_id": str(draft_id), "project_type": "treadle"},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["hide_unused_shafts_treadles"] is True
+
 
 # ---------------------------------------------------------------------------
 # TestDeleteProject

--- a/backend/tests/services/test_wif_parser.py
+++ b/backend/tests/services/test_wif_parser.py
@@ -129,6 +129,26 @@ Version=1.1
         data = parse_picks(content, "treadle")
         assert data.weft_colors[0] == "#c83232"
 
+    def test_weft_global_color_used_when_no_per_pick_section(self):
+        """[WEFT] Color= is used as default when [WEFT COLORS] is absent."""
+        content = wif("[COLOR PALETTE]\nRange=0,255\n\n[COLOR TABLE]\n3=0,0,255\n\n[WEFT]\nColor=3\nThreads=4\n")
+        data = parse_picks(content, "treadle")
+        assert all(c == "#0000ff" for c in data.weft_colors)
+
+    def test_per_pick_colors_override_global_weft_default(self):
+        """[WEFT COLORS] per-pick entries win over [WEFT] Color= global default."""
+        content = wif(
+            "[COLOR PALETTE]\nRange=0,255\n\n"
+            "[COLOR TABLE]\n1=255,0,0\n3=0,0,255\n\n"
+            "[WEFT]\nColor=3\nThreads=4\n\n"
+            "[WEFT COLORS]\n1=1\n2=1\n"
+        )
+        data = parse_picks(content, "treadle")
+        assert data.weft_colors[0] == "#ff0000"  # per-pick overrides global
+        assert data.weft_colors[1] == "#ff0000"
+        assert data.weft_colors[2] == "#0000ff"  # falls back to global
+        assert data.weft_colors[3] == "#0000ff"
+
 
 # ---------------------------------------------------------------------------
 # Color table edge cases (_color_table internals via parse_picks)

--- a/docs/requirements/design-preview.md
+++ b/docs/requirements/design-preview.md
@@ -36,6 +36,39 @@ Each view is accessible individually or as a combined full draft view.
 - Rising vs sinking shed toggle (view fabric from either side)
 - Repeat / tile view (design tiled as it would appear across full fabric width and length)
 
+### Hide Unused Shafts/Treadles
+
+When a draft uses fewer shafts or treadles than the loom supports, the rendered image includes blank rows/columns for the unused ones. This setting clips the rendering to the design's effective counts, reclaiming space and reducing visual noise.
+
+**Behaviour:**
+
+- When enabled: the renderer uses `effective_num_shafts` and `effective_num_treadles` (derived from actual treadling/threading data in the WIF) as the shaft/treadle bounds instead of the declared `num_shafts`/`num_treadles`
+- When disabled (default): all declared shafts and treadles are shown, matching the raw WIF metadata
+- Applies to the drawdown tile viewer and the full-draft preview
+
+**Setting levels:**
+
+| Level | Location | Scope |
+| --- | --- | --- |
+| User default | User Settings → Design Preferences | Applied to all new projects at creation |
+| Project override | Project Settings panel | Per-project; overrides user default for that project only |
+
+- New projects inherit the creating user's default at creation time
+- Changing the project-level setting does not affect other projects or the user default
+- The setting is stored on both `User` and `Project` models as `hide_unused_shafts_treadles` (boolean, default `false`)
+
+**API:**
+
+- `GET /api/drafts/{draft_id}/drawdown?hide_unused_shafts_treadles=true` — query param instructs the renderer to clip to effective counts
+- Frontend reads the project (or user) setting and passes the param; the backend does not auto-resolve the project setting from the project ID
+- `PATCH /api/users/me` and `PATCH /api/projects/{id}` accept `hide_unused_shafts_treadles`
+- `POST /api/projects` inherits the value from the creating user's setting
+
+**Edge cases:**
+
+- If `effective_num_shafts` or `effective_num_treadles` is `null` (e.g. WIF has no treadling section), fall back to declared counts — never fail the render
+- Setting has no effect when `effective_num_shafts == num_shafts` and `effective_num_treadles == num_treadles` (nothing to hide)
+
 ---
 
 ## Color Tools

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -27,6 +27,7 @@ export interface ProjectSummary {
   completed_at: string | null;
   abandoned_at: string | null;
   created_at: string;
+  hide_unused_shafts_treadles: boolean;
 }
 
 export interface ProjectPhoto {
@@ -160,6 +161,17 @@ export function updateProjectNotes(id: string, notes: string | null): Promise<Pr
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ notes }),
+  });
+}
+
+export function updateProjectSettings(
+  id: string,
+  settings: { hide_unused_shafts_treadles?: boolean }
+): Promise<ProjectDetail> {
+  return req(`/api/projects/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(settings),
   });
 }
 

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -19,6 +19,7 @@ export interface UserSettingsUpdate {
   measurement_system?: string;
   ai_training_consent?: boolean;
   show_version_numbers?: boolean;
+  hide_unused_shafts_treadles?: boolean;
 }
 
 export async function updateSettings(body: UserSettingsUpdate): Promise<User> {

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -15,6 +15,7 @@ export interface User {
   measurement_system: string;
   ai_training_consent: boolean;
   show_version_numbers: boolean;
+  hide_unused_shafts_treadles: boolean;
   eula_accepted_version: string | null;
   current_eula_version: string;
   storage_used_bytes: number;

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -7,7 +7,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   getProject, getProjectPicks, stepProject, jumpProject, completeProject, abandonProject,
   restartProject, cloneProject, listProjects, deleteProject,
-  renameProject, updateProjectNotes, uploadProjectPhoto, deleteProjectPhoto, projectPhotoUrl,
+  renameProject, updateProjectNotes, updateProjectSettings, uploadProjectPhoto, deleteProjectPhoto, projectPhotoUrl,
   ApiError, PROJECT_TYPE_LABELS, PROJECT_STATUS_LABELS,
   type ProjectSummary, type ProjectPhoto, type PickRow,
 } from "@/api/projects";
@@ -93,6 +93,105 @@ function DesignPreviewModal({ draftId, onClose }: { draftId: string; onClose: ()
 // Pick display — current pick instructions
 // ---------------------------------------------------------------------------
 
+// Boxes beyond this count switch to compact (no-label) mode with a detail sheet.
+const COMPACT_THRESHOLD = 8;
+
+function PickDetailSheet({
+  pick,
+  totalCount,
+  dimAbove,
+  projectType,
+  colorMode,
+  weftHex,
+  onClose,
+}: {
+  pick: PickRow;
+  totalCount: number;
+  dimAbove: number;
+  projectType: string;
+  colorMode: ColorMode;
+  weftHex: string | null;
+  onClose: () => void;
+}) {
+  const count = Math.max(totalCount, 1);
+  const activeLabel = pick.active.length === 0
+    ? "None active"
+    : `${projectType === "lift" ? "Shafts" : "Treadles"}: ${pick.active.slice().sort((a, b) => a - b).join(", ")}`;
+
+  return (
+    <>
+      <div className="fixed inset-0 z-40 bg-black/40" onClick={onClose} />
+      <div className="fixed bottom-0 inset-x-0 z-50 rounded-t-2xl border-t border-border bg-card px-4 pb-8 pt-4 shadow-xl">
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <p className="text-sm font-semibold">Pick {pick.pick}</p>
+            <p className="text-xs text-muted-foreground">{activeLabel}</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label="Close detail"
+          >
+            <AppIcons.close className="h-4 w-4" />
+          </button>
+        </div>
+
+        {weftHex && (
+          <div
+            className="mb-3 h-6 w-full rounded-md flex items-center justify-center text-xs font-semibold uppercase tracking-wider"
+            style={{ backgroundColor: weftHex, color: contrastColor(weftHex) }}
+          >
+            Weft color
+          </div>
+        )}
+
+        <div
+          className="grid gap-2"
+          style={{ gridTemplateColumns: `repeat(${Math.min(count, 8)}, 1fr)` }}
+        >
+          {Array.from({ length: count }, (_, i) => i + 1).map((n) => {
+            const active = pick.active.includes(n);
+            const trailing = dimAbove > 0 && n > dimAbove;
+            if (colorMode !== "theme" && active && weftHex) {
+              if (colorMode === "filled") {
+                const fg = contrastColor(weftHex);
+                return (
+                  <div key={n} style={{ backgroundColor: weftHex, borderColor: fg }}
+                    className="aspect-square rounded-lg border-2 flex items-center justify-center text-sm font-bold">
+                    <span style={{ color: fg }}>{n}</span>
+                  </div>
+                );
+              }
+              if (colorMode === "strip") {
+                return (
+                  <div key={n}
+                    className="aspect-square rounded-lg border-2 relative overflow-hidden border-primary bg-primary flex items-center justify-center text-sm font-bold">
+                    <span className="absolute bottom-0 left-0 right-0 h-[20%]"
+                      style={{ backgroundColor: weftHex }} />
+                    <span className="relative text-primary-foreground">{n}</span>
+                  </div>
+                );
+              }
+            }
+            return (
+              <div key={n}
+                className={`aspect-square rounded-lg border-2 flex items-center justify-center text-sm font-bold ${
+                  active
+                    ? "bg-primary border-primary text-primary-foreground"
+                    : trailing
+                      ? "border-muted/40 bg-muted/10 text-muted-foreground/30"
+                      : "border-muted bg-muted/30 text-muted-foreground"
+                }`}>
+                {n}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </>
+  );
+}
+
 function PickDisplay({
   pick,
   totalCount,
@@ -110,6 +209,75 @@ function PickDisplay({
 }) {
   const count = Math.max(totalCount, 1);
   const weftHex = pick.color ?? null;
+  const isCompact = count > COMPACT_THRESHOLD;
+  const [detailOpen, setDetailOpen] = useState(false);
+
+  if (isCompact) {
+    return (
+      <>
+        <button
+          className="w-full rounded-xl border-2 border-primary/30 bg-primary/5 dark:bg-primary/10 px-4 py-3 flex items-center gap-3 text-left"
+          onClick={() => setDetailOpen(true)}
+          aria-label="Tap to see pick details"
+        >
+          <div className="shrink-0 text-primary/50">
+            {projectType === "lift" ? (
+              <AppIcons.lift className="h-6 w-6" strokeWidth={1.5} />
+            ) : (
+              <AppIcons.treadle className="h-6 w-6" strokeWidth={1.5} />
+            )}
+          </div>
+
+          {/* Compact dot grid — active boxes filled, inactive dimmed */}
+          <div
+            className="flex-1 grid gap-1"
+            style={{ gridTemplateColumns: `repeat(${count}, 1fr)` }}
+          >
+            {Array.from({ length: count }, (_, i) => i + 1).map((n) => {
+              const active = pick.active.includes(n);
+              const trailing = dimAbove > 0 && n > dimAbove;
+              const bg = active
+                ? (colorMode !== "theme" && weftHex ? weftHex : undefined)
+                : undefined;
+              return (
+                <div
+                  key={n}
+                  className={`aspect-square rounded ${
+                    active
+                      ? "ring-2 ring-primary ring-offset-1"
+                      : trailing
+                        ? "bg-muted/10"
+                        : "bg-muted/40"
+                  }`}
+                  style={bg ? { backgroundColor: bg } : active ? { backgroundColor: "var(--primary)" } : undefined}
+                />
+              );
+            })}
+          </div>
+
+          {/* Active count summary */}
+          <div className="shrink-0 text-right">
+            <p className="text-sm font-semibold text-primary">
+              {pick.active.slice().sort((a, b) => a - b).join(", ")}
+            </p>
+            <p className="text-xs text-muted-foreground">tap for detail</p>
+          </div>
+        </button>
+
+        {detailOpen && (
+          <PickDetailSheet
+            pick={pick}
+            totalCount={totalCount}
+            dimAbove={dimAbove}
+            projectType={projectType}
+            colorMode={colorMode}
+            weftHex={weftHex}
+            onClose={() => setDetailOpen(false)}
+          />
+        )}
+      </>
+    );
+  }
 
   return (
     <div className="rounded-xl border-2 border-primary/30 bg-primary/5 dark:bg-primary/10 px-4 py-4 h-28 flex items-stretch gap-4">
@@ -209,12 +377,14 @@ function WeavingPatternView({
   totalPicks,
   picks,
   maxActive,
+  hideUnusedShaftsTreadles = false,
 }: {
   draftId: string;
   currentPickIndex: number;
   totalPicks: number;
   picks: PickRow[];
   maxActive: number;
+  hideUnusedShaftsTreadles?: boolean;
 }) {
   const containerH = useAdaptivePatternHeight();
   const [pixelsPerRow, setPixelsPerRow] = useState(20);
@@ -288,8 +458,9 @@ function WeavingPatternView({
       try {
         const token = await getAuthToken();
         const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
+        const hideParam = hideUnusedShaftsTreadles ? "&hide_unused_shafts_treadles=true" : "";
         const res = await fetch(
-          `/api/drafts/${draftId}/drawdown?start_row=${startRow}&row_count=${tileSize}`,
+          `/api/drafts/${draftId}/drawdown?start_row=${startRow}&row_count=${tileSize}${hideParam}`,
           { credentials: "include", headers, signal: controller.signal }
         );
         clearTimeout(timeoutId);
@@ -323,7 +494,7 @@ function WeavingPatternView({
     needed.forEach(s => { fetchTile(s); });
 
     return () => { cancelled = true; };
-  }, [draftId, currentPickIndex, totalPicks, tileSize, retryCount]);
+  }, [draftId, currentPickIndex, totalPicks, tileSize, hideUnusedShaftsTreadles, retryCount]);
 
   // Revoke all object URLs on unmount.
   useEffect(() => {
@@ -1075,6 +1246,8 @@ export function ProjectDetailPage() {
     staleTime: Infinity,
   });
 
+  const hideUnusedShaftsTreadles = project?.hide_unused_shafts_treadles ?? false;
+
   const isPlanning = project?.status === "active" && !project?.loom_id;
   const isCompleted = project?.status === "completed";
 
@@ -1456,8 +1629,8 @@ export function ProjectDetailPage() {
           </div>
         )}
 
-        {/* Pick instruction — stays compact */}
-        {!isCompleted && showPickDisplay && <div className="mx-auto max-w-2xl px-8 pt-4">
+        {/* Pick instruction — full width so treadle/lift boxes use available space */}
+        {!isCompleted && showPickDisplay && <div className="w-full px-8 pt-4">
           {isFinished ? (
             <div className="mx-auto max-w-lg rounded-lg border border-dashed p-10 text-center">
               <p className="text-lg font-medium">All {project.total_picks} picks complete!</p>
@@ -1503,6 +1676,7 @@ export function ProjectDetailPage() {
               totalPicks={project.total_picks}
               picks={picksData.picks}
               maxActive={displayCount}
+              hideUnusedShaftsTreadles={hideUnusedShaftsTreadles}
             />
           </div>
         )}
@@ -1874,6 +2048,31 @@ export function ProjectDetailPage() {
                   </div>
                 </div>
               )}
+
+              {/* Project rendering settings (persisted to server) */}
+              <div className="space-y-1.5">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Project settings</p>
+                <div className="flex items-center justify-between">
+                  <div>
+                    <span className="text-sm">Hide unused shafts/treadles</span>
+                    <p className="text-xs text-muted-foreground">Clip rendering to design's effective counts</p>
+                  </div>
+                  <button
+                    role="switch"
+                    aria-checked={hideUnusedShaftsTreadles}
+                    onClick={() => {
+                      const next = !hideUnusedShaftsTreadles;
+                      queryClient.setQueryData(["project", project.id], (old: typeof project | undefined) =>
+                        old ? { ...old, hide_unused_shafts_treadles: next } : old
+                      );
+                      updateProjectSettings(project.id, { hide_unused_shafts_treadles: next });
+                    }}
+                    className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-ring ${hideUnusedShaftsTreadles ? "bg-primary" : "bg-input"}`}
+                  >
+                    <span className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform ${hideUnusedShaftsTreadles ? "translate-x-4" : "translate-x-1"}`} />
+                  </button>
+                </div>
+              </div>
 
               {/* Color mode selector */}
               {picksData?.has_weft_colors && (

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -246,8 +246,8 @@ function PickDisplay({
                     active
                       ? "ring-2 ring-primary ring-offset-1"
                       : trailing
-                        ? "bg-muted/10"
-                        : "bg-muted/40"
+                        ? "bg-muted/10 ring-1 ring-border/30"
+                        : "bg-muted/40 ring-1 ring-border/50"
                   }`}
                   style={bg ? { backgroundColor: bg } : active ? { backgroundColor: "var(--primary)" } : undefined}
                 />
@@ -633,7 +633,7 @@ function WeavingPatternView({
                 <div
                   key={n}
                   className={`rounded-[2px] flex-1 min-w-0 ${
-                    pick.active.includes(n) ? "bg-primary" : "bg-muted/40"
+                    pick.active.includes(n) ? "bg-primary" : "bg-muted/40 ring-[0.5px] ring-border/40"
                   }`}
                   style={{ height: boxH }}
                 />
@@ -1452,11 +1452,21 @@ export function ProjectDetailPage() {
   const declaredCount = project.project_type === "lift"
     ? (project.draft_num_shafts ?? 0)
     : (project.draft_num_treadles ?? 0);
+  const effectiveCount = project.project_type === "lift"
+    ? (project.draft_effective_num_shafts ?? null)
+    : (project.draft_effective_num_treadles ?? null);
   const maxFromPicks = picksData ? Math.max(0, ...picksData.picks.flatMap((p) => p.active)) : 0;
   // When a loom is assigned, use its treadle/shaft count; otherwise fall back to draft declared count.
-  const maxActive = (loomCount !== null && loomCount > 0)
-    ? loomCount
-    : (declaredCount > 0 ? declaredCount : maxFromPicks);
+  // When hiding unused shafts/treadles, cap at the draft's effective count.
+  const maxActive = (() => {
+    const base = (loomCount !== null && loomCount > 0)
+      ? loomCount
+      : (declaredCount > 0 ? declaredCount : maxFromPicks);
+    if (hideUnusedShaftsTreadles && effectiveCount !== null && effectiveCount > 0 && effectiveCount < base) {
+      return effectiveCount;
+    }
+    return base;
+  })();
 
   // Highest treadle/shaft index actually used in any pick across the full sequence.
   const maxUsed = picksData ? Math.max(0, ...picksData.picks.flatMap((p) => p.active)) : 0;
@@ -2074,27 +2084,28 @@ export function ProjectDetailPage() {
                 </div>
               </div>
 
-              {/* Color mode selector */}
-              {picksData?.has_weft_colors && (
-                <div className="space-y-2">
-                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Color mode</p>
-                  <div className="inline-flex rounded-md border border-input overflow-hidden text-sm w-full">
-                    {(["theme", "strip", "filled"] as ColorMode[]).map((mode) => (
-                      <button
-                        key={mode}
-                        onClick={() => { setColorMode(mode); localStorage.setItem("proj-view:colorMode", mode); }}
-                        className={`flex-1 px-2.5 py-1.5 capitalize transition-colors ${
-                          colorMode === mode
-                            ? "bg-primary text-primary-foreground"
-                            : "bg-background text-muted-foreground hover:bg-muted"
-                        }`}
-                      >
-                        {mode}
-                      </button>
-                    ))}
-                  </div>
+              {/* Color mode selector — always shown; strip/filled have no visible effect without weft colors */}
+              <div className="space-y-2">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Color mode</p>
+                <div className="inline-flex rounded-md border border-input overflow-hidden text-sm w-full">
+                  {(["theme", "strip", "filled"] as ColorMode[]).map((mode) => (
+                    <button
+                      key={mode}
+                      onClick={() => { setColorMode(mode); localStorage.setItem("proj-view:colorMode", mode); }}
+                      className={`flex-1 px-2.5 py-1.5 capitalize transition-colors ${
+                        colorMode === mode
+                          ? "bg-primary text-primary-foreground"
+                          : "bg-background text-muted-foreground hover:bg-muted"
+                      }`}
+                    >
+                      {mode}
+                    </button>
+                  ))}
                 </div>
-              )}
+                {!picksData?.has_weft_colors && (
+                  <p className="text-xs text-muted-foreground">This design has no weft colors defined.</p>
+                )}
+              </div>
             </div>
           </div>
         </>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -34,6 +34,7 @@ export function SettingsPage() {
   const [theme, setTheme] = useState(user?.theme ?? "light");
   const [activityTheme, setActivityTheme] = useState(user?.activity_theme ?? "default");
   const [showVersionNumbers, setShowVersionNumbers] = useState(user?.show_version_numbers ?? true);
+  const [hideUnusedShaftsTreadles, setHideUnusedShaftsTreadles] = useState(user?.hide_unused_shafts_treadles ?? false);
   const [idleTimeout, setIdleTimeout] = useState(user?.idle_timeout_minutes ?? 30);
   const [measurementSystem, setMeasurementSystem] = useState(user?.measurement_system ?? "metric");
   const [dataConsent, setDataConsent] = useState(user?.ai_training_consent ?? false);
@@ -188,6 +189,34 @@ export function SettingsPage() {
                   </div>
                   <p className="text-xs text-muted-foreground mt-1">
                     Show or hide the UI, API, and worker version badge in the bottom-right corner.
+                  </p>
+                </Field>
+
+                <Field label="Hide unused shafts and treadles">
+                  <div className="flex items-center gap-3">
+                    <button
+                      role="switch"
+                      aria-checked={hideUnusedShaftsTreadles}
+                      onClick={() => {
+                        const next = !hideUnusedShaftsTreadles;
+                        setHideUnusedShaftsTreadles(next);
+                        save({ hide_unused_shafts_treadles: next });
+                      }}
+                      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+                        hideUnusedShaftsTreadles ? "bg-primary" : "bg-input"
+                      }`}
+                    >
+                      <span
+                        className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                          hideUnusedShaftsTreadles ? "translate-x-6" : "translate-x-1"
+                        }`}
+                      />
+                    </button>
+                    <span className="text-sm">{hideUnusedShaftsTreadles ? "Hidden" : "Shown"}</span>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    When enabled, shafts and treadles not used by the design are hidden in the drawdown
+                    viewer. New projects inherit this setting. Default is off (all shafts/treadles shown).
                   </p>
                 </Field>
               </Section>


### PR DESCRIPTION
## Summary

Two improvements to the project weaving experience, motivated by a 16-shaft Jane loom on a phone-width screen.

### Hide unused shafts/treadles (#563)

When a draft uses fewer shafts/treadles than the loom declares (e.g. 4-treadle design on a 10-treadle loom), this setting clips the rendering to only show what the design actually uses.

- `hide_unused_shafts_treadles` boolean added to **User** (default `false`) and **Project** models
- Alembic migration 0010 adds both columns
- `rendering.py` gains `clip_draft_to_effective()` — slices `draft.shafts` and `draft.treadles` to effective counts before passing to PyWeaving
- `GET /api/drafts/{id}/drawdown?hide_unused_shafts_treadles=true` — new query param
- New projects inherit the creating user's default at creation time
- **User Settings** (Appearance section): "Hide unused shafts and treadles" toggle
- **Project settings drawer**: "Project settings" section with per-project toggle; optimistic cache update on change

### Compact pick display for large shaft/treadle counts

When a project has more than 8 shafts or treadles, `PickDisplay` switches to a compact mode designed for narrow screens:

- Small square dot indicators (no number labels) — active ones highlighted with `ring-primary`
- Active shaft/treadle numbers shown as a text summary on the right (e.g. `3, 7, 12`)
- Tap anywhere on the card → **PickDetailSheet** bottom sheet slides up with:
  - Full-size labeled grid (max 8 columns, wraps for 16+)
  - `Shafts: X, Y, Z` active summary
  - Optional weft color bar
- ≤ 8 shafts/treadles: original labeled box layout unchanged

**Also:** pick instruction card widened from `max-w-2xl` to `w-full` so wide-shaft looms have maximum horizontal space.

## Test plan
- [ ] User Settings: toggle "Hide unused shafts and treadles" → saved; new project inherits it
- [ ] Project with 10-treadle loom + 4-treadle WIF: toggle in project settings → drawdown rerenders with 4 columns
- [ ] Project with ≤ 8 treadles: normal labeled boxes unchanged
- [ ] Project with 16-shaft lift plan: compact dot row visible; tap → full-size bottom sheet with all 16 labeled
- [ ] DB migration runs clean on dev: `alembic upgrade head`
- [ ] `TestHideUnusedShaftsTreadlesInheritance` passes in CI
- [ ] `TestRenameProject::test_sets_hide_unused_shafts_treadles` passes in CI

Closes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)