### PR TITLE
fix: prevent MaxMind GeoLite2 download limit exhaustion on redeploy

### DIFF
--- a/backend/app/tasks/geo.py
+++ b/backend/app/tasks/geo.py
@@ -8,11 +8,14 @@ import logging
 import os
 import tarfile
 import tempfile
+import time
 import urllib.request
 
 from app.celery_app import celery_app
 
 log = logging.getLogger(__name__)
+
+_MIN_AGE_SECONDS = 23 * 3600  # never download more than once per 23 h
 
 
 @celery_app.task(
@@ -30,6 +33,12 @@ def refresh_geoip_database(self) -> dict:
     if not license_key:
         log.info("MAXMIND_LICENSE_KEY not set — skipping GeoLite2 refresh")
         return {"skipped": True, "reason": "no_license_key"}
+
+    if os.path.exists(db_path):
+        age = time.time() - os.path.getmtime(db_path)
+        if age < _MIN_AGE_SECONDS:
+            log.info("GeoLite2-City database is %.1f h old — skipping download", age / 3600)
+            return {"skipped": True, "reason": "fresh", "age_hours": round(age / 3600, 1)}
 
     url = (
         "https://download.maxmind.com/app/geoip_download"

--- a/backend/tests/tasks/test_geo_task.py
+++ b/backend/tests/tasks/test_geo_task.py
@@ -1,0 +1,114 @@
+"""Tests for app/tasks/geo.refresh_geoip_database.
+
+Covers: license-key guard, staleness guard, download + extract path, missing-file path.
+"""
+
+import os
+import tarfile
+import time
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.tasks.geo import _MIN_AGE_SECONDS, refresh_geoip_database
+
+
+def _make_fake_tar_gz(mmdb_content: bytes = b"fake-mmdb") -> bytes:
+    buf = BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        info = tarfile.TarInfo(name="GeoLite2-City_20240101/GeoLite2-City.mmdb")
+        info.size = len(mmdb_content)
+        tf.addfile(info, BytesIO(mmdb_content))
+    return buf.getvalue()
+
+
+def _mock_settings(license_key: str, db_path: str) -> MagicMock:
+    settings = MagicMock()
+    settings.maxmind_license_key = license_key
+    settings.geoip_db_path = db_path
+    return settings
+
+
+class TestRefreshGeoipDatabase:
+    def test_skips_when_no_license_key(self, tmp_path):
+        db_path = str(tmp_path / "GeoLite2-City.mmdb")
+        with patch("app.config.get_settings", return_value=_mock_settings("", db_path)):
+            result = refresh_geoip_database()
+        assert result["skipped"] is True
+        assert result["reason"] == "no_license_key"
+
+    def test_skips_when_file_is_fresh(self, tmp_path):
+        db_path = tmp_path / "GeoLite2-City.mmdb"
+        db_path.write_bytes(b"existing")
+        # mtime = now — well within the 23 h window
+        with patch("app.config.get_settings", return_value=_mock_settings("key", str(db_path))):
+            result = refresh_geoip_database()
+        assert result["skipped"] is True
+        assert result["reason"] == "fresh"
+
+    def test_skips_when_file_just_under_min_age(self, tmp_path):
+        db_path = tmp_path / "GeoLite2-City.mmdb"
+        db_path.write_bytes(b"existing")
+        new_mtime = time.time() - (_MIN_AGE_SECONDS - 60)
+        os.utime(db_path, (new_mtime, new_mtime))
+        with patch("app.config.get_settings", return_value=_mock_settings("key", str(db_path))):
+            result = refresh_geoip_database()
+        assert result["skipped"] is True
+
+    def test_downloads_when_file_absent(self, tmp_path):
+        db_path = str(tmp_path / "GeoLite2-City.mmdb")
+        fake_tar = _make_fake_tar_gz(b"mmdb-data")
+
+        def fake_retrieve(url, dest):
+            with open(dest, "wb") as f:
+                f.write(fake_tar)
+
+        with (
+            patch("app.config.get_settings", return_value=_mock_settings("key", db_path)),
+            patch("urllib.request.urlretrieve", side_effect=fake_retrieve),
+        ):
+            result = refresh_geoip_database()
+
+        assert result.get("refreshed") is True
+        assert open(db_path, "rb").read() == b"mmdb-data"
+
+    def test_downloads_when_file_is_stale(self, tmp_path):
+        db_path = tmp_path / "GeoLite2-City.mmdb"
+        db_path.write_bytes(b"old-data")
+        stale_mtime = time.time() - (_MIN_AGE_SECONDS + 3600)
+        os.utime(db_path, (stale_mtime, stale_mtime))
+        fake_tar = _make_fake_tar_gz(b"new-mmdb-data")
+
+        def fake_retrieve(url, dest):
+            with open(dest, "wb") as f:
+                f.write(fake_tar)
+
+        with (
+            patch("app.config.get_settings", return_value=_mock_settings("key", str(db_path))),
+            patch("urllib.request.urlretrieve", side_effect=fake_retrieve),
+        ):
+            result = refresh_geoip_database()
+
+        assert result.get("refreshed") is True
+        assert open(db_path, "rb").read() == b"new-mmdb-data"
+
+    def test_raises_when_mmdb_not_in_archive(self, tmp_path):
+        db_path = str(tmp_path / "GeoLite2-City.mmdb")
+        buf = BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+            info = tarfile.TarInfo(name="some-other-file.txt")
+            info.size = 4
+            tf.addfile(info, BytesIO(b"data"))
+        empty_tar = buf.getvalue()
+
+        def fake_retrieve(url, dest):
+            with open(dest, "wb") as f:
+                f.write(empty_tar)
+
+        with (
+            patch("app.config.get_settings", return_value=_mock_settings("key", db_path)),
+            patch("urllib.request.urlretrieve", side_effect=fake_retrieve),
+        ):
+            with pytest.raises(RuntimeError, match="GeoLite2-City.mmdb not found"):
+                refresh_geoip_database()

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -204,7 +204,7 @@ services:
     environment:
       <<: *worker-env
       OTEL_SERVICE_NAME: weftmark-beat
-    entrypoint: ["celery", "-A", "app.celery_app", "beat", "--loglevel=info", "--pidfile="]
+    entrypoint: ["celery", "-A", "app.celery_app", "beat", "--loglevel=info", "--pidfile=", "--schedule=/app/data/celerybeat-schedule"]
 
   # ----------------------------------------------------------
   # Redis — Celery broker and result backend


### PR DESCRIPTION
## Summary

- **Root cause**: Celery beat stored `celerybeat-schedule` in the container's ephemeral filesystem. Every container recreation (redeploy) wiped this file, causing beat to think the weekly GeoLite2 task had never run and fire it immediately — burning through the GeoLite 30-downloads/day limit across multiple workers and deploys.
- **Fix 1**: Pass `--schedule=/app/data/celerybeat-schedule` to the beat entrypoint so the schedule state persists on the `geoip_data` named volume across restarts.
- **Fix 2**: Add a 23-hour staleness guard inside `refresh_geoip_database` — if the MMDB is less than 23 hours old, skip the download regardless of what triggered the task. Prevents multi-worker races on first boot.
- **Tests**: 6 new tests in `tests/tasks/test_geo_task.py` covering all guard paths and the full download + extract flow.

## Test plan

- [ ] Deploy to dev — confirm beat does not trigger a GeoLite2 download on startup (MMDB already present and fresh)
- [ ] Verify `celerybeat-schedule` file appears in the `geoip_data` volume after beat starts: `docker exec weftmark-dev_beat ls /app/data/celerybeat-schedule`
- [ ] Confirm no new MaxMind download emails after subsequent deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)