### PR TITLE
feat: 2D project tile rendering keyed to project_id (#427)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -133,6 +133,8 @@ class Settings(BaseSettings):
     render_default_zoom: int = 10
     drawdown_preview_max_px: int = 800
     tile_row_count: int = 100
+    tile_col_count: int = 200
+    tile_prune_inactive_days: int = 10
 
     @model_validator(mode="after")
     def _require_secret_key_in_production(self) -> "Settings":

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -20,7 +20,7 @@ from app.services import storage, wif_parser
 from app.services.images import resize_to_jpeg
 from app.services.storage_quota import check_storage_quota
 from app.tasks.preview import generate_drawdown_preview
-from app.tasks.tiles import prerender_drawdown_tiles
+from app.tasks.tiles import prerender_project_tiles
 
 ALLOWED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/webp", "image/heic", "image/heif"}
 MAX_PROJECT_PHOTOS = 10
@@ -334,8 +334,8 @@ async def create_project(
     from app.config import get_settings
     from app.services.task_history import record_queued
 
-    tile_task = prerender_drawdown_tiles.delay(str(draft.id))
-    record_queued(get_settings(), tile_task.id, "app.tasks.tiles.prerender_drawdown_tiles", "preview")
+    tile_task = prerender_project_tiles.delay(str(project.id))
+    record_queued(get_settings(), tile_task.id, "app.tasks.tiles.prerender_project_tiles", "preview")
     return _to_detail(project, draft, loom)
 
 
@@ -353,6 +353,98 @@ async def list_projects(
         q = q.where(Project.loom_id == loom_id)
     result = await db.scalars(q.order_by(Project.created_at.desc()))
     return [ProjectSummary.model_validate(p) for p in result.all()]
+
+
+@router.get("/{project_id}/drawdown")
+async def get_project_drawdown(
+    project_id: uuid.UUID,
+    start_row: int | None = Query(None, ge=0),
+    row_count: int | None = Query(None, ge=1),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    from app.config import get_settings
+    from app.services import rendering
+    from app.services.storage import afile_exists, aproject_tile_exists, aread_file, aread_project_tile
+
+    project = await _get_owned_project(project_id, current_user, db)
+
+    draft = await db.scalar(select(Draft).where(Draft.id == project.draft_id, Draft.deleted_at.is_(None)))
+    if draft is None:
+        raise HTTPException(status_code=404, detail="Draft not found")
+
+    wif_path = await _wif_path_for_project(draft, project.project_type)
+    if not wif_path or not await afile_exists(wif_path):
+        raise HTTPException(status_code=404, detail="WIF file not found in storage")
+
+    _settings = get_settings()
+    _sr = start_row or 0
+    _rc = row_count
+    tile_row_count = _settings.tile_row_count
+
+    warp_count = draft.warp_threads or 0
+    weft_count = draft.weft_threads or 0
+    if warp_count > 0:
+        expected_scale = min(_settings.render_max_width // warp_count, rendering.DRAWDOWN_SCALE)
+    else:
+        expected_scale = rendering.DRAWDOWN_SCALE
+
+    # Check pre-rendered project tile cache on standard row-boundary alignment
+    if (
+        warp_count > 0
+        and _sr % tile_row_count == 0
+        and _rc == tile_row_count
+        and await aproject_tile_exists(project_id, expected_scale, _sr)
+    ):
+        cached_png = await aread_project_tile(project_id, expected_scale, _sr)
+        actual_rc = min(tile_row_count, weft_count - _sr) if weft_count > 0 else tile_row_count
+        return Response(
+            content=cached_png,
+            media_type="image/png",
+            headers={
+                "X-Pixels-Per-Row": str(expected_scale),
+                "X-Total-Rows": str(weft_count),
+                "X-Total-Cols": str(warp_count),
+                "X-Start-Row": str(_sr),
+                "X-Row-Count": str(actual_rc),
+                "Cache-Control": "public, max-age=31536000, immutable",
+            },
+        )
+
+    wif_bytes = await aread_file(wif_path)
+    try:
+        png, total_rows, actual_start, actual_row_count, actual_scale = await asyncio.to_thread(
+            lambda: rendering.render_drawdown_tile(
+                rendering.load_draft(wif_bytes),
+                start_row=_sr,
+                row_count=_rc,
+            )
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Drawdown rendering failed: {exc}")
+
+    # Trigger background tile pre-render on standard boundary miss only when t0 is absent
+    if _sr % tile_row_count == 0 and _rc == tile_row_count:
+        if not await aproject_tile_exists(project_id, expected_scale, 0):
+            from app.services.task_history import record_queued
+
+            tile_task = prerender_project_tiles.apply_async(args=[str(project_id)])
+            record_queued(_settings, tile_task.id, "app.tasks.tiles.prerender_project_tiles", "preview")
+
+    return Response(
+        content=png,
+        media_type="image/png",
+        headers={
+            "X-Pixels-Per-Row": str(actual_scale),
+            "X-Total-Rows": str(total_rows),
+            "X-Total-Cols": str(warp_count),
+            "X-Start-Row": str(actual_start),
+            "X-Row-Count": str(actual_row_count),
+            "Cache-Control": "no-store",
+        },
+    )
 
 
 @router.get("/{project_id}", response_model=ProjectDetail)

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -155,6 +155,64 @@ async def asave_drawdown_tile(draft_id: uuid.UUID, scale: int, start_row: int, d
 
 
 # ---------------------------------------------------------------------------
+# Project tiles — pre-rendered row strips keyed by project_id
+# ---------------------------------------------------------------------------
+
+
+def project_tile_path(project_id: uuid.UUID, scale: int, start_row: int) -> str:
+    return f"projects/{project_id}/tiles/s{scale}/r{start_row}.png"
+
+
+def save_project_tile(project_id: uuid.UUID, scale: int, start_row: int, data: bytes) -> str:
+    return _put(project_tile_path(project_id, scale, start_row), data)
+
+
+def project_tile_exists(project_id: uuid.UUID, scale: int, start_row: int) -> bool:
+    return _exists(project_tile_path(project_id, scale, start_row))
+
+
+def read_project_tile(project_id: uuid.UUID, scale: int, start_row: int) -> bytes:
+    return _get(project_tile_path(project_id, scale, start_row))
+
+
+async def aproject_tile_exists(project_id: uuid.UUID, scale: int, start_row: int) -> bool:
+    return await asyncio.to_thread(project_tile_exists, project_id, scale, start_row)
+
+
+async def aread_project_tile(project_id: uuid.UUID, scale: int, start_row: int) -> bytes:
+    return await asyncio.to_thread(read_project_tile, project_id, scale, start_row)
+
+
+async def asave_project_tile(project_id: uuid.UUID, scale: int, start_row: int, data: bytes) -> str:
+    return await asyncio.to_thread(save_project_tile, project_id, scale, start_row, data)
+
+
+def delete_project_tiles(project_id: uuid.UUID) -> int:
+    """Delete all pre-rendered tiles for a project. Returns the count of deleted objects."""
+    prefix = f"projects/{project_id}/tiles/"
+    if settings.storage_backend == "s3":
+        paginator = _s3().get_paginator("list_objects_v2")
+        keys = []
+        for page in paginator.paginate(Bucket=settings.s3_bucket_name, Prefix=prefix):
+            for obj in page.get("Contents", []):
+                keys.append(obj["Key"])
+        if keys:
+            for i in range(0, len(keys), 1000):
+                batch = [{"Key": k} for k in keys[i : i + 1000]]
+                _s3().delete_objects(Bucket=settings.s3_bucket_name, Delete={"Objects": batch})
+        return len(keys)
+    else:
+        prefix_path = Path(settings.upload_dir) / prefix
+        if not prefix_path.exists():
+            return 0
+        count = 0
+        for f in prefix_path.rglob("*.png"):
+            f.unlink()
+            count += 1
+        return count
+
+
+# ---------------------------------------------------------------------------
 # Looms — profile photo
 # ---------------------------------------------------------------------------
 

--- a/backend/app/tasks/deletion.py
+++ b/backend/app/tasks/deletion.py
@@ -137,6 +137,13 @@ async def _purge_storage(db: AsyncSession, user_id: uuid.UUID, storage) -> None:
     for p in photos.all():
         _safe_delete(storage, p.file_path)
 
+    projects = await db.scalars(select(Project).where(Project.owner_id == user_id))
+    for project in projects.all():
+        try:
+            storage.delete_project_tiles(project.id)
+        except Exception as exc:
+            log.warning("deletion_storage_error project_tiles project_id=%s error=%s", project.id, exc)
+
     yarns = await db.scalars(select(Yarn).where(Yarn.owner_id == user_id))
     for y in yarns.all():
         if y.photo_path:

--- a/backend/app/tasks/maintenance.py
+++ b/backend/app/tasks/maintenance.py
@@ -8,6 +8,7 @@ Covers:
 - retry_failed_previews                 — re-dispatch preview generation for drafts missing drawdown previews
 - send_admin_digest                     — weekly digest email to all active admins
 - backfill_project_drawdown_previews    — dispatch preview generation for active-project drafts missing tiles
+- prune_inactive_project_tiles          — delete cached tiles for inactive or soft-deleted projects
 """
 
 import logging
@@ -703,3 +704,52 @@ def backfill_project_drawdown_previews(self, limit: int = 50) -> dict:
         engine.dispose()
     log.info("backfill_project_drawdown_previews dispatched=%d limit=%d", dispatched, limit)
     return {"dispatched": dispatched}
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=0,
+    name="app.tasks.maintenance.prune_inactive_project_tiles",
+)
+def prune_inactive_project_tiles(self, inactive_days: int = 10) -> dict:
+    from sqlalchemy import create_engine, or_, select
+    from sqlalchemy.orm import Session
+
+    from app.config import get_settings
+    from app.models.project import Project
+    from app.services import storage
+
+    settings = get_settings()
+    cutoff = datetime.now(timezone.utc) - timedelta(days=inactive_days)
+    pruned_projects = 0
+    pruned_tiles = 0
+
+    engine = create_engine(settings.database_url_sync)
+    try:
+        with Session(engine) as db:
+            project_ids = db.scalars(
+                select(Project.id).where(
+                    or_(
+                        Project.deleted_at.isnot(None),
+                        Project.updated_at < cutoff,
+                    )
+                )
+            ).all()
+            for project_id in project_ids:
+                try:
+                    deleted = storage.delete_project_tiles(project_id)
+                    if deleted > 0:
+                        pruned_projects += 1
+                        pruned_tiles += deleted
+                except Exception:
+                    log.exception("prune_inactive_project_tiles: error deleting tiles for project_id=%s", project_id)
+    finally:
+        engine.dispose()
+
+    log.info(
+        "prune_inactive_project_tiles pruned_projects=%d pruned_tiles=%d inactive_days=%d",
+        pruned_projects,
+        pruned_tiles,
+        inactive_days,
+    )
+    return {"pruned_projects": pruned_projects, "pruned_tiles": pruned_tiles}

--- a/backend/app/tasks/scheduler.py
+++ b/backend/app/tasks/scheduler.py
@@ -117,6 +117,16 @@ REGISTRY: dict[str, dict] = {
         "default_cron": "0 8 * * 1",
         "default_config": {},
     },
+    "tile_prune": {
+        "display_name": "Inactive Tile Prune",
+        "description": (
+            "Removes pre-rendered drawdown tiles for projects that have not been active "
+            "within the configured window, and for soft-deleted projects. "
+            "Tiles are regenerated on demand when the project is reopened."
+        ),
+        "default_cron": "0 6 * * *",
+        "default_config": {"inactive_days": 10},
+    },
 }
 
 
@@ -230,6 +240,17 @@ def _dispatch_admin_digest(settings, task=None):
     return t
 
 
+def _dispatch_tile_prune(settings, task=None):
+    from app.services.task_history import record_queued
+    from app.tasks.maintenance import prune_inactive_project_tiles
+
+    cfg = (task.config or {}) if task else {}
+    inactive_days = int(cfg.get("inactive_days", 10))
+    t = prune_inactive_project_tiles.delay(inactive_days=inactive_days)
+    record_queued(settings, t.id, "app.tasks.maintenance.prune_inactive_project_tiles", "scheduled:tile_prune")
+    return t
+
+
 DISPATCH_FNS: dict[str, object] = {
     "cve_scan": _dispatch_cve_scan,
     "s3_audit": _dispatch_s3_audit,
@@ -242,6 +263,7 @@ DISPATCH_FNS: dict[str, object] = {
     "server_event_log_pruning": _dispatch_server_event_log_pruning,
     "credential_expiry_check": _dispatch_credential_expiry_check,
     "admin_digest": _dispatch_admin_digest,
+    "tile_prune": _dispatch_tile_prune,
 }
 
 

--- a/backend/app/tasks/tiles.py
+++ b/backend/app/tasks/tiles.py
@@ -1,4 +1,8 @@
-"""Celery task: pre-render drawdown tiles for a draft and store them in R2."""
+"""Celery tasks: pre-render drawdown tiles for a draft or project and store them in R2.
+
+prerender_drawdown_tiles — draft-keyed tiles (used by the draft library endpoint)
+prerender_project_tiles  — project-keyed tiles (used by the project weaving view)
+"""
 
 from __future__ import annotations
 
@@ -23,10 +27,22 @@ log = logging.getLogger(__name__)
     name="app.tasks.tiles.prerender_drawdown_tiles",
 )
 def prerender_drawdown_tiles(self: Task, draft_id: str) -> None:
-    asyncio.run(_prerender(self, uuid.UUID(draft_id)))
+    asyncio.run(_prerender_draft(self, uuid.UUID(draft_id)))
 
 
-async def _prerender(task: Task, draft_id: uuid.UUID) -> None:
+@celery_app.task(
+    bind=True,
+    max_retries=2,
+    default_retry_delay=60,
+    soft_time_limit=300,
+    time_limit=360,
+    name="app.tasks.tiles.prerender_project_tiles",
+)
+def prerender_project_tiles(self: Task, project_id: str) -> None:
+    asyncio.run(_prerender_project(self, uuid.UUID(project_id)))
+
+
+async def _prerender_draft(task: Task, draft_id: uuid.UUID) -> None:
     from PIL import Image as PILImage
     from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
     from sqlalchemy.orm import sessionmaker
@@ -51,48 +67,17 @@ async def _prerender(task: Task, draft_id: uuid.UUID) -> None:
 
             try:
                 wif_bytes = storage.read_file(draft.wif_path)
-                wif_draft = rendering.load_draft(wif_bytes)
-
-                warp_count = len(wif_draft.warp)
-                weft_count = len(wif_draft.weft)
-                if warp_count <= 0 or weft_count <= 0:
-                    log.warning("tile_prerender_skip draft_id=%s reason=empty_draft", draft_id)
-                    return
-
-                effective_scale = min(settings.render_max_width // warp_count, rendering.DRAWDOWN_SCALE)
-                if effective_scale < 1:
-                    log.warning("tile_prerender_skip draft_id=%s reason=too_wide", draft_id)
-                    return
-
-                margin = 20
-                renderer = ImageRenderer(wif_draft, scale=effective_scale, margin_pixels=margin)
-                full_im = renderer.make_pil_image()
-
-                offsetx = margin
-                offsety = margin + (6 + len(wif_draft.shafts)) * effective_scale
-                drawdown_w = warp_count * effective_scale
-                drawdown_h = weft_count * effective_scale
-                full_drawdown = full_im.crop((offsetx, offsety, offsetx + drawdown_w, offsety + drawdown_h))
-                full_drawdown = full_drawdown.transpose(PILImage.Transpose.FLIP_TOP_BOTTOM)
-
-                tile_row_count = settings.tile_row_count
-                tile_count = 0
-                for tile_start in range(0, weft_count, tile_row_count):
-                    tile_end = min(tile_start + tile_row_count, weft_count)
-                    tile_px_top = tile_start * effective_scale
-                    tile_px_bottom = tile_end * effective_scale
-                    tile_im = full_drawdown.crop((0, tile_px_top, drawdown_w, tile_px_bottom))
-                    out = io.BytesIO()
-                    tile_im.save(out, format="PNG")
-                    storage.save_drawdown_tile(draft_id, effective_scale, tile_start, out.getvalue())
-                    tile_count += 1
-
-                log.info(
-                    "tile_prerender_done draft_id=%s scale=%d tiles=%d",
-                    draft_id,
-                    effective_scale,
-                    tile_count,
+                tile_count = _render_and_store_tiles(
+                    wif_bytes,
+                    settings,
+                    rendering,
+                    ImageRenderer,
+                    PILImage,
+                    lambda pid, scale, start, data: storage.save_drawdown_tile(draft_id, scale, start, data),
+                    entity_id=draft_id,
+                    entity_label="draft_id",
                 )
+                log.info("tile_prerender_done draft_id=%s tiles=%d", draft_id, tile_count)
             except Exception as exc:
                 log.warning("tile_prerender_failed draft_id=%s error=%s", draft_id, exc)
                 try:
@@ -101,3 +86,109 @@ async def _prerender(task: Task, draft_id: uuid.UUID) -> None:
                     pass
     finally:
         await engine.dispose()
+
+
+async def _prerender_project(task: Task, project_id: uuid.UUID) -> None:
+    from PIL import Image as PILImage
+    from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+    from sqlalchemy.orm import sessionmaker
+
+    from app.config import get_settings
+    from app.models.draft import Draft
+    from app.models.project import Project
+    from app.services import rendering, storage
+    from app.services.rendering import ImageRenderer
+
+    settings = get_settings()
+    engine = create_async_engine(settings.database_url, echo=False)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    try:
+        async with async_session() as db:
+            project = await db.get(Project, project_id)
+            if project is None or project.deleted_at is not None:
+                return
+
+            draft = await db.get(Draft, project.draft_id)
+            if draft is None or draft.deleted_at is not None:
+                return
+
+            wif_path = draft.wif_path
+            if project.project_type == "lift" and draft.wif_modified_path:
+                if storage.file_exists(draft.wif_modified_path):
+                    wif_path = draft.wif_modified_path
+
+            if not wif_path or not storage.file_exists(wif_path):
+                log.warning("tile_prerender_skip project_id=%s reason=no_wif", project_id)
+                return
+
+            try:
+                wif_bytes = storage.read_file(wif_path)
+                tile_count = _render_and_store_tiles(
+                    wif_bytes,
+                    settings,
+                    rendering,
+                    ImageRenderer,
+                    PILImage,
+                    lambda _pid, scale, start, data: storage.save_project_tile(project_id, scale, start, data),
+                    entity_id=project_id,
+                    entity_label="project_id",
+                )
+                log.info("tile_prerender_done project_id=%s tiles=%d", project_id, tile_count)
+            except Exception as exc:
+                log.warning("tile_prerender_failed project_id=%s error=%s", project_id, exc)
+                try:
+                    raise task.retry(exc=exc)
+                except task.MaxRetriesExceededError:
+                    pass
+    finally:
+        await engine.dispose()
+
+
+def _render_and_store_tiles(
+    wif_bytes: bytes,
+    settings,
+    rendering,
+    ImageRenderer,
+    PILImage,
+    save_fn,
+    entity_id: uuid.UUID,
+    entity_label: str,
+) -> int:
+    wif_draft = rendering.load_draft(wif_bytes)
+
+    warp_count = len(wif_draft.warp)
+    weft_count = len(wif_draft.weft)
+    if warp_count <= 0 or weft_count <= 0:
+        log.warning("tile_prerender_skip %s=%s reason=empty_draft", entity_label, entity_id)
+        return 0
+
+    effective_scale = min(settings.render_max_width // warp_count, rendering.DRAWDOWN_SCALE)
+    if effective_scale < 1:
+        log.warning("tile_prerender_skip %s=%s reason=too_wide", entity_label, entity_id)
+        return 0
+
+    margin = 20
+    renderer = ImageRenderer(wif_draft, scale=effective_scale, margin_pixels=margin)
+    full_im = renderer.make_pil_image()
+
+    offsetx = margin
+    offsety = margin + (6 + len(wif_draft.shafts)) * effective_scale
+    drawdown_w = warp_count * effective_scale
+    drawdown_h = weft_count * effective_scale
+    full_drawdown = full_im.crop((offsetx, offsety, offsetx + drawdown_w, offsety + drawdown_h))
+    full_drawdown = full_drawdown.transpose(PILImage.Transpose.FLIP_TOP_BOTTOM)
+
+    tile_row_count = settings.tile_row_count
+    tile_count = 0
+    for tile_start in range(0, weft_count, tile_row_count):
+        tile_end = min(tile_start + tile_row_count, weft_count)
+        tile_px_top = tile_start * effective_scale
+        tile_px_bottom = tile_end * effective_scale
+        tile_im = full_drawdown.crop((0, tile_px_top, drawdown_w, tile_px_bottom))
+        out = io.BytesIO()
+        tile_im.save(out, format="PNG")
+        save_fn(entity_id, effective_scale, tile_start, out.getvalue())
+        tile_count += 1
+
+    return tile_count

--- a/backend/tests/routers/test_projects.py
+++ b/backend/tests/routers/test_projects.py
@@ -25,9 +25,9 @@ def _mock_preview_task(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def _mock_tile_task(monkeypatch):
-    """Prevent prerender_drawdown_tiles.delay() from connecting to Celery in tests."""
+    """Prevent prerender_project_tiles.delay/apply_async() from connecting to Celery in tests."""
     mock = MagicMock()
-    monkeypatch.setattr("app.routers.projects.prerender_drawdown_tiles", mock)
+    monkeypatch.setattr("app.routers.projects.prerender_project_tiles", mock)
     return mock
 
 
@@ -57,11 +57,11 @@ Entries=2
 
 [WARP]
 Threads=4
-Units=cm
+Units=centimeters
 
 [WEFT]
 Threads=2
-Units=cm
+Units=centimeters
 
 [THREADING]
 1=1
@@ -80,6 +80,67 @@ Units=cm
 [LIFTPLAN]
 1=1
 2=2
+"""
+
+# Renderable WIF: includes [WEAVING] section and 4 weft threads required by PyWeaving.
+# Used only by _insert_project_with_wif so existing tests are unaffected.
+_WIF_RENDERABLE = b"""[WIF]
+Version=1.1
+Date=April 1 1997
+Developers=wif@mhsoft.com
+Source Program=Test
+Source Version=1.0
+
+[CONTENTS]
+COLOR PALETTE=true
+COLOR TABLE=true
+WEAVING=true
+WARP=true
+WEFT=true
+THREADING=true
+TIEUP=true
+TREADLING=true
+
+[COLOR PALETTE]
+Range=0,255
+Entries=2
+
+[COLOR TABLE]
+1=255,255,255
+2=0,0,0
+
+[WEAVING]
+Shafts=4
+Treadles=4
+Rising Shed=true
+
+[WARP]
+Threads=4
+Units=centimeters
+Color=1
+
+[WEFT]
+Threads=4
+Units=centimeters
+Color=2
+
+[THREADING]
+1=1
+2=2
+3=3
+4=4
+
+[TIEUP]
+1=1
+2=2
+3=3
+4=4
+
+[TREADLING]
+1=1
+2=2
+3=3
+4=4
 """
 
 _LOOM_PAYLOAD = {
@@ -1609,3 +1670,181 @@ class TestUnsupportedLoomType:
             json={"loom_id": str(loom.id)},
         )
         assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# create_project fires prerender with project.id (not draft.id)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateProjectFiresProjectPrerender:
+    async def test_prerender_called_with_project_id(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User, _mock_tile_task
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        resp = await auth_client.post("/api/projects", json=_base_payload(str(draft.id)))
+        assert resp.status_code == 201
+        project_id = resp.json()["id"]
+
+        _mock_tile_task.delay.assert_called_once_with(project_id)
+
+    async def test_prerender_not_called_with_draft_id(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User, _mock_tile_task
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        await auth_client.post("/api/projects", json=_base_payload(str(draft.id)))
+
+        call_args = _mock_tile_task.delay.call_args
+        assert call_args is not None
+        assert str(draft.id) not in call_args.args
+
+
+# ---------------------------------------------------------------------------
+# GET /api/projects/{id}/drawdown
+# ---------------------------------------------------------------------------
+
+_TILE_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16  # minimal fake PNG header
+
+
+async def _insert_project_with_wif(
+    db_session: AsyncSession,
+    owner: User,
+    *,
+    warp_threads: int = 4,
+    weft_threads: int = 4,
+) -> tuple[Draft, "Project"]:
+    import app.services.storage as storage
+
+    draft_id = uuid.uuid4()
+    wif_key = storage.save_wif(draft_id, "test.wif", _WIF_RENDERABLE)
+    draft = Draft(
+        id=draft_id,
+        owner_id=owner.id,
+        name="Tile Test Draft",
+        wif_filename="test.wif",
+        wif_path=wif_key,
+        has_treadling=True,
+        has_liftplan=False,
+        num_shafts=4,
+        num_treadles=4,
+        warp_threads=warp_threads,
+        weft_threads=weft_threads,
+    )
+    db_session.add(draft)
+    await db_session.flush()
+
+    project = Project(
+        owner_id=owner.id,
+        draft_id=draft.id,
+        name="Tile Test Project",
+        project_type="treadle",
+        status="active",
+        current_pick=1,
+        total_picks=weft_threads,
+    )
+    db_session.add(project)
+    await db_session.commit()
+    return draft, project
+
+
+class TestProjectDrawdown:
+    async def test_returns_401_when_unauthenticated(
+        self, client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        _, project = await _insert_project_with_wif(db_session, test_user)
+        resp = await client.get(f"/api/projects/{project.id}/drawdown?start_row=0&row_count=4")
+        assert resp.status_code == 401
+
+    async def test_returns_404_for_unknown_project(self, auth_client: AsyncClient):
+        resp = await auth_client.get(f"/api/projects/{uuid.uuid4()}/drawdown?start_row=0&row_count=4")
+        assert resp.status_code == 404
+
+    async def test_renders_and_returns_png_on_cache_miss(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        _, project = await _insert_project_with_wif(db_session, test_user)
+        resp = await auth_client.get(f"/api/projects/{project.id}/drawdown?start_row=0&row_count=4")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "image/png"
+        assert resp.content[:4] == b"\x89PNG"
+
+    async def test_returns_dimension_headers(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        _, project = await _insert_project_with_wif(db_session, test_user, warp_threads=4, weft_threads=4)
+        resp = await auth_client.get(f"/api/projects/{project.id}/drawdown?start_row=0&row_count=4")
+        assert resp.status_code == 200
+        assert resp.headers.get("X-Total-Rows") == "4"
+        assert resp.headers.get("X-Total-Cols") == "4"
+        assert resp.headers.get("X-Start-Row") == "0"
+        assert resp.headers.get("X-Pixels-Per-Row") is not None
+
+    async def test_cache_miss_no_store_header(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        _, project = await _insert_project_with_wif(db_session, test_user)
+        resp = await auth_client.get(f"/api/projects/{project.id}/drawdown?start_row=0&row_count=4")
+        assert resp.headers.get("Cache-Control") == "no-store"
+
+    async def test_cache_hit_returns_stored_bytes(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        import app.services.storage as storage
+        from app.config import get_settings
+        from app.services.rendering import DRAWDOWN_SCALE
+
+        settings = get_settings()
+        draft, project = await _insert_project_with_wif(db_session, test_user, warp_threads=4)
+        tile_row_count = settings.tile_row_count
+        expected_scale = min(settings.render_max_width // 4, DRAWDOWN_SCALE)
+        storage.save_project_tile(project.id, expected_scale, 0, _TILE_PNG)
+
+        resp = await auth_client.get(f"/api/projects/{project.id}/drawdown?start_row=0&row_count={tile_row_count}")
+        assert resp.status_code == 200
+        assert resp.content == _TILE_PNG
+
+    async def test_cache_hit_immutable_header(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        import app.services.storage as storage
+        from app.config import get_settings
+        from app.services.rendering import DRAWDOWN_SCALE
+
+        settings = get_settings()
+        draft, project = await _insert_project_with_wif(db_session, test_user, warp_threads=4)
+        tile_row_count = settings.tile_row_count
+        expected_scale = min(settings.render_max_width // 4, DRAWDOWN_SCALE)
+        storage.save_project_tile(project.id, expected_scale, 0, _TILE_PNG)
+
+        resp = await auth_client.get(f"/api/projects/{project.id}/drawdown?start_row=0&row_count={tile_row_count}")
+        assert "immutable" in (resp.headers.get("Cache-Control") or "")
+
+    async def test_cache_miss_triggers_prerender_task(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User, _mock_tile_task
+    ):
+        from app.config import get_settings
+
+        settings = get_settings()
+        _, project = await _insert_project_with_wif(db_session, test_user)
+        tile_row_count = settings.tile_row_count
+
+        await auth_client.get(f"/api/projects/{project.id}/drawdown?start_row=0&row_count={tile_row_count}")
+        _mock_tile_task.apply_async.assert_called_once_with(args=[str(project.id)])
+
+    async def test_cache_miss_skips_task_when_t0_exists(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User, _mock_tile_task
+    ):
+        import app.services.storage as storage
+        from app.config import get_settings
+        from app.services.rendering import DRAWDOWN_SCALE
+
+        settings = get_settings()
+        draft, project = await _insert_project_with_wif(db_session, test_user, warp_threads=4)
+        tile_row_count = settings.tile_row_count
+        expected_scale = min(settings.render_max_width // 4, DRAWDOWN_SCALE)
+
+        storage.save_project_tile(project.id, expected_scale, 0, _TILE_PNG)
+
+        resp = await auth_client.get(
+            f"/api/projects/{project.id}/drawdown?start_row={tile_row_count}&row_count={tile_row_count}"
+        )
+        assert resp.status_code == 200
+        _mock_tile_task.apply_async.assert_not_called()

--- a/backend/tests/tasks/test_maintenance.py
+++ b/backend/tests/tasks/test_maintenance.py
@@ -870,3 +870,153 @@ class TestSendAdminDigest:
         call_kwargs = mock_send.call_args.kwargs
         # storage_delta_str should be set (non-None) since prior baseline exists
         assert call_kwargs["storage_delta_str"] is not None
+
+
+# ---------------------------------------------------------------------------
+# prune_inactive_project_tiles
+# ---------------------------------------------------------------------------
+
+
+class TestPruneInactiveProjectTiles:
+    def test_returns_result_keys(self):
+        from app.tasks.maintenance import prune_inactive_project_tiles
+
+        with patch("app.services.storage.delete_project_tiles", return_value=0):
+            result = prune_inactive_project_tiles.run.__func__(_make_task(), inactive_days=9999)
+
+        assert "pruned_projects" in result
+        assert "pruned_tiles" in result
+        assert isinstance(result["pruned_projects"], int)
+        assert isinstance(result["pruned_tiles"], int)
+
+    def test_zero_when_no_projects(self):
+        from app.tasks.maintenance import prune_inactive_project_tiles
+
+        with patch("app.services.storage.delete_project_tiles", return_value=0) as mock_del:
+            result = prune_inactive_project_tiles.run.__func__(_make_task(), inactive_days=9999)
+
+        assert result["pruned_projects"] == 0
+        assert result["pruned_tiles"] == 0
+        mock_del.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_prunes_inactive_project(self, db_session, test_user):
+        import uuid as _uuid
+
+        import app.services.storage as storage
+        from app.models.draft import Draft
+        from app.models.project import Project
+        from app.tasks.maintenance import prune_inactive_project_tiles
+
+        draft = Draft(
+            id=_uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Draft",
+            wif_filename="test.wif",
+            wif_path=storage.save_wif(_uuid.uuid4(), "test.wif", b"[WIF]"),
+        )
+        db_session.add(draft)
+        await db_session.flush()
+
+        project = Project(
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="Stale Project",
+            project_type="treadle",
+            status="active",
+            current_pick=1,
+            total_picks=10,
+        )
+        db_session.add(project)
+        await db_session.commit()
+
+        # Backdate updated_at to simulate inactive project
+        from sqlalchemy import update as _update
+
+        from app.models.project import Project as _Project
+
+        await db_session.execute(_update(_Project).where(_Project.id == project.id).values(updated_at=_ago(days=20)))
+        await db_session.commit()
+
+        with patch("app.services.storage.delete_project_tiles", return_value=5) as mock_del:
+            result = prune_inactive_project_tiles.run.__func__(_make_task(), inactive_days=10)
+
+        mock_del.assert_called_once_with(project.id)
+        assert result["pruned_projects"] == 1
+        assert result["pruned_tiles"] == 5
+
+    @pytest.mark.asyncio
+    async def test_keeps_recently_active_project(self, db_session, test_user):
+        import uuid as _uuid
+
+        import app.services.storage as storage
+        from app.models.draft import Draft
+        from app.models.project import Project
+        from app.tasks.maintenance import prune_inactive_project_tiles
+
+        draft = Draft(
+            id=_uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Draft",
+            wif_filename="test.wif",
+            wif_path=storage.save_wif(_uuid.uuid4(), "test.wif", b"[WIF]"),
+        )
+        db_session.add(draft)
+        await db_session.flush()
+
+        project = Project(
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="Active Project",
+            project_type="treadle",
+            status="active",
+            current_pick=5,
+            total_picks=10,
+        )
+        db_session.add(project)
+        await db_session.commit()
+        # updated_at is just now — should NOT be pruned
+
+        with patch("app.services.storage.delete_project_tiles", return_value=0) as mock_del:
+            result = prune_inactive_project_tiles.run.__func__(_make_task(), inactive_days=10)
+
+        mock_del.assert_not_called()
+        assert result["pruned_projects"] == 0
+
+    @pytest.mark.asyncio
+    async def test_prunes_soft_deleted_project(self, db_session, test_user):
+        import uuid as _uuid
+
+        import app.services.storage as storage
+        from app.models.draft import Draft
+        from app.models.project import Project
+        from app.tasks.maintenance import prune_inactive_project_tiles
+
+        draft = Draft(
+            id=_uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Draft",
+            wif_filename="test.wif",
+            wif_path=storage.save_wif(_uuid.uuid4(), "test.wif", b"[WIF]"),
+        )
+        db_session.add(draft)
+        await db_session.flush()
+
+        project = Project(
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="Deleted Project",
+            project_type="treadle",
+            status="active",
+            current_pick=1,
+            total_picks=10,
+        )
+        project.deleted_at = _ago(minutes=5)
+        db_session.add(project)
+        await db_session.commit()
+
+        with patch("app.services.storage.delete_project_tiles", return_value=3) as mock_del:
+            result = prune_inactive_project_tiles.run.__func__(_make_task(), inactive_days=9999)
+
+        mock_del.assert_called_once_with(project.id)
+        assert result["pruned_projects"] == 1

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -201,13 +201,13 @@ function useAdaptivePatternHeight(): number {
 }
 
 function WeavingPatternView({
-  draftId,
+  projectId,
   currentPickIndex,
   totalPicks,
   picks,
   maxActive,
 }: {
-  draftId: string;
+  projectId: string;
   currentPickIndex: number;
   totalPicks: number;
   picks: PickRow[];
@@ -286,7 +286,7 @@ function WeavingPatternView({
         const token = await getAuthToken();
         const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
         const res = await fetch(
-          `/api/drafts/${draftId}/drawdown?start_row=${startRow}&row_count=${tileSize}`,
+          `/api/projects/${projectId}/drawdown?start_row=${startRow}&row_count=${tileSize}`,
           { credentials: "include", headers, signal: controller.signal }
         );
         clearTimeout(timeoutId);
@@ -320,7 +320,7 @@ function WeavingPatternView({
     needed.forEach(s => { fetchTile(s); });
 
     return () => { cancelled = true; };
-  }, [draftId, currentPickIndex, totalPicks, tileSize, retryCount]);
+  }, [projectId, currentPickIndex, totalPicks, tileSize, retryCount]);
 
   // Revoke all object URLs on unmount.
   useEffect(() => {
@@ -1500,7 +1500,7 @@ export function ProjectDetailPage() {
           {showDrawdown && picksData && !isFinished && !isCompleted && !isAbandoned && (
             <div className="mx-auto w-full max-w-2xl lg:max-w-5xl xl:max-w-7xl px-8 pb-4 pt-4">
               <WeavingPatternView
-                draftId={project.draft_id}
+                projectId={project.id}
                 currentPickIndex={currentPickIndex}
                 totalPicks={project.total_picks}
                 picks={picksData.picks}


### PR DESCRIPTION
## Summary

- **Storage**: project tiles at `projects/{id}/tiles/s{scale}/r{start_row}.png`, separate from draft tiles
- **Celery task**: `prerender_project_tiles(project_id)` fires on project creation and pre-renders all row tiles
- **Endpoint**: `GET /api/projects/{id}/drawdown` — immutable cache on boundary hits, live render + prerender trigger on misses
- **Maintenance**: `prune_inactive_project_tiles` (10-day default threshold), registered as `tile_prune` scheduled task at 06:00 UTC daily
- **Deletion**: project tiles purged during user deletion cascade
- **Frontend**: `WeavingPatternView` in `ProjectDetailPage` now fetches from `/api/projects/{id}/drawdown`

## Test plan

- [x] TestProjectDrawdown: 9 tests (401, 404, cache miss render, dimension headers, no-store, cache hit bytes, immutable, prerender trigger, skip-task-when-t0-exists)
- [x] TestCreateProjectFiresProjectPrerender: 2 tests
- [x] TestPruneInactiveProjectTiles: 5 tests
- [x] tsc clean, 146 test_projects.py tests pass, no regressions
- [ ] Browser: open a project weaving view and confirm tiles load from `/api/projects/{id}/drawdown`

> **Squash recommendation:** Single feature commit — no squash needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)