### PR TITLE
feat: add column tile slicing to drawdown endpoint (#427)

### DIFF
--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -360,6 +360,8 @@ async def get_project_drawdown(
     project_id: uuid.UUID,
     start_row: int | None = Query(None, ge=0),
     row_count: int | None = Query(None, ge=1),
+    start_col: int | None = Query(None, ge=0),
+    col_count: int | None = Query(None, ge=1),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
@@ -412,12 +414,16 @@ async def get_project_drawdown(
         )
 
     wif_bytes = await aread_file(wif_path)
+    _sc = start_col
+    _cc = col_count
     try:
-        png, total_rows, actual_start, actual_row_count, actual_scale = await asyncio.to_thread(
+        result = await asyncio.to_thread(
             lambda: rendering.render_drawdown_tile(
                 rendering.load_draft(wif_bytes),
                 start_row=_sr,
                 row_count=_rc,
+                start_col=_sc,
+                col_count=_cc,
             )
         )
     except HTTPException:
@@ -425,14 +431,25 @@ async def get_project_drawdown(
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Drawdown rendering failed: {exc}")
 
-    # Trigger background tile pre-render on standard boundary miss only when t0 is absent
-    if _sr % tile_row_count == 0 and _rc == tile_row_count:
+    if len(result) == 7:
+        png, total_rows, actual_start, actual_row_count, actual_scale, actual_start_col, actual_col_count = result
+    else:
+        png, total_rows, actual_start, actual_row_count, actual_scale = result
+        actual_start_col = 0
+        actual_col_count = warp_count
+
+    # Trigger background tile pre-render on standard boundary miss only when t0 is absent.
+    # Only applies to full-width (non-column-sliced) requests.
+    if _sc is None and _sr % tile_row_count == 0 and _rc == tile_row_count:
         if not await aproject_tile_exists(project_id, expected_scale, 0):
             from app.services.task_history import record_queued
 
             tile_task = prerender_project_tiles.apply_async(args=[str(project_id)])
             record_queued(_settings, tile_task.id, "app.tasks.tiles.prerender_project_tiles", "preview")
 
+    extra_headers = (
+        {"X-Start-Col": str(actual_start_col), "X-Col-Count": str(actual_col_count)} if _sc is not None else {}
+    )
     return Response(
         content=png,
         media_type="image/png",
@@ -443,6 +460,7 @@ async def get_project_drawdown(
             "X-Start-Row": str(actual_start),
             "X-Row-Count": str(actual_row_count),
             "Cache-Control": "no-store",
+            **extra_headers,
         },
     )
 

--- a/backend/app/services/rendering.py
+++ b/backend/app/services/rendering.py
@@ -161,15 +161,21 @@ def render_drawdown_tile(
     scale: int = DRAWDOWN_SCALE,
     effective_shafts: int | None = None,
     effective_treadles: int | None = None,
-) -> tuple[bytes, int, int, int, int]:
-    """Render a horizontal strip (tile) of the drawdown.
+    start_col: int | None = None,
+    col_count: int | None = None,
+) -> tuple[bytes, int, int, int, int] | tuple[bytes, int, int, int, int, int, int]:
+    """Render a tile of the drawdown.
 
-    ``start_row`` and ``row_count`` are in image-row terms:
-    row 0 = top of the image = last pick (completed picks accumulate downward).
+    When ``start_col`` / ``col_count`` are omitted the full warp width is
+    returned and the result is a 5-tuple
+    ``(png_bytes, total_rows, actual_start_row, actual_row_count, scale_used)``.
 
-    Only the width cap from settings is applied — height is determined by ``row_count``.
+    When ``start_col`` / ``col_count`` are given a column-sliced tile is returned
+    and the result is a 7-tuple extending the above with
+    ``(actual_start_col, actual_col_count)``.
 
-    Returns (png_bytes, total_rows, actual_start_row, actual_row_count, scale_used).
+    ``start_row`` / ``start_col`` are 0-based; row 0 = top of the drawdown image
+    (= last pick, since completed picks accumulate downward).
     """
     if effective_shafts is not None or effective_treadles is not None:
         draft = clip_draft_to_effective(draft, effective_shafts, effective_treadles)
@@ -220,11 +226,24 @@ def render_drawdown_tile(
 
     tile_top = actual_start * scale
     tile_bottom = tile_top + actual_row_count * scale
-    tile = full_drawdown.crop((0, tile_top, drawdown_w, tile_bottom))
 
+    if start_col is None:
+        tile = full_drawdown.crop((0, tile_top, drawdown_w, tile_bottom))
+        out = io.BytesIO()
+        tile.save(out, format="PNG")
+        return out.getvalue(), weft_count, actual_start, actual_row_count, scale
+
+    actual_start_col = max(0, min(start_col, warp_count - 1))
+    if col_count is None or col_count <= 0:
+        col_count = warp_count
+    actual_col_count = min(col_count, warp_count - actual_start_col)
+
+    tile_left = actual_start_col * scale
+    tile_right = tile_left + actual_col_count * scale
+    tile = full_drawdown.crop((tile_left, tile_top, tile_right, tile_bottom))
     out = io.BytesIO()
     tile.save(out, format="PNG")
-    return out.getvalue(), weft_count, actual_start, actual_row_count, scale
+    return out.getvalue(), weft_count, actual_start, actual_row_count, scale, actual_start_col, actual_col_count
 
 
 def render_drawdown_only(

--- a/backend/tests/routers/test_projects.py
+++ b/backend/tests/routers/test_projects.py
@@ -1848,3 +1848,51 @@ class TestProjectDrawdown:
         )
         assert resp.status_code == 200
         _mock_tile_task.apply_async.assert_not_called()
+
+    # --- column slicing ---
+
+    async def test_col_slice_returns_200(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        _, project = await _insert_project_with_wif(db_session, test_user)
+        resp = await auth_client.get(
+            f"/api/projects/{project.id}/drawdown?start_row=0&row_count=4&start_col=0&col_count=2"
+        )
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "image/png"
+
+    async def test_col_slice_returns_start_col_header(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        _, project = await _insert_project_with_wif(db_session, test_user)
+        resp = await auth_client.get(
+            f"/api/projects/{project.id}/drawdown?start_row=0&row_count=4&start_col=1&col_count=2"
+        )
+        assert resp.status_code == 200
+        assert resp.headers.get("X-Start-Col") == "1"
+        assert resp.headers.get("X-Col-Count") is not None
+
+    async def test_col_slice_narrower_than_full_width(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        import io as _io
+
+        from PIL import Image as PILImage
+
+        _, project = await _insert_project_with_wif(db_session, test_user, warp_threads=4)
+        resp_full = await auth_client.get(f"/api/projects/{project.id}/drawdown?start_row=0&row_count=4")
+        resp_col = await auth_client.get(
+            f"/api/projects/{project.id}/drawdown?start_row=0&row_count=4&start_col=0&col_count=2"
+        )
+        assert resp_full.status_code == 200
+        assert resp_col.status_code == 200
+        img_full = PILImage.open(_io.BytesIO(resp_full.content))
+        img_col = PILImage.open(_io.BytesIO(resp_col.content))
+        assert img_col.width < img_full.width
+
+    async def test_col_slice_invalid_start_col_returns_422(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        _, project = await _insert_project_with_wif(db_session, test_user)
+        resp = await auth_client.get(
+            f"/api/projects/{project.id}/drawdown?start_row=0&row_count=4&start_col=-1&col_count=2"
+        )
+        assert resp.status_code == 422

--- a/backend/tests/services/test_rendering.py
+++ b/backend/tests/services/test_rendering.py
@@ -481,6 +481,68 @@ class TestRenderDrawdownTile:
         img = Image.open(_io.BytesIO(png))
         assert img.height == actual_row_count * scale_used
 
+    # --- column slicing ---
+
+    def test_returns_seven_elements_when_col_params_given(self):
+        draft = load_draft(MINIMAL_WIF)
+        result = render_drawdown_tile(draft, start_row=0, row_count=2, start_col=0, col_count=2)
+        assert isinstance(result, tuple) and len(result) == 7
+
+    def test_col_slice_width_equals_col_count_times_scale(self):
+        import io as _io
+
+        from PIL import Image
+
+        draft = load_draft(MINIMAL_WIF)
+        scale = 10
+        png, _, _, _, scale_used, _, actual_col_count = render_drawdown_tile(
+            draft, start_row=0, row_count=2, scale=scale, start_col=0, col_count=2
+        )
+        img = Image.open(_io.BytesIO(png))
+        assert img.width == actual_col_count * scale_used
+
+    def test_col_slice_narrower_than_full_width(self):
+        import io as _io
+
+        from PIL import Image
+
+        draft = load_draft(MINIMAL_WIF)
+        scale = 10
+        png_full, *_ = render_drawdown_tile(draft, start_row=0, row_count=2, scale=scale)
+        png_col, *_ = render_drawdown_tile(draft, start_row=0, row_count=2, scale=scale, start_col=0, col_count=2)
+        img_full = Image.open(_io.BytesIO(png_full))
+        img_col = Image.open(_io.BytesIO(png_col))
+        assert img_col.width < img_full.width
+        assert img_col.width == 2 * scale
+
+    def test_start_col_offsets_slice(self):
+        draft = load_draft(MINIMAL_WIF)
+        _, _, _, _, _, actual_start_col, _ = render_drawdown_tile(
+            draft, start_row=0, row_count=2, start_col=1, col_count=2
+        )
+        assert actual_start_col == 1
+
+    def test_col_count_clamped_at_draft_end(self):
+        draft = load_draft(MINIMAL_WIF)
+        warp_count = len(draft.warp)
+        _, _, _, _, _, actual_start_col, actual_col_count = render_drawdown_tile(
+            draft, start_row=0, row_count=2, start_col=2, col_count=100
+        )
+        assert actual_start_col + actual_col_count <= warp_count
+
+    def test_start_col_clamped_to_valid_range(self):
+        draft = load_draft(MINIMAL_WIF)
+        warp_count = len(draft.warp)
+        _, _, _, _, _, actual_start_col, _ = render_drawdown_tile(
+            draft, start_row=0, row_count=2, start_col=999, col_count=2
+        )
+        assert actual_start_col <= warp_count - 1
+
+    def test_no_col_params_returns_five_elements(self):
+        draft = load_draft(MINIMAL_WIF)
+        result = render_drawdown_tile(draft, start_row=0, row_count=2)
+        assert len(result) == 5
+
 
 # ---------------------------------------------------------------------------
 # render_drawdown_preview

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -200,6 +200,11 @@ function useAdaptivePatternHeight(): number {
   return height;
 }
 
+// Fixed at backend TILE_ROW_COUNT / TILE_COL_COUNT — requests must align with
+// pre-rendered tile boundaries in R2.
+const TILE_ROW_COUNT = 100;
+const TILE_COL_COUNT = 200;
+
 function WeavingPatternView({
   projectId,
   currentPickIndex,
@@ -215,112 +220,136 @@ function WeavingPatternView({
 }) {
   const containerH = useAdaptivePatternHeight();
   const [pixelsPerRow, setPixelsPerRow] = useState(20);
+  const [warpCount, setWarpCount] = useState(0);
   // tilesRef: synchronous mirror used in effects for deduplication and eviction.
-  // tiles state: snapshot used during render (updated only on tile add, not eviction).
-  const tilesRef = useRef<Record<number, string>>({});
-  const [tiles, setTiles] = useState<Record<number, string>>({});
-  const fetchingRef = useRef<Set<number>>(new Set());
-  const fetchControllersRef = useRef<Map<number, AbortController>>(new Map());
-  // tileErrorsRef: per-tile error messages (Map<startRow, message>). Ref so fetchTile
-  // can check it without adding to effect deps. State mirror for render.
-  const tileErrorsRef = useRef<Map<number, string>>(new Map());
-  const [tileErrors, setTileErrors] = useState<Map<number, string>>(new Map());
-  // Incrementing retryCount forces the fetch effect to rerun on explicit retry.
+  // Key: `${startRow}_${startCol}`. tiles state: snapshot for render.
+  const tilesRef = useRef<Record<string, string>>({});
+  const [tiles, setTiles] = useState<Record<string, string>>({});
+  const fetchingRef = useRef<Set<string>>(new Set());
+  const fetchControllersRef = useRef<Map<string, AbortController>>(new Map());
+  const tileErrorsRef = useRef<Map<string, string>>(new Map());
+  const [tileErrors, setTileErrors] = useState<Map<string, string>>(new Map());
   const [retryCount, setRetryCount] = useState(0);
+  // scrollColStart: leftmost visible column tile boundary (multiple of TILE_COL_COUNT).
+  // State only changes when a new column tile boundary is crossed, avoiding per-pixel re-renders.
+  const [scrollColStart, setScrollColStart] = useState(0);
 
-  // Fixed at backend TILE_ROW_COUNT so requests align with pre-rendered tile boundaries in R2.
-  const tileSize = 100;
+  const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+    const raw = e.currentTarget.scrollLeft;
+    const colIndex = pixelsPerRow > 0 ? Math.floor(raw / pixelsPerRow) : 0;
+    const snapped = Math.floor(colIndex / TILE_COL_COUNT) * TILE_COL_COUNT;
+    setScrollColStart(prev => prev === snapped ? prev : snapped);
+  }, [pixelsPerRow]);
 
   useEffect(() => {
     let cancelled = false;
 
-    // Image row 0 = top = last pick. Advancing decreases imageRow toward 0.
-    // Past work is at higher image row numbers (below current in the container).
+    // --- Row range ---
+    // Image row 0 = top = last pick; advancing decreases imageRow toward 0.
     const imageRow = totalPicks - 1 - currentPickIndex;
-    const currentTileStart = Math.floor(imageRow / tileSize) * tileSize;
-    // 1 tile toward row 0 (future picks, above current line).
-    const lookaheadStart = currentTileStart - tileSize;
-    // 1 tile away from row 0 (past picks, below current line = work done).
-    const lookbehindStart = currentTileStart + tileSize;
-    const needed = new Set<number>([currentTileStart]);
-    if (lookaheadStart >= 0) needed.add(lookaheadStart);
-    if (lookbehindStart < totalPicks) needed.add(lookbehindStart);
+    const currentRowStart = Math.floor(imageRow / TILE_ROW_COUNT) * TILE_ROW_COUNT;
+    const lookaheadRowStart = currentRowStart - TILE_ROW_COUNT;
+    const lookbehindRowStart = currentRowStart + TILE_ROW_COUNT;
+    const neededRows: number[] = [currentRowStart];
+    if (lookaheadRowStart >= 0) neededRows.push(lookaheadRowStart);
+    if (lookbehindRowStart < totalPicks) neededRows.push(lookbehindRowStart);
 
-    // Evict tiles and errors outside the needed set (errors auto-clear on eviction so
-    // re-entering the same position retries fresh without an explicit user action).
-    // Also abort any in-flight fetches for evicted tiles — if we re-enter that range
-    // before the old fetch completes, fetchingRef would block a new fetch and the
-    // cancelled result would be discarded, leaving the tile permanently unloaded.
+    // --- Column range ---
+    // Always column-tile: for narrow drafts only col 0 exists; for wide drafts
+    // fetch visible column + 1 lookahead on the right.
+    const neededCols: number[] = [scrollColStart];
+    const nextCol = scrollColStart + TILE_COL_COUNT;
+    if (warpCount === 0 || nextCol < warpCount) neededCols.push(nextCol);
+
+    // All needed (row, col) pairs as `${row}_${col}` keys.
+    const needed = new Set<string>();
+    for (const r of neededRows) {
+      for (const c of neededCols) {
+        needed.add(`${r}_${c}`);
+      }
+    }
+
+    // Evict tiles and errors outside the needed set; abort in-flight fetches.
     let errorsChanged = false;
     for (const k of Object.keys(tilesRef.current)) {
-      const n = parseInt(k);
-      if (!needed.has(n)) {
-        URL.revokeObjectURL(tilesRef.current[n]);
-        delete tilesRef.current[n];
+      if (!needed.has(k)) {
+        URL.revokeObjectURL(tilesRef.current[k]);
+        delete tilesRef.current[k];
       }
     }
-    for (const n of fetchingRef.current) {
-      if (!needed.has(n)) {
-        fetchControllersRef.current.get(n)?.abort();
-        fetchControllersRef.current.delete(n);
-        fetchingRef.current.delete(n);
+    for (const k of fetchingRef.current) {
+      if (!needed.has(k)) {
+        fetchControllersRef.current.get(k)?.abort();
+        fetchControllersRef.current.delete(k);
+        fetchingRef.current.delete(k);
       }
     }
-    for (const n of tileErrorsRef.current.keys()) {
-      if (!needed.has(n)) {
-        tileErrorsRef.current.delete(n);
+    for (const k of tileErrorsRef.current.keys()) {
+      if (!needed.has(k)) {
+        tileErrorsRef.current.delete(k);
         errorsChanged = true;
       }
     }
     if (errorsChanged) setTileErrors(new Map(tileErrorsRef.current));
 
-    const fetchTile = async (startRow: number) => {
-      if (fetchingRef.current.has(startRow)) return;
-      if (tilesRef.current[startRow] !== undefined) return;
-      if (tileErrorsRef.current.has(startRow)) return;
-      fetchingRef.current.add(startRow);
+    const fetchTile = async (startRow: number, startCol: number) => {
+      const key = `${startRow}_${startCol}`;
+      if (fetchingRef.current.has(key)) return;
+      if (tilesRef.current[key] !== undefined) return;
+      if (tileErrorsRef.current.has(key)) return;
+      fetchingRef.current.add(key);
       const controller = new AbortController();
-      fetchControllersRef.current.set(startRow, controller);
+      fetchControllersRef.current.set(key, controller);
       const timeoutId = setTimeout(() => controller.abort(), 15000);
+      const url =
+        `/api/projects/${projectId}/drawdown` +
+        `?start_row=${startRow}&row_count=${TILE_ROW_COUNT}` +
+        `&start_col=${startCol}&col_count=${TILE_COL_COUNT}`;
       try {
         const token = await getAuthToken();
         const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
-        const res = await fetch(
-          `/api/projects/${projectId}/drawdown?start_row=${startRow}&row_count=${tileSize}`,
-          { credentials: "include", headers, signal: controller.signal }
-        );
+        const res = await fetch(url, { credentials: "include", headers, signal: controller.signal });
         clearTimeout(timeoutId);
         if (cancelled) return;
         if (!res.ok) {
-          tileErrorsRef.current.set(startRow, "Pattern tile failed to load.");
+          tileErrorsRef.current.set(key, "Pattern tile failed to load.");
           setTileErrors(new Map(tileErrorsRef.current));
           return;
         }
         const ppr = parseInt(res.headers.get("X-Pixels-Per-Row") ?? "20", 10);
-        if (!cancelled) setPixelsPerRow(ppr);
+        const wc = parseInt(res.headers.get("X-Total-Cols") ?? "0", 10);
+        if (!cancelled) {
+          setPixelsPerRow(ppr);
+          if (wc > 0) setWarpCount(wc);
+        }
         const blob = await res.blob();
         if (cancelled) return;
-        tilesRef.current[startRow] = URL.createObjectURL(blob);
+        tilesRef.current[key] = URL.createObjectURL(blob);
         setTiles({ ...tilesRef.current });
       } catch (err) {
         clearTimeout(timeoutId);
         if (!cancelled) {
-          const msg = err instanceof Error && err.name === "AbortError"
-            ? "Pattern tile timed out."
-            : "Pattern tile failed to load.";
-          tileErrorsRef.current.set(startRow, msg);
+          const msg =
+            err instanceof Error && err.name === "AbortError"
+              ? "Pattern tile timed out."
+              : "Pattern tile failed to load.";
+          tileErrorsRef.current.set(key, msg);
           setTileErrors(new Map(tileErrorsRef.current));
         }
       } finally {
-        fetchingRef.current.delete(startRow);
-        fetchControllersRef.current.delete(startRow);
+        fetchingRef.current.delete(key);
+        fetchControllersRef.current.delete(key);
       }
     };
 
-    needed.forEach(s => { fetchTile(s); });
+    for (const r of neededRows) {
+      for (const c of neededCols) {
+        fetchTile(r, c);
+      }
+    }
 
     return () => { cancelled = true; };
-  }, [projectId, currentPickIndex, totalPicks, tileSize, retryCount]);
+  }, [projectId, currentPickIndex, totalPicks, scrollColStart, warpCount, retryCount]);
 
   // Revoke all object URLs on unmount.
   useEffect(() => {
@@ -330,14 +359,17 @@ function WeavingPatternView({
     };
   }, []);
 
-  // Compute current tile position for overlay decisions (needed before early returns).
+  // Current row tile boundary for overlay / retry decisions.
   const imageRowForTile = totalPicks - 1 - currentPickIndex;
-  const currentTileStart = Math.floor(imageRowForTile / tileSize) * tileSize;
-  const currentTileReady = tiles[currentTileStart] !== undefined;
-  const currentTileError = tileErrors.get(currentTileStart);
+  const currentTileStart = Math.floor(imageRowForTile / TILE_ROW_COUNT) * TILE_ROW_COUNT;
+  const currentRowPrefix = `${currentTileStart}_`;
+  const currentTileReady = Object.keys(tiles).some(k => k.startsWith(currentRowPrefix));
+  const currentTileError = [...tileErrors.entries()].find(([k]) => k.startsWith(currentRowPrefix))?.[1];
 
   const retryCurrentTile = () => {
-    tileErrorsRef.current.delete(currentTileStart);
+    for (const k of tileErrorsRef.current.keys()) {
+      if (k.startsWith(currentRowPrefix)) tileErrorsRef.current.delete(k);
+    }
     setTileErrors(new Map(tileErrorsRef.current));
     setRetryCount(c => c + 1);
   };
@@ -371,6 +403,9 @@ function WeavingPatternView({
   const highlightH = pixelsPerRow + 2;
   const boxH = Math.max(4, pixelsPerRow - 6);
 
+  const totalImgW = warpCount > 0 ? warpCount * pixelsPerRow : undefined;
+  const totalImgH = totalPicks * pixelsPerRow;
+
   // Picks reversed so the last pick renders first (topmost) — matches drawdown orientation.
   const reversedPicks = [...picks].reverse();
 
@@ -392,37 +427,44 @@ function WeavingPatternView({
     </>
   );
 
-  const totalImgH = totalPicks * pixelsPerRow;
-
   return (
     // Outer wrapper: no overflow-hidden so highlight bars bleed left/right.
     <div className="relative flex gap-2" style={{ height: containerH }}>
 
-      {/* Drawdown tiles — horizontally scrollable to view wide designs */}
-      <div className="flex-1 rounded-lg border overflow-x-auto overflow-y-hidden relative bg-white dark:bg-zinc-900">
+      {/* Drawdown tiles — horizontally scrollable for wide designs */}
+      <div
+        className="flex-1 rounded-lg border overflow-x-auto overflow-y-hidden relative bg-white dark:bg-zinc-900"
+        onScroll={handleScroll}
+      >
         <div
           style={{
             position: "relative",
+            width: totalImgW,
             height: totalImgH,
             transform: `translateY(${translateY}px)`,
             transition: "transform 0.15s ease",
           }}
         >
-          {Object.entries(tiles).map(([k, url]) => (
-            <img
-              key={k}
-              src={url}
-              alt=""
-              style={{
-                position: "absolute",
-                top: parseInt(k) * pixelsPerRow,
-                left: 0,
-                display: "block",
-                imageRendering: "pixelated",
-                maxWidth: "none",
-              }}
-            />
-          ))}
+          {Object.entries(tiles).map(([k, url]) => {
+            const [rowStr, colStr] = k.split("_");
+            const startRow = parseInt(rowStr, 10);
+            const startCol = parseInt(colStr, 10);
+            return (
+              <img
+                key={k}
+                src={url}
+                alt=""
+                style={{
+                  position: "absolute",
+                  top: startRow * pixelsPerRow,
+                  left: startCol * pixelsPerRow,
+                  display: "block",
+                  imageRendering: "pixelated",
+                  maxWidth: "none",
+                }}
+              />
+            );
+          })}
         </div>
         {washoutOverlay}
         {/* Loading overlay — shown whenever the current tile hasn't arrived yet */}


### PR DESCRIPTION
## Summary

- Extends `render_drawdown_tile` with `start_col`/`col_count` parameters; returns a 7-tuple when column params are given (5-tuple preserved for backwards-compatible callers)
- Adds `?start_col=&col_count=` query params to `GET /projects/{id}/drawdown`; response includes `X-Start-Col` and `X-Col-Count` headers; column-sliced requests skip the pre-render task trigger
- Rewrites `WeavingPatternView` to a 2D tile grid: scroll position snaps to `TILE_COL_COUNT=200` warp-thread boundaries; tile keys use `"${startRow}_${startCol}"` strings; narrow drafts fall through identically (single col tile, no horizontal scroll)

## Test plan

- [ ] `pytest tests/services/test_rendering.py::TestRenderDrawdownTile tests/routers/test_projects.py::TestProjectDrawdown` — all 33 tests pass
- [ ] Open a narrow draft (<200 warps): single tile loads normally, no horizontal scroll
- [ ] Open a wide draft (>200 warps): horizontal scroll appears; scrolling past the 200-warp boundary triggers a new column tile fetch
- [ ] Verify `X-Start-Col` / `X-Col-Count` headers appear on column-sliced requests in DevTools Network tab
- [ ] Confirm `tsc` is clean (frontend build passes in Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)