### PR TITLE
fix: resolve column tile display bugs — blob race and cache bypass

### DIFF
--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -391,9 +391,12 @@ async def get_project_drawdown(
     else:
         expected_scale = rendering.DRAWDOWN_SCALE
 
-    # Check pre-rendered project tile cache on standard row-boundary alignment
+    # Check pre-rendered project tile cache on standard row-boundary alignment.
+    # Only for full-width requests (start_col=None) — column-sliced requests must
+    # go through render_drawdown_tile so they return the correct pixel slice.
     if (
-        warp_count > 0
+        start_col is None
+        and warp_count > 0
         and _sr % tile_row_count == 0
         and _rc == tile_row_count
         and await aproject_tile_exists(project_id, expected_scale, _sr)

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -318,14 +318,15 @@ function WeavingPatternView({
         }
         const ppr = parseInt(res.headers.get("X-Pixels-Per-Row") ?? "20", 10);
         const wc = parseInt(res.headers.get("X-Total-Cols") ?? "0", 10);
-        if (!cancelled) {
-          setPixelsPerRow(ppr);
-          if (wc > 0) setWarpCount(wc);
-        }
+        // Await blob BEFORE any state setters — calling setWarpCount/setPixelsPerRow
+        // here would trigger an effect cleanup (cancelled=true) before the blob resolves,
+        // causing the tile to be silently discarded.
         const blob = await res.blob();
         if (cancelled) return;
         tilesRef.current[key] = URL.createObjectURL(blob);
         setTiles({ ...tilesRef.current });
+        setPixelsPerRow(ppr);
+        if (wc > 0) setWarpCount(wc);
       } catch (err) {
         clearTimeout(timeoutId);
         if (!cancelled) {


### PR DESCRIPTION
## Summary

Two bugs introduced with the column tile rendering feature (#427) that caused the drawdown to stay permanently on "Loading pattern…":

- **Race condition (frontend)**: `setPixelsPerRow`/`setWarpCount` were called before `await res.blob()`. Both state updates triggered an effect cleanup setting `cancelled=true`, which discarded the blob when it arrived — tile never stored, spinner never cleared. Fixed by awaiting blob before any state setters.

- **Cache bypass (backend)**: The pre-rendered tile cache lookup had no `start_col is None` guard. Column-sliced requests (`?start_col=0&col_count=200`) hit the cache and received the full-width pre-rendered PNG instead of the requested column slice. Fixed by adding `start_col is None` to the cache-hit condition.

## Test plan

- [ ] Open a project weaving view — pattern should render on first load without staying stuck on spinner
- [ ] Confirm DevTools shows a single successful tile fetch (no duplicate requests)
- [ ] Wide draft (>200 warps): confirm column-sliced requests bypass cache and return correct slice width

🤖 Generated with [Claude Code](https://claude.com/claude-code)