### PR TITLE
fix: keep step controls visible when project reaches last pick (#588)

### DIFF
--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1625,7 +1625,7 @@ export function ProjectDetailPage() {
 
         {/* Step controls — active tracking and planning */}
         <div className="w-full px-4 pb-6">
-          {(isActiveTracking || isPlanning) && !isFinished && (
+          {(isActiveTracking || isPlanning) && (
             <div className="flex flex-col gap-6 lg:grid lg:grid-cols-[1fr_auto_1fr] lg:items-center lg:gap-8 mb-4">
               {/* Left 1/3 on desktop, below step buttons on mobile */}
               <div className="order-2 lg:order-1 lg:flex lg:justify-center">


### PR DESCRIPTION
## Summary
- Removes `!isFinished` guard from the step controls block so reverse navigation remains available after the final pick is woven
- `StepControls` already disables the advance button via `pastEnd` when `currentPick > total`, so forward navigation is correctly blocked at completion
- The drawdown pattern view (`WeavingPatternView`) retains its `!isFinished` guard and is unaffected

## Test plan
- [ ] Advance an active-tracking project to the last pick — step controls remain visible
- [ ] Verify the advance (›) button is disabled at the final pick
- [ ] Verify the reverse (‹) button is enabled and navigates backwards correctly
- [ ] Confirm no regressions on projects mid-weave

Closes #588

🤖 Generated with [Claude Code](https://claude.com/claude-code)