### PR TITLE
chore: upgrade Docker build image Node 20→24 LTS (#587)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weaving-site",
-  "version": "0.134.0",
+  "version": "0.134.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weaving-site",
-      "version": "0.134.0",
+      "version": "0.134.2",
       "dependencies": {
         "@clerk/clerk-react": "^5.61.6",
         "@tanstack/react-query": "^5.100.9",
@@ -19,7 +19,7 @@
         "tailwind-merge": "^2.5.2"
       },
       "devDependencies": {
-        "@types/node": "^20.15.0",
+        "@types/node": "^24.0.0",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^8.59.2",
@@ -983,13 +983,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -3591,9 +3591,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
     "tailwind-merge": "^2.5.2"
   },
   "devDependencies": {
-    "@types/node": "^20.15.0",
+    "@types/node": "^24.0.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^8.59.2",


### PR DESCRIPTION
## Summary
- `frontend/Dockerfile` builder stage: `node:20-alpine` → `node:24-alpine`
- `@types/node`: `^20.15.0` → `^24.0.0` (resolves to `24.12.4`)
- `package-lock.json` regenerated inside `node:24-alpine` — Linux-specific rolldown/emnapi packages present for `npm ci` in Docker

Node 20 moved to Maintenance LTS in April 2026 (security patches only). Node 24 is Active LTS with the longest support runway before Node 26 LTS begins in October 2026.

## Test plan
- [ ] CI Docker build passes (frontend image builds with node:24-alpine)
- [ ] `tsc` clean — confirmed locally
- [ ] No runtime regressions in the built frontend

Closes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)