### PR TITLE
feat: weave session detection and project metrics (#596)

### DIFF
--- a/backend/alembic/versions/0011_weave_sessions.py
+++ b/backend/alembic/versions/0011_weave_sessions.py
@@ -1,0 +1,45 @@
+"""add weave_sessions table and dwell_ms to project_steps
+
+Revision ID: e4f5a6b7c8d9
+Revises: d3e4f5a6b7c8
+Create Date: 2026-05-12
+
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+
+from alembic import op
+
+revision = "e4f5a6b7c8d9"
+down_revision = "d3e4f5a6b7c8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "weave_sessions",
+        sa.Column("id", PG_UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "project_id",
+            PG_UUID(as_uuid=True),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("ended_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.create_index("ix_weave_sessions_project_id", "weave_sessions", ["project_id"])
+    op.add_column(
+        "project_steps",
+        sa.Column("dwell_ms", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("project_steps", "dwell_ms")
+    op.drop_index("ix_weave_sessions_project_id", table_name="weave_sessions")
+    op.drop_table("weave_sessions")

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -61,6 +61,9 @@ class Project(Base, TimestampMixin, SoftDeleteMixin):
     steps: Mapped[list["ProjectStep"]] = relationship(
         "ProjectStep", back_populates="project", order_by="ProjectStep.created_at"
     )
+    sessions: Mapped[list["WeaveSession"]] = relationship(
+        "WeaveSession", back_populates="project", order_by="WeaveSession.started_at"
+    )
     photos: Mapped[list["ProjectPhoto"]] = relationship(
         "ProjectPhoto", back_populates="project", order_by="ProjectPhoto.display_order"
     )
@@ -76,5 +79,19 @@ class ProjectStep(Base, TimestampMixin):
     event_type: Mapped[str] = mapped_column(String(10), nullable=False)  # "advance" | "reverse"
     from_pick: Mapped[int] = mapped_column(Integer, nullable=False)
     to_pick: Mapped[int] = mapped_column(Integer, nullable=False)
+    dwell_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     project: Mapped["Project"] = relationship("Project", back_populates="steps")
+
+
+class WeaveSession(Base, TimestampMixin):
+    __tablename__ = "weave_sessions"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id"), nullable=False, index=True
+    )
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    ended_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    project: Mapped["Project"] = relationship("Project", back_populates="sessions")

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -89,7 +89,7 @@ class WeaveSession(Base, TimestampMixin):
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     project_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("projects.id"), nullable=False, index=True
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
     )
     started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     ended_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import selectinload
 from app.deps import get_current_user, get_db
 from app.models.draft import Draft
 from app.models.loom import PROJECT_SUPPORTED_LOOM_TYPES, Loom, LoomVersion
-from app.models.project import Project, ProjectPhoto, ProjectStep
+from app.models.project import Project, ProjectPhoto, ProjectStep, WeaveSession
 from app.models.user import User
 from app.services import storage, wif_parser
 from app.services.images import resize_to_jpeg
@@ -133,9 +133,37 @@ class PicksResponse(BaseModel):
     has_weft_colors: bool
 
 
+class SessionInfo(BaseModel):
+    id: uuid.UUID
+    started_at: datetime
+    ended_at: datetime | None
+    duration_ms: int
+
+
+class ProjectMetricsResponse(BaseModel):
+    total_sessions: int
+    total_session_time_ms: int
+    current_session_started_at: datetime | None
+    total_advance_steps: int
+    total_reverse_steps: int
+    total_worked_picks: int
+    sessions: list[SessionInfo]
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+_WORKED_PICK_THRESHOLD_MS = 3_000  # < 3 s gap = navigation/review, not a woven pick
+
+
+async def _close_open_session(project_id: uuid.UUID, db: AsyncSession) -> None:
+    open_session = await db.scalar(
+        select(WeaveSession).where(WeaveSession.project_id == project_id, WeaveSession.ended_at.is_(None))
+    )
+    if open_session is not None:
+        open_session.ended_at = datetime.now(timezone.utc)
 
 
 async def _check_loom_conflict(
@@ -595,15 +623,47 @@ async def step_project(
             raise HTTPException(status_code=400, detail="Already at first pick")
         project.current_pick -= 1
 
+    # Compute dwell and manage session gap-on-arrival
+    now = datetime.now(timezone.utc)
+    idle_timeout_ms = current_user.idle_timeout_minutes * 60 * 1_000
+
+    last_step = await db.scalar(
+        select(ProjectStep).where(ProjectStep.project_id == project_id).order_by(ProjectStep.created_at.desc()).limit(1)
+    )
+
+    dwell_ms: int | None = None
+    gap_ms: int | None = None
+    if last_step is not None:
+        last_dt = last_step.created_at
+        if last_dt.tzinfo is None:
+            last_dt = last_dt.replace(tzinfo=timezone.utc)
+        gap_ms = int((now - last_dt).total_seconds() * 1_000)
+        dwell_ms = min(gap_ms, idle_timeout_ms)
+
+    open_session = await db.scalar(
+        select(WeaveSession).where(WeaveSession.project_id == project_id, WeaveSession.ended_at.is_(None))
+    )
+
+    is_gap_too_long = gap_ms is not None and gap_ms >= idle_timeout_ms
+    if is_gap_too_long and open_session is not None:
+        close_dt = last_step.created_at  # type: ignore[union-attr]
+        if close_dt.tzinfo is None:
+            close_dt = close_dt.replace(tzinfo=timezone.utc)
+        open_session.ended_at = close_dt
+        open_session = None
+
+    if open_session is None:
+        db.add(WeaveSession(project_id=project_id, started_at=now))
+
     step = ProjectStep(
         project_id=project.id,
         event_type=body.direction,
         from_pick=from_pick,
         to_pick=project.current_pick,
+        dwell_ms=dwell_ms,
     )
     db.add(step)
     await db.commit()
-    # current_pick is already updated in-memory; no need to re-fetch draft/loom
     return StepResponse(current_pick=project.current_pick, total_picks=project.total_picks)
 
 
@@ -636,6 +696,7 @@ async def complete_project(
         raise HTTPException(status_code=400, detail="Project is not active")
     project.status = "completed"
     project.completed_at = datetime.now(timezone.utc)
+    await _close_open_session(project_id, db)
     await db.commit()
     await db.refresh(project)
     draft = await db.get(Draft, project.draft_id)
@@ -654,6 +715,7 @@ async def abandon_project(
         raise HTTPException(status_code=400, detail="Project is not active")
     project.status = "abandoned"
     project.abandoned_at = datetime.now(timezone.utc)
+    await _close_open_session(project_id, db)
     await db.commit()
     await db.refresh(project)
     draft = await db.get(Draft, project.draft_id)
@@ -680,6 +742,52 @@ async def restart_project(
     if draft is not None and draft.drawdown_preview_path is None:
         generate_drawdown_preview.delay(str(draft.id))
     return _to_detail(project, draft, loom)  # type: ignore[arg-type]
+
+
+@router.get("/{project_id}/metrics", response_model=ProjectMetricsResponse)
+async def get_project_metrics(
+    project_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ProjectMetricsResponse:
+    await _get_owned_project(project_id, current_user, db)
+
+    now = datetime.now(timezone.utc)
+
+    sessions = (
+        await db.scalars(
+            select(WeaveSession).where(WeaveSession.project_id == project_id).order_by(WeaveSession.started_at)
+        )
+    ).all()
+
+    steps = (await db.scalars(select(ProjectStep).where(ProjectStep.project_id == project_id))).all()
+
+    total_advance = sum(1 for s in steps if s.event_type == "advance")
+    total_reverse = sum(1 for s in steps if s.event_type == "reverse")
+    total_worked = sum(1 for s in steps if s.dwell_ms is not None and s.dwell_ms >= _WORKED_PICK_THRESHOLD_MS)
+
+    total_session_ms = 0
+    session_infos: list[SessionInfo] = []
+    current_session_started_at: datetime | None = None
+    for sess in sessions:
+        end = sess.ended_at or now
+        duration_ms = int((end - sess.started_at).total_seconds() * 1_000)
+        total_session_ms += duration_ms
+        session_infos.append(
+            SessionInfo(id=sess.id, started_at=sess.started_at, ended_at=sess.ended_at, duration_ms=duration_ms)
+        )
+        if sess.ended_at is None:
+            current_session_started_at = sess.started_at
+
+    return ProjectMetricsResponse(
+        total_sessions=len(sessions),
+        total_session_time_ms=total_session_ms,
+        current_session_started_at=current_session_started_at,
+        total_advance_steps=total_advance,
+        total_reverse_steps=total_reverse,
+        total_worked_picks=total_worked,
+        sessions=session_infos,
+    )
 
 
 @router.post("/{project_id}/clone", response_model=ProjectDetail, status_code=201)

--- a/backend/tests/routers/test_projects.py
+++ b/backend/tests/routers/test_projects.py
@@ -1,6 +1,6 @@
 import io
 import uuid
-from datetime import date
+from datetime import date, datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
 import pytest
@@ -1896,3 +1896,253 @@ class TestProjectDrawdown:
             f"/api/projects/{project.id}/drawdown?start_row=0&row_count=4&start_col=-1&col_count=2"
         )
         assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# TestWeaveSessions
+# ---------------------------------------------------------------------------
+
+
+class TestWeaveSessions:
+    async def test_first_step_opens_session(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        from sqlalchemy import select
+
+        from app.models.project import WeaveSession
+
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
+        session = await db_session.scalar(select(WeaveSession).where(WeaveSession.project_id == project.id))
+        assert session is not None
+        assert session.ended_at is None
+
+    async def test_second_step_within_timeout_keeps_session(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        from sqlalchemy import select
+
+        from app.models.project import ProjectStep, WeaveSession
+
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+
+        await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
+        await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
+
+        sessions = (await db_session.scalars(select(WeaveSession).where(WeaveSession.project_id == project.id))).all()
+        assert len(sessions) == 1
+        assert sessions[0].ended_at is None
+
+        # Second step should have a dwell_ms set
+        steps = (
+            await db_session.scalars(
+                select(ProjectStep).where(ProjectStep.project_id == project.id).order_by(ProjectStep.created_at)
+            )
+        ).all()
+        assert steps[0].dwell_ms is None  # first step has no previous
+        assert steps[1].dwell_ms is not None
+
+    async def test_step_after_idle_timeout_closes_old_and_opens_new_session(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        from sqlalchemy import select
+
+        from app.models.project import ProjectStep, WeaveSession
+
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+
+        # Insert a step with a timestamp older than the idle timeout (30 min default)
+        old_step = ProjectStep(
+            project_id=project.id,
+            event_type="advance",
+            from_pick=1,
+            to_pick=2,
+            created_at=datetime.now(timezone.utc) - timedelta(hours=1),
+        )
+        db_session.add(old_step)
+        project.current_pick = 2
+        # Manually insert an open session
+        old_session = WeaveSession(
+            project_id=project.id,
+            started_at=datetime.now(timezone.utc) - timedelta(hours=1),
+        )
+        db_session.add(old_session)
+        await db_session.commit()
+
+        # Trigger a new step — gap is > 30 min, so should close old session and open new
+        resp = await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
+        assert resp.status_code == 200
+
+        await db_session.refresh(old_session)
+        assert old_session.ended_at is not None
+
+        sessions = (await db_session.scalars(select(WeaveSession).where(WeaveSession.project_id == project.id))).all()
+        assert len(sessions) == 2
+        open_sessions = [s for s in sessions if s.ended_at is None]
+        assert len(open_sessions) == 1
+
+    async def test_dwell_ms_capped_at_idle_timeout(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        from sqlalchemy import select
+
+        from app.models.project import ProjectStep, WeaveSession
+
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+
+        old_step = ProjectStep(
+            project_id=project.id,
+            event_type="advance",
+            from_pick=1,
+            to_pick=2,
+            created_at=datetime.now(timezone.utc) - timedelta(hours=2),
+        )
+        db_session.add(old_step)
+        project.current_pick = 2
+        db_session.add(
+            WeaveSession(
+                project_id=project.id,
+                started_at=datetime.now(timezone.utc) - timedelta(hours=2),
+            )
+        )
+        await db_session.commit()
+
+        await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
+
+        new_step = await db_session.scalar(
+            select(ProjectStep)
+            .where(ProjectStep.project_id == project.id)
+            .order_by(ProjectStep.created_at.desc())
+            .limit(1)
+        )
+        assert new_step is not None
+        idle_timeout_ms = test_user.idle_timeout_minutes * 60 * 1_000
+        assert new_step.dwell_ms == idle_timeout_ms
+
+    async def test_complete_closes_open_session(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+
+        from app.models.project import WeaveSession
+
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+
+        open_session = WeaveSession(project_id=project.id, started_at=datetime.now(timezone.utc))
+        db_session.add(open_session)
+        await db_session.commit()
+
+        resp = await auth_client.post(f"/api/projects/{project.id}/complete")
+        assert resp.status_code == 200
+
+        await db_session.refresh(open_session)
+        assert open_session.ended_at is not None
+
+    async def test_abandon_closes_open_session(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+
+        from app.models.project import WeaveSession
+
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+
+        open_session = WeaveSession(project_id=project.id, started_at=datetime.now(timezone.utc))
+        db_session.add(open_session)
+        await db_session.commit()
+
+        resp = await auth_client.post(f"/api/projects/{project.id}/abandon")
+        assert resp.status_code == 200
+
+        await db_session.refresh(open_session)
+        assert open_session.ended_at is not None
+
+
+# ---------------------------------------------------------------------------
+# TestProjectMetrics
+# ---------------------------------------------------------------------------
+
+
+class TestProjectMetrics:
+    async def test_returns_200(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        resp = await auth_client.get(f"/api/projects/{project.id}/metrics")
+        assert resp.status_code == 200
+
+    async def test_empty_metrics_for_new_project(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        body = (await auth_client.get(f"/api/projects/{project.id}/metrics")).json()
+        assert body["total_sessions"] == 0
+        assert body["total_advance_steps"] == 0
+        assert body["total_worked_picks"] == 0
+
+    async def test_counts_advance_and_reverse_steps(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
+        await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
+        await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "reverse"})
+        body = (await auth_client.get(f"/api/projects/{project.id}/metrics")).json()
+        assert body["total_advance_steps"] == 2
+        assert body["total_reverse_steps"] == 1
+
+    async def test_worked_picks_excludes_fast_steps(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+
+        from app.models.project import ProjectStep
+
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+
+        # Insert two steps: first with dwell > threshold, second with dwell < threshold
+        step1 = ProjectStep(
+            project_id=project.id,
+            event_type="advance",
+            from_pick=1,
+            to_pick=2,
+            dwell_ms=5_000,  # 5s — worked
+        )
+        step2 = ProjectStep(
+            project_id=project.id,
+            event_type="advance",
+            from_pick=2,
+            to_pick=3,
+            dwell_ms=500,  # 0.5s — navigation
+        )
+        db_session.add_all([step1, step2])
+        await db_session.commit()
+
+        body = (await auth_client.get(f"/api/projects/{project.id}/metrics")).json()
+        assert body["total_worked_picks"] == 1
+
+    async def test_current_session_started_at_set_when_open(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        from app.models.project import WeaveSession
+
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        db_session.add(WeaveSession(project_id=project.id, started_at=datetime.now(timezone.utc)))
+        await db_session.commit()
+
+        body = (await auth_client.get(f"/api/projects/{project.id}/metrics")).json()
+        assert body["current_session_started_at"] is not None
+
+    async def test_not_found_returns_404(self, auth_client: AsyncClient):
+        resp = await auth_client.get(f"/api/projects/{uuid.uuid4()}/metrics")
+        assert resp.status_code == 404
+
+    async def test_unauthenticated_returns_401(self, client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        resp = await client.get(f"/api/projects/{project.id}/metrics")
+        assert resp.status_code == 401

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -86,6 +86,23 @@ export interface PicksResponse {
   has_weft_colors: boolean;
 }
 
+export interface SessionInfo {
+  id: string;
+  started_at: string;
+  ended_at: string | null;
+  duration_ms: number;
+}
+
+export interface ProjectMetrics {
+  total_sessions: number;
+  total_session_time_ms: number;
+  current_session_started_at: string | null;
+  total_advance_steps: number;
+  total_reverse_steps: number;
+  total_worked_picks: number;
+  sessions: SessionInfo[];
+}
+
 import { getAuthToken } from "@/api/client";
 
 export class ApiError extends Error {
@@ -205,6 +222,10 @@ export function deleteProject(id: string): Promise<void> {
 
 export function getProjectPicks(id: string): Promise<PicksResponse> {
   return req(`/api/projects/${id}/picks`);
+}
+
+export function getProjectMetrics(id: string): Promise<ProjectMetrics> {
+  return req(`/api/projects/${id}/metrics`);
 }
 
 export function projectPhotoUrl(projectId: string, photoId: string): string {

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -5,11 +5,11 @@ import { AppIcons } from "@/lib/icons";
 import { usePresentMode } from "@/hooks/usePresentMode";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  getProject, getProjectPicks, stepProject, jumpProject, completeProject, abandonProject,
+  getProject, getProjectPicks, getProjectMetrics, stepProject, jumpProject, completeProject, abandonProject,
   restartProject, cloneProject, listProjects, deleteProject,
   renameProject, updateProjectNotes, uploadProjectPhoto, deleteProjectPhoto, projectPhotoUrl,
   ApiError, PROJECT_TYPE_LABELS, PROJECT_STATUS_LABELS,
-  type ProjectSummary, type ProjectPhoto, type PickRow,
+  type ProjectSummary, type ProjectPhoto, type PickRow, type ProjectMetrics,
 } from "@/api/projects";
 import { previewUrl } from "@/api/drafts";
 import { getAuthToken } from "@/api/client";
@@ -57,6 +57,53 @@ function CollapsibleSection({
       </button>
       {open && <div className="pb-5">{children}</div>}
     </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Metrics helpers
+// ---------------------------------------------------------------------------
+
+function fmtDuration(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m`;
+  return `${totalSec}s`;
+}
+
+function SessionMetricsPanel({ metrics }: { metrics: ProjectMetrics }) {
+  const [elapsed, setElapsed] = useState(0);
+
+  useEffect(() => {
+    if (!metrics.current_session_started_at) return;
+    const tick = () =>
+      setElapsed(Date.now() - new Date(metrics.current_session_started_at!).getTime());
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [metrics.current_session_started_at]);
+
+  return (
+    <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+      <dt className="text-muted-foreground">Total woven picks</dt>
+      <dd>{metrics.total_worked_picks}</dd>
+      <dt className="text-muted-foreground">Total advances</dt>
+      <dd>{metrics.total_advance_steps}</dd>
+      <dt className="text-muted-foreground">Reverses</dt>
+      <dd>{metrics.total_reverse_steps}</dd>
+      <dt className="text-muted-foreground">Sessions</dt>
+      <dd>{metrics.total_sessions}</dd>
+      <dt className="text-muted-foreground">Total weaving time</dt>
+      <dd>{fmtDuration(metrics.total_session_time_ms)}</dd>
+      {metrics.current_session_started_at && (
+        <>
+          <dt className="text-muted-foreground">Current session</dt>
+          <dd className="text-accent font-medium">{fmtDuration(elapsed)}</dd>
+        </>
+      )}
+    </dl>
   );
 }
 
@@ -1192,6 +1239,13 @@ export function ProjectDetailPage() {
     enabled: isCompleted && !!project?.draft_id,
   });
 
+  const { data: metrics } = useQuery<ProjectMetrics>({
+    queryKey: ["project-metrics", id],
+    queryFn: () => getProjectMetrics(id!),
+    enabled: !!id && !!project && !isPlanning,
+    refetchInterval: project?.status === "active" && !!project?.loom_id ? 30_000 : false,
+  });
+
   const invalidate = () => queryClient.invalidateQueries({ queryKey: ["project", id] });
 
   const handleJump = useCallback(async (pick: number) => {
@@ -1694,6 +1748,12 @@ export function ProjectDetailPage() {
                   )
                 }
               />
+            </CollapsibleSection>
+          )}
+
+          {metrics && (
+            <CollapsibleSection title="Session metrics">
+              <SessionMetricsPanel metrics={metrics} />
             </CollapsibleSection>
           )}
 


### PR DESCRIPTION
## Summary

- **Gap-on-arrival session detection**: each `POST /step` checks the gap from the last step's `created_at` to now; if gap ≥ `idle_timeout_minutes` (default 30 min, user-configurable), the current session is closed at the last-known activity time and a new session is opened
- **`dwell_ms` on `ProjectStep`**: records the gap from the previous step, capped at `idle_timeout_ms`; null for the first step; picks with `dwell_ms >= 3000 ms` count as "worked picks"
- **`WeaveSession` model + migration `0011`**: new table tracks `started_at` / `ended_at` per project; complete and abandon both close the open session
- **`GET /api/projects/{id}/metrics`**: returns session list with durations, total session time, advance/reverse counts, worked-pick count, and current-session start time
- **Frontend metrics panel**: "Session metrics" collapsible section in the project details drawer; shows totals and a live elapsed-time counter for the active session (updates every second)
- 13 new tests covering session lifecycle, dwell capping, and the metrics endpoint

## Test plan

- [ ] Open a project with loom tracking and advance/reverse a few picks — confirm "Session metrics" section appears in Details drawer
- [ ] Leave the project idle for 30+ min, then advance — confirm a second session is created in the metrics panel
- [ ] Complete / abandon a project — confirm metrics shows closed session
- [ ] `pytest tests/routers/test_projects.py::TestWeaveSessions tests/routers/test_projects.py::TestProjectMetrics` — 13 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)