### PR TITLE
fix: include show_version_numbers and hide_unused_shafts_treadles in /auth/me response (#599)

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -312,6 +312,8 @@ class UserResponse(BaseModel):
     idle_timeout_minutes: int
     measurement_system: str
     ai_training_consent: bool
+    show_version_numbers: bool
+    hide_unused_shafts_treadles: bool
     eula_accepted_version: str | None
     current_eula_version: str
     storage_used_bytes: int
@@ -341,6 +343,8 @@ async def me(
         idle_timeout_minutes=current_user.idle_timeout_minutes,
         measurement_system=current_user.measurement_system,
         ai_training_consent=current_user.ai_training_consent,
+        show_version_numbers=current_user.show_version_numbers,
+        hide_unused_shafts_treadles=current_user.hide_unused_shafts_treadles,
         eula_accepted_version=current_user.eula_accepted_version,
         current_eula_version=current_eula_version,
         storage_used_bytes=storage_used,

--- a/backend/tests/routers/test_auth.py
+++ b/backend/tests/routers/test_auth.py
@@ -45,6 +45,14 @@ class TestMe:
         resp = await superuser_client.get("/auth/me")
         assert resp.json()["is_superuser"] is True
 
+    async def test_returns_show_version_numbers(self, auth_client: AsyncClient):
+        resp = await auth_client.get("/auth/me")
+        assert "show_version_numbers" in resp.json()
+
+    async def test_returns_hide_unused_shafts_treadles(self, auth_client: AsyncClient):
+        resp = await auth_client.get("/auth/me")
+        assert "hide_unused_shafts_treadles" in resp.json()
+
 
 class TestLogout:
     async def test_returns_200(self, auth_client: AsyncClient):


### PR DESCRIPTION
## Root cause

`GET /auth/me` (`UserResponse` in `auth.py`) was missing `show_version_numbers` and `hide_unused_shafts_treadles`. Both fields are set and stored correctly by `PATCH /api/users/me`, but since `AuthContext` loads from `/auth/me`, they always came back as `undefined`.

Consequences:
- `user?.show_version_numbers ?? true` → always `true` → VersionBadge never hid
- SettingsPage toggle local state re-initialized from `undefined ?? true` = on after every reload
- `hide_unused_shafts_treadles` had the same silent bug (defaulting to `false` masked it)

## Fix

Added both fields to `UserResponse` schema and the `/auth/me` handler constructor. Added two regression tests to `TestMe` confirming the fields are present in the response.

## Test plan

- [ ] Toggle "Show version numbers" off → VersionBadge disappears immediately
- [ ] Reload page → toggle stays off, VersionBadge stays hidden
- [ ] `pytest tests/routers/test_auth.py::TestMe` — 10 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)