### PR TITLE
feat: activity heatmap calendar on user dashboard (#40)

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -11,11 +11,12 @@ Routes:
 
 import logging
 import uuid
+from datetime import date as date_cls
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from pydantic import BaseModel
-from sqlalchemy import Date, cast, delete, func, select, text
+from sqlalchemy import Date, and_, cast, delete, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.deps import get_current_user, get_db
@@ -149,6 +150,8 @@ class ActivityDayResponse(BaseModel):
 
 class ActivityHeatmapResponse(BaseModel):
     days: list[ActivityDayResponse]
+    earliest_activity_date: str | None
+    years_with_activity: list[int]
 
 
 @router.get("/me", response_model=UserSettingsResponse)
@@ -281,25 +284,33 @@ async def data_export(_: User = Depends(get_current_user)) -> dict:
 
 @router.get("/me/activity-heatmap", response_model=ActivityHeatmapResponse)
 async def get_activity_heatmap(
+    year: int | None = Query(default=None),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> ActivityHeatmapResponse:
     from collections import defaultdict
 
+    day_col = cast(func.timezone("UTC", ProjectStep.created_at), Date)
+    base_filter = and_(
+        Project.owner_id == current_user.id,
+        Project.deleted_at.is_(None),
+    )
+
+    if year is not None:
+        date_filter = and_(day_col >= date_cls(year, 1, 1), day_col <= date_cls(year, 12, 31))
+    else:
+        date_filter = ProjectStep.created_at >= func.now() - text("interval '366 days'")
+
     rows = (
         await db.execute(
             select(
-                cast(func.timezone("UTC", ProjectStep.created_at), Date).label("day"),
+                day_col.label("day"),
                 Project.id.label("project_id"),
                 Project.name.label("project_name"),
                 func.count().label("step_count"),
             )
             .join(Project, ProjectStep.project_id == Project.id)
-            .where(
-                Project.owner_id == current_user.id,
-                Project.deleted_at.is_(None),
-                ProjectStep.created_at >= func.now() - text("interval '366 days'"),
-            )
+            .where(base_filter, date_filter)
             .group_by(text("1"), Project.id, Project.name)
             .order_by(text("1"), func.count().desc())
         )
@@ -311,6 +322,20 @@ async def get_activity_heatmap(
             HeatmapProjectEntry(id=str(row.project_id), name=row.project_name, step_count=row.step_count)
         )
 
+    earliest = await db.scalar(
+        select(func.min(day_col)).join(Project, ProjectStep.project_id == Project.id).where(base_filter)
+    )
+
+    years_rows = (
+        await db.execute(
+            select(func.extract("year", day_col).label("yr"))
+            .join(Project, ProjectStep.project_id == Project.id)
+            .where(base_filter)
+            .distinct()
+            .order_by(text("1"))
+        )
+    ).all()
+
     return ActivityHeatmapResponse(
         days=[
             ActivityDayResponse(
@@ -319,7 +344,9 @@ async def get_activity_heatmap(
                 projects=projects,
             )
             for date_str, projects in sorted(days_map.items())
-        ]
+        ],
+        earliest_activity_date=str(earliest) if earliest else None,
+        years_with_activity=[int(r.yr) for r in years_rows],
     )
 
 

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Response
 from pydantic import BaseModel
-from sqlalchemy import delete, select
+from sqlalchemy import Date, cast, delete, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.deps import get_current_user, get_db
@@ -133,6 +133,22 @@ async def get_current_eula(db: AsyncSession = Depends(get_db)) -> EulaCurrentRes
 
 
 router = APIRouter(prefix="/api/users", tags=["users"])
+
+
+class HeatmapProjectEntry(BaseModel):
+    id: str
+    name: str
+    step_count: int
+
+
+class ActivityDayResponse(BaseModel):
+    date: str
+    count: int
+    projects: list[HeatmapProjectEntry]
+
+
+class ActivityHeatmapResponse(BaseModel):
+    days: list[ActivityDayResponse]
 
 
 @router.get("/me", response_model=UserSettingsResponse)
@@ -261,6 +277,50 @@ async def data_export(_: User = Depends(get_current_user)) -> dict:
             "It will package your WIF files, photos, and project history into a downloadable archive."
         ),
     }
+
+
+@router.get("/me/activity-heatmap", response_model=ActivityHeatmapResponse)
+async def get_activity_heatmap(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ActivityHeatmapResponse:
+    from collections import defaultdict
+
+    rows = (
+        await db.execute(
+            select(
+                cast(func.timezone("UTC", ProjectStep.created_at), Date).label("day"),
+                Project.id.label("project_id"),
+                Project.name.label("project_name"),
+                func.count().label("step_count"),
+            )
+            .join(Project, ProjectStep.project_id == Project.id)
+            .where(
+                Project.owner_id == current_user.id,
+                Project.deleted_at.is_(None),
+                ProjectStep.created_at >= func.now() - text("interval '366 days'"),
+            )
+            .group_by(text("1"), Project.id, Project.name)
+            .order_by(text("1"), func.count().desc())
+        )
+    ).all()
+
+    days_map: dict[str, list[HeatmapProjectEntry]] = defaultdict(list)
+    for row in rows:
+        days_map[str(row.day)].append(
+            HeatmapProjectEntry(id=str(row.project_id), name=row.project_name, step_count=row.step_count)
+        )
+
+    return ActivityHeatmapResponse(
+        days=[
+            ActivityDayResponse(
+                date=date_str,
+                count=sum(p.step_count for p in projects),
+                projects=projects,
+            )
+            for date_str, projects in sorted(days_map.items())
+        ]
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime, timedelta, timezone
 
 from httpx import AsyncClient
 from sqlalchemy import select
@@ -482,3 +482,184 @@ class TestGetCurrentEula:
     async def test_returns_effective_date(self, client: AsyncClient):
         data = (await client.get("/api/eula/current")).json()
         assert "effective_date" in data
+
+
+# ---------------------------------------------------------------------------
+# GET /api/users/me/activity-heatmap
+# ---------------------------------------------------------------------------
+
+
+class TestActivityHeatmap:
+    async def test_returns_200_with_days_key(self, auth_client: AsyncClient):
+        resp = await auth_client.get("/api/users/me/activity-heatmap")
+        assert resp.status_code == 200
+        assert "days" in resp.json()
+
+    async def test_empty_when_no_steps(self, auth_client: AsyncClient):
+        resp = await auth_client.get("/api/users/me/activity-heatmap")
+        assert resp.json()["days"] == []
+
+    async def test_counts_steps_on_a_day(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = Draft(
+            owner_id=test_user.id,
+            name="Heatmap Draft",
+            wif_filename="h.wif",
+            wif_path="drafts/h/original.wif",
+        )
+        db_session.add(draft)
+        await db_session.flush()
+
+        project = Project(
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="Heatmap Project",
+            project_type="treadle",
+            status="active",
+            current_pick=1,
+            total_picks=10,
+        )
+        db_session.add(project)
+        await db_session.flush()
+
+        today = datetime.now(timezone.utc).replace(hour=12, minute=0, second=0, microsecond=0)
+        for _ in range(3):
+            db_session.add(
+                ProjectStep(
+                    project_id=project.id,
+                    event_type="advance",
+                    from_pick=1,
+                    to_pick=2,
+                    created_at=today,
+                )
+            )
+        await db_session.commit()
+
+        resp = await auth_client.get("/api/users/me/activity-heatmap")
+        days = resp.json()["days"]
+        assert len(days) == 1
+        assert days[0]["count"] == 3
+        assert days[0]["date"] == today.strftime("%Y-%m-%d")
+
+    async def test_multiple_days_returned_separately(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = Draft(
+            owner_id=test_user.id,
+            name="Multi Draft",
+            wif_filename="m.wif",
+            wif_path="drafts/m/original.wif",
+        )
+        db_session.add(draft)
+        await db_session.flush()
+
+        project = Project(
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="Multi Project",
+            project_type="treadle",
+            status="active",
+            current_pick=1,
+            total_picks=10,
+        )
+        db_session.add(project)
+        await db_session.flush()
+
+        now = datetime.now(timezone.utc)
+        day1 = now.replace(hour=12, minute=0, second=0, microsecond=0)
+        day2 = (now - timedelta(days=1)).replace(hour=12, minute=0, second=0, microsecond=0)
+        db_session.add(
+            ProjectStep(project_id=project.id, event_type="advance", from_pick=1, to_pick=2, created_at=day1)
+        )
+        db_session.add(
+            ProjectStep(project_id=project.id, event_type="advance", from_pick=2, to_pick=3, created_at=day2)
+        )
+        db_session.add(
+            ProjectStep(project_id=project.id, event_type="advance", from_pick=3, to_pick=4, created_at=day2)
+        )
+        await db_session.commit()
+
+        resp = await auth_client.get("/api/users/me/activity-heatmap")
+        days = {d["date"]: d["count"] for d in resp.json()["days"]}
+        assert days[day1.strftime("%Y-%m-%d")] == 1
+        assert days[day2.strftime("%Y-%m-%d")] == 2
+
+    async def test_excludes_other_users_steps(
+        self, auth_client: AsyncClient, db_session: AsyncSession, admin_user: User
+    ):
+        draft = Draft(
+            owner_id=admin_user.id,
+            name="Admin Draft",
+            wif_filename="a.wif",
+            wif_path="drafts/a/original.wif",
+        )
+        db_session.add(draft)
+        await db_session.flush()
+
+        project = Project(
+            owner_id=admin_user.id,
+            draft_id=draft.id,
+            name="Admin Project",
+            project_type="treadle",
+            status="active",
+            current_pick=1,
+            total_picks=10,
+        )
+        db_session.add(project)
+        await db_session.flush()
+
+        db_session.add(
+            ProjectStep(
+                project_id=project.id,
+                event_type="advance",
+                from_pick=1,
+                to_pick=2,
+                created_at=datetime.now(timezone.utc),
+            )
+        )
+        await db_session.commit()
+
+        resp = await auth_client.get("/api/users/me/activity-heatmap")
+        assert resp.json()["days"] == []
+
+    async def test_excludes_steps_older_than_366_days(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = Draft(
+            owner_id=test_user.id,
+            name="Old Draft",
+            wif_filename="o.wif",
+            wif_path="drafts/o/original.wif",
+        )
+        db_session.add(draft)
+        await db_session.flush()
+
+        project = Project(
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="Old Project",
+            project_type="treadle",
+            status="active",
+            current_pick=1,
+            total_picks=10,
+        )
+        db_session.add(project)
+        await db_session.flush()
+
+        old_date = datetime.now(timezone.utc) - timedelta(days=400)
+        db_session.add(
+            ProjectStep(
+                project_id=project.id,
+                event_type="advance",
+                from_pick=1,
+                to_pick=2,
+                created_at=old_date,
+            )
+        )
+        await db_session.commit()
+
+        resp = await auth_client.get("/api/users/me/activity-heatmap")
+        assert resp.json()["days"] == []
+
+    async def test_unauthenticated_returns_401(self, client: AsyncClient):
+        resp = await client.get("/api/users/me/activity-heatmap")
+        assert resp.status_code == 401

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -663,3 +663,123 @@ class TestActivityHeatmap:
     async def test_unauthenticated_returns_401(self, client: AsyncClient):
         resp = await client.get("/api/users/me/activity-heatmap")
         assert resp.status_code == 401
+
+    async def test_returns_earliest_activity_date(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = Draft(owner_id=test_user.id, name="E Draft", wif_filename="e.wif", wif_path="drafts/e/original.wif")
+        db_session.add(draft)
+        await db_session.flush()
+        project = Project(
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="E Project",
+            project_type="treadle",
+            status="active",
+            current_pick=1,
+            total_picks=10,
+        )
+        db_session.add(project)
+        await db_session.flush()
+        step_dt = datetime.now(timezone.utc).replace(hour=12, minute=0, second=0, microsecond=0)
+        db_session.add(
+            ProjectStep(project_id=project.id, event_type="advance", from_pick=1, to_pick=2, created_at=step_dt)
+        )
+        await db_session.commit()
+
+        resp = await auth_client.get("/api/users/me/activity-heatmap")
+        assert resp.json()["earliest_activity_date"] == step_dt.strftime("%Y-%m-%d")
+
+    async def test_earliest_activity_date_null_when_no_steps(self, auth_client: AsyncClient):
+        resp = await auth_client.get("/api/users/me/activity-heatmap")
+        assert resp.json()["earliest_activity_date"] is None
+
+    async def test_returns_years_with_activity(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = Draft(owner_id=test_user.id, name="Y Draft", wif_filename="y.wif", wif_path="drafts/y/original.wif")
+        db_session.add(draft)
+        await db_session.flush()
+        project = Project(
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="Y Project",
+            project_type="treadle",
+            status="active",
+            current_pick=1,
+            total_picks=10,
+        )
+        db_session.add(project)
+        await db_session.flush()
+        step_dt = datetime.now(timezone.utc).replace(hour=12, minute=0, second=0, microsecond=0)
+        db_session.add(
+            ProjectStep(project_id=project.id, event_type="advance", from_pick=1, to_pick=2, created_at=step_dt)
+        )
+        await db_session.commit()
+
+        resp = await auth_client.get("/api/users/me/activity-heatmap")
+        current_year = datetime.now(timezone.utc).year
+        assert current_year in resp.json()["years_with_activity"]
+
+    async def test_year_param_filters_to_calendar_year(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = Draft(owner_id=test_user.id, name="YP Draft", wif_filename="yp.wif", wif_path="drafts/yp/original.wif")
+        db_session.add(draft)
+        await db_session.flush()
+        project = Project(
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="YP Project",
+            project_type="treadle",
+            status="active",
+            current_pick=1,
+            total_picks=10,
+        )
+        db_session.add(project)
+        await db_session.flush()
+
+        this_year = datetime.now(timezone.utc).year
+        last_year = this_year - 1
+        dt_this = datetime(this_year, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        dt_last = datetime(last_year, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        db_session.add(
+            ProjectStep(project_id=project.id, event_type="advance", from_pick=1, to_pick=2, created_at=dt_this)
+        )
+        db_session.add(
+            ProjectStep(project_id=project.id, event_type="advance", from_pick=2, to_pick=3, created_at=dt_last)
+        )
+        await db_session.commit()
+
+        resp = await auth_client.get(f"/api/users/me/activity-heatmap?year={last_year}")
+        dates = {d["date"] for d in resp.json()["days"]}
+        assert f"{last_year}-06-15" in dates
+        assert f"{this_year}-06-15" not in dates
+
+    async def test_days_include_project_list(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = Draft(owner_id=test_user.id, name="PL Draft", wif_filename="pl.wif", wif_path="drafts/pl/original.wif")
+        db_session.add(draft)
+        await db_session.flush()
+        project = Project(
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="PL Project",
+            project_type="treadle",
+            status="active",
+            current_pick=1,
+            total_picks=10,
+        )
+        db_session.add(project)
+        await db_session.flush()
+        step_dt = datetime.now(timezone.utc).replace(hour=12, minute=0, second=0, microsecond=0)
+        db_session.add(
+            ProjectStep(project_id=project.id, event_type="advance", from_pick=1, to_pick=2, created_at=step_dt)
+        )
+        await db_session.commit()
+
+        resp = await auth_client.get("/api/users/me/activity-heatmap")
+        day = resp.json()["days"][0]
+        assert len(day["projects"]) == 1
+        assert day["projects"][0]["name"] == "PL Project"
+        assert day["projects"][0]["step_count"] == 1
+        assert "id" in day["projects"][0]

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -37,3 +37,23 @@ export async function deleteAccount(confirm: string): Promise<void> {
 export async function getDataExport(): Promise<{ status: string; milestone: string; message: string }> {
   return api.get("/api/users/me/data-export");
 }
+
+export interface HeatmapProject {
+  id: string;
+  name: string;
+  step_count: number;
+}
+
+export interface ActivityDay {
+  date: string;
+  count: number;
+  projects: HeatmapProject[];
+}
+
+export interface ActivityHeatmapData {
+  days: ActivityDay[];
+}
+
+export function getActivityHeatmap(): Promise<ActivityHeatmapData> {
+  return api.get<ActivityHeatmapData>("/api/users/me/activity-heatmap");
+}

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -52,8 +52,11 @@ export interface ActivityDay {
 
 export interface ActivityHeatmapData {
   days: ActivityDay[];
+  earliest_activity_date: string | null;
+  years_with_activity: number[];
 }
 
-export function getActivityHeatmap(): Promise<ActivityHeatmapData> {
-  return api.get<ActivityHeatmapData>("/api/users/me/activity-heatmap");
+export function getActivityHeatmap(params?: { year?: number }): Promise<ActivityHeatmapData> {
+  const qs = params?.year != null ? `?year=${params.year}` : "";
+  return api.get<ActivityHeatmapData>(`/api/users/me/activity-heatmap${qs}`);
 }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,10 +1,164 @@
 import { useAuth } from "@/hooks/useAuth";
 import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
+import { useRef, useState } from "react";
 import { listProjects, PROJECT_TYPE_LABELS } from "@/api/projects";
 import { listDrafts } from "@/api/drafts";
 import { listLooms } from "@/api/looms";
+import { getActivityHeatmap, type ActivityHeatmapData, type ActivityDay } from "@/api/users";
 import { AppIcons } from "@/lib/icons";
+
+const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function intensityClass(count: number): string {
+  if (count === 0) return "bg-muted";
+  if (count <= 2) return "bg-accent/30";
+  if (count <= 5) return "bg-accent/55";
+  if (count <= 10) return "bg-accent/80";
+  return "bg-accent";
+}
+
+function toDateStr(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+interface TooltipState {
+  day: ActivityDay;
+  x: number;
+  y: number;
+}
+
+function ActivityHeatmap({ data }: { data: ActivityHeatmapData }) {
+  const dayByDate = new Map(data.days.map((d) => [d.date, d]));
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const startDate = new Date(today);
+  startDate.setDate(today.getDate() - 364);
+  startDate.setDate(startDate.getDate() - startDate.getDay());
+
+  const days: Date[] = [];
+  const cur = new Date(startDate);
+  while (cur <= today) {
+    days.push(new Date(cur));
+    cur.setDate(cur.getDate() + 1);
+  }
+
+  const weeks: Date[][] = [];
+  for (let i = 0; i < days.length; i += 7) {
+    weeks.push(days.slice(i, i + 7));
+  }
+
+  const monthLabels: { label: string; col: number }[] = [];
+  weeks.forEach((week, wi) => {
+    week.forEach((d) => {
+      if (d.getDate() === 1) {
+        monthLabels.push({ label: d.toLocaleString("default", { month: "short" }), col: wi });
+      }
+    });
+  });
+
+  const totalSteps = data.days.reduce((s, d) => s + d.count, 0);
+  const activeDays = data.days.filter((d) => d.count > 0).length;
+
+  function scheduleHide() {
+    hideTimerRef.current = setTimeout(() => setTooltip(null), 120);
+  }
+
+  function cancelHide() {
+    if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+  }
+
+  function handleCellEnter(e: React.MouseEvent, dateStr: string) {
+    cancelHide();
+    const day = dayByDate.get(dateStr);
+    if (!day || day.count === 0) { setTooltip(null); return; }
+    setTooltip({ day, x: e.clientX, y: e.clientY });
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-muted-foreground">
+        {totalSteps.toLocaleString()} steps across {activeDays} day{activeDays !== 1 ? "s" : ""} in the past year
+      </p>
+      <div className="overflow-x-auto pb-1">
+        <div className="inline-flex flex-col gap-[3px]" style={{ minWidth: "max-content" }}>
+          <div className="flex gap-[3px]" style={{ paddingLeft: "22px" }}>
+            {weeks.map((_, wi) => {
+              const label = monthLabels.find((m) => m.col === wi);
+              return (
+                <div key={wi} className="w-[10px] text-[9px] text-muted-foreground leading-none overflow-visible whitespace-nowrap">
+                  {label ? label.label : ""}
+                </div>
+              );
+            })}
+          </div>
+          {[0, 1, 2, 3, 4, 5, 6].map((dow) => (
+            <div key={dow} className="flex items-center gap-[3px]">
+              <span className="w-[18px] text-[9px] text-muted-foreground text-right shrink-0 leading-none">
+                {dow % 2 === 1 ? DOW_LABELS[dow] : ""}
+              </span>
+              {weeks.map((week, wi) => {
+                const day = week[dow];
+                if (!day || day > today) return <div key={wi} className="w-[10px] h-[10px] rounded-[2px] opacity-0" />;
+                const dateStr = toDateStr(day);
+                const count = dayByDate.get(dateStr)?.count ?? 0;
+                return (
+                  <div
+                    key={wi}
+                    className={`w-[10px] h-[10px] rounded-[2px] ${intensityClass(count)} ${count > 0 ? "cursor-pointer" : "cursor-default"}`}
+                    onMouseEnter={(e) => handleCellEnter(e, dateStr)}
+                    onMouseLeave={scheduleHide}
+                  />
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="flex items-center gap-1.5 justify-end">
+        <span className="text-[9px] text-muted-foreground">Less</span>
+        {[0, 2, 5, 10, 11].map((v) => (
+          <div key={v} className={`w-[10px] h-[10px] rounded-[2px] ${intensityClass(v)}`} />
+        ))}
+        <span className="text-[9px] text-muted-foreground">More</span>
+      </div>
+
+      {/* Custom tooltip rendered at cursor position */}
+      {tooltip && (
+        <div
+          className="fixed z-50 w-52 rounded-lg border bg-popover text-popover-foreground shadow-md p-3 space-y-2"
+          style={{ left: tooltip.x + 12, top: tooltip.y - 8 }}
+          onMouseEnter={cancelHide}
+          onMouseLeave={scheduleHide}
+        >
+          <p className="text-xs font-medium text-muted-foreground">
+            {new Date(tooltip.day.date + "T12:00:00").toLocaleDateString("default", {
+              weekday: "short", year: "numeric", month: "short", day: "numeric",
+            })}
+          </p>
+          <ul className="space-y-1">
+            {tooltip.day.projects.map((p) => (
+              <li key={p.id}>
+                <Link
+                  to={`/projects/${p.id}`}
+                  className="flex items-center justify-between gap-2 rounded px-1.5 py-1 text-xs hover:bg-muted transition-colors"
+                  onClick={() => setTooltip(null)}
+                >
+                  <span className="truncate font-medium">{p.name}</span>
+                  <span className="shrink-0 text-muted-foreground tabular-nums">{p.step_count} step{p.step_count !== 1 ? "s" : ""}</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
 
 export function DashboardPage() {
   const { user } = useAuth();
@@ -22,6 +176,12 @@ export function DashboardPage() {
   const { data: looms = [] } = useQuery({
     queryKey: ["looms"],
     queryFn: listLooms,
+  });
+
+  const { data: heatmap } = useQuery({
+    queryKey: ["activity-heatmap"],
+    queryFn: getActivityHeatmap,
+    staleTime: 60_000,
   });
 
   const activeProjects = projects.filter((a) => a.status === "active" && !!a.loom_id);
@@ -231,6 +391,16 @@ export function DashboardPage() {
           </div>
         </div>
       </section>
+
+      {/* Activity heatmap */}
+      {heatmap && (
+        <section>
+          <h2 className="mb-3 text-sm font-medium text-muted-foreground uppercase tracking-wide">Activity</h2>
+          <div className="rounded-lg border p-4">
+            <ActivityHeatmap data={heatmap} />
+          </div>
+        </section>
+      )}
 
       {/* Storage */}
       {user && (

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,14 +1,20 @@
 import { useAuth } from "@/hooks/useAuth";
 import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { listProjects, PROJECT_TYPE_LABELS } from "@/api/projects";
 import { listDrafts } from "@/api/drafts";
 import { listLooms } from "@/api/looms";
-import { getActivityHeatmap, type ActivityHeatmapData, type ActivityDay } from "@/api/users";
+import { getActivityHeatmap, type ActivityDay } from "@/api/users";
 import { AppIcons } from "@/lib/icons";
 
 const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const RANGE_OPTIONS = [
+  { label: "1M", days: 30 },
+  { label: "3M", days: 90 },
+  { label: "6M", days: 180 },
+  { label: "1Y", days: 366 },
+] as const;
 
 function intensityClass(count: number): string {
   if (count === 0) return "bg-muted";
@@ -28,50 +34,167 @@ interface TooltipState {
   y: number;
 }
 
-function ActivityHeatmap({ data }: { data: ActivityHeatmapData }) {
-  const dayByDate = new Map(data.days.map((d) => [d.date, d]));
-  const [tooltip, setTooltip] = useState<TooltipState | null>(null);
-  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+function defaultDaysFromHistory(earliestDate: string | null): number {
+  if (!earliestDate) return 30;
+  const ageDays = (Date.now() - new Date(earliestDate + "T00:00:00Z").getTime()) / 86_400_000;
+  if (ageDays < 30) return 30;
+  if (ageDays < 90) return 90;
+  if (ageDays < 180) return 180;
+  return 366;
+}
 
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-
-  const startDate = new Date(today);
-  startDate.setDate(today.getDate() - 364);
-  startDate.setDate(startDate.getDate() - startDate.getDay());
-
+function buildGrid(rangeStart: Date, rangeEnd: Date): Date[][] {
+  const start = new Date(rangeStart);
+  start.setDate(start.getDate() - start.getDay()); // align to Sunday
   const days: Date[] = [];
-  const cur = new Date(startDate);
-  while (cur <= today) {
+  const cur = new Date(start);
+  while (cur <= rangeEnd) {
     days.push(new Date(cur));
     cur.setDate(cur.getDate() + 1);
   }
-
   const weeks: Date[][] = [];
-  for (let i = 0; i < days.length; i += 7) {
-    weeks.push(days.slice(i, i + 7));
-  }
+  for (let i = 0; i < days.length; i += 7) weeks.push(days.slice(i, i + 7));
+  return weeks;
+}
 
+function HeatmapGrid({
+  weeks,
+  rangeEnd,
+  dayByDate,
+  onCellEnter,
+  onCellLeave,
+}: {
+  weeks: Date[][];
+  rangeEnd: Date;
+  dayByDate: Map<string, ActivityDay>;
+  onCellEnter: (e: React.MouseEvent, dateStr: string) => void;
+  onCellLeave: () => void;
+}) {
   const monthLabels: { label: string; col: number }[] = [];
   weeks.forEach((week, wi) => {
     week.forEach((d) => {
-      if (d.getDate() === 1) {
-        monthLabels.push({ label: d.toLocaleString("default", { month: "short" }), col: wi });
-      }
+      if (d.getDate() === 1) monthLabels.push({ label: d.toLocaleString("default", { month: "short" }), col: wi });
     });
   });
 
-  const totalSteps = data.days.reduce((s, d) => s + d.count, 0);
-  const activeDays = data.days.filter((d) => d.count > 0).length;
+  return (
+    <div className="overflow-x-auto pb-1">
+      <div className="inline-flex flex-col gap-[3px]" style={{ minWidth: "max-content" }}>
+        <div className="flex gap-[3px]" style={{ paddingLeft: "22px" }}>
+          {weeks.map((_, wi) => {
+            const label = monthLabels.find((m) => m.col === wi);
+            return (
+              <div key={wi} className="w-[10px] text-[9px] text-muted-foreground leading-none overflow-visible whitespace-nowrap">
+                {label ? label.label : ""}
+              </div>
+            );
+          })}
+        </div>
+        {[0, 1, 2, 3, 4, 5, 6].map((dow) => (
+          <div key={dow} className="flex items-center gap-[3px]">
+            <span className="w-[18px] text-[9px] text-muted-foreground text-right shrink-0 leading-none">
+              {dow % 2 === 1 ? DOW_LABELS[dow] : ""}
+            </span>
+            {weeks.map((week, wi) => {
+              const day = week[dow];
+              if (!day || day > rangeEnd) return <div key={wi} className="w-[10px] h-[10px] rounded-[2px] opacity-0" />;
+              const dateStr = toDateStr(day);
+              const count = dayByDate.get(dateStr)?.count ?? 0;
+              return (
+                <div
+                  key={wi}
+                  className={`w-[10px] h-[10px] rounded-[2px] ${intensityClass(count)} ${count > 0 ? "cursor-pointer" : "cursor-default"}`}
+                  onMouseEnter={(e) => onCellEnter(e, dateStr)}
+                  onMouseLeave={onCellLeave}
+                />
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ActivityHeatmap() {
+  const today = useMemo(() => {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    return d;
+  }, []);
+
+  // null = user hasn't made an explicit choice; effective values are derived from data
+  const [selectedDays, setSelectedDays] = useState<number | null>(null);
+  const [selectedYear, setSelectedYear] = useState<number>(today.getFullYear());
+  const [mode, setMode] = useState<"range" | "year" | null>(null);
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Base fetch: always 366-day window + metadata
+  const { data: baseData } = useQuery({
+    queryKey: ["activity-heatmap"],
+    queryFn: () => getActivityHeatmap(),
+    staleTime: 60_000,
+  });
+
+  const earliestDate = baseData?.earliest_activity_date ?? null;
+
+  // Derive effective mode — user choice wins; fall back to data-driven default
+  const effectiveMode = useMemo((): "range" | "year" => {
+    if (mode !== null) return mode;
+    if (!earliestDate) return "range";
+    return (today.getTime() - new Date(earliestDate + "T00:00:00Z").getTime()) / 86_400_000 >= 365
+      ? "year"
+      : "range";
+  }, [mode, earliestDate, today]);
+
+  // Derive effective days — user choice wins; fall back to data-driven default
+  const effectiveDays = useMemo(
+    () => selectedDays ?? defaultDaysFromHistory(earliestDate),
+    [selectedDays, earliestDate],
+  );
+
+  // Year fetch: only when in year mode
+  const { data: yearData } = useQuery({
+    queryKey: ["activity-heatmap-year", selectedYear],
+    queryFn: () => getActivityHeatmap({ year: selectedYear }),
+    enabled: effectiveMode === "year",
+    staleTime: 5 * 60_000,
+  });
+
+  const displayData = effectiveMode === "year" ? yearData : baseData;
+  const dayByDate = new Map((displayData?.days ?? []).map((d) => [d.date, d]));
+
+  const yearsWithActivity = baseData?.years_with_activity ?? [];
+  const hasMultipleYears = useMemo(() => {
+    if (effectiveMode === "year") return true;
+    if (yearsWithActivity.length > 1) return true;
+    if (!earliestDate) return false;
+    return (today.getTime() - new Date(earliestDate + "T00:00:00Z").getTime()) / 86_400_000 >= 365;
+  }, [effectiveMode, yearsWithActivity, earliestDate, today]);
+
+  // Grid bounds
+  let rangeStart: Date;
+  let rangeEnd: Date;
+  if (effectiveMode === "year") {
+    rangeStart = new Date(selectedYear, 0, 1);
+    rangeEnd = selectedYear === today.getFullYear() ? today : new Date(selectedYear, 11, 31);
+  } else {
+    rangeEnd = today;
+    rangeStart = new Date(today);
+    rangeStart.setDate(today.getDate() - effectiveDays + 1);
+  }
+  const weeks = buildGrid(rangeStart, rangeEnd);
+
+  const totalSteps = (displayData?.days ?? []).reduce((s, d) => s + d.count, 0);
+  const activeDays = (displayData?.days ?? []).filter((d) => d.count > 0).length;
 
   function scheduleHide() {
     hideTimerRef.current = setTimeout(() => setTooltip(null), 120);
   }
-
   function cancelHide() {
     if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
   }
-
   function handleCellEnter(e: React.MouseEvent, dateStr: string) {
     cancelHide();
     const day = dayByDate.get(dateStr);
@@ -80,45 +203,49 @@ function ActivityHeatmap({ data }: { data: ActivityHeatmapData }) {
   }
 
   return (
-    <div className="space-y-2">
-      <p className="text-xs text-muted-foreground">
-        {totalSteps.toLocaleString()} steps across {activeDays} day{activeDays !== 1 ? "s" : ""} in the past year
-      </p>
-      <div className="overflow-x-auto pb-1">
-        <div className="inline-flex flex-col gap-[3px]" style={{ minWidth: "max-content" }}>
-          <div className="flex gap-[3px]" style={{ paddingLeft: "22px" }}>
-            {weeks.map((_, wi) => {
-              const label = monthLabels.find((m) => m.col === wi);
-              return (
-                <div key={wi} className="w-[10px] text-[9px] text-muted-foreground leading-none overflow-visible whitespace-nowrap">
-                  {label ? label.label : ""}
-                </div>
-              );
-            })}
+    <div className="space-y-3">
+      {/* Selector row */}
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-xs text-muted-foreground">
+          {totalSteps.toLocaleString()} step{totalSteps !== 1 ? "s" : ""} across {activeDays} day{activeDays !== 1 ? "s" : ""}
+        </p>
+        {hasMultipleYears ? (
+          <select
+            value={selectedYear}
+            onChange={(e) => { setMode("year"); setSelectedYear(Number(e.target.value)); setTooltip(null); }}
+            className="text-xs rounded border border-border bg-background px-2 py-0.5 text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+          >
+            {(yearsWithActivity.length > 0 ? yearsWithActivity : [today.getFullYear()]).map((y) => (
+              <option key={y} value={y}>{y}</option>
+            ))}
+          </select>
+        ) : (
+          <div className="flex gap-1">
+            {RANGE_OPTIONS.map(({ label, days }) => (
+              <button
+                key={label}
+                onClick={() => { setMode("range"); setSelectedDays(days); setTooltip(null); }}
+                className={`px-2 py-0.5 text-xs rounded border transition-colors ${
+                  effectiveMode === "range" && effectiveDays === days
+                    ? "border-ring bg-accent text-accent-foreground font-medium"
+                    : "border-border text-muted-foreground hover:text-foreground hover:border-ring"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
           </div>
-          {[0, 1, 2, 3, 4, 5, 6].map((dow) => (
-            <div key={dow} className="flex items-center gap-[3px]">
-              <span className="w-[18px] text-[9px] text-muted-foreground text-right shrink-0 leading-none">
-                {dow % 2 === 1 ? DOW_LABELS[dow] : ""}
-              </span>
-              {weeks.map((week, wi) => {
-                const day = week[dow];
-                if (!day || day > today) return <div key={wi} className="w-[10px] h-[10px] rounded-[2px] opacity-0" />;
-                const dateStr = toDateStr(day);
-                const count = dayByDate.get(dateStr)?.count ?? 0;
-                return (
-                  <div
-                    key={wi}
-                    className={`w-[10px] h-[10px] rounded-[2px] ${intensityClass(count)} ${count > 0 ? "cursor-pointer" : "cursor-default"}`}
-                    onMouseEnter={(e) => handleCellEnter(e, dateStr)}
-                    onMouseLeave={scheduleHide}
-                  />
-                );
-              })}
-            </div>
-          ))}
-        </div>
+        )}
       </div>
+
+      <HeatmapGrid
+        weeks={weeks}
+        rangeEnd={rangeEnd}
+        dayByDate={dayByDate}
+        onCellEnter={handleCellEnter}
+        onCellLeave={scheduleHide}
+      />
+
       <div className="flex items-center gap-1.5 justify-end">
         <span className="text-[9px] text-muted-foreground">Less</span>
         {[0, 2, 5, 10, 11].map((v) => (
@@ -127,7 +254,6 @@ function ActivityHeatmap({ data }: { data: ActivityHeatmapData }) {
         <span className="text-[9px] text-muted-foreground">More</span>
       </div>
 
-      {/* Custom tooltip rendered at cursor position */}
       {tooltip && (
         <div
           className="fixed z-50 w-52 rounded-lg border bg-popover text-popover-foreground shadow-md p-3 space-y-2"
@@ -176,12 +302,6 @@ export function DashboardPage() {
   const { data: looms = [] } = useQuery({
     queryKey: ["looms"],
     queryFn: listLooms,
-  });
-
-  const { data: heatmap } = useQuery({
-    queryKey: ["activity-heatmap"],
-    queryFn: getActivityHeatmap,
-    staleTime: 60_000,
   });
 
   const activeProjects = projects.filter((a) => a.status === "active" && !!a.loom_id);
@@ -393,14 +513,12 @@ export function DashboardPage() {
       </section>
 
       {/* Activity heatmap */}
-      {heatmap && (
-        <section>
-          <h2 className="mb-3 text-sm font-medium text-muted-foreground uppercase tracking-wide">Activity</h2>
-          <div className="rounded-lg border p-4">
-            <ActivityHeatmap data={heatmap} />
-          </div>
-        </section>
-      )}
+      <section>
+        <h2 className="mb-3 text-sm font-medium text-muted-foreground uppercase tracking-wide">Activity</h2>
+        <div className="rounded-lg border p-4">
+          <ActivityHeatmap />
+        </div>
+      </section>
 
       {/* Storage */}
       {user && (


### PR DESCRIPTION
## Summary

- Adds `GET /api/users/me/activity-heatmap` — returns step counts grouped by UTC date for the trailing 366 days, with per-day project breakdown (project id, name, step count)
- Dashboard gets a new **Activity** section with a GitHub-style 52-week heatmap; cell intensity scales across 5 levels using `bg-accent` opacity variants
- Custom hoverable tooltip on active cells shows the date and each project with step counts; project entries are clickable `Link`s to `/projects/{id}`; tooltip stays open when cursor moves into it (120ms hide delay)
- 7 new tests in `TestActivityHeatmap` covering: happy path, empty state, per-day count, multi-day grouping, cross-user isolation, 366-day cutoff, unauthenticated 401

## Test plan

- [ ] Dashboard shows Activity section with 52-week grid
- [ ] Cells with activity show copper intensity; empty cells are muted
- [ ] Hovering an active cell shows tooltip with date + project list
- [ ] Clicking a project in the tooltip navigates to that project and closes tooltip
- [ ] Empty cells have no tooltip / default cursor
- [ ] `pytest tests/routers/test_users.py::TestActivityHeatmap` — 7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)