### PR TITLE
feat: vendor PyWeaving, SVG full-draft preview, zoomable preview modal (#572 #604 #609)

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,42 @@
+# Third-Party Licenses
+
+WeftMark includes code derived from the following open-source projects.
+
+---
+
+## PyWeaving
+
+**Source:** https://github.com/storborg/pyweaving  
+**License:** MIT  
+**Copyright:** Copyright 2014-2015 Scott Torborg (storborg@gmail.com)  
+**Vendored as:** `backend/app/weaving/`
+
+WeftMark's internal weaving engine (`backend/app/weaving/`) is derived from
+PyWeaving v0.0.7. The original source has been modernised for Python 3.10+,
+bugs have been fixed, and the code is maintained as an internal package.
+The original MIT copyright notice is retained in each derived source file and
+in full in `backend/app/weaving/UPSTREAM_LICENSE`.
+
+```
+The MIT License (MIT)
+
+Copyright 2014-2015 Scott Torborg (storborg@gmail.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,13 +9,10 @@ WORKDIR /app
 COPY backend/requirements.txt backend/requirements-dev.txt ./
 RUN pip install --no-cache-dir -r requirements-dev.txt
 
-# PyWeaving expects Arial.ttf in its data directory; substitute DejaVu Sans
-RUN PYWEAVING_DATA=$(python -c "import pyweaving.render as r, os; print(os.path.join(os.path.dirname(r.__file__), 'data'))") && \
-    mkdir -p "$PYWEAVING_DATA" && \
-    cp /usr/share/fonts/truetype/dejavu/DejaVuSans.ttf "$PYWEAVING_DATA/Arial.ttf"
-
 COPY backend/ .
 COPY VERSION .
+# Substitute DejaVu Sans for Arial in the vendored weaving engine
+RUN cp /usr/share/fonts/truetype/dejavu/DejaVuSans.ttf /app/app/weaving/data/Arial.ttf
 
 RUN sed -i 's/\r$//' entrypoint.sh && chmod +x entrypoint.sh
 

--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -219,6 +219,24 @@ async def get_preview(
     return Response(content=png, media_type="image/png")
 
 
+@router.get("/{draft_id}/preview/svg")
+async def get_preview_svg(
+    draft_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    draft = await _get_owned_draft(draft_id, current_user, db)
+    if not draft.wif_path:
+        raise HTTPException(status_code=404, detail="No WIF file for this draft")
+    wif_bytes = await storage.aread_file(draft.wif_path)
+    try:
+        wif_draft = await asyncio.to_thread(rendering.load_draft, wif_bytes)
+        svg = await asyncio.to_thread(rendering.render_full_draft_svg, wif_draft)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"SVG rendering failed: {exc}") from exc
+    return Response(content=svg, media_type="image/svg+xml; charset=utf-8")
+
+
 # ---------------------------------------------------------------------------
 # Drawdown-only image
 # ---------------------------------------------------------------------------

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -496,6 +496,50 @@ async def get_project_drawdown(
     )
 
 
+@router.get("/{project_id}/drawdown/svg")
+async def get_project_drawdown_svg(
+    project_id: uuid.UUID,
+    cell_px: int = Query(10, ge=4, le=30),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    from app.services import rendering
+    from app.services.storage import afile_exists, aread_file
+
+    project = await _get_owned_project(project_id, current_user, db)
+    draft = await db.scalar(select(Draft).where(Draft.id == project.draft_id, Draft.deleted_at.is_(None)))
+    if draft is None:
+        raise HTTPException(status_code=404, detail="Draft not found")
+
+    wif_path = await _wif_path_for_project(draft, project.project_type)
+    if not wif_path or not await afile_exists(wif_path):
+        raise HTTPException(status_code=404, detail="WIF file not found in storage")
+
+    wif_bytes = await aread_file(wif_path)
+    try:
+
+        def _render() -> tuple:
+            d = rendering.load_draft(wif_bytes)
+            s = rendering.render_drawdown_svg(d, cell_px)
+            return d, s
+
+        wif_draft, svg = await asyncio.to_thread(_render)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"SVG rendering failed: {exc}") from exc
+
+    return Response(
+        content=svg,
+        media_type="image/svg+xml; charset=utf-8",
+        headers={
+            "X-Pixels-Per-Row": str(cell_px),
+            "X-Total-Rows": str(len(wif_draft.weft)),
+            "X-Total-Cols": str(len(wif_draft.warp)),
+        },
+    )
+
+
 @router.get("/{project_id}", response_model=ProjectDetail)
 async def get_project(
     project_id: uuid.UUID,

--- a/backend/app/services/rendering.py
+++ b/backend/app/services/rendering.py
@@ -13,6 +13,7 @@ from PIL import Image as PILImage
 from app.config import get_settings
 from app.weaving import Draft
 from app.weaving._render import ImageRenderer, SVGRenderer
+from app.weaving._render import drawdown_svg as _drawdown_svg
 from app.weaving._wif import WIFReader
 
 tracer = trace.get_tracer(__name__)
@@ -226,6 +227,21 @@ def render_drawdown_tile(
     out = io.BytesIO()
     tile.save(out, format="PNG")
     return out.getvalue(), weft_count, actual_start, actual_row_count, scale, actual_start_col, actual_col_count
+
+
+def render_drawdown_svg(draft: Draft, cell_px: int = 10) -> str:
+    """Render the drawdown grid as a symbol-deduped SVG string.
+
+    Suitable for project step-tracking: load once, highlight current pick via
+    CSS/DOM on the client — zero server round-trips per step advance or reverse.
+    """
+    with tracer.start_as_current_span("render.drawdown_svg") as span:
+        span.set_attribute("render.cell_px", cell_px)
+        span.set_attribute("render.warp_threads", len(draft.warp))
+        span.set_attribute("render.weft_threads", len(draft.weft))
+        svg = _drawdown_svg(draft, cell_px=cell_px)
+        span.set_attribute("render.svg_bytes", len(svg.encode()))
+    return svg
 
 
 def render_drawdown_only(

--- a/backend/app/services/rendering.py
+++ b/backend/app/services/rendering.py
@@ -12,7 +12,7 @@ from PIL import Image as PILImage
 
 from app.config import get_settings
 from app.weaving import Draft
-from app.weaving._render import ImageRenderer
+from app.weaving._render import ImageRenderer, SVGRenderer
 from app.weaving._wif import WIFReader
 
 tracer = trace.get_tracer(__name__)
@@ -52,6 +52,18 @@ def render_full_draft(draft: Draft, scale: int = 10) -> bytes:
     out = io.BytesIO()
     im.save(out, format="PNG")
     return out.getvalue()
+
+
+def render_full_draft_svg(draft: Draft, scale: int = 10) -> str:
+    """Render the full draft (threading + tie-up/liftplan + drawdown) as an SVG string."""
+    renderer = SVGRenderer(draft, scale=scale)
+    with tracer.start_as_current_span("render.full_draft_svg") as span:
+        span.set_attribute("render.scale", scale)
+        span.set_attribute("render.warp_threads", len(draft.warp))
+        span.set_attribute("render.weft_threads", len(draft.weft))
+        svg = renderer.render_to_string()
+        span.set_attribute("render.svg_bytes", len(svg.encode()))
+    return svg
 
 
 def render_full_draft_liftplan(draft: Draft, scale: int = 10) -> bytes:

--- a/backend/app/services/rendering.py
+++ b/backend/app/services/rendering.py
@@ -1,9 +1,4 @@
-"""
-WIF rendering service using PyWeaving.
-
-PyWeaving 0.0.7 calls draw.textsize() which was removed in Pillow 10.
-We restore it before importing the renderer so PyWeaving works unmodified.
-"""
+"""WIF rendering service backed by the vendored app.weaving engine."""
 
 from __future__ import annotations
 
@@ -12,38 +7,13 @@ import os
 import tempfile
 
 from fastapi import HTTPException
+from opentelemetry import trace
 from PIL import Image as PILImage
-from PIL import ImageDraw as _ImageDraw
 
-# Pillow ≥10 removed ImageDraw.textsize — patch it back for PyWeaving compatibility
-if not hasattr(_ImageDraw.ImageDraw, "textsize"):
-
-    def _textsize(self, text: str, font=None, *args, **kwargs):  # type: ignore[override]
-        bbox = self.textbbox((0, 0), text, font=font)
-        return bbox[2] - bbox[0], bbox[3] - bbox[1]
-
-    _ImageDraw.ImageDraw.textsize = _textsize  # type: ignore[attr-defined]
-
-from pyweaving import Draft  # noqa: E402
-from pyweaving.render import ImageRenderer  # noqa: E402
-from pyweaving.wif import WIFReader  # noqa: E402
-
-
-# PyWeaving's paint_fill_marker insets by 2px on each side; at scale < 4 this
-# produces endx - 2 < startx + 2, causing Pillow to raise "x1 must be >= x0".
-# Patch it to skip drawing when the cell is too small to fit the inset.
-def _paint_fill_marker(self, draw, box):  # type: ignore[override]
-    startx, starty, endx, endy = box
-    x0, y0, x1, y1 = startx + 2, starty + 2, endx - 2, endy - 2
-    if x0 < x1 and y0 < y1:
-        draw.rectangle((x0, y0, x1, y1), fill=self.markers)
-
-
-ImageRenderer.paint_fill_marker = _paint_fill_marker  # type: ignore[method-assign]
-
-from opentelemetry import trace  # noqa: E402
-
-from app.config import get_settings  # noqa: E402
+from app.config import get_settings
+from app.weaving import Draft
+from app.weaving._render import ImageRenderer
+from app.weaving._wif import WIFReader
 
 tracer = trace.get_tracer(__name__)
 

--- a/backend/app/weaving/UPSTREAM_LICENSE
+++ b/backend/app/weaving/UPSTREAM_LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright 2014-2015 Scott Torborg (storborg@gmail.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/backend/app/weaving/__init__.py
+++ b/backend/app/weaving/__init__.py
@@ -1,0 +1,382 @@
+# Copyright 2014-2015 Scott Torborg (storborg@gmail.com) — MIT License
+# Vendored and modernised by WeftMark. See UPSTREAM_LICENSE for full text.
+#
+# Public API surface — only these names are part of the stable interface.
+# Internal modules are prefixed with _ and should not be imported directly.
+
+import datetime
+import json
+from collections import defaultdict
+from copy import deepcopy
+
+__version__ = "1.0.0"
+
+__all__ = [
+    "Color",
+    "Draft",
+    "DraftError",
+    "Shaft",
+    "Treadle",
+    "WarpThread",
+    "WeftThread",
+]
+
+
+class Color:
+    """RGB colour; no transparency support."""
+
+    def __init__(self, rgb):
+        if not isinstance(rgb, tuple):
+            rgb = tuple(rgb)
+        self.rgb = rgb
+
+    def __eq__(self, other):
+        return self.rgb == other.rgb
+
+    def __ne__(self, other):
+        return self.rgb != other.rgb
+
+    @property
+    def css(self):
+        return f"rgb({self.rgb[0]}, {self.rgb[1]}, {self.rgb[2]})"
+
+    def __str__(self):
+        return str(self.rgb)
+
+    def __repr__(self):
+        return f"Color({self.rgb!r})"
+
+
+class WarpThread:
+    """A single warp thread."""
+
+    def __init__(self, color=None, shaft=None):
+        if color and not isinstance(color, Color):
+            color = Color(color)
+        self.color = color
+        self.shaft = shaft
+
+    def __repr__(self):
+        return f"<WarpThread color:{self.color.rgb} shaft:{self.shaft}>"
+
+
+class WeftThread:
+    """A single weft thread."""
+
+    def __init__(self, color=None, shafts=None, treadles=None):
+        if color and not isinstance(color, Color):
+            color = Color(color)
+        self.color = color
+        assert not (shafts and treadles), "cannot specify both shafts (liftplan) and treadles"
+        self.treadles = treadles or set()
+        self.shafts = shafts or set()
+
+    @property
+    def connected_shafts(self):
+        if self.shafts:
+            return self.shafts
+        assert self.treadles
+        ret = set()
+        for treadle in self.treadles:
+            ret.update(treadle.shafts)
+        return ret
+
+    def __repr__(self):
+        if self.treadles:
+            return f"<WeftThread color:{self.color.rgb} treadles:{self.treadles}>"
+        return f"<WeftThread color:{self.color.rgb} shafts:{self.shafts}>"
+
+
+class Shaft:
+    """A single loom shaft."""
+
+    pass
+
+
+class Treadle:
+    """A single loom treadle."""
+
+    def __init__(self, shafts=None):
+        self.shafts = shafts or set()
+
+
+class DraftError(Exception):
+    pass
+
+
+class Draft:
+    """The core representation of a weaving draft."""
+
+    def __init__(
+        self,
+        num_shafts,
+        num_treadles=0,
+        liftplan=False,
+        rising_shed=True,
+        start_at_lowest_thread=True,
+        date=None,
+        title="",
+        author="",
+        address="",
+        email="",
+        telephone="",
+        fax="",
+        notes="",
+    ):
+        self.liftplan = liftplan or (num_treadles == 0)
+        self.rising_shed = rising_shed
+        self.start_at_lowest_thread = start_at_lowest_thread
+
+        self.shafts = [Shaft() for _ in range(num_shafts)]
+        self.treadles = [Treadle() for _ in range(num_treadles)]
+
+        self.warp: list[WarpThread] = []
+        self.weft: list[WeftThread] = []
+
+        self.date = date or datetime.date.today().strftime("%b %d, %Y")
+        self.title = title
+        self.author = author
+        self.address = address
+        self.email = email
+        self.telephone = telephone
+        self.fax = fax
+        self.notes = notes
+
+    @classmethod
+    def from_json(cls, s: str) -> "Draft":
+        """Construct a Draft from its JSON representation (counterpart to to_json)."""
+        obj = json.loads(s)
+        warp = obj.pop("warp")
+        weft = obj.pop("weft")
+        tieup = obj.pop("tieup")
+
+        draft = cls(**obj)
+
+        for thread_obj in warp:
+            draft.add_warp_thread(color=thread_obj["color"], shaft=draft.shafts[thread_obj["shaft"]])
+
+        for thread_obj in weft:
+            draft.add_weft_thread(
+                color=thread_obj["color"],
+                shafts=set(draft.shafts[n] for n in thread_obj["shafts"]),
+                treadles=set(draft.treadles[n] for n in thread_obj["treadles"]),
+            )
+
+        for ii, shaft_nos in enumerate(tieup):
+            draft.treadles[ii].shafts = set(draft.shafts[n] for n in shaft_nos)
+
+        return draft
+
+    def to_json(self) -> str:
+        """Serialize to JSON (counterpart to from_json)."""
+        return json.dumps(
+            {
+                "liftplan": self.liftplan,
+                "rising_shed": self.rising_shed,
+                "num_shafts": len(self.shafts),
+                "num_treadles": len(self.treadles),
+                "warp": [{"color": thread.color.rgb, "shaft": self.shafts.index(thread.shaft)} for thread in self.warp],
+                "weft": [
+                    {
+                        "color": thread.color.rgb,
+                        "treadles": [self.treadles.index(tr) for tr in thread.treadles],
+                        "shafts": [self.shafts.index(sh) for sh in thread.shafts],
+                    }
+                    for thread in self.weft
+                ],
+                "tieup": [[self.shafts.index(sh) for sh in treadle.shafts] for treadle in self.treadles],
+                "date": self.date,
+                "title": self.title,
+                "author": self.author,
+                "address": self.address,
+                "email": self.email,
+                "telephone": self.telephone,
+                "fax": self.fax,
+                "notes": self.notes,
+            }
+        )
+
+    def copy(self) -> "Draft":
+        return deepcopy(self)
+
+    def add_warp_thread(self, color=None, index=None, shaft=0) -> None:
+        if shaft is not None and not isinstance(shaft, Shaft):
+            shaft = self.shafts[shaft]
+        thread = WarpThread(color=color, shaft=shaft)
+        if index is None:
+            self.warp.append(thread)
+        else:
+            self.warp.insert(index, thread)
+
+    def add_weft_thread(self, color=None, index=None, shafts=None, treadles=None) -> None:
+        shafts = shafts or set()
+        shaft_objs: set[Shaft] = set()
+        for shaft in shafts:
+            if not isinstance(shaft, Shaft):
+                shaft = self.shafts[shaft]
+            shaft_objs.add(shaft)
+        treadles = treadles or set()
+        treadle_objs: set[Treadle] = set()
+        for treadle in treadles:
+            if not isinstance(treadle, Treadle):
+                treadle = self.treadles[treadle]
+            treadle_objs.add(treadle)
+        thread = WeftThread(color=color, shafts=shaft_objs, treadles=treadle_objs)
+        if index is None:
+            self.weft.append(thread)
+        else:
+            self.weft.insert(index, thread)
+
+    def compute_drawdown_at(self, position: tuple[int, int]) -> WarpThread | WeftThread:
+        x, y = position
+        warp_thread = self.warp[x]
+        weft_thread = self.weft[y]
+        connected_shafts = weft_thread.connected_shafts
+        warp_at_rest = warp_thread.shaft not in connected_shafts
+        if warp_at_rest ^ self.rising_shed:
+            return warp_thread
+        return weft_thread
+
+    def compute_drawdown(self) -> list[list[WarpThread | WeftThread]]:
+        num_warp = len(self.warp)
+        num_weft = len(self.weft)
+        return [[self.compute_drawdown_at((x, y)) for y in range(num_weft)] for x in range(num_warp)]
+
+    def compute_floats(self):
+        """
+        Yield ``(start, end, visible, length, thread)`` for every float.
+        FIXME: ignores the back side of the fabric.
+        """
+        num_warp = len(self.warp)
+        num_weft = len(self.weft)
+        drawdown = self.compute_drawdown()
+
+        for x, thread in enumerate(self.warp):
+            this_vis = thread == drawdown[x][0]
+            this_start = last = (x, 0)
+            for y in range(1, num_weft):
+                check_vis = thread == drawdown[x][y]
+                if check_vis != this_vis:
+                    yield this_start, last, this_vis, last[1] - this_start[1], thread
+                    this_vis = check_vis
+                    this_start = x, y
+                last = x, y
+            yield this_start, last, this_vis, last[1] - this_start[1], thread
+
+        for y, thread in enumerate(self.weft):
+            this_vis = thread == drawdown[0][y]
+            this_start = last = (0, y)
+            for x in range(1, num_warp):
+                check_vis = thread == drawdown[x][y]
+                if check_vis != this_vis:
+                    yield this_start, last, this_vis, last[0] - this_start[0], thread
+                    this_vis = check_vis
+                    this_start = x, y
+                last = x, y
+            yield this_start, last, this_vis, last[0] - this_start[0], thread
+
+    def compute_longest_floats(self) -> tuple[int, int]:
+        """
+        Return (longest_warp_float, longest_weft_float).
+        FIXME: upstream noted this might produce incorrect results.
+        """
+        floats = list(self.compute_floats())
+        warp_max = max(
+            (length for _, _, _, length, thread in floats if isinstance(thread, WarpThread)),
+            default=0,
+        )
+        weft_max = max(
+            (length for _, _, _, length, thread in floats if isinstance(thread, WeftThread)),
+            default=0,
+        )
+        return warp_max, weft_max
+
+    def all_threads_attached(self) -> bool:
+        """Return True if every warp thread has a shaft assignment."""
+        return all(t.shaft is not None for t in self.warp)
+
+    def reduce_shafts(self):
+        raise NotImplementedError
+
+    def reduce_treadles(self):
+        raise NotImplementedError
+
+    def reduce_active_treadles(self) -> None:
+        if self.liftplan:
+            raise ValueError("cannot reduce treadles on a liftplan draft")
+        used_shaft_combos: dict = defaultdict(list)
+        for thread in self.weft:
+            used_shaft_combos[frozenset(thread.connected_shafts)].append(thread)
+        self.treadles = []
+        for shafts, threads in used_shaft_combos.items():
+            treadle = Treadle(shafts=set(shafts))
+            self.treadles.append(treadle)
+            for thread in threads:
+                thread.treadles = {treadle}
+
+    def sort_threading(self):
+        raise NotImplementedError
+
+    def sort_treadles(self):
+        raise NotImplementedError
+
+    def invert_shed(self) -> None:
+        self.rising_shed = not self.rising_shed
+        for thread in self.weft:
+            thread.shafts = self.shafts - thread.shafts  # type: ignore[assignment]
+        for treadle in self.treadles:
+            treadle.shafts = self.shafts - treadle.shafts  # type: ignore[assignment]
+
+    def rotate(self):
+        raise NotImplementedError
+
+    def flip_weftwise(self) -> None:
+        self.warp.reverse()
+
+    def flip_warpwise(self) -> None:
+        self.weft.reverse()
+
+    def selvedges_continuous(self) -> bool:
+        return self.selvedge_continuous(False) and self.selvedge_continuous(True)
+
+    def selvedge_continuous(self, low: bool) -> bool:
+        offset = 0 if low ^ self.start_at_lowest_thread else 1
+        thread = self.warp[0] if low else self.warp[-1]
+        for ii in range(offset, len(self.weft) - 1, 2):
+            a_state = thread.shaft in self.weft[ii].connected_shafts
+            b_state = thread.shaft in self.weft[ii + 1].connected_shafts
+            if not a_state ^ b_state:
+                return False
+        return True
+
+    def make_selvedges_continuous(self, add_new_shafts: bool = False) -> None:
+        for low_thread in (False, True):
+            success = False
+            warp_thread = self.warp[0] if low_thread else self.warp[-1]
+            if self.selvedge_continuous(low_thread):
+                success = True
+                continue
+            for shaft in self.shafts:
+                warp_thread.shaft = shaft
+                if self.selvedge_continuous(low_thread):
+                    success = True
+                    break
+            if not success:
+                if add_new_shafts:
+                    raise NotImplementedError
+                raise DraftError("cannot make continuous selvedges")
+
+    def compute_weft_crossings(self):
+        raise NotImplementedError
+
+    def compute_warp_crossings(self):
+        raise NotImplementedError
+
+    def repeat(self, n: int) -> None:
+        initial_warp = list(self.warp)
+        initial_weft = list(self.weft)
+        for _ in range(n):
+            for thread in initial_warp:
+                self.add_warp_thread(color=thread.color, shaft=thread.shaft)
+            for thread in initial_weft:
+                self.add_weft_thread(color=thread.color, treadles=thread.treadles, shafts=thread.shafts)

--- a/backend/app/weaving/_render.py
+++ b/backend/app/weaving/_render.py
@@ -1,0 +1,565 @@
+# Copyright 2014-2015 Scott Torborg (storborg@gmail.com) — MIT License
+# Vendored and modernised by WeftMark. See UPSTREAM_LICENSE for full text.
+#
+# Changes from upstream:
+#   - Dropped Python 2/3 compat shims (from __future__ import)
+#   - Fixed paint_fill_marker: skip draw when cell is too small for the 2px inset
+#   - Fixed paint_tieup: replaced removed Pillow textsize() with textbbox()
+#   - Font path resolved relative to this package's data/ directory
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFont
+
+_DATA_DIR = Path(__file__).parent / "data"
+_FONT_PATH = str(_DATA_DIR / "Arial.ttf")
+
+
+class ImageRenderer:
+    def __init__(
+        self,
+        draft,
+        liftplan=None,
+        margin_pixels: int = 20,
+        scale: int = 10,
+        foreground=(127, 127, 127),
+        background=(255, 255, 255),
+        markers=(0, 0, 0),
+        numbering=(200, 0, 0),
+    ):
+        self.draft = draft
+        self.liftplan = liftplan
+        self.margin_pixels = margin_pixels
+        self.pixels_per_square = scale
+        self.background = background
+        self.foreground = foreground
+        self.markers = markers
+        self.numbering = numbering
+        self.font_size = int(round(scale * 1.2))
+        self.font = ImageFont.truetype(_FONT_PATH, self.font_size)
+
+    def pad_image(self, im: Image.Image) -> Image.Image:
+        w, h = im.size
+        new = Image.new("RGB", (w + self.margin_pixels * 2, h + self.margin_pixels * 2), self.background)
+        new.paste(im, (self.margin_pixels, self.margin_pixels))
+        return new
+
+    def make_pil_image(self) -> Image.Image:
+        width_squares = len(self.draft.warp) + 6
+        if self.liftplan or self.draft.liftplan:
+            width_squares += len(self.draft.shafts)
+        else:
+            width_squares += len(self.draft.treadles)
+        height_squares = len(self.draft.weft) + 6 + len(self.draft.shafts)
+
+        # +1 prevents content overflow at the canvas edge
+        width = width_squares * self.pixels_per_square + 1
+        height = height_squares * self.pixels_per_square + 1
+
+        im = Image.new("RGB", (width, height), self.background)
+        draw = ImageDraw.Draw(im)
+
+        self.paint_warp(draw)
+        self.paint_threading(draw)
+        self.paint_weft(draw)
+        if self.liftplan or self.draft.liftplan:
+            self.paint_liftplan(draw)
+        else:
+            self.paint_tieup(draw)
+            self.paint_treadling(draw)
+        self.paint_drawdown(draw)
+        self.paint_start_indicator(draw)
+        del draw
+
+        return self.pad_image(im)
+
+    def paint_start_indicator(self, draw: ImageDraw.ImageDraw) -> None:
+        pps = self.pixels_per_square
+        endy = (len(self.draft.shafts) + 6) * pps - 1
+        starty = endy - pps // 2
+        if self.draft.start_at_lowest_thread:
+            endx = len(self.draft.warp) * pps
+            startx = endx - pps
+        else:
+            startx, endx = 0, pps
+        draw.polygon(
+            [(startx, starty), (endx, starty), (startx + pps // 2, endy)],
+            fill=self.markers,
+        )
+
+    def paint_warp(self, draw: ImageDraw.ImageDraw) -> None:
+        pps = self.pixels_per_square
+        for ii, thread in enumerate(self.draft.warp):
+            startx = pps * ii
+            draw.rectangle((startx, 0, startx + pps, pps), outline=self.foreground, fill=thread.color.rgb)
+
+    def paint_fill_marker(self, draw: ImageDraw.ImageDraw, box: tuple) -> None:
+        startx, starty, endx, endy = box
+        x0, y0, x1, y1 = startx + 2, starty + 2, endx - 2, endy - 2
+        if x0 < x1 and y0 < y1:
+            draw.rectangle((x0, y0, x1, y1), fill=self.markers)
+
+    def paint_threading(self, draw: ImageDraw.ImageDraw) -> None:
+        pps = self.pixels_per_square
+        num_threads = len(self.draft.warp)
+        num_shafts = len(self.draft.shafts)
+
+        for ii, thread in enumerate(self.draft.warp):
+            startx = (num_threads - ii - 1) * pps
+            endx = startx + pps
+
+            for jj, shaft in enumerate(self.draft.shafts):
+                starty = (4 + num_shafts - jj) * pps
+                endy = starty + pps
+                draw.rectangle((startx, starty, endx, endy), outline=self.foreground)
+                if shaft == thread.shaft:
+                    self.paint_fill_marker(draw, (startx, starty, endx, endy))
+
+            thread_no = ii + 1
+            if thread_no != num_threads and thread_no != 0 and thread_no % 4 == 0:
+                tick_x = (num_threads - ii - 1) * pps
+                tick_ys, tick_ye = 3 * pps, 5 * pps - 1
+                draw.line((tick_x, tick_ys, tick_x, tick_ye), fill=self.numbering)
+                draw.text((tick_x + 2, tick_ys + 2), str(thread_no), font=self.font, fill=self.numbering)
+
+    def paint_weft(self, draw: ImageDraw.ImageDraw) -> None:
+        pps = self.pixels_per_square
+        offsety = (6 + len(self.draft.shafts)) * pps
+        startx_sq = len(self.draft.warp) + 5
+        if self.liftplan or self.draft.liftplan:
+            startx_sq += len(self.draft.shafts)
+        else:
+            startx_sq += len(self.draft.treadles)
+        startx = startx_sq * pps
+
+        for ii, thread in enumerate(self.draft.weft):
+            starty = ii * pps + offsety
+            draw.rectangle((startx, starty, startx + pps, starty + pps), outline=self.foreground, fill=thread.color.rgb)
+
+    def paint_liftplan(self, draw: ImageDraw.ImageDraw) -> None:
+        pps = self.pixels_per_square
+        num_threads = len(self.draft.weft)
+        offsetx = (1 + len(self.draft.warp)) * pps
+        offsety = (6 + len(self.draft.shafts)) * pps
+
+        for ii, thread in enumerate(self.draft.weft):
+            starty = ii * pps + offsety
+            endy = starty + pps
+
+            for jj, shaft in enumerate(self.draft.shafts):
+                startx = jj * pps + offsetx
+                endx = startx + pps
+                draw.rectangle((startx, starty, endx, endy), outline=self.foreground)
+                if shaft in thread.connected_shafts:
+                    self.paint_fill_marker(draw, (startx, starty, endx, endy))
+
+            thread_no = ii + 1
+            if thread_no != num_threads and thread_no != 0 and thread_no % 4 == 0:
+                line_startx = offsetx + len(self.draft.shafts) * pps
+                draw.line((line_startx, endy, line_startx + 2 * pps, endy), fill=self.numbering)
+                draw.text(
+                    (line_startx + 2, endy - 2 - self.font_size),
+                    str(thread_no),
+                    font=self.font,
+                    fill=self.numbering,
+                )
+
+    def paint_tieup(self, draw: ImageDraw.ImageDraw) -> None:
+        pps = self.pixels_per_square
+        offsetx = (1 + len(self.draft.warp)) * pps
+        offsety = 5 * pps
+        num_treadles = len(self.draft.treadles)
+        num_shafts = len(self.draft.shafts)
+
+        for ii, treadle in enumerate(self.draft.treadles):
+            startx = ii * pps + offsetx
+            endx = startx + pps
+            treadle_no = ii + 1
+
+            for jj, shaft in enumerate(self.draft.shafts):
+                starty = (num_shafts - jj - 1) * pps + offsety
+                endy = starty + pps
+                draw.rectangle((startx, starty, endx, endy), outline=self.foreground)
+                if shaft in treadle.shafts:
+                    self.paint_fill_marker(draw, (startx, starty, endx, endy))
+
+                if treadle_no == num_treadles:
+                    shaft_no = jj + 1
+                    if shaft_no != 0 and shaft_no % 4 == 0:
+                        lx = endx
+                        draw.line((lx, starty, lx + 2 * pps, starty), fill=self.numbering)
+                        draw.text((lx + 2, starty + 2), str(shaft_no), font=self.font, fill=self.numbering)
+
+            if treadle_no != 0 and treadle_no % 4 == 0:
+                tick_x = treadle_no * pps + offsetx
+                tick_ys, tick_ye = 3 * pps, 5 * pps - 1
+                draw.line((tick_x, tick_ys, tick_x, tick_ye), fill=self.numbering)
+                # textbbox replaces removed textsize (Pillow ≥10)
+                bbox = draw.textbbox((0, 0), str(treadle_no), font=self.font)
+                textw = bbox[2] - bbox[0]
+                draw.text((tick_x - textw - 2, tick_ys + 2), str(treadle_no), font=self.font, fill=self.numbering)
+
+    def paint_treadling(self, draw: ImageDraw.ImageDraw) -> None:
+        pps = self.pixels_per_square
+        num_threads = len(self.draft.weft)
+        offsetx = (1 + len(self.draft.warp)) * pps
+        offsety = (6 + len(self.draft.shafts)) * pps
+
+        for ii, thread in enumerate(self.draft.weft):
+            starty = ii * pps + offsety
+            endy = starty + pps
+
+            for jj, treadle in enumerate(self.draft.treadles):
+                startx = jj * pps + offsetx
+                endx = startx + pps
+                draw.rectangle((startx, starty, endx, endy), outline=self.foreground)
+                if treadle in thread.treadles:
+                    self.paint_fill_marker(draw, (startx, starty, endx, endy))
+
+            thread_no = ii + 1
+            if thread_no != num_threads and thread_no != 0 and thread_no % 4 == 0:
+                line_startx = offsetx + len(self.draft.treadles) * pps
+                draw.line((line_startx, endy, line_startx + 2 * pps, endy), fill=self.numbering)
+                draw.text(
+                    (line_startx + 2, endy - 2 - self.font_size),
+                    str(thread_no),
+                    font=self.font,
+                    fill=self.numbering,
+                )
+
+    def paint_drawdown(self, draw: ImageDraw.ImageDraw) -> None:
+        pps = self.pixels_per_square
+        offsety = (6 + len(self.draft.shafts)) * pps
+        for start, end, visible, length, thread in self.draft.compute_floats():
+            if visible:
+                startx = start[0] * pps
+                starty = start[1] * pps + offsety
+                endx = (end[0] + 1) * pps
+                endy = (end[1] + 1) * pps + offsety
+                draw.rectangle((startx, starty, endx, endy), outline=self.foreground, fill=thread.color.rgb)
+
+    def show(self) -> None:
+        self.make_pil_image().show()
+
+    def save(self, filename: str) -> None:
+        self.make_pil_image().save(filename)
+
+
+# ---------------------------------------------------------------------------
+# SVG renderer
+# ---------------------------------------------------------------------------
+
+_SVG_PREAMBLE = '<?xml version="1.0" encoding="utf-8" standalone="no"?>'
+_SVG_HEADER = (
+    '<svg width="{width}" height="{height}" '
+    'viewBox="0 0 {width} {height}" '
+    'xmlns="http://www.w3.org/2000/svg" '
+    'xmlns:xlink="http://www.w3.org/1999/xlink">'
+)
+
+
+class _TagGenerator:
+    def __getattr__(self, name):
+        def tag(*children, **attrs):
+            inner = "".join(children)
+            if attrs:
+                attr_str = " ".join(f'{k.replace("_", "-")}="{v}"' for k, v in attrs.items())
+                return f"<{name} {attr_str}>{inner}</{name}>"
+            return f"<{name}>{inner}</{name}>"
+
+        return tag
+
+
+_SVG = _TagGenerator()
+
+
+class SVGRenderer:
+    def __init__(
+        self,
+        draft,
+        liftplan=None,
+        scale: int = 10,
+        foreground: str = "#7f7f7f",
+        background: str = "#ffffff",
+        markers: str = "#000000",
+        numbering: str = "#c80000",
+    ):
+        self.draft = draft
+        self.liftplan = liftplan
+        self.scale = scale
+        self.background = background
+        self.foreground = foreground
+        self.markers = markers
+        self.numbering = numbering
+        self.font_family = "Arial, sans-serif"
+        self.font_size = 12
+
+    def make_svg_doc(self) -> str:
+        s = self.scale
+        width_sq = len(self.draft.warp) + 6
+        if self.liftplan or self.draft.liftplan:
+            width_sq += len(self.draft.shafts)
+        else:
+            width_sq += len(self.draft.treadles)
+        height_sq = len(self.draft.weft) + 6 + len(self.draft.shafts)
+
+        doc = [_SVG_HEADER.format(width=width_sq * s, height=height_sq * s)]
+        doc.append(_SVG.title(self.draft.title))
+        self.paint_warp(doc)
+        self.paint_threading(doc)
+        self.paint_weft(doc)
+        if self.liftplan or self.draft.liftplan:
+            self.paint_liftplan(doc)
+        else:
+            self.paint_tieup(doc)
+            self.paint_treadling(doc)
+        self.paint_drawdown(doc)
+        doc.append("</svg>")
+        return "\n".join(doc)
+
+    def paint_warp(self, doc) -> None:
+        s = self.scale
+        grp = []
+        for ii, thread in enumerate(self.draft.warp):
+            grp.append(
+                _SVG.rect(
+                    x=s * ii,
+                    y=0,
+                    width=s,
+                    height=s,
+                    style=f"stroke:{self.foreground}; fill:{thread.color.css}",
+                )
+            )
+        doc.append(_SVG.g(*grp))
+
+    def paint_weft(self, doc) -> None:
+        s = self.scale
+        offsety = (6 + len(self.draft.shafts)) * s
+        startx_sq = len(self.draft.warp) + 5
+        if self.liftplan or self.draft.liftplan:
+            startx_sq += len(self.draft.shafts)
+        else:
+            startx_sq += len(self.draft.treadles)
+        startx = startx_sq * s
+
+        grp = []
+        for ii, thread in enumerate(self.draft.weft):
+            grp.append(
+                _SVG.rect(
+                    x=startx,
+                    y=ii * s + offsety,
+                    width=s,
+                    height=s,
+                    style=f"stroke:{self.foreground}; fill:{thread.color.css}",
+                )
+            )
+        doc.append(_SVG.g(*grp))
+
+    def paint_fill_marker(self, doc, box) -> None:
+        startx, starty, endx, endy = box
+        doc.append(
+            _SVG.rect(
+                x=startx + 2,
+                y=starty + 2,
+                width=self.scale - 4,
+                height=self.scale - 4,
+                style=f"fill:{self.markers}",
+            )
+        )
+
+    def paint_threading(self, doc) -> None:
+        s = self.scale
+        num_threads = len(self.draft.warp)
+        num_shafts = len(self.draft.shafts)
+        grp = []
+        for ii, thread in enumerate(self.draft.warp):
+            startx = (num_threads - ii - 1) * s
+            endx = startx + s
+            for jj, shaft in enumerate(self.draft.shafts):
+                starty = (4 + num_shafts - jj) * s
+                endy = starty + s
+                grp.append(
+                    _SVG.rect(
+                        x=startx,
+                        y=starty,
+                        width=s,
+                        height=s,
+                        style=f"stroke:{self.foreground}; fill:{self.background}",
+                    )
+                )
+                if shaft == thread.shaft:
+                    self.paint_fill_marker(grp, (startx, starty, endx, endy))
+            thread_no = ii + 1
+            if thread_no != num_threads and thread_no != 0 and thread_no % 4 == 0:
+                tx = (num_threads - ii - 1) * s
+                grp.append(_SVG.line(x1=tx, y1=3 * s, x2=tx, y2=5 * s - 1, style=f"stroke:{self.numbering}"))
+                grp.append(
+                    _SVG.text(
+                        str(thread_no),
+                        x=tx + 3,
+                        y=3 * s + self.font_size,
+                        style=f"font-family:{self.font_family}; font-size:{self.font_size}; fill:{self.numbering}",
+                    )
+                )
+        doc.append(_SVG.g(*grp))
+
+    def paint_liftplan(self, doc) -> None:
+        s = self.scale
+        num_threads = len(self.draft.weft)
+        offsetx = (1 + len(self.draft.warp)) * s
+        offsety = (6 + len(self.draft.shafts)) * s
+        grp = []
+        for ii, thread in enumerate(self.draft.weft):
+            starty = ii * s + offsety
+            endy = starty + s
+            for jj, shaft in enumerate(self.draft.shafts):
+                startx = jj * s + offsetx
+                endx = startx + s
+                grp.append(
+                    _SVG.rect(
+                        x=startx,
+                        y=starty,
+                        width=s,
+                        height=s,
+                        style=f"stroke:{self.foreground}; fill:{self.background}",
+                    )
+                )
+                if shaft in thread.connected_shafts:
+                    self.paint_fill_marker(grp, (startx, starty, endx, endy))
+            thread_no = ii + 1
+            if thread_no != num_threads and thread_no != 0 and thread_no % 4 == 0:
+                lx = offsetx + len(self.draft.shafts) * s
+                grp.append(_SVG.line(x1=lx, y1=endy, x2=lx + 2 * s, y2=endy, style=f"stroke:{self.numbering}"))
+                grp.append(
+                    _SVG.text(
+                        str(thread_no),
+                        x=lx + 3,
+                        y=endy - 4,
+                        style=f"font-family:{self.font_family}; font-size:{self.font_size}; fill:{self.numbering}",
+                    )
+                )
+        doc.append(_SVG.g(*grp))
+
+    def paint_tieup(self, doc) -> None:
+        s = self.scale
+        offsetx = (1 + len(self.draft.warp)) * s
+        offsety = 5 * s
+        num_treadles = len(self.draft.treadles)
+        num_shafts = len(self.draft.shafts)
+        grp = []
+        for ii, treadle in enumerate(self.draft.treadles):
+            startx = ii * s + offsetx
+            endx = startx + s
+            treadle_no = ii + 1
+            for jj, shaft in enumerate(self.draft.shafts):
+                starty = (num_shafts - jj - 1) * s + offsety
+                endy = starty + s
+                grp.append(
+                    _SVG.rect(
+                        x=startx,
+                        y=starty,
+                        width=s,
+                        height=s,
+                        style=f"stroke:{self.foreground}; fill:{self.background}",
+                    )
+                )
+                if shaft in treadle.shafts:
+                    self.paint_fill_marker(grp, (startx, starty, endx, endy))
+                if treadle_no == num_treadles:
+                    shaft_no = jj + 1
+                    if shaft_no != 0 and shaft_no % 4 == 0:
+                        lx = endx
+                        grp.append(
+                            _SVG.line(x1=lx, y1=starty, x2=lx + 2 * s, y2=starty, style=f"stroke:{self.numbering}")
+                        )
+                        grp.append(
+                            _SVG.text(
+                                str(shaft_no),
+                                x=lx + 3,
+                                y=starty + 2 + self.font_size,
+                                style=(
+                                    f"font-family:{self.font_family}; font-size:{self.font_size}; fill:{self.numbering}"
+                                ),
+                            )
+                        )
+            if treadle_no != 0 and treadle_no % 4 == 0:
+                tx = treadle_no * s + offsetx
+                grp.append(_SVG.line(x1=tx, y1=3 * s, x2=tx, y2=5 * s - 1, style=f"stroke:{self.numbering}"))
+                grp.append(
+                    _SVG.text(
+                        str(treadle_no),
+                        x=tx - 3,
+                        y=3 * s + self.font_size,
+                        text_anchor="end",
+                        style=f"font-family:{self.font_family}; font-size:{self.font_size}; fill:{self.numbering}",
+                    )
+                )
+        doc.append(_SVG.g(*grp))
+
+    def paint_treadling(self, doc) -> None:
+        s = self.scale
+        num_threads = len(self.draft.weft)
+        offsetx = (1 + len(self.draft.warp)) * s
+        offsety = (6 + len(self.draft.shafts)) * s
+        grp = []
+        for ii, thread in enumerate(self.draft.weft):
+            starty = ii * s + offsety
+            endy = starty + s
+            for jj, treadle in enumerate(self.draft.treadles):
+                startx = jj * s + offsetx
+                endx = startx + s
+                grp.append(
+                    _SVG.rect(
+                        x=startx,
+                        y=starty,
+                        width=s,
+                        height=s,
+                        style=f"stroke:{self.foreground}; fill:{self.background}",
+                    )
+                )
+                if treadle in thread.treadles:
+                    self.paint_fill_marker(grp, (startx, starty, endx, endy))
+            thread_no = ii + 1
+            if thread_no != num_threads and thread_no != 0 and thread_no % 4 == 0:
+                lx = offsetx + len(self.draft.treadles) * s
+                grp.append(_SVG.line(x1=lx, y1=endy, x2=lx + 2 * s, y2=endy, style=f"stroke:{self.numbering}"))
+                grp.append(
+                    _SVG.text(
+                        str(thread_no),
+                        x=lx + 3,
+                        y=endy - 4,
+                        style=f"font-family:{self.font_family}; font-size:{self.font_size}; fill:{self.numbering}",
+                    )
+                )
+        doc.append(_SVG.g(*grp))
+
+    def paint_drawdown(self, doc) -> None:
+        s = self.scale
+        offsety = (6 + len(self.draft.shafts)) * s
+        grp = []
+        for start, end, visible, length, thread in self.draft.compute_floats():
+            if visible:
+                startx = start[0] * s
+                starty = start[1] * s + offsety
+                w = (end[0] - start[0] + 1) * s
+                h = (end[1] - start[1] + 1) * s
+                grp.append(
+                    _SVG.rect(
+                        x=startx,
+                        y=starty,
+                        width=w,
+                        height=h,
+                        style=f"stroke:{self.foreground}; fill:{thread.color.css}",
+                    )
+                )
+        doc.append(_SVG.g(*grp))
+
+    def render_to_string(self) -> str:
+        return self.make_svg_doc()
+
+    def save(self, filename: str) -> None:
+        s = _SVG_PREAMBLE + "\n" + self.make_svg_doc()
+        with open(filename, "w") as f:
+            f.write(s)

--- a/backend/app/weaving/_render.py
+++ b/backend/app/weaving/_render.py
@@ -563,3 +563,63 @@ class SVGRenderer:
         s = _SVG_PREAMBLE + "\n" + self.make_svg_doc()
         with open(filename, "w") as f:
             f.write(s)
+
+
+# ---------------------------------------------------------------------------
+# Symbol-deduped drawdown SVG (project step tracking)
+# ---------------------------------------------------------------------------
+
+
+def drawdown_svg(draft, cell_px: int = 10) -> str:
+    """Render the drawdown grid as a symbol-deduped SVG string.
+
+    Orientation matches the tile renderer: last pick at y=0 (top), first pick at
+    bottom.  Identical lift patterns share a <symbol> element so byte size scales
+    with unique_patterns × warp_count rather than total_picks × warp_count.
+
+    Returns an SVG string without an XML declaration — suitable for inline DOM
+    injection via dangerouslySetInnerHTML.
+    """
+    warp_count = len(draft.warp)
+    weft_count = len(draft.weft)
+    total_w = warp_count * cell_px
+    total_h = weft_count * cell_px
+
+    warp_colors = [t.color.css for t in draft.warp]
+
+    symbol_map: dict[tuple[int, ...], int] = {}
+    symbol_defs: list[str] = []
+    row_data: list[tuple[int, str]] = []  # (symbol_id, weft_css)
+
+    for weft_thread in draft.weft:
+        connected = weft_thread.connected_shafts
+        # Columns where the warp thread is visible (mirrors compute_drawdown_at logic).
+        warp_up = tuple(x for x, wt in enumerate(draft.warp) if (wt.shaft not in connected) ^ draft.rising_shed)
+        if warp_up not in symbol_map:
+            sid = len(symbol_map)
+            symbol_map[warp_up] = sid
+            rects = "".join(
+                f'<rect x="{x * cell_px}" y="0" width="{cell_px}" height="{cell_px}" fill="{warp_colors[x]}"/>'
+                for x in warp_up
+            )
+            symbol_defs.append(f'<symbol id="s{sid}" width="{total_w}" height="{cell_px}">{rects}</symbol>')
+        weft_css = weft_thread.color.css if weft_thread.color else "#ffffff"
+        row_data.append((symbol_map[warp_up], weft_css))
+
+    rows: list[str] = []
+    for weft_idx, (sid, weft_css) in enumerate(row_data):
+        # Flip: weft index 0 (first pick) at bottom, last pick at top (y=0).
+        svg_row = weft_count - 1 - weft_idx
+        y = svg_row * cell_px
+        rows.append(f'<rect x="0" y="{y}" width="{total_w}" height="{cell_px}" fill="{weft_css}"/>')
+        rows.append(f'<use href="#s{sid}" x="0" y="{y}"/>')
+
+    defs = f"<defs>{''.join(symbol_defs)}</defs>"
+    body = "".join(rows)
+    return (
+        f'<svg width="{total_w}" height="{total_h}"'
+        f' viewBox="0 0 {total_w} {total_h}"'
+        f' xmlns="http://www.w3.org/2000/svg"'
+        f' xmlns:xlink="http://www.w3.org/1999/xlink">'
+        f"{defs}{body}</svg>"
+    )

--- a/backend/app/weaving/_wif.py
+++ b/backend/app/weaving/_wif.py
@@ -1,0 +1,258 @@
+# Copyright 2014-2015 Scott Torborg (storborg@gmail.com) — MIT License
+# Vendored and modernised by WeftMark. See UPSTREAM_LICENSE for full text.
+#
+# Changes from upstream:
+#   - Dropped Python 2/3 compat shims (from __future__ import, six dependency)
+#   - configparser imported from stdlib (Python 3 standard)
+
+from __future__ import annotations
+
+from configparser import RawConfigParser
+
+from app.weaving import Draft, __version__
+
+
+class WIFReader:
+    """Parse a WIF file into a Draft."""
+
+    allowed_units = ("decipoints", "inches", "centimeters")
+
+    def __init__(self, filename: str):
+        self.filename = filename
+
+    def getbool(self, section: str, option: str) -> bool:
+        if self.config.has_option(section, option):
+            return self.config.getboolean(section, option)
+        return False
+
+    def put_metadata(self, draft: Draft) -> None:
+        draft.date = self.config.get("WIF", "Date")
+
+    def put_warp(self, draft: Draft, wif_palette: dict) -> None:
+        warp_thread_count = self.config.getint("WARP", "Threads")
+        warp_units = self.config.get("WARP", "Units").lower()
+        assert warp_units in self.allowed_units, f"Warp Units of {warp_units!r} is not understood"
+
+        has_warp_colors = self.getbool("CONTENTS", "WARP COLORS")
+        warp_color_map: dict[int, int] | None = None
+        if has_warp_colors:
+            warp_color_map = {}
+            for thread_no, value in self.config.items("WARP COLORS"):
+                warp_color_map[int(thread_no)] = int(value)
+
+        warp_color = None
+        if not warp_color_map:
+            has_warp_colors = False
+            warp_color = self.config.getint("WARP", "Color")
+
+        has_threading = self.getbool("CONTENTS", "THREADING")
+        threading_map: dict[int, list[int]] = {}
+        if has_threading:
+            for thread_no, value in self.config.items("THREADING"):
+                threading_map[int(thread_no)] = [int(sn) for sn in value.split(",")]
+
+        for thread_no in range(1, warp_thread_count + 1):
+            if thread_no not in threading_map:
+                continue
+            color = wif_palette[warp_color_map[thread_no] if has_warp_colors else warp_color]
+            shaft = None
+            if has_threading:
+                shafts = {draft.shafts[sn - 1] for sn in threading_map[thread_no]}
+                assert len(shafts) == 1
+                shaft = next(iter(shafts))
+            draft.add_warp_thread(color=color, shaft=shaft)
+
+    def put_weft(self, draft: Draft, wif_palette: dict) -> None:
+        weft_thread_count = self.config.getint("WEFT", "Threads")
+        weft_units = self.config.get("WEFT", "Units").lower()
+        assert weft_units in self.allowed_units, f"Weft Units of {weft_units!r} is not understood"
+
+        has_weft_colors = self.getbool("CONTENTS", "WEFT COLORS")
+        weft_color_map: dict[int, int] | None = None
+        if has_weft_colors:
+            weft_color_map = {}
+            for thread_no, value in self.config.items("WEFT COLORS"):
+                weft_color_map[int(thread_no)] = int(value)
+
+        weft_color = None
+        if not weft_color_map:
+            has_weft_colors = False
+            weft_color = self.config.getint("WEFT", "Color")
+
+        has_liftplan = self.getbool("CONTENTS", "LIFTPLAN")
+        liftplan_map: dict[int, list[int]] = {}
+        if has_liftplan:
+            for thread_no, value in self.config.items("LIFTPLAN"):
+                liftplan_map[int(thread_no)] = [int(sn) for sn in value.split(",")]
+
+        has_treadling = self.getbool("CONTENTS", "TREADLING")
+        treadling_map: dict[int, list[int]] = {}
+        if has_treadling:
+            for thread_no, value in self.config.items("TREADLING"):
+                try:
+                    treadling_map[int(thread_no)] = [int(tn) for tn in value.split(",")]
+                except ValueError:
+                    pass
+
+        for thread_no in range(1, weft_thread_count + 1):
+            if not ((has_liftplan and thread_no in liftplan_map) or (has_treadling and thread_no in treadling_map)):
+                continue
+            color = wif_palette[weft_color_map[thread_no] if has_weft_colors else weft_color]
+            shafts = {draft.shafts[sn - 1] for sn in liftplan_map[thread_no]} if has_liftplan else set()
+            treadles = {draft.treadles[tn - 1] for tn in treadling_map[thread_no]} if has_treadling else set()
+            draft.add_weft_thread(color=color, shafts=shafts, treadles=treadles)
+
+    def put_tieup(self, draft: Draft) -> None:
+        for treadle_no, value in self.config.items("TIEUP"):
+            treadle = draft.treadles[int(treadle_no) - 1]
+            for shaft_no in (int(sn) for sn in value.split(",")):
+                treadle.shafts.add(draft.shafts[shaft_no - 1])
+
+    def read(self) -> Draft:
+        self.config = RawConfigParser()
+        self.config.read(self.filename)
+
+        rising_shed = self.getbool("WEAVING", "Rising Shed")
+        num_shafts = self.config.getint("WEAVING", "Shafts")
+        num_treadles = self.config.getint("WEAVING", "Treadles")
+
+        liftplan = self.getbool("CONTENTS", "LIFTPLAN")
+        treadling = self.getbool("CONTENTS", "TREADLING")
+        assert not (liftplan and treadling), "WIF contains both liftplan and treadling"
+        assert not (liftplan and num_treadles > 0), "WIF contains liftplan and non-zero treadle count"
+
+        if self.getbool("CONTENTS", "COLOR PALETTE"):
+            rstart, rend = self.config.get("COLOR PALETTE", "Range").split(",")
+            palette_range = int(rstart), int(rend)
+        else:
+            palette_range = 0, 255
+
+        wif_palette: dict[int, list[int]] | None = None
+        if self.getbool("CONTENTS", "COLOR TABLE"):
+            wif_palette = {}
+            for color_no, value in self.config.items("COLOR TABLE"):
+                channels = [int(ch) for ch in value.split(",")]
+                channels = [int(round(ch * (255.0 / palette_range[1]))) for ch in channels]
+                wif_palette[int(color_no)] = channels
+
+        draft = Draft(num_shafts=num_shafts, num_treadles=num_treadles, rising_shed=rising_shed)
+        self.put_metadata(draft)
+        self.put_warp(draft, wif_palette)
+        self.put_weft(draft, wif_palette)
+        if treadling:
+            self.put_tieup(draft)
+
+        return draft
+
+
+class WIFWriter:
+    """Write a Draft to WIF format."""
+
+    def __init__(self, draft: Draft):
+        self.draft = draft
+
+    def write_metadata(self, config: RawConfigParser, liftplan: bool) -> None:
+        config.add_section("WIF")
+        config.set("WIF", "Date", self.draft.date)
+        config.set("WIF", "Version", "1.1")
+        config.set("WIF", "Developers", "storborg@gmail.com")
+        config.set("WIF", "Source Program", "PyWeaving")
+        config.set("WIF", "Source Version", __version__)
+
+        config.set("CONTENTS", "WEAVING", 1)
+        config.add_section("WEAVING")
+        config.set("WEAVING", "Rising Shed", self.draft.rising_shed)
+        config.set("WEAVING", "Shafts", len(self.draft.shafts))
+        config.set("WEAVING", "Treadles", 0 if liftplan else len(self.draft.treadles))
+
+        config.set("CONTENTS", "TEXT", 1)
+        config.add_section("TEXT")
+        config.set("TEXT", "Title", self.draft.title)
+        config.set("TEXT", "Author", self.draft.author)
+        config.set("TEXT", "Address", self.draft.address)
+        config.set("TEXT", "EMail", self.draft.email)
+        config.set("TEXT", "Telephone", self.draft.telephone)
+        config.set("TEXT", "FAX", self.draft.fax)
+
+        if self.draft.notes:
+            config.set("CONTENTS", "NOTES", 1)
+            config.add_section("NOTES")
+            for ii, line in enumerate(self.draft.notes.split("\n")):
+                config.set("NOTES", str(ii), line)
+
+    def write_palette(self, config: RawConfigParser) -> dict:
+        colors = set(thread.color.rgb for thread in self.draft.warp + self.draft.weft)
+        wif_palette: dict = {}
+        config.set("CONTENTS", "COLOR TABLE", 1)
+        config.add_section("COLOR TABLE")
+        for ii, color in enumerate(colors, start=1):
+            config.set("COLOR TABLE", str(ii), f"{color[0]},{color[1]},{color[2]}")
+            wif_palette[color] = ii
+
+        config.set("CONTENTS", "COLOR PALETTE", 1)
+        config.add_section("COLOR PALETTE")
+        config.set("COLOR PALETTE", "Form", "RGB")
+        config.set("COLOR PALETTE", "Range", "0,255")
+        return wif_palette
+
+    def write_threads(self, config: RawConfigParser, wif_palette: dict, dir: str) -> None:
+        assert dir in ("warp", "weft")
+        threads = getattr(self.draft, dir)
+        dir_upper = dir.upper()
+        config.set("CONTENTS", dir_upper, 1)
+        config.add_section(dir_upper)
+        config.set(dir_upper, "Threads", len(threads))
+        config.set(dir_upper, "Units", "Inches")
+
+        config.set("CONTENTS", f"{dir_upper} COLORS", 1)
+        config.add_section(f"{dir_upper} COLORS")
+        for ii, thread in enumerate(threads, start=1):
+            config.set(f"{dir_upper} COLORS", str(ii), wif_palette[thread.color.rgb])
+
+    def write_threading(self, config: RawConfigParser) -> None:
+        config.set("CONTENTS", "THREADING", 1)
+        config.add_section("THREADING")
+        for ii, thread in enumerate(self.draft.warp, start=1):
+            config.set("THREADING", str(ii), str(self.draft.shafts.index(thread.shaft) + 1))
+
+    def write_liftplan(self, config: RawConfigParser) -> None:
+        config.set("CONTENTS", "LIFTPLAN", 1)
+        config.add_section("LIFTPLAN")
+        for ii, thread in enumerate(self.draft.weft, start=1):
+            shaft_nos = [self.draft.shafts.index(shaft) + 1 for shaft in thread.connected_shafts]
+            config.set("LIFTPLAN", str(ii), ",".join(str(n) for n in shaft_nos))
+
+    def write_treadling(self, config: RawConfigParser) -> None:
+        config.set("CONTENTS", "TREADLING", 1)
+        config.add_section("TREADLING")
+        for ii, thread in enumerate(self.draft.weft, start=1):
+            treadle_nos = [self.draft.treadles.index(tr) + 1 for tr in thread.treadles]
+            config.set("TREADLING", str(ii), ",".join(str(n) for n in treadle_nos))
+
+    def write_tieup(self, config: RawConfigParser) -> None:
+        config.set("CONTENTS", "TIEUP", 1)
+        config.add_section("TIEUP")
+        for ii, treadle in enumerate(self.draft.treadles, start=1):
+            shaft_nos = [self.draft.shafts.index(shaft) + 1 for shaft in treadle.shafts]
+            config.set("TIEUP", str(ii), ",".join(str(n) for n in shaft_nos))
+
+    def write(self, filename: str, liftplan: bool = False) -> None:
+        assert self.draft.start_at_lowest_thread
+
+        config = RawConfigParser()
+        config.optionxform = str  # type: ignore[method-assign]
+        config.add_section("CONTENTS")
+
+        self.write_metadata(config, liftplan=liftplan)
+        wif_palette = self.write_palette(config)
+        self.write_threads(config, wif_palette, "warp")
+        self.write_threads(config, wif_palette, "weft")
+        self.write_threading(config)
+        if liftplan or not self.draft.treadles:
+            self.write_liftplan(config)
+        else:
+            self.write_treadling(config)
+            self.write_tieup(config)
+
+        with open(filename, "w", encoding="utf-8") as f:
+            config.write(f)

--- a/backend/app/weaving/generators/__init__.py
+++ b/backend/app/weaving/generators/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2014-2015 Scott Torborg (storborg@gmail.com) — MIT License
+# Vendored and modernised by WeftMark. See UPSTREAM_LICENSE for full text.
+
+from app.weaving.generators.tartan import tartan
+from app.weaving.generators.twill import twill
+
+__all__ = ["tartan", "twill"]

--- a/backend/app/weaving/generators/tartan.py
+++ b/backend/app/weaving/generators/tartan.py
@@ -1,0 +1,45 @@
+# Copyright 2014-2015 Scott Torborg (storborg@gmail.com) — MIT License
+# Vendored and modernised by WeftMark. See UPSTREAM_LICENSE for full text.
+
+import re
+
+from app.weaving import Draft
+
+_COLOR_MAP = {
+    "A": (92, 140, 168),
+    "G": (0, 104, 24),
+    "B": (44, 44, 128),
+    "K": (0, 0, 0),
+    "W": (224, 224, 224),
+    "Y": (232, 192, 0),
+    "R": (200, 0, 44),
+    "P": (120, 0, 120),
+    "C": (208, 80, 84),
+    "LP": (180, 104, 172),
+}
+
+
+def tartan(sett: str, repeats: int = 1) -> Draft:
+    """Generate a tartan draft from a sett string (e.g. 'B24, K4, G36')."""
+    colors = []
+    for piece in sett.split(", "):
+        m = re.match(r"([A-Z]+)(\d+)", piece)
+        if m:
+            colors.append((_COLOR_MAP[m.group(1)], int(m.group(2))))
+
+    colors = colors + list(reversed(colors))
+
+    draft = Draft(num_shafts=4, num_treadles=4)
+    for ii in range(4):
+        draft.treadles[3 - ii].shafts.add(draft.shafts[ii])
+        draft.treadles[3 - ii].shafts.add(draft.shafts[(ii + 1) % 4])
+
+    thread_no = 0
+    for _ in range(repeats):
+        for color, count in colors:
+            for _ in range(count):
+                draft.add_warp_thread(color=color, shaft=thread_no % 4)
+                draft.add_weft_thread(color=color, treadles=[thread_no % 4])
+                thread_no += 1
+
+    return draft

--- a/backend/app/weaving/generators/twill.py
+++ b/backend/app/weaving/generators/twill.py
@@ -1,0 +1,20 @@
+# Copyright 2014-2015 Scott Torborg (storborg@gmail.com) — MIT License
+# Vendored and modernised by WeftMark. See UPSTREAM_LICENSE for full text.
+
+from app.weaving import Draft
+
+
+def twill(size: int = 2, warp_color=(0, 0, 100), weft_color=(255, 255, 255)) -> Draft:
+    """Generate a twill draft. size=2 → 2/2 twill, size=3 → 3/3 twill, etc."""
+    shafts = 2 * size
+    draft = Draft(num_shafts=shafts, num_treadles=shafts)
+
+    for ii in range(shafts):
+        for jj in range(size):
+            draft.treadles[ii].shafts.add(draft.shafts[(ii + jj) % shafts])
+
+    for ii in range(8 * size):
+        draft.add_warp_thread(color=warp_color, shaft=ii % shafts)
+        draft.add_weft_thread(color=weft_color, treadles=[ii % shafts])
+
+    return draft

--- a/backend/app/weaving/pyproject.toml.stub
+++ b/backend/app/weaving/pyproject.toml.stub
@@ -1,0 +1,49 @@
+# Extraction-ready package metadata stub.
+# NOT used by the WeftMark build system — this is a living checklist that
+# documents how to extract app/weaving/ as a standalone library.
+#
+# To activate: copy to pyproject.toml at repo root, rename package directory
+# from backend/app/weaving/ to src/weaving/, update imports, publish to PyPI.
+#
+# WeftMark BSL 1.1 converts to MIT on 2029-01-01 — extraction target date.
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "pyweaving2"
+version = "1.0.0"
+description = "A Python library for working with weaving drafts (WIF, rendering, analysis)"
+authors = [
+    { name = "Scott Torborg", email = "storborg@gmail.com" },
+    { name = "WeftMark Contributors" },
+]
+license = { text = "MIT" }
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "pillow>=10.0",
+    "numpy>=1.24",   # Phase 3: NumPy drawdown matrix
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+    "pytest-asyncio",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/weaving"]
+
+# ---------------------------------------------------------------------------
+# Extraction checklist (verify before publishing)
+# ---------------------------------------------------------------------------
+# [ ] Zero imports from app.models, app.routers, app.services, app.db
+# [ ] All WeftMark-specific integrations removed or moved to app layer
+# [ ] backend/app/weaving/tests/ passes with: pytest backend/app/weaving/tests/
+# [ ] No WeftMark conftest.py fixtures used in the tests
+# [ ] No settings / .env reads inside the package
+# [ ] Font bundled or documented as external dependency
+# [ ] UPSTREAM_LICENSE and THIRD_PARTY_LICENSES.md included in sdist
+# [ ] __all__ in __init__.py is complete and accurate

--- a/backend/app/weaving/tests/fixtures/plain_weave_4s.wif
+++ b/backend/app/weaving/tests/fixtures/plain_weave_4s.wif
@@ -1,0 +1,69 @@
+[WIF]
+Version=1.1
+Date=Jan 01, 2024
+Developers=weftmark
+Source Program=WeftMark Test
+Source Version=1.0
+
+[CONTENTS]
+COLOR PALETTE=1
+COLOR TABLE=1
+WARP=1
+WEFT=1
+WARP COLORS=1
+WEFT COLORS=1
+THREADING=1
+TREADLING=1
+TIEUP=1
+WEAVING=1
+
+[COLOR PALETTE]
+Range=0,255
+Form=RGB
+
+[COLOR TABLE]
+1=0,0,0
+2=255,255,255
+
+[WEAVING]
+Rising Shed=true
+Shafts=4
+Treadles=2
+
+[WARP]
+Threads=4
+Units=Inches
+Color=1
+
+[WEFT]
+Threads=4
+Units=Inches
+Color=2
+
+[WARP COLORS]
+1=1
+2=1
+3=1
+4=1
+
+[WEFT COLORS]
+1=2
+2=2
+3=2
+4=2
+
+[THREADING]
+1=1
+2=2
+3=3
+4=4
+
+[TREADLING]
+1=1
+2=2
+3=1
+4=2
+
+[TIEUP]
+1=1,3
+2=2,4

--- a/backend/app/weaving/tests/test_draft.py
+++ b/backend/app/weaving/tests/test_draft.py
@@ -1,0 +1,174 @@
+"""Independent tests for the Draft domain model.
+
+Run standalone: pytest backend/app/weaving/tests/test_draft.py
+No WeftMark fixtures, database, or Celery stack required.
+"""
+
+import json
+
+import pytest
+
+from app.weaving import Color, Draft, WarpThread, WeftThread
+
+
+class TestColor:
+    def test_rgb_stored_as_tuple(self):
+        c = Color([255, 0, 128])
+        assert c.rgb == (255, 0, 128)
+
+    def test_equality(self):
+        assert Color((1, 2, 3)) == Color((1, 2, 3))
+        assert Color((1, 2, 3)) != Color((1, 2, 4))
+
+    def test_css(self):
+        assert Color((255, 0, 0)).css == "rgb(255, 0, 0)"
+
+
+class TestDraftCreation:
+    def test_shaft_count(self):
+        d = Draft(num_shafts=4, num_treadles=4)
+        assert len(d.shafts) == 4
+
+    def test_treadle_count(self):
+        d = Draft(num_shafts=4, num_treadles=4)
+        assert len(d.treadles) == 4
+
+    def test_liftplan_when_no_treadles(self):
+        d = Draft(num_shafts=4, num_treadles=0)
+        assert d.liftplan is True
+
+    def test_explicit_liftplan(self):
+        d = Draft(num_shafts=4, num_treadles=0, liftplan=True)
+        assert d.liftplan is True
+
+    def test_empty_thread_lists(self):
+        d = Draft(num_shafts=4, num_treadles=4)
+        assert d.warp == []
+        assert d.weft == []
+
+
+def _make_plain_weave_4s() -> Draft:
+    """4-shaft plain-weave treadle draft, 4 warp × 4 weft."""
+    d = Draft(num_shafts=4, num_treadles=2)
+    d.treadles[0].shafts = {d.shafts[0], d.shafts[2]}
+    d.treadles[1].shafts = {d.shafts[1], d.shafts[3]}
+    for ii in range(4):
+        d.add_warp_thread(color=(0, 0, 0), shaft=ii % 4)
+        d.add_weft_thread(color=(255, 255, 255), treadles=[ii % 2])
+    return d
+
+
+class TestThreadManipulation:
+    def test_add_warp_thread(self):
+        d = Draft(num_shafts=4, num_treadles=2)
+        d.add_warp_thread(color=(0, 0, 255), shaft=0)
+        assert len(d.warp) == 1
+        assert d.warp[0].color.rgb == (0, 0, 255)
+
+    def test_add_weft_thread_treadle(self):
+        d = Draft(num_shafts=4, num_treadles=2)
+        d.add_weft_thread(color=(255, 0, 0), treadles=[0])
+        assert len(d.weft) == 1
+        assert 0 in [d.treadles.index(t) for t in d.weft[0].treadles]
+
+    def test_add_weft_thread_liftplan(self):
+        d = Draft(num_shafts=4, num_treadles=0)
+        d.add_weft_thread(color=(255, 0, 0), shafts=[0, 2])
+        assert d.weft[0].shafts == {d.shafts[0], d.shafts[2]}
+
+    def test_insert_warp_thread_at_index(self):
+        d = Draft(num_shafts=4, num_treadles=2)
+        d.add_warp_thread(color=(0, 0, 0), shaft=0)
+        d.add_warp_thread(color=(255, 0, 0), shaft=1, index=0)
+        assert d.warp[0].color.rgb == (255, 0, 0)
+
+    def test_all_threads_attached(self):
+        d = _make_plain_weave_4s()
+        assert d.all_threads_attached() is True
+
+    def test_all_threads_attached_missing_shaft(self):
+        d = Draft(num_shafts=4, num_treadles=2)
+        d.add_warp_thread(color=(0, 0, 0), shaft=None)
+        assert d.all_threads_attached() is False
+
+
+class TestDrawdown:
+    def test_drawdown_returns_correct_shape(self):
+        d = _make_plain_weave_4s()
+        dd = d.compute_drawdown()
+        assert len(dd) == 4
+        assert len(dd[0]) == 4
+
+    def test_drawdown_at_returns_thread(self):
+        d = _make_plain_weave_4s()
+        result = d.compute_drawdown_at((0, 0))
+        assert isinstance(result, (WarpThread, WeftThread))
+
+    def test_compute_floats_yields_tuples(self):
+        d = _make_plain_weave_4s()
+        floats = list(d.compute_floats())
+        assert len(floats) > 0
+        for item in floats:
+            assert len(item) == 5
+
+    def test_longest_floats_returns_ints(self):
+        d = _make_plain_weave_4s()
+        warp_max, weft_max = d.compute_longest_floats()
+        assert isinstance(warp_max, int)
+        assert isinstance(weft_max, int)
+
+
+class TestJsonRoundtrip:
+    def test_roundtrip_preserves_thread_counts(self):
+        d = _make_plain_weave_4s()
+        restored = Draft.from_json(d.to_json())
+        assert len(restored.warp) == len(d.warp)
+        assert len(restored.weft) == len(d.weft)
+
+    def test_roundtrip_preserves_shaft_count(self):
+        d = _make_plain_weave_4s()
+        restored = Draft.from_json(d.to_json())
+        assert len(restored.shafts) == len(d.shafts)
+
+    def test_roundtrip_preserves_colors(self):
+        d = _make_plain_weave_4s()
+        restored = Draft.from_json(d.to_json())
+        assert restored.warp[0].color.rgb == d.warp[0].color.rgb
+
+    def test_to_json_is_valid_json(self):
+        d = _make_plain_weave_4s()
+        obj = json.loads(d.to_json())
+        assert "warp" in obj
+        assert "weft" in obj
+
+
+class TestTransformations:
+    def test_copy_is_independent(self):
+        d = _make_plain_weave_4s()
+        c = d.copy()
+        c.warp[0].color = Color((1, 2, 3))
+        assert d.warp[0].color.rgb != (1, 2, 3)
+
+    def test_flip_weftwise_reverses_warp(self):
+        d = _make_plain_weave_4s()
+        original_last = d.warp[-1]
+        d.flip_weftwise()
+        assert d.warp[0] is original_last
+
+    def test_flip_warpwise_reverses_weft(self):
+        d = _make_plain_weave_4s()
+        original_last = d.weft[-1]
+        d.flip_warpwise()
+        assert d.weft[0] is original_last
+
+    def test_reduce_active_treadles(self):
+        d = _make_plain_weave_4s()
+        d.reduce_active_treadles()
+        assert len(d.treadles) <= 2
+
+    def test_not_implemented_stubs_raise(self):
+        d = _make_plain_weave_4s()
+        with pytest.raises(NotImplementedError):
+            d.reduce_shafts()
+        with pytest.raises(NotImplementedError):
+            d.rotate()

--- a/backend/app/weaving/tests/test_rendering.py
+++ b/backend/app/weaving/tests/test_rendering.py
@@ -1,0 +1,117 @@
+"""Independent tests for the PNG rendering pipeline.
+
+Run standalone: pytest backend/app/weaving/tests/test_rendering.py
+No WeftMark fixtures, database, or Celery stack required.
+Requires the font file at backend/app/weaving/data/Arial.ttf.
+"""
+
+import io
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from app.weaving import Draft
+from app.weaving._render import _FONT_PATH, ImageRenderer
+
+_FONT_AVAILABLE = Path(_FONT_PATH).exists()
+
+
+def _skip_if_no_font():
+    if not _FONT_AVAILABLE:
+        pytest.skip("Font not available at app/weaving/data/Arial.ttf — skipping render tests")
+
+
+def _make_twill_draft() -> Draft:
+    d = Draft(num_shafts=4, num_treadles=4)
+    for ii in range(4):
+        for jj in range(2):
+            d.treadles[ii].shafts.add(d.shafts[(ii + jj) % 4])
+    for ii in range(16):
+        d.add_warp_thread(color=(0, 0, 100), shaft=ii % 4)
+        d.add_weft_thread(color=(255, 255, 255), treadles=[ii % 4])
+    return d
+
+
+def _make_liftplan_draft() -> Draft:
+    d = Draft(num_shafts=4, num_treadles=0)
+    for ii in range(8):
+        d.add_warp_thread(color=(0, 0, 100), shaft=ii % 4)
+        d.add_weft_thread(color=(255, 255, 255), shafts=[(ii % 4), (ii + 1) % 4])
+    return d
+
+
+class TestImageRendererBasic:
+    def test_make_pil_image_returns_image(self):
+        _skip_if_no_font()
+        draft = _make_twill_draft()
+        renderer = ImageRenderer(draft, scale=10)
+        im = renderer.make_pil_image()
+        assert isinstance(im, Image.Image)
+
+    def test_image_is_rgb(self):
+        _skip_if_no_font()
+        draft = _make_twill_draft()
+        renderer = ImageRenderer(draft, scale=10)
+        im = renderer.make_pil_image()
+        assert im.mode == "RGB"
+
+    def test_image_has_positive_dimensions(self):
+        _skip_if_no_font()
+        draft = _make_twill_draft()
+        renderer = ImageRenderer(draft, scale=10)
+        im = renderer.make_pil_image()
+        assert im.width > 0
+        assert im.height > 0
+
+    def test_png_bytes_returned(self):
+        _skip_if_no_font()
+        draft = _make_twill_draft()
+        renderer = ImageRenderer(draft, scale=10)
+        im = renderer.make_pil_image()
+        out = io.BytesIO()
+        im.save(out, format="PNG")
+        assert out.getvalue()[:4] == b"\x89PNG"
+
+    def test_small_scale_no_crash(self):
+        """paint_fill_marker must not crash at scale=3 (2px inset would be invalid)."""
+        _skip_if_no_font()
+        draft = _make_twill_draft()
+        renderer = ImageRenderer(draft, scale=3)
+        im = renderer.make_pil_image()
+        assert im.width > 0
+
+    def test_liftplan_draft_renders(self):
+        _skip_if_no_font()
+        draft = _make_liftplan_draft()
+        renderer = ImageRenderer(draft, scale=10)
+        im = renderer.make_pil_image()
+        assert isinstance(im, Image.Image)
+
+    def test_liftplan_flag_overrides(self):
+        _skip_if_no_font()
+        draft = _make_twill_draft()
+        renderer = ImageRenderer(draft, liftplan=True, scale=10)
+        im = renderer.make_pil_image()
+        assert isinstance(im, Image.Image)
+
+    def test_margin_pixels_applied(self):
+        _skip_if_no_font()
+        draft = _make_twill_draft()
+        no_margin = ImageRenderer(draft, scale=10, margin_pixels=0).make_pil_image()
+        with_margin = ImageRenderer(draft, scale=10, margin_pixels=20).make_pil_image()
+        assert with_margin.width == no_margin.width + 40
+        assert with_margin.height == no_margin.height + 40
+
+    def test_many_treadles_numbering_no_crash(self):
+        """paint_tieup textbbox path is exercised when treadles >= 4."""
+        _skip_if_no_font()
+        draft = Draft(num_shafts=8, num_treadles=8)
+        for ii in range(8):
+            draft.treadles[ii].shafts.add(draft.shafts[ii])
+        for ii in range(16):
+            draft.add_warp_thread(color=(0, 0, 0), shaft=ii % 8)
+            draft.add_weft_thread(color=(255, 255, 255), treadles=[ii % 8])
+        renderer = ImageRenderer(draft, scale=10)
+        im = renderer.make_pil_image()
+        assert im.width > 0

--- a/backend/app/weaving/tests/test_wif_io.py
+++ b/backend/app/weaving/tests/test_wif_io.py
@@ -1,0 +1,97 @@
+"""Independent tests for WIF I/O.
+
+Run standalone: pytest backend/app/weaving/tests/test_wif_io.py
+No WeftMark fixtures, database, or Celery stack required.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+from app.weaving import Draft
+from app.weaving._wif import WIFReader, WIFWriter
+
+_FIXTURES = Path(__file__).parent / "fixtures"
+
+
+class TestWIFReader:
+    def test_reads_plain_weave_fixture(self):
+        path = str(_FIXTURES / "plain_weave_4s.wif")
+        draft = WIFReader(path).read()
+        assert isinstance(draft, Draft)
+
+    def test_correct_shaft_count(self):
+        path = str(_FIXTURES / "plain_weave_4s.wif")
+        draft = WIFReader(path).read()
+        assert len(draft.shafts) == 4
+
+    def test_correct_treadle_count(self):
+        path = str(_FIXTURES / "plain_weave_4s.wif")
+        draft = WIFReader(path).read()
+        assert len(draft.treadles) == 2
+
+    def test_correct_warp_thread_count(self):
+        path = str(_FIXTURES / "plain_weave_4s.wif")
+        draft = WIFReader(path).read()
+        assert len(draft.warp) == 4
+
+    def test_correct_weft_thread_count(self):
+        path = str(_FIXTURES / "plain_weave_4s.wif")
+        draft = WIFReader(path).read()
+        assert len(draft.weft) == 4
+
+    def test_warp_thread_has_shaft(self):
+        path = str(_FIXTURES / "plain_weave_4s.wif")
+        draft = WIFReader(path).read()
+        assert draft.all_threads_attached()
+
+    def test_weft_thread_has_treadles(self):
+        path = str(_FIXTURES / "plain_weave_4s.wif")
+        draft = WIFReader(path).read()
+        assert all(len(t.treadles) > 0 for t in draft.weft)
+
+    def test_colors_parsed(self):
+        path = str(_FIXTURES / "plain_weave_4s.wif")
+        draft = WIFReader(path).read()
+        assert draft.warp[0].color is not None
+        assert draft.weft[0].color is not None
+
+
+class TestWIFWriter:
+    def _round_trip(self, draft: Draft) -> Draft:
+        with tempfile.NamedTemporaryFile(suffix=".wif", delete=False) as f:
+            path = f.name
+        try:
+            WIFWriter(draft).write(path)
+            return WIFReader(path).read()
+        finally:
+            os.unlink(path)
+
+    def _make_draft(self) -> Draft:
+        d = Draft(num_shafts=4, num_treadles=2)
+        d.treadles[0].shafts = {d.shafts[0], d.shafts[2]}
+        d.treadles[1].shafts = {d.shafts[1], d.shafts[3]}
+        for ii in range(4):
+            d.add_warp_thread(color=(0, 0, 0), shaft=ii % 4)
+            d.add_weft_thread(color=(255, 255, 255), treadles=[ii % 2])
+        return d
+
+    def test_roundtrip_shaft_count(self):
+        d = self._make_draft()
+        restored = self._round_trip(d)
+        assert len(restored.shafts) == len(d.shafts)
+
+    def test_roundtrip_warp_thread_count(self):
+        d = self._make_draft()
+        restored = self._round_trip(d)
+        assert len(restored.warp) == len(d.warp)
+
+    def test_roundtrip_weft_thread_count(self):
+        d = self._make_draft()
+        restored = self._round_trip(d)
+        assert len(restored.weft) == len(d.weft)
+
+    def test_roundtrip_all_threads_attached(self):
+        d = self._make_draft()
+        restored = self._round_trip(d)
+        assert restored.all_threads_attached()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,7 +10,6 @@ celery[redis]==5.6.3
 redis==6.4.0
 httpx==0.28.1
 python-multipart==0.0.27
-pyweaving==0.0.7
 pillow==12.2.0
 aiosmtplib==5.1.0
 email-validator==2.3.0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,7 +8,6 @@ from unittest.mock import AsyncMock
 
 import psycopg2
 import pytest
-import pyweaving.render as _pwr
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -21,13 +20,14 @@ from sqlalchemy.pool import NullPool
 SEEDED_EULA_VERSION = "0.9"
 
 # ---------------------------------------------------------------------------
-# Font patch — must run at import time (rendering tests require it)
+# Font — ensure app/weaving/data/Arial.ttf exists for render tests
 # ---------------------------------------------------------------------------
 
 
-def _patch_pyweaving_font() -> None:
-    data_dir = Path(os.path.dirname(_pwr.__file__)) / "data"
-    target = data_dir / "Arial.ttf"
+def _ensure_weaving_font() -> None:
+    from app.weaving._render import _DATA_DIR
+
+    target = _DATA_DIR / "Arial.ttf"
     if target.exists():
         return
     candidates = [
@@ -38,13 +38,13 @@ def _patch_pyweaving_font() -> None:
     ]
     for src in candidates:
         if src.exists():
-            data_dir.mkdir(parents=True, exist_ok=True)
+            _DATA_DIR.mkdir(parents=True, exist_ok=True)
             shutil.copy(src, target)
             return
-    pytest.skip("No suitable system font found to patch PyWeaving — skipping render tests")
+    pytest.skip("No suitable system font found for render tests")
 
 
-_patch_pyweaving_font()
+_ensure_weaving_font()
 
 # Prevent the production secret-key guard from firing in tests.
 os.environ.setdefault("APP_SECRET_KEY", "test-only-insecure-key-not-for-production")

--- a/backend/tests/routers/test_drafts.py
+++ b/backend/tests/routers/test_drafts.py
@@ -764,6 +764,67 @@ class TestGetPreview:
 
 
 # ---------------------------------------------------------------------------
+# GET /api/drafts/{draft_id}/preview/svg
+# ---------------------------------------------------------------------------
+
+
+class TestGetPreviewSvg:
+    async def _draft_with_wif(self, db_session: AsyncSession, user: User) -> Draft:
+        import app.services.storage as storage
+
+        draft_id = uuid.uuid4()
+        wif_key = storage.save_wif(draft_id, "test.wif", _WIF)
+        draft = Draft(
+            id=draft_id,
+            owner_id=user.id,
+            name="SVG Preview Draft",
+            wif_filename="test.wif",
+            wif_path=wif_key,
+            has_treadling=True,
+            num_shafts=4,
+            num_treadles=4,
+            weft_threads=4,
+        )
+        db_session.add(draft)
+        await db_session.commit()
+        return draft
+
+    async def test_returns_svg_content_type(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await self._draft_with_wif(db_session, test_user)
+        resp = await auth_client.get(f"/api/drafts/{draft.id}/preview/svg")
+        assert resp.status_code == 200
+        assert "image/svg+xml" in resp.headers["content-type"]
+
+    async def test_response_body_is_valid_svg(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await self._draft_with_wif(db_session, test_user)
+        resp = await auth_client.get(f"/api/drafts/{draft.id}/preview/svg")
+        assert resp.status_code == 200
+        assert b"<svg" in resp.content
+        assert b"</svg>" in resp.content
+
+    async def test_returns_404_when_no_wif(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user, wif_path="")
+        resp = await auth_client.get(f"/api/drafts/{draft.id}/preview/svg")
+        assert resp.status_code == 404
+
+    async def test_other_users_draft_returns_404(
+        self, auth_client: AsyncClient, db_session: AsyncSession, admin_user: User
+    ):
+        draft = await _insert_draft(db_session, admin_user, wif_path="d/other.wif")
+        resp = await auth_client.get(f"/api/drafts/{draft.id}/preview/svg")
+        assert resp.status_code == 404
+
+    async def test_unauthenticated_returns_401(
+        self, raw_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user, wif_path="d/x.wif")
+        resp = await raw_client.get(f"/api/drafts/{draft.id}/preview/svg")
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
 # POST /api/drafts/{draft_id}/generate-liftplan
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/routers/test_projects.py
+++ b/backend/tests/routers/test_projects.py
@@ -2146,3 +2146,91 @@ class TestProjectMetrics:
         project = await _insert_active_project(db_session, test_user, draft, None)
         resp = await client.get(f"/api/projects/{project.id}/metrics")
         assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /api/projects/{id}/drawdown/svg
+# ---------------------------------------------------------------------------
+
+
+class TestProjectDrawdownSvg:
+    async def test_returns_200_with_svg_content_type(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        _, project = await _insert_project_with_wif(db_session, test_user)
+        resp = await auth_client.get(f"/api/projects/{project.id}/drawdown/svg")
+        assert resp.status_code == 200
+        assert "image/svg+xml" in resp.headers["content-type"]
+
+    async def test_response_body_is_valid_svg(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        _, project = await _insert_project_with_wif(db_session, test_user)
+        resp = await auth_client.get(f"/api/projects/{project.id}/drawdown/svg")
+        assert b"<svg" in resp.content
+        assert b"</svg>" in resp.content
+
+    async def test_response_contains_symbol_defs(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        _, project = await _insert_project_with_wif(db_session, test_user)
+        resp = await auth_client.get(f"/api/projects/{project.id}/drawdown/svg")
+        assert b"<symbol" in resp.content
+        assert b"<use" in resp.content
+
+    async def test_returns_dimension_headers(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        _, project = await _insert_project_with_wif(db_session, test_user, warp_threads=4, weft_threads=4)
+        resp = await auth_client.get(f"/api/projects/{project.id}/drawdown/svg")
+        assert resp.headers.get("X-Total-Rows") == "4"
+        assert resp.headers.get("X-Total-Cols") == "4"
+        assert resp.headers.get("X-Pixels-Per-Row") == "10"
+
+    async def test_cell_px_param_scales_output(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        _, project = await _insert_project_with_wif(db_session, test_user, warp_threads=4, weft_threads=4)
+        resp = await auth_client.get(f"/api/projects/{project.id}/drawdown/svg?cell_px=20")
+        assert resp.status_code == 200
+        assert resp.headers.get("X-Pixels-Per-Row") == "20"
+        assert b'width="80"' in resp.content  # 4 warps × 20 px
+
+    async def test_returns_404_when_wif_missing_from_storage(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft_id = uuid.uuid4()
+        draft = Draft(
+            id=draft_id,
+            owner_id=test_user.id,
+            name="Missing WIF Draft",
+            wif_filename="missing.wif",
+            wif_path="drafts/missing/original.wif",  # path not in storage
+            has_treadling=True,
+            num_shafts=4,
+            num_treadles=4,
+        )
+        db_session.add(draft)
+        await db_session.flush()
+        project = Project(
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="No WIF Project",
+            project_type="treadle",
+            status="active",
+            current_pick=1,
+            total_picks=2,
+        )
+        db_session.add(project)
+        await db_session.commit()
+        resp = await auth_client.get(f"/api/projects/{project.id}/drawdown/svg")
+        assert resp.status_code == 404
+
+    async def test_returns_401_when_unauthenticated(
+        self, client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        _, project = await _insert_project_with_wif(db_session, test_user)
+        resp = await client.get(f"/api/projects/{project.id}/drawdown/svg")
+        assert resp.status_code == 401
+
+    async def test_returns_404_for_unknown_project(self, auth_client: AsyncClient):
+        resp = await auth_client.get(f"/api/projects/{uuid.uuid4()}/drawdown/svg")
+        assert resp.status_code == 404

--- a/backend/tests/services/test_rendering.py
+++ b/backend/tests/services/test_rendering.py
@@ -1,9 +1,9 @@
 """
 Tests for app.services.rendering.
 
-PyWeaving requires a real filesystem file, so load_draft uses a temp file
-internally.  These tests verify the Pillow compat patch, basic parse
-correctness, and that render output is valid PNG bytes.
+WIFReader requires a real filesystem file, so load_draft uses a temp file
+internally.  These tests verify basic parse correctness and that render
+output is valid PNG bytes.
 
 A full PyWeaving-compatible WIF requires: [WIF] with Date, [CONTENTS],
 [WEAVING] with Rising Shed, [WARP]/[WEFT] with Threads+Units+Color,
@@ -155,21 +155,16 @@ Form=Decimal
 
 
 # ---------------------------------------------------------------------------
-# Pillow compatibility patch
+# Pillow API compatibility
 # ---------------------------------------------------------------------------
 
 
-class TestPillowPatch:
-    def test_textsize_attribute_exists(self):
-        """The Pillow >=10 compat patch must have added textsize back."""
+class TestPillowCompat:
+    def test_textbbox_available(self):
+        """The vendored renderer uses textbbox (Pillow ≥8); verify it exists."""
         from PIL.ImageDraw import ImageDraw
 
-        assert hasattr(ImageDraw, "textsize"), "Pillow compat patch missing — PyWeaving will fail to render"
-
-    def test_textsize_callable(self):
-        from PIL.ImageDraw import ImageDraw
-
-        assert callable(getattr(ImageDraw, "textsize"))
+        assert hasattr(ImageDraw, "textbbox"), "Pillow textbbox missing — upgrade Pillow"
 
 
 # ---------------------------------------------------------------------------
@@ -179,7 +174,7 @@ class TestPillowPatch:
 
 class TestLoadDraft:
     def test_returns_draft_object(self):
-        from pyweaving import Draft
+        from app.weaving import Draft
 
         draft = load_draft(MINIMAL_WIF)
         assert isinstance(draft, Draft)

--- a/frontend/src/api/drafts.ts
+++ b/frontend/src/api/drafts.ts
@@ -76,6 +76,10 @@ export function previewUrl(id: string): string {
   return `/api/drafts/${id}/preview`;
 }
 
+export function previewSvgUrl(id: string): string {
+  return `/api/drafts/${id}/preview/svg`;
+}
+
 export async function generateLiftplan(id: string): Promise<DraftDetail> {
   return req(`/api/drafts/${id}/generate-liftplan`, { method: "POST" });
 }

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -129,6 +129,10 @@ async function req<T>(url: string, init?: RequestInit): Promise<T> {
   return res.json();
 }
 
+export function drawdownSvgUrl(projectId: string, cellPx = 10): string {
+  return `/api/projects/${projectId}/drawdown/svg?cell_px=${cellPx}`;
+}
+
 export function listProjects(params?: { draftId?: string; loomId?: string }): Promise<ProjectSummary[]> {
   const qs = new URLSearchParams();
   if (params?.draftId) qs.set("draft_id", params.draftId);

--- a/frontend/src/components/drafts/DraftPreviewModal.tsx
+++ b/frontend/src/components/drafts/DraftPreviewModal.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useRef, useState } from "react";
+import { getAuthToken } from "@/api/client";
+import { previewSvgUrl } from "@/api/drafts";
+import { AppIcons } from "@/lib/icons";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  draftId: string;
+  draftName: string;
+  onClose: () => void;
+}
+
+const ZOOM_STEP = 0.25;
+const ZOOM_MIN = 0.25;
+const ZOOM_MAX = 4;
+const ZOOM_DEFAULT = 1;
+
+function parseSvgDimensions(svg: string): { w: number; h: number } {
+  const m = svg.match(/width="(\d+(?:\.\d+)?)"[^>]*height="(\d+(?:\.\d+)?)"/);
+  return m ? { w: parseFloat(m[1]), h: parseFloat(m[2]) } : { w: 800, h: 600 };
+}
+
+export function DraftPreviewModal({ draftId, draftName, onClose }: Props) {
+  const [svgContent, setSvgContent] = useState<string | null>(null);
+  const [naturalDims, setNaturalDims] = useState({ w: 0, h: 0 });
+  const [zoom, setZoom] = useState(ZOOM_DEFAULT);
+  const [error, setError] = useState<string | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const token = await getAuthToken();
+        const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
+        const res = await fetch(previewSvgUrl(draftId), { headers, credentials: "include" });
+        if (!res.ok) throw new Error(`Failed to load preview (${res.status})`);
+        const text = await res.text();
+        if (cancelled) return;
+        const dims = parseSvgDimensions(text);
+        // Replace width/height attrs so SVG fills its wrapper div
+        const patched = text
+          .replace(/(<svg[^>]*)\bwidth="[^"]*"/, '$1width="100%"')
+          .replace(/(<svg[^>]*)\bheight="[^"]*"/, '$1height="100%"');
+        setNaturalDims(dims);
+        setSvgContent(patched);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Preview unavailable");
+      }
+    }
+    load();
+    return () => { cancelled = true; };
+  }, [draftId]);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const clampZoom = (z: number) => Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, z));
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex flex-col bg-black/60"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="flex flex-col w-full h-full max-w-7xl mx-auto bg-background shadow-xl rounded-none sm:rounded-lg sm:my-6 sm:h-[calc(100vh-3rem)] overflow-hidden">
+
+        {/* Toolbar */}
+        <div className="flex items-center gap-2 px-4 py-2 border-b bg-card shrink-0">
+          <span className="text-sm font-medium truncate flex-1">{draftName}</span>
+
+          {svgContent && (
+            <div className="flex items-center gap-1">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={() => setZoom((z) => clampZoom(z - ZOOM_STEP))}
+                disabled={zoom <= ZOOM_MIN}
+                title="Zoom out"
+              >
+                <AppIcons.zoomOut className="h-4 w-4" />
+              </Button>
+
+              <span className="w-12 text-center text-sm tabular-nums select-none">
+                {Math.round(zoom * 100)}%
+              </span>
+
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={() => setZoom((z) => clampZoom(z + ZOOM_STEP))}
+                disabled={zoom >= ZOOM_MAX}
+                title="Zoom in"
+              >
+                <AppIcons.zoomIn className="h-4 w-4" />
+              </Button>
+
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={() => setZoom(ZOOM_DEFAULT)}
+                disabled={zoom === ZOOM_DEFAULT}
+                title="Reset zoom"
+              >
+                <AppIcons.zoomReset className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+
+          <Button variant="ghost" size="icon" className="h-8 w-8 ml-1" onClick={onClose} title="Close">
+            <AppIcons.close className="h-4 w-4" />
+          </Button>
+        </div>
+
+        {/* Content */}
+        <div ref={scrollRef} className="flex-1 overflow-auto bg-muted/30 p-4">
+          {error && (
+            <div className="flex items-center justify-center h-full">
+              <p className="text-sm text-destructive">{error}</p>
+            </div>
+          )}
+
+          {!error && !svgContent && (
+            <div className="flex items-center justify-center h-full">
+              <p className="text-sm text-muted-foreground">Loading preview…</p>
+            </div>
+          )}
+
+          {svgContent && (
+            <div
+              style={{
+                width: naturalDims.w * zoom,
+                height: naturalDims.h * zoom,
+                minWidth: naturalDims.w * zoom,
+              }}
+              dangerouslySetInnerHTML={{ __html: svgContent }}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/icons.ts
+++ b/frontend/src/lib/icons.ts
@@ -19,12 +19,15 @@ import {
   Maximize2,
   Menu,
   Minimize2,
+  RotateCcw,
   Scroll,
   Settings,
   ShieldCheck,
   Wrench,
   X,
   Zap,
+  ZoomIn,
+  ZoomOut,
 } from "lucide-react";
 
 export type { LucideIcon } from "lucide-react";
@@ -55,6 +58,9 @@ export const AppIcons = {
   chevronDoubleRight: ChevronsRight,
   presentMode: Maximize2,
   exitPresentMode: Minimize2,
+  zoomIn: ZoomIn,
+  zoomOut: ZoomOut,
+  zoomReset: RotateCcw,
 
   // ── Landing page features ─────────────────────────────────────────────────
   designLibrary: Layers,

--- a/frontend/src/pages/DraftDetailPage.tsx
+++ b/frontend/src/pages/DraftDetailPage.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { AppIcons } from "@/lib/icons";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getDraft, deleteDraft, generateLiftplan, overrideDraftMetadata, previewUrl, downloadWif, downloadWifModified } from "@/api/drafts";
+import { getDraft, deleteDraft, generateLiftplan, overrideDraftMetadata, previewSvgUrl, downloadWif, downloadWifModified } from "@/api/drafts";
 import { listProjects } from "@/api/projects";
 import { ProjectSummaryList } from "@/components/projects/ProjectSummaryList";
 import { CreateProjectModal } from "@/components/projects/CreateProjectModal";
@@ -316,10 +316,10 @@ export function DraftDetailPage() {
           {/* Right column: Preview */}
           <div>
             <h2 className="text-base font-semibold mb-3">Design Preview</h2>
-            {draft.has_preview ? (
+            {draft.wif_filename ? (
               <div className="overflow-auto rounded-lg border bg-card p-2">
                 <AuthedImage
-                  src={previewUrl(draft.id)}
+                  src={previewSvgUrl(draft.id)}
                   alt={`Draft preview for ${draft.name}`}
                   className="max-w-full"
                   data-testid="draft-preview-img"

--- a/frontend/src/pages/DraftDetailPage.tsx
+++ b/frontend/src/pages/DraftDetailPage.tsx
@@ -6,6 +6,7 @@ import { getDraft, deleteDraft, generateLiftplan, overrideDraftMetadata, preview
 import { listProjects } from "@/api/projects";
 import { ProjectSummaryList } from "@/components/projects/ProjectSummaryList";
 import { CreateProjectModal } from "@/components/projects/CreateProjectModal";
+import { DraftPreviewModal } from "@/components/drafts/DraftPreviewModal";
 import { Button } from "@/components/ui/button";
 import { AuthedImage } from "@/components/ui/AuthedImage";
 
@@ -18,6 +19,7 @@ export function DraftDetailPage() {
   const [showCreateProject, setShowCreateProject] = useState(false);
   const [downloading, setDownloading] = useState(false);
   const [downloadError, setDownloadError] = useState<string | null>(null);
+  const [showPreviewModal, setShowPreviewModal] = useState(false);
 
   const { data: draft, isLoading, error } = useQuery({
     queryKey: ["draft", id],
@@ -317,14 +319,22 @@ export function DraftDetailPage() {
           <div>
             <h2 className="text-base font-semibold mb-3">Design Preview</h2>
             {draft.wif_filename ? (
-              <div className="overflow-auto rounded-lg border bg-card p-2">
+              <button
+                type="button"
+                className="group w-full overflow-auto rounded-lg border bg-card p-2 cursor-zoom-in text-left"
+                onClick={() => setShowPreviewModal(true)}
+                title="Click to open interactive preview"
+              >
                 <AuthedImage
                   src={previewSvgUrl(draft.id)}
                   alt={`Draft preview for ${draft.name}`}
-                  className="max-w-full"
+                  className="max-w-full group-hover:opacity-90 transition-opacity"
                   data-testid="draft-preview-img"
                 />
-              </div>
+                <p className="mt-1.5 text-xs text-muted-foreground text-center opacity-0 group-hover:opacity-100 transition-opacity">
+                  Click to zoom
+                </p>
+              </button>
             ) : (
               <div className="rounded-lg border border-dashed p-8 text-center">
                 <p className="text-sm text-muted-foreground">
@@ -391,6 +401,14 @@ export function DraftDetailPage() {
             navigate(`/projects/${newId}`);
           }}
           onClose={() => setShowCreateProject(false)}
+        />
+      )}
+
+      {showPreviewModal && (
+        <DraftPreviewModal
+          draftId={draft.id}
+          draftName={draft.name}
+          onClose={() => setShowPreviewModal(false)}
         />
       )}
     </div>

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { Loader2 } from "lucide-react";
 import { AppIcons } from "@/lib/icons";
@@ -247,11 +247,6 @@ function useAdaptivePatternHeight(): number {
   return height;
 }
 
-// Fixed at backend TILE_ROW_COUNT / TILE_COL_COUNT — requests must align with
-// pre-rendered tile boundaries in R2.
-const TILE_ROW_COUNT = 100;
-const TILE_COL_COUNT = 200;
-
 function WeavingPatternView({
   projectId,
   currentPickIndex,
@@ -266,253 +261,56 @@ function WeavingPatternView({
   maxActive: number;
 }) {
   const containerH = useAdaptivePatternHeight();
-  const [pixelsPerRow, setPixelsPerRow] = useState(20);
+  const [pixelsPerRow, setPixelsPerRow] = useState(10);
   const [warpCount, setWarpCount] = useState(0);
-  const warpCountRef = useRef(0);
-  const neededRef = useRef<Set<string>>(new Set());
-  const tilesRef = useRef<Record<string, string>>({});
-  const [tiles, setTiles] = useState<Record<string, string>>({});
-  const fetchingRef = useRef<Set<string>>(new Set());
-  const fetchControllersRef = useRef<Map<string, AbortController>>(new Map());
-  const tileErrorsRef = useRef<Map<string, string>>(new Map());
-  const [tileErrors, setTileErrors] = useState<Map<string, string>>(new Map());
-  const [retryCount, setRetryCount] = useState(0);
+  const [svgContent, setSvgContent] = useState<string | null>(null);
+  const [svgError, setSvgError] = useState<string | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
 
-  // Persist/restore the user's horizontal scroll position per project in localStorage.
   const lsColKey = `project-drawdown-col-${projectId}`;
-  const [scrollColStart, setScrollColStart] = useState<number>(() => {
-    try {
-      const saved = localStorage.getItem(`project-drawdown-col-${projectId}`);
-      if (saved !== null) {
-        const parsed = parseInt(saved, 10);
-        if (!isNaN(parsed) && parsed >= 0)
-          return Math.floor(parsed / TILE_COL_COUNT) * TILE_COL_COUNT;
-      }
-    } catch { /* localStorage unavailable */ }
-    return 0;
-  });
-
-  // scrollDivRef + pendingScrollRef: used to restore the saved scroll position after
-  // the first tile response confirms the real pixelsPerRow value.
-  const scrollDivRef = useRef<HTMLDivElement>(null);
-  const scrollRestoredRef = useRef(false);
-  const pendingScrollRef = useRef<number | null>(null);
-
-  // Apply any pending programmatic scroll synchronously after DOM paint.
-  useLayoutEffect(() => {
-    if (pendingScrollRef.current !== null && scrollDivRef.current) {
-      scrollDivRef.current.scrollLeft = pendingScrollRef.current;
-      pendingScrollRef.current = null;
-    }
-  });
-
-  const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
-    const raw = e.currentTarget.scrollLeft;
-    const colIndex = pixelsPerRow > 0 ? Math.floor(raw / pixelsPerRow) : 0;
-    const snapped = Math.floor(colIndex / TILE_COL_COUNT) * TILE_COL_COUNT;
-    setScrollColStart(prev => {
-      if (prev === snapped) return prev;
-      try { localStorage.setItem(lsColKey, String(snapped)); } catch { /* noop */ }
-      return snapped;
-    });
-  }, [pixelsPerRow, lsColKey]);
 
   useEffect(() => {
     let cancelled = false;
-
-    // --- Row range ---
-    // Image row 0 = top = last pick; advancing decreases imageRow toward 0.
-    const imageRow = totalPicks - 1 - currentPickIndex;
-    const currentRowStart = Math.floor(imageRow / TILE_ROW_COUNT) * TILE_ROW_COUNT;
-    const lookaheadRowStart = currentRowStart - TILE_ROW_COUNT;
-    const lookbehindRowStart = currentRowStart + TILE_ROW_COUNT;
-    const neededRows: number[] = [currentRowStart];
-    if (lookaheadRowStart >= 0) neededRows.push(lookaheadRowStart);
-    if (lookbehindRowStart < totalPicks) neededRows.push(lookbehindRowStart);
-
-    // --- Column range ---
-    // Buffer: 1 column behind, current, +1 and +2 ahead. Keeps adjacent tiles warm
-    // so fast scrolling doesn't hit a blank gap. Uses warpCountRef (not state) to
-    // avoid adding warpCount as an effect dep.
-    const W = warpCountRef.current;
-    const neededCols: number[] = [];
-    for (let offset = -1; offset <= 2; offset++) {
-      const c = scrollColStart + offset * TILE_COL_COUNT;
-      if (c >= 0 && (W === 0 || c < W)) neededCols.push(c);
-    }
-
-    // All needed (row, col) pairs as `${row}_${col}` keys.
-    const needed = new Set<string>();
-    for (const r of neededRows) {
-      for (const c of neededCols) {
-        needed.add(`${r}_${c}`);
-      }
-    }
-    // Keep neededRef current so in-flight fetchTile calls can check it after awaiting blob.
-    neededRef.current = needed;
-
-    // Evict tiles and errors outside the needed set; abort in-flight fetches.
-    let tilesEvicted = false;
-    let errorsChanged = false;
-    for (const k of Object.keys(tilesRef.current)) {
-      if (!needed.has(k)) {
-        URL.revokeObjectURL(tilesRef.current[k]);
-        delete tilesRef.current[k];
-        tilesEvicted = true;
-      }
-    }
-    for (const k of fetchingRef.current) {
-      if (!needed.has(k)) {
-        fetchControllersRef.current.get(k)?.abort();
-        fetchControllersRef.current.delete(k);
-        fetchingRef.current.delete(k);
-      }
-    }
-    for (const k of tileErrorsRef.current.keys()) {
-      if (!needed.has(k)) {
-        tileErrorsRef.current.delete(k);
-        errorsChanged = true;
-      }
-    }
-    if (tilesEvicted) setTiles({ ...tilesRef.current });
-    if (errorsChanged) setTileErrors(new Map(tileErrorsRef.current));
-
-    const fetchTile = async (startRow: number, startCol: number) => {
-      const key = `${startRow}_${startCol}`;
-      if (fetchingRef.current.has(key)) return;
-      if (tilesRef.current[key] !== undefined) return;
-      if (tileErrorsRef.current.has(key)) return;
-      fetchingRef.current.add(key);
-      const controller = new AbortController();
-      fetchControllersRef.current.set(key, controller);
-      const timeoutId = setTimeout(() => controller.abort(), 15000);
-      const url =
-        `/api/projects/${projectId}/drawdown` +
-        `?start_row=${startRow}&row_count=${TILE_ROW_COUNT}` +
-        `&start_col=${startCol}&col_count=${TILE_COL_COUNT}`;
+    async function load() {
       try {
         const token = await getAuthToken();
         const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
-        const res = await fetch(url, { credentials: "include", headers, signal: controller.signal });
-        clearTimeout(timeoutId);
-        if (!res.ok) {
-          tileErrorsRef.current.set(key, "Pattern tile failed to load.");
-          setTileErrors(new Map(tileErrorsRef.current));
-          return;
-        }
-        const ppr = parseInt(res.headers.get("X-Pixels-Per-Row") ?? "20", 10);
+        const res = await fetch(`/api/projects/${projectId}/drawdown/svg`, { headers, credentials: "include" });
+        if (!res.ok) throw new Error(`Pattern failed to load (${res.status})`);
+        const ppr = parseInt(res.headers.get("X-Pixels-Per-Row") ?? "10", 10);
         const wc = parseInt(res.headers.get("X-Total-Cols") ?? "0", 10);
-        const blob = await res.blob();
-        // Use neededRef rather than `cancelled`: any dep change updates neededRef so we
-        // only discard tiles that genuinely fell out of the needed window.  The `cancelled`
-        // flag is too broad — it fires on every dep change (including TanStack Query
-        // re-renders) and would discard tiles that are still wanted.
-        if (!neededRef.current.has(key)) return;
-        tilesRef.current[key] = URL.createObjectURL(blob);
-        setTiles({ ...tilesRef.current });
+        const text = await res.text();
+        if (cancelled) return;
         setPixelsPerRow(ppr);
-        if (wc > 0 && wc !== warpCountRef.current) {
-          warpCountRef.current = wc;
-          setWarpCount(wc);
-          // Clamp saved scroll position if it falls outside the actual warp extent.
-          setScrollColStart(prev => {
-            if (prev >= wc) {
-              try { localStorage.setItem(lsColKey, "0"); } catch { /* noop */ }
-              return 0;
-            }
-            return prev;
-          });
-        }
-        // Restore the user's saved column position once we know the real pixelsPerRow.
-        if (!scrollRestoredRef.current && scrollColStart > 0) {
-          scrollRestoredRef.current = true;
-          pendingScrollRef.current = scrollColStart * ppr;
-        }
+        if (wc > 0) setWarpCount(wc);
+        setSvgContent(text);
+        try {
+          const saved = localStorage.getItem(lsColKey);
+          if (saved !== null && scrollRef.current) {
+            scrollRef.current.scrollLeft = parseInt(saved, 10) || 0;
+          }
+        } catch { /* localStorage unavailable */ }
       } catch (err) {
-        clearTimeout(timeoutId);
-        if (!cancelled) {
-          const msg =
-            err instanceof Error && err.name === "AbortError"
-              ? "Pattern tile timed out."
-              : "Pattern tile failed to load.";
-          tileErrorsRef.current.set(key, msg);
-          setTileErrors(new Map(tileErrorsRef.current));
-        }
-      } finally {
-        fetchingRef.current.delete(key);
-        fetchControllersRef.current.delete(key);
+        if (!cancelled) setSvgError(err instanceof Error ? err.message : "Failed to load pattern");
       }
-    };
-
-    // Fetch current column × all rows first so the visible tile arrives ASAP.
-    const priorityCols = neededCols.filter(c => c === scrollColStart);
-    const otherCols = neededCols.filter(c => c !== scrollColStart);
-    for (const r of neededRows) {
-      for (const c of priorityCols) fetchTile(r, c);
     }
-    for (const r of neededRows) {
-      for (const c of otherCols) fetchTile(r, c);
-    }
-
+    load();
     return () => { cancelled = true; };
-  }, [projectId, currentPickIndex, totalPicks, scrollColStart, retryCount, lsColKey]);
+  }, [projectId, lsColKey]);
 
-  // Revoke all object URLs on unmount.
-  useEffect(() => {
-    return () => {
-      Object.values(tilesRef.current).forEach(url => URL.revokeObjectURL(url));
-      tilesRef.current = {};
-    };
-  }, []);
+  const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+    try { localStorage.setItem(lsColKey, String(e.currentTarget.scrollLeft)); } catch { /* noop */ }
+  }, [lsColKey]);
 
-  // Current row tile boundary for overlay / retry decisions.
-  const imageRowForTile = totalPicks - 1 - currentPickIndex;
-  const currentTileStart = Math.floor(imageRowForTile / TILE_ROW_COUNT) * TILE_ROW_COUNT;
-  const currentRowPrefix = `${currentTileStart}_`;
-  const currentTileReady = Object.keys(tiles).some(k => k.startsWith(currentRowPrefix));
-  const currentTileError = [...tileErrors.entries()].find(([k]) => k.startsWith(currentRowPrefix))?.[1];
-
-  const retryCurrentTile = () => {
-    for (const k of tileErrorsRef.current.keys()) {
-      if (k.startsWith(currentRowPrefix)) tileErrorsRef.current.delete(k);
-    }
-    setTileErrors(new Map(tileErrorsRef.current));
-    setRetryCount(c => c + 1);
-  };
-
-  // Full skeleton while no tiles are loaded yet.
-  if (Object.keys(tiles).length === 0) return (
-    <div className="relative flex gap-2" style={{ height: containerH }}>
-      <div className="flex-1 rounded-lg border overflow-hidden relative bg-muted flex flex-col items-center justify-center gap-2">
-        {currentTileError ? (
-          <>
-            <span className="text-sm text-muted-foreground">{currentTileError}</span>
-            <button className="text-xs underline text-accent" onClick={retryCurrentTile}>Tap to retry</button>
-          </>
-        ) : (
-          <>
-            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-            <span className="text-xs text-muted-foreground">Loading pattern…</span>
-          </>
-        )}
-      </div>
-      <div className="rounded-lg border overflow-hidden relative shrink-0 bg-muted animate-pulse" style={{ width: STEP_PANEL_W }} />
-      <div className="rounded-lg border overflow-hidden relative shrink-0 bg-muted animate-pulse" style={{ width: COLOR_COL_W }} />
-    </div>
-  );
-
-  // Image is flipped: last pick at y=0 (top), pick 1 at bottom.
+  // SVG is flipped: last pick at y=0 (top), first pick at bottom — same orientation as tiles.
   const flippedIndex = totalPicks - 1 - currentPickIndex;
   const translateY = containerH / 2 - pixelsPerRow / 2 - flippedIndex * pixelsPerRow;
   const futureRegionH = Math.max(0, containerH / 2 - pixelsPerRow / 2);
   const highlightTop = containerH / 2 - pixelsPerRow / 2 - 1;
   const highlightH = pixelsPerRow + 2;
   const boxH = Math.max(4, pixelsPerRow - 6);
-
   const totalImgW = warpCount > 0 ? warpCount * pixelsPerRow : undefined;
-  const totalImgH = totalPicks * pixelsPerRow;
 
-  // Picks reversed so the last pick renders first (topmost) — matches drawdown orientation.
   const reversedPicks = [...picks].reverse();
 
   const washoutOverlay = (
@@ -533,63 +331,39 @@ function WeavingPatternView({
     </>
   );
 
+  if (!svgContent) return (
+    <div className="relative flex gap-2" style={{ height: containerH }}>
+      <div className="flex-1 rounded-lg border overflow-hidden relative bg-muted flex flex-col items-center justify-center gap-2">
+        {svgError ? (
+          <span className="text-sm text-muted-foreground">{svgError}</span>
+        ) : (
+          <>
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            <span className="text-xs text-muted-foreground">Loading pattern…</span>
+          </>
+        )}
+      </div>
+      <div className="rounded-lg border overflow-hidden relative shrink-0 bg-muted animate-pulse" style={{ width: STEP_PANEL_W }} />
+      <div className="rounded-lg border overflow-hidden relative shrink-0 bg-muted animate-pulse" style={{ width: COLOR_COL_W }} />
+    </div>
+  );
+
   return (
-    // Outer wrapper: no overflow-hidden so highlight bars bleed left/right.
     <div className="relative flex gap-2" style={{ height: containerH }}>
 
-      {/* Drawdown tiles — wrapper keeps overlays fixed to the viewport area, not the scroll content */}
+      {/* Drawdown SVG — single load, translate to center current pick */}
       <div className="flex-1 relative rounded-lg border overflow-hidden">
         <div
-          ref={scrollDivRef}
+          ref={scrollRef}
           className="absolute inset-0 overflow-x-auto overflow-y-hidden bg-white dark:bg-zinc-900"
           onScroll={handleScroll}
         >
           <div
-            style={{
-              position: "relative",
-              width: totalImgW,
-              height: totalImgH,
-              transform: `translateY(${translateY}px)`,
-              transition: "transform 0.15s ease",
-            }}
-          >
-            {Object.entries(tiles).map(([k, url]) => {
-              const [rowStr, colStr] = k.split("_");
-              const startRow = parseInt(rowStr, 10);
-              const startCol = parseInt(colStr, 10);
-              return (
-                <img
-                  key={k}
-                  src={url}
-                  alt=""
-                  style={{
-                    position: "absolute",
-                    top: startRow * pixelsPerRow,
-                    left: startCol * pixelsPerRow,
-                    display: "block",
-                    imageRendering: "pixelated",
-                    maxWidth: "none",
-                  }}
-                />
-              );
-            })}
-          </div>
+            style={{ transform: `translateY(${translateY}px)`, transition: "transform 0.15s ease", width: totalImgW }}
+            dangerouslySetInnerHTML={{ __html: svgContent }}
+          />
         </div>
         {washoutOverlay}
-        {/* Loading overlay — shown whenever the current tile hasn't arrived yet */}
-        {!currentTileReady && !currentTileError && (
-          <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 pointer-events-none z-10">
-            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-            <span className="text-xs text-muted-foreground">Loading pattern…</span>
-          </div>
-        )}
-        {/* Error overlay — shown on tile fetch failure or timeout */}
-        {currentTileError && (
-          <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-background/80 z-10">
-            <span className="text-sm text-muted-foreground">{currentTileError}</span>
-            <button className="text-xs underline text-accent" onClick={retryCurrentTile}>Tap to retry</button>
-          </div>
-        )}
       </div>
 
       {/* Lift/treadle step panel */}
@@ -597,9 +371,7 @@ function WeavingPatternView({
         className="rounded-lg border overflow-hidden relative bg-background shrink-0"
         style={{ width: STEP_PANEL_W }}
       >
-        <div
-          style={{ transform: `translateY(${translateY}px)`, transition: "transform 0.15s ease" }}
-        >
+        <div style={{ transform: `translateY(${translateY}px)`, transition: "transform 0.15s ease" }}>
           {reversedPicks.map((pick) => (
             <div
               key={pick.pick}
@@ -625,16 +397,11 @@ function WeavingPatternView({
         className="rounded-lg border overflow-hidden relative shrink-0"
         style={{ width: COLOR_COL_W }}
       >
-        <div
-          style={{ transform: `translateY(${translateY}px)`, transition: "transform 0.15s ease" }}
-        >
+        <div style={{ transform: `translateY(${translateY}px)`, transition: "transform 0.15s ease" }}>
           {reversedPicks.map((pick) => (
             <div
               key={pick.pick}
-              style={{
-                height: pixelsPerRow,
-                backgroundColor: pick.color ?? "hsl(var(--muted))",
-              }}
+              style={{ height: pixelsPerRow, backgroundColor: pick.color ?? "hsl(var(--muted))" }}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary

- **#572** — Vendor PyWeaving as internal `app.weaving` engine (MIT, pinned at 0.0.7); ruff fixes for UP031 ×2 and E501 ×1
- **#604** — Wire `SVGRenderer` into API + frontend: `GET /api/drafts/{id}/preview/svg` endpoint; `AuthedImage`-based static preview on draft detail page
- **#609** — Zoomable SVG preview modal on draft detail page: inline SVG injection, ±/reset zoom controls, Escape-to-close, scroll/pan
- **#605** — Symbol-deduped SVG drawdown for project step tracking: replaces PNG tile strategy with a single SVG load per project open; identical lift patterns share a `<symbol>` element so byte size scales sub-linearly; step advance/reverse is zero server round-trips (translateY CSS shift only)

## Test plan

- [ ] Open a draft with a WIF file — design preview renders as SVG
- [ ] Click the preview — zoomable modal opens; zoom in/out/reset and Escape work
- [ ] Open an active project — drawdown pattern loads as SVG (no tile network requests)
- [ ] Step advance and reverse — pattern scrolls smoothly with no server calls
- [ ] Horizontal scroll on a wide draft — persists across steps
- [ ] `pytest` full suite passes (1358 passed, 0 failed)
- [ ] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)