### PR TITLE
fix: correct SVG drawdown scale and add cell border grid (#605)

### DIFF
--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -499,7 +499,7 @@ async def get_project_drawdown(
 @router.get("/{project_id}/drawdown/svg")
 async def get_project_drawdown_svg(
     project_id: uuid.UUID,
-    cell_px: int = Query(10, ge=4, le=30),
+    cell_px: int = Query(20, ge=4, le=30),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> Response:

--- a/backend/app/weaving/_render.py
+++ b/backend/app/weaving/_render.py
@@ -570,7 +570,7 @@ class SVGRenderer:
 # ---------------------------------------------------------------------------
 
 
-def drawdown_svg(draft, cell_px: int = 10) -> str:
+def drawdown_svg(draft, cell_px: int = 20) -> str:
     """Render the drawdown grid as a symbol-deduped SVG string.
 
     Orientation matches the tile renderer: last pick at y=0 (top), first pick at
@@ -614,6 +614,15 @@ def drawdown_svg(draft, cell_px: int = 10) -> str:
         rows.append(f'<rect x="0" y="{y}" width="{total_w}" height="{cell_px}" fill="{weft_css}"/>')
         rows.append(f'<use href="#s{sid}" x="0" y="{y}"/>')
 
+    # Single <path> grid overlay — all cell borders in one element (one draw call).
+    # Vertical lines at every column boundary, horizontal at every row boundary.
+    grid_parts: list[str] = []
+    for x in range(0, total_w + 1, cell_px):
+        grid_parts.append(f"M{x} 0V{total_h}")
+    for y in range(0, total_h + 1, cell_px):
+        grid_parts.append(f"M0 {y}H{total_w}")
+    grid = f'<path d="{"".join(grid_parts)}" stroke="#7f7f7f" stroke-width="0.5" fill="none"/>'
+
     defs = f"<defs>{''.join(symbol_defs)}</defs>"
     body = "".join(rows)
     return (
@@ -621,5 +630,5 @@ def drawdown_svg(draft, cell_px: int = 10) -> str:
         f' viewBox="0 0 {total_w} {total_h}"'
         f' xmlns="http://www.w3.org/2000/svg"'
         f' xmlns:xlink="http://www.w3.org/1999/xlink">'
-        f"{defs}{body}</svg>"
+        f"{defs}{body}{grid}</svg>"
     )

--- a/backend/tests/routers/test_projects.py
+++ b/backend/tests/routers/test_projects.py
@@ -2183,16 +2183,16 @@ class TestProjectDrawdownSvg:
         resp = await auth_client.get(f"/api/projects/{project.id}/drawdown/svg")
         assert resp.headers.get("X-Total-Rows") == "4"
         assert resp.headers.get("X-Total-Cols") == "4"
-        assert resp.headers.get("X-Pixels-Per-Row") == "10"
+        assert resp.headers.get("X-Pixels-Per-Row") == "20"
 
     async def test_cell_px_param_scales_output(
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
     ):
         _, project = await _insert_project_with_wif(db_session, test_user, warp_threads=4, weft_threads=4)
-        resp = await auth_client.get(f"/api/projects/{project.id}/drawdown/svg?cell_px=20")
+        resp = await auth_client.get(f"/api/projects/{project.id}/drawdown/svg?cell_px=10")
         assert resp.status_code == 200
-        assert resp.headers.get("X-Pixels-Per-Row") == "20"
-        assert b'width="80"' in resp.content  # 4 warps × 20 px
+        assert resp.headers.get("X-Pixels-Per-Row") == "10"
+        assert b'width="40"' in resp.content  # 4 warps × 10 px
 
     async def test_returns_404_when_wif_missing_from_storage(
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User


### PR DESCRIPTION
## Summary

- SVG drawdown was rendering at `cell_px=10` (half the PNG tile scale of 20 px/cell), compressing the step panel vertically — changed default to 20 to match `DRAWDOWN_SCALE`
- No cell border/grid lines — PNG renderer drew `outline=foreground` on every cell; added a single `<path>` grid overlay (one draw call, O(warp + weft) elements) at 0.5px / #7f7f7f

## Test plan

- [ ] Open an active project — drawdown renders at correct height matching old PNG view
- [ ] Cell grid lines visible between floats
- [ ] Step panel boxes are properly sized (~14px tall at default scale)
- [ ] `pytest tests/routers/test_projects.py::TestProjectDrawdownSvg` passes (8 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)