### PR TITLE
feat: symbol-deduped SVG drawdown for project step tracking (#605)

### DIFF
--- a/backend/app/services/rendering.py
+++ b/backend/app/services/rendering.py
@@ -229,7 +229,7 @@ def render_drawdown_tile(
     return out.getvalue(), weft_count, actual_start, actual_row_count, scale, actual_start_col, actual_col_count
 
 
-def render_drawdown_svg(draft: Draft, cell_px: int = 10) -> str:
+def render_drawdown_svg(draft: Draft, cell_px: int = 20) -> str:
     """Render the drawdown grid as a symbol-deduped SVG string.
 
     Suitable for project step-tracking: load once, highlight current pick via

--- a/backend/app/weaving/_render.py
+++ b/backend/app/weaving/_render.py
@@ -571,11 +571,14 @@ class SVGRenderer:
 
 
 def drawdown_svg(draft, cell_px: int = 20) -> str:
-    """Render the drawdown grid as a symbol-deduped SVG string.
+    """Render the drawdown as a float-based SVG string.
 
-    Orientation matches the tile renderer: last pick at y=0 (top), first pick at
-    bottom.  Identical lift patterns share a <symbol> element so byte size scales
-    with unique_patterns × warp_count rather than total_picks × warp_count.
+    Each visible float (consecutive same-thread cells) is one <rect> with a
+    border — matching ImageRenderer.paint_drawdown() exactly.  No internal cell
+    borders are drawn within multi-cell floats.
+
+    Orientation: last pick at y=0 (top), first pick at bottom — matches the
+    PNG tile renderer used by the project step-tracking view.
 
     Returns an SVG string without an XML declaration — suitable for inline DOM
     injection via dangerouslySetInnerHTML.
@@ -585,50 +588,27 @@ def drawdown_svg(draft, cell_px: int = 20) -> str:
     total_w = warp_count * cell_px
     total_h = weft_count * cell_px
 
-    warp_colors = [t.color.css for t in draft.warp]
+    rects: list[str] = []
+    for start, end, visible, _length, thread in draft.compute_floats():
+        if not visible:
+            continue
+        # Flip y: weft index 0 is the first pick (bottom of image); last pick is at y=0.
+        # A float spanning weft rows y_start..y_end maps to:
+        #   svg_y = (weft_count - 1 - y_end) * cell_px   (top edge of the rect)
+        svg_x = start[0] * cell_px
+        svg_y = (weft_count - 1 - end[1]) * cell_px
+        w = (end[0] - start[0] + 1) * cell_px
+        h = (end[1] - start[1] + 1) * cell_px
+        color = thread.color.css if thread.color else "#ffffff"
+        rects.append(
+            f'<rect x="{svg_x}" y="{svg_y}" width="{w}" height="{h}"'
+            f' fill="{color}" stroke="#7f7f7f" stroke-width="0.5"/>'
+        )
 
-    symbol_map: dict[tuple[int, ...], int] = {}
-    symbol_defs: list[str] = []
-    row_data: list[tuple[int, str]] = []  # (symbol_id, weft_css)
-
-    for weft_thread in draft.weft:
-        connected = weft_thread.connected_shafts
-        # Columns where the warp thread is visible (mirrors compute_drawdown_at logic).
-        warp_up = tuple(x for x, wt in enumerate(draft.warp) if (wt.shaft not in connected) ^ draft.rising_shed)
-        if warp_up not in symbol_map:
-            sid = len(symbol_map)
-            symbol_map[warp_up] = sid
-            rects = "".join(
-                f'<rect x="{x * cell_px}" y="0" width="{cell_px}" height="{cell_px}" fill="{warp_colors[x]}"/>'
-                for x in warp_up
-            )
-            symbol_defs.append(f'<symbol id="s{sid}" width="{total_w}" height="{cell_px}">{rects}</symbol>')
-        weft_css = weft_thread.color.css if weft_thread.color else "#ffffff"
-        row_data.append((symbol_map[warp_up], weft_css))
-
-    rows: list[str] = []
-    for weft_idx, (sid, weft_css) in enumerate(row_data):
-        # Flip: weft index 0 (first pick) at bottom, last pick at top (y=0).
-        svg_row = weft_count - 1 - weft_idx
-        y = svg_row * cell_px
-        rows.append(f'<rect x="0" y="{y}" width="{total_w}" height="{cell_px}" fill="{weft_css}"/>')
-        rows.append(f'<use href="#s{sid}" x="0" y="{y}"/>')
-
-    # Single <path> grid overlay — all cell borders in one element (one draw call).
-    # Vertical lines at every column boundary, horizontal at every row boundary.
-    grid_parts: list[str] = []
-    for x in range(0, total_w + 1, cell_px):
-        grid_parts.append(f"M{x} 0V{total_h}")
-    for y in range(0, total_h + 1, cell_px):
-        grid_parts.append(f"M0 {y}H{total_w}")
-    grid = f'<path d="{"".join(grid_parts)}" stroke="#7f7f7f" stroke-width="0.5" fill="none"/>'
-
-    defs = f"<defs>{''.join(symbol_defs)}</defs>"
-    body = "".join(rows)
+    body = "".join(rects)
     return (
         f'<svg width="{total_w}" height="{total_h}"'
         f' viewBox="0 0 {total_w} {total_h}"'
-        f' xmlns="http://www.w3.org/2000/svg"'
-        f' xmlns:xlink="http://www.w3.org/1999/xlink">'
-        f"{defs}{body}{grid}</svg>"
+        f' xmlns="http://www.w3.org/2000/svg">'
+        f"{body}</svg>"
     )

--- a/backend/tests/routers/test_projects.py
+++ b/backend/tests/routers/test_projects.py
@@ -2170,13 +2170,14 @@ class TestProjectDrawdownSvg:
         assert b"<svg" in resp.content
         assert b"</svg>" in resp.content
 
-    async def test_response_contains_symbol_defs(
+    async def test_response_contains_float_rects_with_stroke(
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
     ):
         _, project = await _insert_project_with_wif(db_session, test_user)
         resp = await auth_client.get(f"/api/projects/{project.id}/drawdown/svg")
-        assert b"<symbol" in resp.content
-        assert b"<use" in resp.content
+        # Float-based rendering: each visible float is a <rect> with a stroke attribute.
+        assert b"<rect" in resp.content
+        assert b'stroke="#7f7f7f"' in resp.content
 
     async def test_returns_dimension_headers(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
         _, project = await _insert_project_with_wif(db_session, test_user, warp_threads=4, weft_threads=4)

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -314,21 +314,14 @@ function WeavingPatternView({
   const reversedPicks = [...picks].reverse();
 
   const washoutOverlay = (
-    <>
-      <div
-        className="absolute left-0 right-0 pointer-events-none"
-        style={{
-          top: 0,
-          height: futureRegionH,
-          backdropFilter: "saturate(0) brightness(1.6)",
-          WebkitBackdropFilter: "saturate(0) brightness(1.6)",
-        }}
-      />
-      <div
-        className="absolute left-0 right-0 pointer-events-none bg-white/50 dark:bg-zinc-900/55"
-        style={{ top: 0, height: futureRegionH }}
-      />
-    </>
+    <div
+      className="absolute left-0 right-0 pointer-events-none"
+      style={{
+        top: 0,
+        height: futureRegionH,
+        background: "linear-gradient(to bottom, hsl(var(--background)) 20%, transparent)",
+      }}
+    />
   );
 
   if (!svgContent) return (
@@ -359,7 +352,7 @@ function WeavingPatternView({
           onScroll={handleScroll}
         >
           <div
-            style={{ transform: `translateY(${translateY}px)`, transition: "transform 0.15s ease", width: totalImgW }}
+            style={{ transform: `translateY(${translateY}px)`, transition: "transform 0.15s ease", width: totalImgW, willChange: "transform" }}
             dangerouslySetInnerHTML={{ __html: svgContent }}
           />
         </div>
@@ -371,7 +364,7 @@ function WeavingPatternView({
         className="rounded-lg border overflow-hidden relative bg-background shrink-0"
         style={{ width: STEP_PANEL_W }}
       >
-        <div style={{ transform: `translateY(${translateY}px)`, transition: "transform 0.15s ease" }}>
+        <div style={{ transform: `translateY(${translateY}px)`, transition: "transform 0.15s ease", willChange: "transform" }}>
           {reversedPicks.map((pick) => (
             <div
               key={pick.pick}
@@ -397,7 +390,7 @@ function WeavingPatternView({
         className="rounded-lg border overflow-hidden relative shrink-0"
         style={{ width: COLOR_COL_W }}
       >
-        <div style={{ transform: `translateY(${translateY}px)`, transition: "transform 0.15s ease" }}>
+        <div style={{ transform: `translateY(${translateY}px)`, transition: "transform 0.15s ease", willChange: "transform" }}>
           {reversedPicks.map((pick) => (
             <div
               key={pick.pick}


### PR DESCRIPTION
## Summary

- Vendors PyWeaving as `app.weaving` internal engine (Phase 1, #572)
- Replaces PNG tile fetch-per-step with a single-load SVG drawdown using float-based rendering — one `<rect>` per visible float, borders only at float edges, matching `ImageRenderer.paint_drawdown()` exactly
- Adds `/api/projects/{id}/drawdown/svg` endpoint with `X-Pixels-Per-Row`, `X-Total-Rows`, `X-Total-Cols` headers; `cell_px` query param (default 20)
- Fixes step rendering performance on mobile: removes `backdrop-filter` from the washout overlay (was forcing GPU re-sampling on every `translateY` change) and replaces with a CSS gradient; adds `willChange: "transform"` to the three translating panels for compositor layer promotion

## Test plan

- [ ] Open an active project — drawdown SVG loads and centers on current pick
- [ ] Step advance/reverse — scroll is smooth, highlight tracks current pick, no false internal borders within floats
- [ ] Verify on mobile (Safari/Chrome) — stepping noticeably faster than before with PNG tiles
- [ ] Dark mode — washout gradient uses `--background` token, renders correctly
- [ ] `pytest tests/routers/test_projects.py::TestProjectDrawdownSvg` — 8 tests pass
- [ ] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)