### PR TITLE
feat: validate env vars at boot and surface config warnings in /health/ready (#85)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@
 # ------------------------------------------------------------
 
 # Secret key for signing sessions and tokens (generate with: openssl rand -hex 32)
+# → if blank: server refuses to start when DEBUG=false (production guard)
 APP_SECRET_KEY=
 
 # Runtime environment — controls HSTS, CSP, and other security features
@@ -33,14 +34,13 @@ COMPOSE_PROFILES=
 # Set to "true" in development only — enables debug output and auto-reload
 DEBUG=false
 
-# Allow the CLI seed command to run (set to "true" only on a fresh local instance)
-SEED_ENABLED=false
-
 # Log level for the backend: DEBUG, INFO, WARNING, ERROR (default: INFO)
+# → if invalid: server refuses to start (validated at boot; must be one of the five standard levels)
 # Output is always structured JSON for observability platform ingestion.
 LOG_LEVEL=INFO
 
 # Comma-separated list of allowed CORS origins for the API
+# → spaces between origins trigger a /health/ready config warning (degraded status)
 # Dev:  CORS_ORIGINS=https://dev.weftmark.com,http://localhost:3000
 # Prod: CORS_ORIGINS=https://weftmark.com
 CORS_ORIGINS=http://localhost:3000
@@ -93,6 +93,7 @@ POSTGRES_HOST=db
 POSTGRES_PORT=5432
 POSTGRES_DB=weaving_site
 POSTGRES_USER=weaving_user
+# → if blank: database connection fails; PostgreSQL probe shows "error" on /health/ready (critical)
 POSTGRES_PASSWORD=
 
 
@@ -104,15 +105,19 @@ POSTGRES_PASSWORD=
 
 # Publishable key — injected into the frontend container at runtime (not baked into the image).
 # Local Vite dev also needs VITE_CLERK_PUBLISHABLE_KEY set to the same value (see below).
+# → if blank: Clerk probe shows "error" on /health/ready (critical); frontend can't authenticate
 CLERK_PUBLISHABLE_KEY=
 
 # Secret key — backend only, never expose to the browser (sk_test_... or sk_live_...)
+# → if blank: Clerk probe shows "error" on /health/ready (critical); JWT verification fails
 CLERK_SECRET_KEY=
 
 # Webhook signing secret — Clerk Dashboard → Webhooks → your endpoint → Signing Secret
 # Register the endpoint as: https://your-domain.com/auth/clerk/webhook
 # Subscribe to: user.created, user.deleted
 # Looks like: whsec_...
+# → if blank or wrong format: /health/ready shows "Configuration" degraded; user.created /
+#   user.deleted webhooks are rejected and user records are never created or synced
 CLERK_WEBHOOK_SECRET=
 
 # Override base URL for webhook delivery (optional — falls back to API_URL when blank)
@@ -160,13 +165,17 @@ UPLOAD_DIR=/app/uploads
 MAX_UPLOAD_SIZE=52428800
 
 # Storage backend: "local" or "s3"
+# → if invalid: server refuses to start (validated at boot)
 STORAGE_BACKEND=local
 
 # S3-compatible storage (required if STORAGE_BACKEND=s3)
+# → if any of these are blank with STORAGE_BACKEND=s3: /health/ready shows "Configuration"
+#   degraded listing every missing var; file uploads and downloads will fail at runtime
 S3_ENDPOINT_URL=
 S3_ACCESS_KEY_ID=
 S3_SECRET_ACCESS_KEY=
 S3_BUCKET_NAME=
+# → S3_REGION is optional for most S3-compatible providers; leave blank for Cloudflare R2
 S3_REGION=
 
 
@@ -176,6 +185,8 @@ S3_REGION=
 # ------------------------------------------------------------
 SMTP_HOST=mail.smtp2go.com
 SMTP_PORT=587
+# → if any of the three below are blank: SMTP probe shows "failed" on /health/ready;
+#   invitation emails and alert notifications cannot be sent
 SMTP_USER=
 SMTP_PASSWORD=
 SMTP_FROM_EMAIL=
@@ -184,11 +195,17 @@ SMTP_FROM_NAME=WeftMark
 # Default invite link expiry in days (admins can override per invite)
 INVITE_EXPIRY_DAYS_DEFAULT=7
 
+# Enable startup/recovery health alert emails to superusers.
+# Set to "false" in dev and staging to suppress alert noise.
+# → if false: health transitions (degraded/error/recovery) are logged but not emailed
+STACK_ALERT_EMAILS_ENABLED=true
+
 
 # ------------------------------------------------------------
 # Redis — Celery broker and result backend
 # For Docker deployments: redis://redis:6379/0 (service name matches compose)
 # For external Redis: redis://:password@host:6379/0
+# → if blank or unreachable: all background tasks fail; Redis probe shows "error" on /health/ready
 # ------------------------------------------------------------
 REDIS_URL=redis://redis:6379/0
 
@@ -234,7 +251,7 @@ SOFT_DELETE_RETENTION_DAYS=365
 
 # Base URL of the OTLP HTTP receiver (port 4318).
 # Example: http://observability_otel-collector:4318
-# Leave empty in local dev — SDK no-ops gracefully when unset.
+# → if blank: telemetry disabled; SDK no-ops gracefully (safe for local dev)
 OTEL_EXPORTER_OTLP_ENDPOINT=
 
 
@@ -242,7 +259,7 @@ OTEL_EXPORTER_OTLP_ENDPOINT=
 # GeoIP — MaxMind GeoLite2-City (optional)
 # Register at https://www.maxmind.com/en/geolite2/signup for a free license key.
 # When set, the weekly refresh task downloads and updates the MMDB automatically.
-# Leave empty to disable geo lookups; metrics increment without geo attributes.
+# → if blank: geo lookups disabled; IP-based location data absent from metrics/audit logs
 # ------------------------------------------------------------
 MAXMIND_LICENSE_KEY=
 GEOIP_DB_PATH=/app/data/GeoLite2-City.mmdb

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 .env.local
 .env.komodo
 .env.*.local
+.env.test85
 # .env.example and .env.*.example are intentionally tracked
 .remotehost
 # .remotehost.example is intentionally tracked

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,6 +1,6 @@
 from functools import lru_cache
 
-from pydantic import model_validator
+from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 _DEFAULT_SECRET = "change-me-in-production"
@@ -135,6 +135,62 @@ class Settings(BaseSettings):
     tile_row_count: int = 100
     tile_col_count: int = 200
     tile_prune_inactive_days: int = 10
+
+    @field_validator("log_level", mode="before")
+    @classmethod
+    def _validate_log_level(cls, v: object) -> str:
+        _VALID = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+        s = str(v).upper().strip()
+        if s not in _VALID:
+            raise ValueError(f"LOG_LEVEL {v!r} is invalid. Must be one of: {', '.join(sorted(_VALID))}")
+        return s
+
+    @field_validator("storage_backend", mode="before")
+    @classmethod
+    def _validate_storage_backend(cls, v: object) -> str:
+        s = str(v).lower().strip()
+        if s not in ("local", "s3"):
+            raise ValueError(f"STORAGE_BACKEND {v!r} is invalid. Must be 'local' or 's3'.")
+        return s
+
+    def config_warnings(self) -> list[str]:
+        """Return human-readable warnings for non-fatal configuration issues.
+
+        Surfaced via /health/ready through _probe_config(). Does not raise —
+        callers decide severity.
+        """
+        issues: list[str] = []
+
+        # S3 credentials must all be set together when STORAGE_BACKEND=s3
+        if self.storage_backend == "s3":
+            missing = [
+                k
+                for k, v in {
+                    "S3_ENDPOINT_URL": self.s3_endpoint_url,
+                    "S3_ACCESS_KEY_ID": self.s3_access_key_id,
+                    "S3_SECRET_ACCESS_KEY": self.s3_secret_access_key,
+                    "S3_BUCKET_NAME": self.s3_bucket_name,
+                }.items()
+                if not v
+            ]
+            if missing:
+                issues.append(f"STORAGE_BACKEND=s3 but the following vars are not set: {', '.join(missing)}")
+
+        # CORS origins must be comma-separated without spaces
+        if " " in self.cors_origins:
+            issues.append(
+                "CORS_ORIGINS contains spaces — values must be comma-separated with no spaces "
+                "(e.g. http://a.com,http://b.com)"
+            )
+
+        # Webhook secret required for Clerk user-sync
+        if not self.clerk_webhook_secret or not self.clerk_webhook_secret.startswith("whsec_"):
+            issues.append(
+                "CLERK_WEBHOOK_SECRET is not set or does not start with 'whsec_' — "
+                "user-sync webhooks (user.created / user.deleted) will not function"
+            )
+
+        return issues
 
     @model_validator(mode="after")
     def _require_secret_key_in_production(self) -> "Settings":

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -941,18 +941,30 @@ def _probe_webhook_info() -> ServiceCheckResult:
     return _make_result("Clerk Webhook", checks, meta=meta)
 
 
+async def _probe_config() -> ServiceCheckResult:
+    """Check for non-fatal configuration issues surfaced via /health/ready."""
+    settings = get_settings()
+    checks: list[ServicePermCheck] = []
+    for warning in settings.config_warnings():
+        checks.append(ServicePermCheck(name="config", status="error", message=warning))
+    if not checks:
+        checks.append(ServicePermCheck(name="config", status="ok", message="All configuration checks passed"))
+    return _make_result("Configuration", checks)
+
+
 @router.get("/services", response_model=list[ServiceCheckResult])
 async def check_services(
     _: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ) -> list[ServiceCheckResult]:
-    db_result, s3_result, clerk_result, smtp_result = await asyncio.gather(
+    db_result, s3_result, clerk_result, smtp_result, config_result = await asyncio.gather(
         _probe_postgres(db),
         _probe_s3(),
         _probe_clerk(),
         _probe_smtp(),
+        _probe_config(),
     )
-    return [db_result, s3_result, clerk_result, smtp_result, _probe_webhook_info()]
+    return [db_result, s3_result, clerk_result, smtp_result, _probe_webhook_info(), config_result]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -161,11 +161,11 @@ def _build_readiness_from_results(
 async def run_startup_probes() -> ReadinessResponse:
     """Run service probes concurrently and return a ReadinessResponse.
 
-    Covers PostgreSQL, S3, Clerk API, and SMTP — services that gate startup.
-    Webhook round-trip health is checked separately via /health/detailed.
+    Covers PostgreSQL, S3, Clerk API, SMTP, and configuration — services that
+    gate startup. Webhook round-trip health is checked separately via /health/detailed.
     """
     from app.database import AsyncSessionLocal
-    from app.routers.admin import _probe_clerk, _probe_postgres, _probe_s3, _probe_smtp
+    from app.routers.admin import _probe_clerk, _probe_config, _probe_postgres, _probe_s3, _probe_smtp
 
     try:
         async with AsyncSessionLocal() as db:
@@ -174,6 +174,7 @@ async def run_startup_probes() -> ReadinessResponse:
                 _probe_s3(),
                 _probe_clerk(),
                 _probe_smtp(),
+                _probe_config(),
                 return_exceptions=True,
             )
     except Exception as exc:
@@ -193,9 +194,9 @@ async def run_startup_probes() -> ReadinessResponse:
 
 
 async def _run_detailed_probes() -> ReadinessResponse:
-    """Run all 5 probes and return a ReadinessResponse with a fresh checked_at."""
+    """Run all probes and return a ReadinessResponse with a fresh checked_at."""
     from app.database import AsyncSessionLocal
-    from app.routers.admin import _probe_clerk, _probe_postgres, _probe_s3, _probe_smtp
+    from app.routers.admin import _probe_clerk, _probe_config, _probe_postgres, _probe_s3, _probe_smtp
     from app.services.clerk_webhook_probe import run_webhook_probe
 
     try:
@@ -206,6 +207,7 @@ async def _run_detailed_probes() -> ReadinessResponse:
                     _probe_s3(),
                     _probe_clerk(),
                     _probe_smtp(),
+                    _probe_config(),
                     return_exceptions=True,
                 ),
                 run_webhook_probe(),

--- a/backend/tests/routers/test_admin.py
+++ b/backend/tests/routers/test_admin.py
@@ -1123,11 +1123,11 @@ class TestAdminServices:
         resp = await admin_client.get("/api/admin/services")
         assert resp.status_code == 200
 
-    async def test_returns_five_services(self, admin_client: AsyncClient):
+    async def test_returns_six_services(self, admin_client: AsyncClient):
         data = (await admin_client.get("/api/admin/services")).json()
-        assert len(data) == 5
+        assert len(data) == 6
         names = {s["service"] for s in data}
-        assert names == {"PostgreSQL", "S3", "Clerk", "SMTP", "Clerk Webhook"}
+        assert names == {"PostgreSQL", "S3", "Clerk", "SMTP", "Clerk Webhook", "Configuration"}
 
     async def test_webhook_service_includes_url(self, admin_client: AsyncClient):
         data = (await admin_client.get("/api/admin/services")).json()

--- a/backend/tests/services/test_config.py
+++ b/backend/tests/services/test_config.py
@@ -1,0 +1,165 @@
+"""Unit tests for Settings field validators and config_warnings()."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.config import Settings
+
+
+def _s(**kwargs) -> Settings:
+    """Build a Settings with test-safe defaults, overriding with kwargs.
+
+    All S3 vars are explicitly cleared so ambient container env vars don't
+    bleed into tests that check for missing-S3 warnings.
+    """
+    defaults = {
+        "app_env": "dev",
+        "debug": True,
+        "app_secret_key": "test-secret-key",
+        "clerk_webhook_secret": "whsec_test123",
+        "cors_origins": "http://localhost:3000",
+        "storage_backend": "local",
+        "log_level": "INFO",
+        # Explicitly clear S3 vars so container env doesn't pollute tests
+        "s3_endpoint_url": "",
+        "s3_access_key_id": "",
+        "s3_secret_access_key": "",
+        "s3_bucket_name": "",
+        "s3_region": "",
+    }
+    return Settings(**{**defaults, **kwargs})
+
+
+class TestLogLevelValidator:
+    def test_valid_levels_accepted(self):
+        for level in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
+            s = _s(log_level=level)
+            assert s.log_level == level
+
+    def test_lowercase_normalised_to_upper(self):
+        assert _s(log_level="info").log_level == "INFO"
+        assert _s(log_level="debug").log_level == "DEBUG"
+        assert _s(log_level="warning").log_level == "WARNING"
+
+    def test_mixed_case_normalised(self):
+        assert _s(log_level="Warning").log_level == "WARNING"
+
+    def test_invalid_level_raises_with_message(self):
+        with pytest.raises(Exception, match="LOG_LEVEL"):
+            _s(log_level="VERBOSE")
+
+    def test_numeric_string_raises(self):
+        with pytest.raises(Exception, match="LOG_LEVEL"):
+            _s(log_level="3")
+
+    def test_empty_string_raises(self):
+        with pytest.raises(Exception, match="LOG_LEVEL"):
+            _s(log_level="")
+
+
+class TestStorageBackendValidator:
+    def test_local_accepted(self):
+        assert _s(storage_backend="local").storage_backend == "local"
+
+    def test_s3_accepted(self):
+        assert _s(storage_backend="s3").storage_backend == "s3"
+
+    def test_uppercase_normalised_to_lower(self):
+        assert _s(storage_backend="LOCAL").storage_backend == "local"
+        assert _s(storage_backend="S3").storage_backend == "s3"
+
+    def test_invalid_backend_raises_with_message(self):
+        with pytest.raises(Exception, match="STORAGE_BACKEND"):
+            _s(storage_backend="gcs")
+
+    def test_azure_raises(self):
+        with pytest.raises(Exception, match="STORAGE_BACKEND"):
+            _s(storage_backend="azure")
+
+    def test_empty_string_raises(self):
+        with pytest.raises(Exception, match="STORAGE_BACKEND"):
+            _s(storage_backend="")
+
+
+class TestConfigWarnings:
+    def test_no_warnings_with_clean_local_config(self):
+        assert _s().config_warnings() == []
+
+    def test_no_warnings_with_full_s3_config(self):
+        s = _s(
+            storage_backend="s3",
+            s3_endpoint_url="https://s3.example.com",
+            s3_access_key_id="AKIDTEST",
+            s3_secret_access_key="secretvalue",
+            s3_bucket_name="my-bucket",
+        )
+        assert s.config_warnings() == []
+
+    def test_s3_backend_all_vars_missing_warns(self):
+        s = _s(storage_backend="s3")
+        warnings = s.config_warnings()
+        assert len(warnings) >= 1
+        assert any("S3" in w for w in warnings)
+
+    def test_s3_backend_partial_vars_warns(self):
+        s = _s(storage_backend="s3", s3_bucket_name="bucket")
+        warnings = s.config_warnings()
+        combined = " ".join(warnings)
+        assert "S3_ACCESS_KEY_ID" in combined or "S3_SECRET_ACCESS_KEY" in combined
+
+    def test_s3_backend_only_endpoint_set_warns(self):
+        s = _s(storage_backend="s3", s3_endpoint_url="https://r2.example.com")
+        warnings = s.config_warnings()
+        assert any("S3" in w for w in warnings)
+
+    def test_local_backend_unused_s3_vars_no_warning(self):
+        s = _s(
+            storage_backend="local",
+            s3_endpoint_url="https://s3.example.com",
+            s3_access_key_id="KEY",
+            s3_secret_access_key="secret",
+            s3_bucket_name="bucket",
+        )
+        assert s.config_warnings() == []
+
+    def test_cors_with_space_after_comma_warns(self):
+        s = _s(cors_origins="http://localhost:3000, http://localhost:3001")
+        warnings = s.config_warnings()
+        assert any("CORS_ORIGINS" in w for w in warnings)
+
+    def test_cors_with_leading_space_warns(self):
+        s = _s(cors_origins=" http://localhost:3000")
+        warnings = s.config_warnings()
+        assert any("CORS_ORIGINS" in w for w in warnings)
+
+    def test_cors_without_spaces_no_warning(self):
+        s = _s(cors_origins="http://localhost:3000,http://localhost:3001")
+        assert s.config_warnings() == []
+
+    def test_cors_single_origin_no_warning(self):
+        s = _s(cors_origins="https://example.com")
+        assert s.config_warnings() == []
+
+    def test_missing_webhook_secret_warns(self):
+        s = _s(clerk_webhook_secret="")
+        warnings = s.config_warnings()
+        assert any("CLERK_WEBHOOK_SECRET" in w for w in warnings)
+
+    def test_malformed_webhook_secret_warns(self):
+        s = _s(clerk_webhook_secret="notawhsec_format")
+        warnings = s.config_warnings()
+        assert any("CLERK_WEBHOOK_SECRET" in w for w in warnings)
+
+    def test_valid_webhook_secret_no_warning(self):
+        s = _s(clerk_webhook_secret="whsec_abcdef1234567890")
+        assert s.config_warnings() == []
+
+    def test_multiple_issues_all_reported(self):
+        s = _s(
+            storage_backend="s3",
+            cors_origins="http://a.com, http://b.com",
+            clerk_webhook_secret="",
+        )
+        warnings = s.config_warnings()
+        assert len(warnings) >= 3

--- a/docker-compose.test85.yml
+++ b/docker-compose.test85.yml
@@ -1,0 +1,117 @@
+# Test stack for issue #85 — env-var resilience validation.
+# Runs db + redis + backend only; backend exposed on :8085.
+# No hardcoded container names — docker compose project name prefixes them.
+# Usage:
+#   docker compose -p test85 -f docker-compose.test85.yml --env-file .env.test85 up -d
+#   curl http://localhost:8085/health/ready | python -m json.tool
+#   docker compose -p test85 -f docker-compose.test85.yml down -v
+
+services:
+
+  db:
+    profiles: ["local-db"]
+    image: postgres:17-alpine
+    networks:
+      - internal
+    ports:
+      - "127.0.0.1:${DB_HOST_PORT:-5436}:5432"
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - test85_postgres:/var/lib/postgresql/data
+      - ./scripts/init-db.sh:/docker-entrypoint-initdb.d/init-db.sh:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    networks:
+      - internal
+    ports:
+      - "127.0.0.1:6380:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+
+  backend:
+    image: weaving_site_backend:${IMAGE_TAG:-dev}
+    networks:
+      - internal
+    ports:
+      - "127.0.0.1:8085:8000"
+    environment:
+      APP_ENV: ${APP_ENV}
+      APP_SECRET_KEY: ${APP_SECRET_KEY}
+      DEBUG: ${DEBUG:-false}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      SEED_ENABLED: "false"
+      CORS_ORIGINS: ${CORS_ORIGINS}
+      FRONTEND_URL: ${FRONTEND_URL:-http://localhost:3000}
+      API_URL: ${API_URL:-http://localhost:8085}
+      POSTGRES_DSN: ${POSTGRES_DSN:-}
+      POSTGRES_DSN_DIRECT: ${POSTGRES_DSN_DIRECT:-}
+      POSTGRES_HOST: ${POSTGRES_HOST:-db}
+      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      CLERK_PUBLISHABLE_KEY: ${CLERK_PUBLISHABLE_KEY:-}
+      CLERK_SECRET_KEY: ${CLERK_SECRET_KEY:-}
+      CLERK_WEBHOOK_SECRET: ${CLERK_WEBHOOK_SECRET:-}
+      WEBHOOK_BASE_URL: ${WEBHOOK_BASE_URL:-}
+      CF_ZERO_TRUST_ENABLED: "false"
+      STORAGE_BACKEND: ${STORAGE_BACKEND:-local}
+      UPLOAD_DIR: ${UPLOAD_DIR:-/app/uploads}
+      MAX_UPLOAD_SIZE: ${MAX_UPLOAD_SIZE:-52428800}
+      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-}
+      S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID:-}
+      S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY:-}
+      S3_BUCKET_NAME: ${S3_BUCKET_NAME:-}
+      S3_REGION: ${S3_REGION:-}
+      SMTP_HOST: ${SMTP_HOST:-mail.smtp2go.com}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_USER: ${SMTP_USER:-}
+      SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+      SMTP_FROM_EMAIL: ${SMTP_FROM_EMAIL:-}
+      SMTP_FROM_NAME: ${SMTP_FROM_NAME:-WeftMark}
+      INVITE_EXPIRY_DAYS_DEFAULT: ${INVITE_EXPIRY_DAYS_DEFAULT:-7}
+      REDIS_URL: redis://redis:6379/0
+      RENDER_MAX_WIDTH: ${RENDER_MAX_WIDTH:-4000}
+      RENDER_MAX_HEIGHT: ${RENDER_MAX_HEIGHT:-4000}
+      RENDER_DEFAULT_ZOOM: ${RENDER_DEFAULT_ZOOM:-10}
+      STACK_ALERT_EMAILS_ENABLED: ${STACK_ALERT_EMAILS_ENABLED:-false}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      OTEL_SERVICE_NAME: weftmark-test85
+      MAXMIND_LICENSE_KEY: ${MAXMIND_LICENSE_KEY:-}
+    volumes:
+      - test85_uploads:/app/uploads
+    depends_on:
+      redis:
+        condition: service_healthy
+      db:
+        condition: service_healthy
+        required: false
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    restart: unless-stopped
+
+networks:
+  internal:
+    driver: bridge
+
+volumes:
+  test85_postgres:
+  test85_uploads:


### PR DESCRIPTION
## Summary

- `LOG_LEVEL` and `STORAGE_BACKEND` are now validated at boot by `field_validator`; invalid values hard-fail with a clear error before the server accepts any traffic
- `config_warnings()` on `Settings` checks for non-fatal but operationally significant issues: CORS origins with spaces, missing/malformed `CLERK_WEBHOOK_SECRET`, and incomplete S3 credentials when `STORAGE_BACKEND=s3`
- `_probe_config()` wired into both startup probes (`/health/ready`) and the 30-second detailed refresh loop — surfaces a "Configuration" service entry showing all active warnings
- `.env.example` updated with `→ if blank:` consequence annotations on every key variable

## Validation

Manually verified with an isolated `docker-compose.test85.yml` stack using `.env.test85` (intentionally broken: blank `CLERK_WEBHOOK_SECRET`, spaces in `CORS_ORIGINS`, blank Clerk keys):

```json
{
  "status": "error",
  "services": [
    {"name": "PostgreSQL", "ok": true},
    {"name": "S3", "ok": true},
    {"name": "Clerk", "ok": false, "critical": true, "detail": "Missing or unexpected format"},
    {"name": "SMTP", "ok": false, "detail": "Missing: smtp_user, smtp_password, smtp_from_email"},
    {"name": "Configuration", "ok": false, "message": "2/2 checks failed",
     "detail": "CORS_ORIGINS contains spaces..."}
  ]
}
```

## Test plan

- [x] 26 unit tests in `backend/tests/services/test_config.py` — all passing
- [x] `TestLogLevelValidator` — valid levels accepted, lowercase normalised, invalid raises with message
- [x] `TestStorageBackendValidator` — local/s3 accepted, invalid raises with message
- [x] `TestConfigWarnings` — CORS spaces, missing/malformed webhook secret, partial S3 vars, clean configs
- [x] Isolated test85 stack verified at `/health/ready`
- [x] Existing 28 health router tests still passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)