### PR TITLE
feat: WIF measurements, color palette, weaving width, and EPI (#47, #625)

### DIFF
--- a/backend/alembic/versions/0014_draft_wif_measurements.py
+++ b/backend/alembic/versions/0014_draft_wif_measurements.py
@@ -1,0 +1,30 @@
+"""Add wif_measurements, warp_length_cm, warp_length_overridden to drafts
+
+Revision ID: 0014
+Revises: 0013
+Create Date: 2026-05-13
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "b2c3d4e5f6a7"
+down_revision = "a1b2c3d4e5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("drafts", sa.Column("wif_measurements", JSONB(), nullable=True))
+    op.add_column("drafts", sa.Column("warp_length_cm", sa.Float(), nullable=True))
+    op.add_column(
+        "drafts",
+        sa.Column("warp_length_overridden", sa.Boolean(), nullable=False, server_default="false"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("drafts", "warp_length_overridden")
+    op.drop_column("drafts", "warp_length_cm")
+    op.drop_column("drafts", "wif_measurements")

--- a/backend/alembic/versions/0015_draft_wif_colors.py
+++ b/backend/alembic/versions/0015_draft_wif_colors.py
@@ -1,0 +1,23 @@
+"""Add wif_colors to drafts
+
+Revision ID: 0015
+Revises: 0014
+Create Date: 2026-05-13
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "c3d4e5f6a7b8"
+down_revision = "b2c3d4e5f6a7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("drafts", sa.Column("wif_colors", JSONB(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("drafts", "wif_colors")

--- a/backend/alembic/versions/0016_draft_measurements_extended.py
+++ b/backend/alembic/versions/0016_draft_measurements_extended.py
@@ -1,0 +1,24 @@
+"""Add weaving_width_override_cm and epi_override to drafts
+
+Revision ID: 0016
+Revises: 0015
+Create Date: 2026-05-13
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "d4e5f6a7b8c9"
+down_revision = "c3d4e5f6a7b8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("drafts", sa.Column("weaving_width_override_cm", sa.Float(), nullable=True))
+    op.add_column("drafts", sa.Column("epi_override", sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("drafts", "epi_override")
+    op.drop_column("drafts", "weaving_width_override_cm")

--- a/backend/app/models/draft.py
+++ b/backend/app/models/draft.py
@@ -1,6 +1,6 @@
 import uuid
 
-from sqlalchemy import Boolean, ForeignKey, Integer, String, Text
+from sqlalchemy import Boolean, Float, ForeignKey, Integer, String, Text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -57,6 +57,28 @@ class Draft(Base, TimestampMixin, SoftDeleteMixin):
     # Pre-generated reduced-size drawdown for fast serving
     drawdown_preview_path: Mapped[str | None] = mapped_column(String(512), nullable=True)
     drawdown_preview_scale: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # WIF-extracted dimensional measurements (normalized to cm where applicable).
+    # Keys: warp_length, warp_length_original, warp_length_unit, warp_spacing, ...,
+    #       weft_length, weft_length_original, weft_length_unit, weft_spacing, ...
+    # Only keys that were present in the WIF are stored; {} or null if none found.
+    wif_measurements: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    # Color palette extracted from WIF [COLOR TABLE], normalized to 0–255 RGB.
+    # List of {index, r, g, b, hex} objects sorted by index; null if no COLOR TABLE in WIF.
+    wif_colors: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+
+    # Effective warp length in cm — populated from WIF on import or set manually.
+    warp_length_cm: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    # True when the user has explicitly overridden the WIF's warp_length value.
+    warp_length_overridden: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+
+    # User-entered weaving width override in cm (null = derive from WIF weft_length or thread count × spacing).
+    weaving_width_override_cm: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    # User-entered EPI override (ends per inch; null = derive from WIF warp_spacing or width ÷ thread count).
+    epi_override: Mapped[float | None] = mapped_column(Float, nullable=True)
 
     # Sharing
     is_shared: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)

--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -75,6 +75,12 @@ class DraftSummary(BaseModel):
     has_drawdown_preview: bool
     has_modified_file: bool
     metadata_overrides: dict | None
+    wif_measurements: dict | None
+    wif_colors: list | None
+    warp_length_cm: float | None
+    warp_length_overridden: bool
+    weaving_width_override_cm: float | None
+    epi_override: float | None
     is_shared: bool
     created_at: datetime
     updated_at: datetime
@@ -127,6 +133,7 @@ async def create_draft(
         )
 
     lint = wif_linter.lint(wif_bytes)
+    measurements = wif_parser.extract_measurements(wif_bytes)
 
     draft = Draft(
         owner_id=current_user.id,
@@ -149,6 +156,9 @@ async def create_draft(
         lint_errors=lint.errors,
         wif_source_software=lint.source_software,
         wif_source_version=lint.source_version,
+        wif_measurements=measurements or None,
+        warp_length_cm=measurements.get("warp_length") if measurements else None,
+        wif_colors=wif_parser.extract_colors(wif_bytes) or None,
     )
     db.add(draft)
     await db.flush()  # get draft.id without committing
@@ -586,6 +596,55 @@ async def override_metadata(
     from app.services.task_history import record_queued
 
     record_queued(get_settings(), _prev_task2.id, "app.tasks.preview.generate_drawdown_preview", "preview")
+    return DraftDetail(**_draft_detail_data(draft))
+
+
+# ---------------------------------------------------------------------------
+# Set / override measurements
+# ---------------------------------------------------------------------------
+
+
+class PatchMeasurementsRequest(BaseModel):
+    warp_length: float | None = None
+    weaving_width: float | None = None
+    epi: float | None = None
+    unit: str = "cm"  # "cm" | "in" — applies to warp_length and weaving_width; epi is always ends/inch
+
+
+@router.patch("/{draft_id}/measurements", response_model=DraftDetail)
+async def patch_measurements(
+    draft_id: uuid.UUID,
+    body: PatchMeasurementsRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> DraftDetail:
+    if body.unit not in ("cm", "in"):
+        raise HTTPException(status_code=400, detail="unit must be 'cm' or 'in'")
+
+    draft = await _get_owned_draft(draft_id, current_user, db)
+
+    if body.warp_length is not None:
+        if body.warp_length <= 0:
+            raise HTTPException(status_code=400, detail="warp_length must be positive")
+        warp_length_cm = body.warp_length if body.unit == "cm" else round(body.warp_length * 2.54, 4)
+        was_from_wif = bool(draft.wif_measurements and "warp_length" in draft.wif_measurements)
+        draft.warp_length_cm = warp_length_cm
+        draft.warp_length_overridden = was_from_wif
+
+    if body.weaving_width is not None:
+        if body.weaving_width <= 0:
+            raise HTTPException(status_code=400, detail="weaving_width must be positive")
+        draft.weaving_width_override_cm = (
+            body.weaving_width if body.unit == "cm" else round(body.weaving_width * 2.54, 4)
+        )
+
+    if body.epi is not None:
+        if body.epi <= 0:
+            raise HTTPException(status_code=400, detail="epi must be positive")
+        draft.epi_override = body.epi
+
+    await db.commit()
+    await db.refresh(draft)
     return DraftDetail(**_draft_detail_data(draft))
 
 

--- a/backend/app/services/wif_parser.py
+++ b/backend/app/services/wif_parser.py
@@ -1,8 +1,5 @@
 """
-Parse treadling and liftplan pick data from WIF bytes.
-
-Returns a list of picks, each with the set of active treadles or shafts (1-indexed),
-plus optional per-pick weft color derived from [COLOR TABLE] and [WEFT COLORS].
+Parse treadling, liftplan, and dimensional measurements from WIF bytes.
 """
 
 from __future__ import annotations
@@ -13,6 +10,150 @@ from dataclasses import dataclass
 from opentelemetry import trace
 
 tracer = trace.get_tracer(__name__)
+
+# WIF unit → (canonical label, cm multiplier)
+_UNIT_CONVERSIONS: dict[str, tuple[str, float]] = {
+    "centimeters": ("cm", 1.0),
+    "inches": ("in", 2.54),
+    "decipoints": ("dp", 2.54 / 720),
+}
+
+
+def _parse_unit(raw: str) -> tuple[str, float]:
+    """Return (canonical_label, cm_multiplier). Defaults to inches per WIF spec."""
+    return _UNIT_CONVERSIONS.get(raw.lower().strip(), ("in", 2.54))
+
+
+def extract_measurements(wif_bytes: bytes) -> dict:
+    """Extract dimensional measurements from WIF [WARP] and [WEFT] sections.
+
+    Returns a dict with a subset of these keys (only present if found in WIF):
+      warp_length, warp_length_original, warp_length_unit
+      warp_spacing, warp_spacing_original, warp_spacing_unit
+      weft_length, weft_length_original, weft_length_unit
+      weft_spacing, weft_spacing_original, weft_spacing_unit
+
+    *_length and *_spacing values are normalized to centimeters.
+    *_original values are the raw numbers from the WIF file.
+    *_unit values are the canonical label ("in", "cm", "dp").
+    Never raises — returns {} on any parse failure.
+    """
+    try:
+        try:
+            text = wif_bytes.decode("utf-8")
+        except UnicodeDecodeError:
+            text = wif_bytes.decode("latin-1")
+
+        config = RawConfigParser()
+        config.optionxform = str
+        config.read_string(text)
+
+        result: dict = {}
+
+        for section, prefix in (("WARP", "warp"), ("WEFT", "weft")):
+            if not config.has_section(section):
+                continue
+
+            raw_unit = ""
+            try:
+                raw_unit = config.get(section, "Units").strip()
+            except Exception:
+                pass
+            unit_label, multiplier = _parse_unit(raw_unit or "Inches")
+
+            try:
+                length_val = float(config.get(section, "Length").strip())
+                result[f"{prefix}_length_original"] = length_val
+                result[f"{prefix}_length_unit"] = unit_label
+                result[f"{prefix}_length"] = round(length_val * multiplier, 4)
+            except Exception:
+                pass
+
+            try:
+                spacing_val = float(config.get(section, "Spacing").strip())
+                result[f"{prefix}_spacing_original"] = spacing_val
+                result[f"{prefix}_spacing_unit"] = unit_label
+                result[f"{prefix}_spacing"] = round(spacing_val * multiplier, 4)
+            except Exception:
+                pass
+
+        return result
+    except Exception:
+        return {}
+
+
+def extract_colors(wif_bytes: bytes) -> list[dict]:
+    """Extract only the colors referenced in the design from WIF [COLOR TABLE].
+
+    A color is considered "used" if its palette index appears in any of:
+      [WEFT COLORS], [WARP COLORS], [WEFT] Color=, [WARP] Color=
+
+    Returns a list of dicts, each with:
+      index (int), r (int, 0–255), g (int, 0–255), b (int, 0–255), hex (str)
+
+    Values are normalized from the [COLOR PALETTE] Range to 0–255.
+    Returns [] if no color table exists or no colors are referenced in the design.
+    Never raises.
+    """
+    try:
+        try:
+            text = wif_bytes.decode("utf-8")
+        except UnicodeDecodeError:
+            text = wif_bytes.decode("latin-1")
+
+        config = RawConfigParser()
+        config.optionxform = str
+        config.read_string(text)
+
+        if not config.has_section("COLOR TABLE"):
+            return []
+
+        # Collect palette indices actually referenced in the design.
+        used: set[int] = set()
+
+        for sect in ("WEFT", "WARP"):
+            if config.has_section(sect):
+                try:
+                    used.add(int(config.get(sect, "Color").split(",")[0].strip()))
+                except Exception:
+                    pass
+
+        for sect in ("WEFT COLORS", "WARP COLORS"):
+            if config.has_section(sect):
+                for _, v in config.items(sect):
+                    try:
+                        used.add(int(v.split(",")[0].strip()))
+                    except ValueError:
+                        continue
+
+        if not used:
+            return []
+
+        scale = _color_scale(config)
+        colors: list[dict] = []
+
+        for k, v in config.items("COLOR TABLE"):
+            try:
+                idx = int(k)
+                if idx not in used:
+                    continue
+                parts = [int(p.strip()) for p in v.split(",")]
+                if len(parts) < 3:
+                    continue
+                r, g, b = parts[:3]
+                if scale != 255:
+                    r = round(r * 255 / scale)
+                    g = round(g * 255 / scale)
+                    b = round(b * 255 / scale)
+                r, g, b = (max(0, min(255, c)) for c in (r, g, b))
+                colors.append({"index": idx, "r": r, "g": g, "b": b, "hex": f"#{r:02x}{g:02x}{b:02x}"})
+            except (ValueError, ZeroDivisionError):
+                continue
+
+        colors.sort(key=lambda c: c["index"])
+        return colors
+    except Exception:
+        return []
 
 
 @dataclass

--- a/backend/app/tasks/reparse.py
+++ b/backend/app/tasks/reparse.py
@@ -1,0 +1,72 @@
+"""Celery task: re-parse WIF measurements and color palette for all existing drafts."""
+
+import asyncio
+import logging
+
+from celery import Task
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.celery_app import celery_app
+
+log = logging.getLogger(__name__)
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=0,
+    soft_time_limit=600,
+    time_limit=660,
+    name="app.tasks.reparse.reparse_all_drafts",
+)
+def reparse_all_drafts(self: Task) -> dict:
+    return asyncio.run(_reparse_all())
+
+
+async def _reparse_all() -> dict:
+    from app.config import get_settings
+    from app.models.draft import Draft
+    from app.services import storage
+    from app.services.wif_parser import extract_colors, extract_measurements
+
+    settings = get_settings()
+    engine = create_async_engine(settings.database_url, echo=False)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    updated = skipped = errors = 0
+
+    try:
+        async with async_session() as db:
+            drafts = (
+                await db.scalars(select(Draft).where(Draft.deleted_at.is_(None)).order_by(Draft.created_at))
+            ).all()
+
+            for draft in drafts:
+                if not draft.wif_path or not storage.file_exists(draft.wif_path):
+                    skipped += 1
+                    continue
+                try:
+                    wif_bytes = storage.read_file(draft.wif_path)
+                    measurements = extract_measurements(wif_bytes)
+                    colors = extract_colors(wif_bytes)
+
+                    draft.wif_measurements = measurements or None
+                    draft.wif_colors = colors or None
+
+                    # Only update warp_length_cm if the user hasn't manually overridden it.
+                    if not draft.warp_length_overridden:
+                        draft.warp_length_cm = measurements.get("warp_length")
+
+                    updated += 1
+                except Exception as exc:
+                    log.warning("reparse_draft_failed draft_id=%s error=%s", draft.id, exc)
+                    errors += 1
+
+            await db.commit()
+    finally:
+        await engine.dispose()
+
+    result = {"updated": updated, "skipped": skipped, "errors": errors}
+    log.info("reparse_all_drafts_complete %s", result)
+    return result

--- a/backend/tests/services/test_wif_parser.py
+++ b/backend/tests/services/test_wif_parser.py
@@ -7,7 +7,7 @@ color scale normalisation, liftplan computation, encoding fallback.
 
 import pytest
 
-from app.services.wif_parser import PickData, compute_liftplan, parse_picks
+from app.services.wif_parser import PickData, compute_liftplan, extract_colors, extract_measurements, parse_picks
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -512,3 +512,236 @@ Version=1.1
         )
         result = compute_liftplan(latin1_content)
         assert b"[LIFTPLAN]" in result
+
+
+# ---------------------------------------------------------------------------
+# extract_measurements
+# ---------------------------------------------------------------------------
+
+
+def _mwif(warp: str = "", weft: str = "") -> bytes:
+    sections = ["[WIF]\nVersion=1.1\n\n[WEAVING]\nShafts=4\nTreadles=4"]
+    if warp:
+        sections.append(f"[WARP]\n{warp}")
+    if weft:
+        sections.append(f"[WEFT]\n{weft}")
+    return "\n\n".join(sections).encode()
+
+
+class TestExtractMeasurements:
+    def test_returns_dict(self):
+        result = extract_measurements(_mwif())
+        assert isinstance(result, dict)
+
+    def test_empty_when_no_warp_section(self):
+        result = extract_measurements(b"[WIF]\nVersion=1.1")
+        assert result == {}
+
+    def test_warp_length_inches_normalized_to_cm(self):
+        result = extract_measurements(_mwif(warp="Units=Inches\nLength=100"))
+        assert pytest.approx(result["warp_length"], rel=1e-4) == 254.0
+        assert result["warp_length_original"] == 100.0
+        assert result["warp_length_unit"] == "in"
+
+    def test_warp_length_centimeters_unchanged(self):
+        result = extract_measurements(_mwif(warp="Units=Centimeters\nLength=200"))
+        assert pytest.approx(result["warp_length"]) == 200.0
+        assert result["warp_length_unit"] == "cm"
+
+    def test_warp_length_decipoints_normalized(self):
+        # 720 decipoints = 1 inch = 2.54 cm
+        result = extract_measurements(_mwif(warp="Units=Decipoints\nLength=720"))
+        assert pytest.approx(result["warp_length"], rel=1e-3) == 2.54
+        assert result["warp_length_unit"] == "dp"
+
+    def test_default_unit_is_inches_when_absent(self):
+        result = extract_measurements(_mwif(warp="Length=10"))
+        assert pytest.approx(result["warp_length"], rel=1e-4) == 25.4
+        assert result["warp_length_unit"] == "in"
+
+    def test_warp_spacing_extracted(self):
+        result = extract_measurements(_mwif(warp="Units=Inches\nSpacing=0.2"))
+        assert pytest.approx(result["warp_spacing"], rel=1e-4) == 0.508
+        assert result["warp_spacing_original"] == 0.2
+        assert result["warp_spacing_unit"] == "in"
+
+    def test_weft_spacing_extracted(self):
+        result = extract_measurements(_mwif(weft="Units=Centimeters\nSpacing=0.3"))
+        assert pytest.approx(result["weft_spacing"]) == 0.3
+        assert result["weft_spacing_unit"] == "cm"
+
+    def test_warp_length_absent_key_missing(self):
+        result = extract_measurements(_mwif(warp="Units=Inches\nSpacing=0.2"))
+        assert "warp_length" not in result
+        assert "warp_spacing" in result
+
+    def test_weft_length_inches_normalized(self):
+        result = extract_measurements(_mwif(weft="Units=Inches\nLength=50"))
+        assert pytest.approx(result["weft_length"], rel=1e-4) == 127.0
+        assert result["weft_length_original"] == 50.0
+        assert result["weft_length_unit"] == "in"
+
+    def test_weft_length_centimeters_unchanged(self):
+        result = extract_measurements(_mwif(weft="Units=Centimeters\nLength=300"))
+        assert pytest.approx(result["weft_length"]) == 300.0
+        assert result["weft_length_unit"] == "cm"
+
+    def test_weft_length_absent_key_missing(self):
+        result = extract_measurements(_mwif(weft="Units=Inches\nSpacing=0.2"))
+        assert "weft_length" not in result
+        assert "weft_spacing" in result
+
+    def test_non_numeric_length_skipped(self):
+        result = extract_measurements(_mwif(warp="Units=Inches\nLength=not_a_number"))
+        assert "warp_length" not in result
+
+    def test_warp_and_weft_different_units(self):
+        result = extract_measurements(_mwif(warp="Units=Inches\nLength=100", weft="Units=Centimeters\nSpacing=0.5"))
+        assert result["warp_length_unit"] == "in"
+        assert result["weft_spacing_unit"] == "cm"
+        assert pytest.approx(result["weft_spacing"]) == 0.5
+
+    def test_invalid_wif_bytes_returns_empty(self):
+        result = extract_measurements(b"\xff\xfe invalid binary \x00")
+        assert isinstance(result, dict)
+
+    def test_latin1_wif_parsed(self):
+        latin1_wif = "[WIF]\nVersion=1.1\n\n[WARP]\nUnits=Inches\nLength=50\n".encode("latin-1")
+        result = extract_measurements(latin1_wif)
+        assert pytest.approx(result["warp_length"], rel=1e-4) == 127.0
+
+
+# ---------------------------------------------------------------------------
+# extract_colors
+# ---------------------------------------------------------------------------
+
+
+def _cwif(
+    table_body: str = "",
+    palette: str = "Range=0,255\nForm=Decimal",
+    weft_colors: str = "",
+    warp_colors: str = "",
+    weft_default: str = "",
+    warp_default: str = "",
+) -> bytes:
+    """Build a minimal WIF for color extraction tests.
+
+    table_body: content of [COLOR TABLE]
+    weft_colors: content of [WEFT COLORS] (per-pick palette index refs)
+    warp_colors: content of [WARP COLORS] (per-thread palette index refs)
+    weft_default: value for [WEFT] Color= key
+    warp_default: value for [WARP] Color= key
+    """
+    sections = [f"[WIF]\nVersion=1.1\n\n[COLOR PALETTE]\n{palette}"]
+    if table_body:
+        sections.append(f"[COLOR TABLE]\n{table_body}")
+    if weft_colors:
+        sections.append(f"[WEFT COLORS]\n{weft_colors}")
+    if warp_colors:
+        sections.append(f"[WARP COLORS]\n{warp_colors}")
+    if weft_default or warp_default:
+        weft_line = f"Color={weft_default}" if weft_default else ""
+        warp_line = f"Color={warp_default}" if warp_default else ""
+        if weft_line:
+            sections.append(f"[WEFT]\n{weft_line}")
+        if warp_line:
+            sections.append(f"[WARP]\n{warp_line}")
+    return "\n\n".join(sections).encode()
+
+
+class TestExtractColors:
+    def test_returns_list(self):
+        result = extract_colors(_cwif("1=255,0,0", weft_colors="1=1"))
+        assert isinstance(result, list)
+
+    def test_empty_when_no_color_table(self):
+        result = extract_colors(b"[WIF]\nVersion=1.1")
+        assert result == []
+
+    def test_empty_when_no_references_in_design(self):
+        """Color table exists but nothing in the design references any index."""
+        result = extract_colors(_cwif("1=255,0,0\n2=0,255,0"))
+        assert result == []
+
+    def test_single_color_via_weft_colors(self):
+        result = extract_colors(_cwif("1=255,0,0", weft_colors="1=1"))
+        assert len(result) == 1
+        c = result[0]
+        assert c["index"] == 1
+        assert c["r"] == 255
+        assert c["hex"] == "#ff0000"
+
+    def test_single_color_via_global_weft_default(self):
+        result = extract_colors(_cwif("2=0,255,0", weft_default="2"))
+        assert len(result) == 1
+        assert result[0]["index"] == 2
+        assert result[0]["hex"] == "#00ff00"
+
+    def test_single_color_via_global_warp_default(self):
+        result = extract_colors(_cwif("3=0,0,255", warp_default="3"))
+        assert len(result) == 1
+        assert result[0]["hex"] == "#0000ff"
+
+    def test_single_color_via_warp_colors(self):
+        result = extract_colors(_cwif("4=128,0,128", warp_colors="1=4"))
+        assert len(result) == 1
+        assert result[0]["index"] == 4
+
+    def test_unreferenced_color_excluded(self):
+        """Color 2 is in the table but not referenced — must not appear."""
+        result = extract_colors(_cwif("1=255,0,0\n2=0,255,0", weft_colors="1=1"))
+        assert len(result) == 1
+        assert result[0]["index"] == 1
+
+    def test_multiple_referenced_colors_sorted(self):
+        result = extract_colors(_cwif("3=0,0,255\n1=255,0,0\n2=0,255,0", weft_colors="1=3\n2=1\n3=2"))
+        assert [c["index"] for c in result] == [1, 2, 3]
+        assert result[0]["hex"] == "#ff0000"
+        assert result[1]["hex"] == "#00ff00"
+        assert result[2]["hex"] == "#0000ff"
+
+    def test_scale_65535_normalized_to_255(self):
+        result = extract_colors(_cwif("1=65535,0,0", palette="Range=0,65535", weft_colors="1=1"))
+        assert result[0]["r"] == 255
+        assert result[0]["hex"] == "#ff0000"
+
+    def test_scale_100_normalized(self):
+        result = extract_colors(_cwif("1=100,0,0", palette="Range=0,100", weft_colors="1=1"))
+        assert result[0]["r"] == 255
+        assert result[0]["hex"] == "#ff0000"
+
+    def test_values_clamped_below_zero(self):
+        result = extract_colors(_cwif("1=-10,0,0", weft_colors="1=1"))
+        assert result[0]["r"] == 0
+
+    def test_values_clamped_above_255(self):
+        result = extract_colors(_cwif("1=300,0,0", weft_colors="1=1"))
+        assert result[0]["r"] == 255
+
+    def test_short_rgb_entry_skipped(self):
+        result = extract_colors(_cwif("1=100,50\n2=200,100,50", weft_colors="1=1\n2=2"))
+        assert len(result) == 1
+        assert result[0]["index"] == 2
+
+    def test_non_numeric_entry_skipped(self):
+        result = extract_colors(_cwif("1=abc,def,ghi\n2=0,255,0", weft_colors="1=1\n2=2"))
+        assert len(result) == 1
+        assert result[0]["hex"] == "#00ff00"
+
+    def test_invalid_bytes_returns_empty(self):
+        result = extract_colors(b"\xff\xfe not a wif")
+        assert result == []
+
+    def test_all_fields_present(self):
+        result = extract_colors(_cwif("1=128,64,32", weft_colors="1=1"))
+        c = result[0]
+        assert set(c.keys()) == {"index", "r", "g", "b", "hex"}
+        assert c["hex"] == f"#{128:02x}{64:02x}{32:02x}"
+
+    def test_latin1_wif_parsed(self):
+        latin1_wif = (
+            "[WIF]\nVersion=1.1\n\n[COLOR PALETTE]\nRange=0,255\n\n[COLOR TABLE]\n1=255,0,0\n\n[WEFT COLORS]\n1=1\n"
+        ).encode("latin-1")
+        result = extract_colors(latin1_wif)
+        assert len(result) == 1
+        assert result[0]["hex"] == "#ff0000"

--- a/frontend/src/api/drafts.ts
+++ b/frontend/src/api/drafts.ts
@@ -1,3 +1,26 @@
+export interface WifMeasurements {
+  warp_length?: number;           // cm, normalized
+  warp_length_original?: number;
+  warp_length_unit?: string;      // "in" | "cm" | "dp"
+  warp_spacing?: number;          // cm
+  warp_spacing_original?: number;
+  warp_spacing_unit?: string;
+  weft_length?: number;           // cm, normalized
+  weft_length_original?: number;
+  weft_length_unit?: string;
+  weft_spacing?: number;          // cm
+  weft_spacing_original?: number;
+  weft_spacing_unit?: string;
+}
+
+export interface WifColor {
+  index: number;
+  r: number;
+  g: number;
+  b: number;
+  hex: string;
+}
+
 export interface Draft {
   id: string;
   name: string;
@@ -21,6 +44,12 @@ export interface Draft {
   has_drawdown_preview: boolean;
   has_modified_file: boolean;
   metadata_overrides: Record<string, { original: number | null; override: number }> | null;
+  wif_measurements: WifMeasurements | null;
+  wif_colors: WifColor[] | null;
+  warp_length_cm: number | null;
+  warp_length_overridden: boolean;
+  weaving_width_override_cm: number | null;
+  epi_override: number | null;
   is_shared: boolean;
   created_at: string;
   updated_at: string;
@@ -122,5 +151,40 @@ export async function overrideDraftMetadata(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ field, value }),
+  });
+}
+
+export async function setDraftWarpLength(
+  id: string,
+  warpLength: number,
+  unit: "cm" | "in",
+): Promise<DraftDetail> {
+  return req(`/api/drafts/${id}/measurements`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ warp_length: warpLength, unit }),
+  });
+}
+
+export async function setDraftWeavingWidth(
+  id: string,
+  width: number,
+  unit: "cm" | "in",
+): Promise<DraftDetail> {
+  return req(`/api/drafts/${id}/measurements`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ weaving_width: width, unit }),
+  });
+}
+
+export async function setDraftEpi(
+  id: string,
+  epi: number,
+): Promise<DraftDetail> {
+  return req(`/api/drafts/${id}/measurements`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ epi, unit: "cm" }),
   });
 }

--- a/frontend/src/components/projects/CreateProjectModal.tsx
+++ b/frontend/src/components/projects/CreateProjectModal.tsx
@@ -4,6 +4,8 @@ import { createProject, completeProject, abandonProject, listProjects, ApiError,
 import { listDrafts } from "@/api/drafts";
 import { listLooms, getLoom, SUPPORTED_LOOM_TYPES } from "@/api/looms";
 import { Button } from "@/components/ui/button";
+import { useAuthContext } from "@/context/AuthContext";
+import { measurementSystemToUnit, convertLength, formatLength } from "@/lib/units";
 
 interface Props {
   onSuccess: (id: string) => void;
@@ -23,6 +25,7 @@ function convertLen(value: string, toUnit: "cm" | "in"): string {
 const f = "w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
 
 export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props) {
+  const { user } = useAuthContext();
   const [name, setName] = useState("");
   const [draftId, setDraftId] = useState(defaultDraftId ?? "");
   const [projectType, setProjectType] = useState<ProjectType | "">("");
@@ -32,7 +35,11 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
   const [numItems, setNumItems] = useState("1");
   const [wasteBetween, setWasteBetween] = useState("");
   const [warpWaste, setWarpWaste] = useState("");
-  const [lengthUnit, setLengthUnit] = useState<"cm" | "in">("cm");
+  const [lengthUnit, setLengthUnit] = useState<"cm" | "in">(
+    measurementSystemToUnit(user?.measurement_system ?? "metric")
+  );
+  // Track previous draft ID to detect when draft selection changes.
+  const [prevDraftId, setPrevDraftId] = useState<string | undefined>(undefined);
 
   const handleUnitChange = (newUnit: "cm" | "in") => {
     setFinishedLength((v) => convertLen(v, newUnit));
@@ -54,6 +61,18 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
 
   const selectedDraft = drafts.find((d) => d.id === draftId);
   const selectedLoom = looms.find((l) => l.id === loomId);
+
+  // Pre-populate finished length when draft selection changes (setState during render — React-approved).
+  const warpLengthDefaultCm = selectedDraft?.warp_length_cm ?? null;
+  if (selectedDraft?.id !== prevDraftId) {
+    setPrevDraftId(selectedDraft?.id);
+    if (selectedDraft?.warp_length_cm != null) {
+      const val = convertLength(selectedDraft.warp_length_cm, "cm", lengthUnit);
+      setFinishedLength(parseFloat(val.toFixed(1)).toString());
+    } else {
+      setFinishedLength("");
+    }
+  }
 
   // Filter project types by what the WIF supports and loom supports
   const availableTypes: ProjectType[] = [];
@@ -110,6 +129,20 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
     selectedDraft?.num_shafts != null &&
     selectedDraft?.effective_num_shafts != null &&
     selectedDraft.num_shafts !== selectedDraft.effective_num_shafts;
+
+  const draftHasWarpLength = selectedDraft?.warp_length_cm != null;
+  const finishedLengthCm = finishedLength !== "" && !isNaN(parseFloat(finishedLength))
+    ? convertLength(parseFloat(finishedLength), lengthUnit, "cm")
+    : null;
+  const warpLengthDefaultLabel = warpLengthDefaultCm != null
+    ? formatLength(convertLength(warpLengthDefaultCm, "cm", lengthUnit), lengthUnit)
+    : null;
+  const finishedLengthDeviatesFromDefault = warpLengthDefaultCm != null
+    && finishedLengthCm != null
+    && Math.abs(finishedLengthCm - warpLengthDefaultCm) > 0.5;
+  const finishedLengthMatchesDefault = warpLengthDefaultCm != null
+    && finishedLengthCm != null
+    && Math.abs(finishedLengthCm - warpLengthDefaultCm) <= 0.5;
 
   const loomWasteInCurrentUnit = (allowance: string | null | undefined, wasteUnit: string): string => {
     if (!allowance) return "";
@@ -311,40 +344,73 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
           <div className="border-t pt-4">
             <p className="mb-3 text-xs font-medium text-muted-foreground uppercase tracking-wide">Warp plan</p>
             <p className="mb-3 text-xs text-muted-foreground">Warp plan tracking is not yet available. These fields are coming in a future update.</p>
+
+            {selectedDraft && !draftHasWarpLength && (
+              <div className="mb-3 rounded-md border border-border bg-muted px-3 py-2.5 text-sm">
+                <p className="font-medium text-foreground">Warp length not set</p>
+                <p className="mt-0.5 text-xs text-subdued">
+                  Set the warp length on the draft page to enable warp waste and spacing calculations.
+                </p>
+              </div>
+            )}
+
             <div className="grid grid-cols-3 gap-3">
               <div className="col-span-2">
                 <label className="mb-1 block text-sm font-medium">Finished length / item</label>
                 <div className="flex gap-2">
-                  <input type="number" min={0} step="0.1" className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring" value={finishedLength} onChange={(e) => setFinishedLength(e.target.value)} placeholder="50" />
-                  <select className="rounded-md border border-input bg-background px-2 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring" value={lengthUnit} onChange={(e) => handleUnitChange(e.target.value as "cm" | "in")}>
+                  <input
+                    type="number"
+                    min={0}
+                    step="0.1"
+                    className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                    value={finishedLength}
+                    onChange={(e) => setFinishedLength(e.target.value)}
+                    placeholder="50"
+                  />
+                  <select
+                    className="rounded-md border border-input bg-background px-2 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                    value={lengthUnit}
+                    onChange={(e) => handleUnitChange(e.target.value as "cm" | "in")}
+                  >
                     <option value="cm">cm</option>
                     <option value="in">in</option>
                   </select>
                 </div>
+                {finishedLengthDeviatesFromDefault && (
+                  <p className="mt-1 text-xs text-copper-on-subtle">
+                    Changed from WIF warp length ({warpLengthDefaultLabel})
+                  </p>
+                )}
+                {finishedLengthMatchesDefault && (
+                  <p className="mt-1 text-xs text-muted-foreground">Pre-filled from WIF warp length</p>
+                )}
               </div>
               <div>
                 <label className="mb-1 block text-sm font-medium">Number of items</label>
                 <input type="number" min={1} step="1" className={f} value={numItems} onChange={(e) => setNumItems(e.target.value)} />
               </div>
             </div>
-            <div className="grid grid-cols-2 gap-3 mt-3">
-              {parseInt(numItems, 10) > 1 && (
-                <div>
-                  <label className="mb-1 block text-sm font-medium">Waste between items</label>
+
+            {draftHasWarpLength && (
+              <div className="grid grid-cols-2 gap-3 mt-3">
+                {parseInt(numItems, 10) > 1 && (
+                  <div>
+                    <label className="mb-1 block text-sm font-medium">Waste between items</label>
+                    <div className="flex gap-1">
+                      <input type="number" min={0} step="0.1" className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring" value={wasteBetween} onChange={(e) => setWasteBetween(e.target.value)} placeholder="5" />
+                      <span className="flex items-center rounded-md border border-input bg-muted px-2 text-sm text-muted-foreground">{lengthUnit}</span>
+                    </div>
+                  </div>
+                )}
+                <div className={parseInt(numItems, 10) <= 1 ? "col-span-2" : ""}>
+                  <label className="mb-1 block text-sm font-medium">Loom warp waste</label>
                   <div className="flex gap-1">
-                    <input type="number" min={0} step="0.1" className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring" value={wasteBetween} onChange={(e) => setWasteBetween(e.target.value)} placeholder="5" />
+                    <input type="number" min={0} step="0.1" className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring" value={warpWaste || loomWasteInCurrentUnit(selectedVersion?.warp_waste_allowance ?? loomDetail?.versions.at(-1)?.warp_waste_allowance, selectedVersion?.warp_waste_unit ?? loomDetail?.versions.at(-1)?.warp_waste_unit ?? "cm")} onChange={(e) => setWarpWaste(e.target.value)} placeholder="30" />
                     <span className="flex items-center rounded-md border border-input bg-muted px-2 text-sm text-muted-foreground">{lengthUnit}</span>
                   </div>
                 </div>
-              )}
-              <div className={parseInt(numItems, 10) <= 1 ? "col-span-2" : ""}>
-                <label className="mb-1 block text-sm font-medium">Loom warp waste</label>
-                <div className="flex gap-1">
-                  <input type="number" min={0} step="0.1" className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring" value={warpWaste || loomWasteInCurrentUnit(selectedVersion?.warp_waste_allowance ?? loomDetail?.versions.at(-1)?.warp_waste_allowance, selectedVersion?.warp_waste_unit ?? loomDetail?.versions.at(-1)?.warp_waste_unit ?? "cm")} onChange={(e) => setWarpWaste(e.target.value)} placeholder="30" />
-                  <span className="flex items-center rounded-md border border-input bg-muted px-2 text-sm text-muted-foreground">{lengthUnit}</span>
-                </div>
               </div>
-            </div>
+            )}
           </div>
 
           {conflictProject && (

--- a/frontend/src/lib/colorName.ts
+++ b/frontend/src/lib/colorName.ts
@@ -1,0 +1,74 @@
+// Nearest CSS named color lookup using squared Euclidean RGB distance.
+// Grey/gray duplicates and CSS aliases (aqua=cyan, fuchsia=magenta) are deduplicated.
+
+const NAMED: [string, string][] = [
+  ["f0f8ff","aliceblue"],["faebd7","antiquewhite"],["00ffff","aqua"],
+  ["7fffd4","aquamarine"],["f0ffff","azure"],["f5f5dc","beige"],
+  ["ffe4c4","bisque"],["000000","black"],["ffebcd","blanchedalmond"],
+  ["0000ff","blue"],["8a2be2","blueviolet"],["a52a2a","brown"],
+  ["deb887","burlywood"],["5f9ea0","cadetblue"],["7fff00","chartreuse"],
+  ["d2691e","chocolate"],["ff7f50","coral"],["6495ed","cornflowerblue"],
+  ["fff8dc","cornsilk"],["dc143c","crimson"],["00008b","darkblue"],
+  ["008b8b","darkcyan"],["b8860b","darkgoldenrod"],["a9a9a9","darkgray"],
+  ["006400","darkgreen"],["bdb76b","darkkhaki"],["8b008b","darkmagenta"],
+  ["556b2f","darkolivegreen"],["ff8c00","darkorange"],["9932cc","darkorchid"],
+  ["8b0000","darkred"],["e9967a","darksalmon"],["8fbc8f","darkseagreen"],
+  ["483d8b","darkslateblue"],["2f4f4f","darkslategray"],["00ced1","darkturquoise"],
+  ["9400d3","darkviolet"],["ff1493","deeppink"],["00bfff","deepskyblue"],
+  ["696969","dimgray"],["1e90ff","dodgerblue"],["b22222","firebrick"],
+  ["fffaf0","floralwhite"],["228b22","forestgreen"],["dcdcdc","gainsboro"],
+  ["f8f8ff","ghostwhite"],["ffd700","gold"],["daa520","goldenrod"],
+  ["808080","gray"],["008000","green"],["adff2f","greenyellow"],
+  ["f0fff0","honeydew"],["ff69b4","hotpink"],["cd5c5c","indianred"],
+  ["4b0082","indigo"],["fffff0","ivory"],["f0e68c","khaki"],
+  ["e6e6fa","lavender"],["fff0f5","lavenderblush"],["7cfc00","lawngreen"],
+  ["fffacd","lemonchiffon"],["add8e6","lightblue"],["f08080","lightcoral"],
+  ["e0ffff","lightcyan"],["fafad2","lightgoldenrodyellow"],["d3d3d3","lightgray"],
+  ["90ee90","lightgreen"],["ffb6c1","lightpink"],["ffa07a","lightsalmon"],
+  ["20b2aa","lightseagreen"],["87cefa","lightskyblue"],["778899","lightslategray"],
+  ["b0c4de","lightsteelblue"],["ffffe0","lightyellow"],["00ff00","lime"],
+  ["32cd32","limegreen"],["faf0e6","linen"],["ff00ff","magenta"],
+  ["800000","maroon"],["66cdaa","mediumaquamarine"],["0000cd","mediumblue"],
+  ["ba55d3","mediumorchid"],["9370db","mediumpurple"],["3cb371","mediumseagreen"],
+  ["7b68ee","mediumslateblue"],["00fa9a","mediumspringgreen"],["48d1cc","mediumturquoise"],
+  ["c71585","mediumvioletred"],["191970","midnightblue"],["f5fffa","mintcream"],
+  ["ffe4e1","mistyrose"],["ffe4b5","moccasin"],["ffdead","navajowhite"],
+  ["000080","navy"],["fdf5e6","oldlace"],["808000","olive"],
+  ["6b8e23","olivedrab"],["ffa500","orange"],["ff4500","orangered"],
+  ["da70d6","orchid"],["eee8aa","palegoldenrod"],["98fb98","palegreen"],
+  ["afeeee","paleturquoise"],["db7093","palevioletred"],["ffefd5","papayawhip"],
+  ["ffdab9","peachpuff"],["cd853f","peru"],["ffc0cb","pink"],
+  ["dda0dd","plum"],["b0e0e6","powderblue"],["800080","purple"],
+  ["663399","rebeccapurple"],["ff0000","red"],["bc8f8f","rosybrown"],
+  ["4169e1","royalblue"],["8b4513","saddlebrown"],["fa8072","salmon"],
+  ["f4a460","sandybrown"],["2e8b57","seagreen"],["fff5ee","seashell"],
+  ["a0522d","sienna"],["c0c0c0","silver"],["87ceeb","skyblue"],
+  ["6a5acd","slateblue"],["708090","slategray"],["fffafa","snow"],
+  ["00ff7f","springgreen"],["4682b4","steelblue"],["d2b48c","tan"],
+  ["008080","teal"],["d8bfd8","thistle"],["ff6347","tomato"],
+  ["40e0d0","turquoise"],["ee82ee","violet"],["f5deb3","wheat"],
+  ["ffffff","white"],["f5f5f5","whitesmoke"],["ffff00","yellow"],
+  ["9acd32","yellowgreen"],
+];
+
+const TABLE: [number, number, number, string][] = NAMED.map(([h, n]) => [
+  parseInt(h.slice(0, 2), 16),
+  parseInt(h.slice(2, 4), 16),
+  parseInt(h.slice(4, 6), 16),
+  n,
+]);
+
+export function nearestColorName(hex: string): string {
+  const h = hex.replace("#", "");
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  let best = TABLE[0][3];
+  let bestD = Infinity;
+  for (const [tr, tg, tb, name] of TABLE) {
+    const d = (r - tr) ** 2 + (g - tg) ** 2 + (b - tb) ** 2;
+    if (d < bestD) { bestD = d; best = name; }
+    if (d === 0) break;
+  }
+  return best;
+}

--- a/frontend/src/lib/units.ts
+++ b/frontend/src/lib/units.ts
@@ -1,0 +1,28 @@
+export type LengthUnit = "cm" | "in";
+
+const CM_PER_IN = 2.54;
+
+export function measurementSystemToUnit(system: string): LengthUnit {
+  return system === "imperial" ? "in" : "cm";
+}
+
+export function convertLength(value: number, from: LengthUnit, to: LengthUnit): number {
+  if (from === to) return value;
+  return from === "cm" ? value / CM_PER_IN : value * CM_PER_IN;
+}
+
+export function formatLength(value: number, unit: LengthUnit, decimals = 1): string {
+  return `${value.toFixed(decimals)} ${unit}`;
+}
+
+export function displayLength(
+  value: number | string | null | undefined,
+  storedUnit: string,
+  displayUnit: LengthUnit,
+): string | null {
+  if (value == null || value === "") return null;
+  const num = typeof value === "string" ? parseFloat(value) : value;
+  if (isNaN(num)) return null;
+  const converted = convertLength(num, storedUnit as LengthUnit, displayUnit);
+  return formatLength(converted, displayUnit);
+}

--- a/frontend/src/pages/DraftDetailPage.tsx
+++ b/frontend/src/pages/DraftDetailPage.tsx
@@ -2,24 +2,37 @@ import { useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { AppIcons } from "@/lib/icons";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getDraft, deleteDraft, generateLiftplan, overrideDraftMetadata, previewSvgUrl, downloadWif, downloadWifModified } from "@/api/drafts";
+import { getDraft, deleteDraft, generateLiftplan, overrideDraftMetadata, setDraftWarpLength, setDraftWeavingWidth, setDraftEpi, previewSvgUrl, downloadWif, downloadWifModified } from "@/api/drafts";
 import { listProjects } from "@/api/projects";
 import { ProjectSummaryList } from "@/components/projects/ProjectSummaryList";
 import { CreateProjectModal } from "@/components/projects/CreateProjectModal";
 import { DraftPreviewModal } from "@/components/drafts/DraftPreviewModal";
 import { Button } from "@/components/ui/button";
 import { AuthedImage } from "@/components/ui/AuthedImage";
+import { useAuthContext } from "@/context/AuthContext";
+import { measurementSystemToUnit, convertLength, formatLength } from "@/lib/units";
+import { nearestColorName } from "@/lib/colorName";
 
 export function DraftDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { user } = useAuthContext();
+  const displayUnit = measurementSystemToUnit(user?.measurement_system ?? "metric");
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [showDangerZone, setShowDangerZone] = useState(false);
   const [showCreateProject, setShowCreateProject] = useState(false);
   const [downloading, setDownloading] = useState(false);
   const [downloadError, setDownloadError] = useState<string | null>(null);
   const [showPreviewModal, setShowPreviewModal] = useState(false);
+  const [editingWarpLength, setEditingWarpLength] = useState(false);
+  const [warpLengthInput, setWarpLengthInput] = useState("");
+  const [warpLengthUnit, setWarpLengthUnit] = useState<"cm" | "in">(displayUnit);
+  const [editingWeavingWidth, setEditingWeavingWidth] = useState(false);
+  const [weavingWidthInput, setWeavingWidthInput] = useState("");
+  const [weavingWidthUnit, setWeavingWidthUnit] = useState<"cm" | "in">(displayUnit);
+  const [editingEpi, setEditingEpi] = useState(false);
+  const [epiInput, setEpiInput] = useState("");
 
   const { data: draft, isLoading, error } = useQuery({
     queryKey: ["draft", id],
@@ -58,6 +71,38 @@ export function DraftDetailPage() {
     },
   });
 
+  const warpLengthMutation = useMutation({
+    mutationFn: ({ length, unit }: { length: number; unit: "cm" | "in" }) =>
+      setDraftWarpLength(id!, length, unit),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(["draft", id], updated);
+      queryClient.invalidateQueries({ queryKey: ["drafts"] });
+      setEditingWarpLength(false);
+      setWarpLengthInput("");
+    },
+  });
+
+  const weavingWidthMutation = useMutation({
+    mutationFn: ({ width, unit }: { width: number; unit: "cm" | "in" }) =>
+      setDraftWeavingWidth(id!, width, unit),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(["draft", id], updated);
+      queryClient.invalidateQueries({ queryKey: ["drafts"] });
+      setEditingWeavingWidth(false);
+      setWeavingWidthInput("");
+    },
+  });
+
+  const epiMutation = useMutation({
+    mutationFn: ({ epi }: { epi: number }) => setDraftEpi(id!, epi),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(["draft", id], updated);
+      queryClient.invalidateQueries({ queryKey: ["drafts"] });
+      setEditingEpi(false);
+      setEpiInput("");
+    },
+  });
+
   if (isLoading) {
     return (
       <div className="flex h-screen items-center justify-center">
@@ -73,6 +118,36 @@ export function DraftDetailPage() {
       </div>
     );
   }
+
+  // Weaving width: user override → WIF weft_length → calculated from thread count × spacing
+  const weavingWidthCm: number | null =
+    draft.weaving_width_override_cm ??
+    draft.wif_measurements?.weft_length ??
+    (draft.warp_threads != null && draft.wif_measurements?.warp_spacing != null
+      ? draft.warp_threads * draft.wif_measurements.warp_spacing
+      : null);
+  const weavingWidthSource: "override" | "wif" | "calculated" | null =
+    draft.weaving_width_override_cm != null ? "override" :
+    draft.wif_measurements?.weft_length != null ? "wif" :
+    (draft.warp_threads != null && draft.wif_measurements?.warp_spacing != null) ? "calculated" :
+    null;
+
+  // EPI: user override → WIF warp_spacing → calculated from width ÷ thread count
+  const epiFromSpacing =
+    draft.wif_measurements?.warp_spacing != null && draft.wif_measurements.warp_spacing > 0
+      ? Math.round((2.54 / draft.wif_measurements.warp_spacing) * 10) / 10
+      : null;
+  const epiFromWidthAndCount =
+    weavingWidthCm != null && weavingWidthCm > 0 && draft.warp_threads != null
+      ? Math.round((draft.warp_threads / (weavingWidthCm / 2.54)) * 10) / 10
+      : null;
+  const resolvedEpi: number | null =
+    draft.epi_override ?? epiFromSpacing ?? epiFromWidthAndCount;
+  const epiSource: "override" | "spacing" | "calculated" | null =
+    draft.epi_override != null ? "override" :
+    epiFromSpacing != null ? "spacing" :
+    epiFromWidthAndCount != null ? "calculated" :
+    null;
 
   return (
     <div className="p-6 max-w-5xl mx-auto w-full space-y-6">
@@ -175,7 +250,251 @@ export function DraftDetailPage() {
                     <dd>{draft.wif_source_software}{draft.wif_source_version ? ` ${draft.wif_source_version}` : ""}</dd>
                   </>
                 )}
+                <dt className="text-muted-foreground">Warp length</dt>
+                <dd>
+                  {editingWarpLength ? (
+                    <form
+                      className="flex items-center gap-1.5 flex-wrap"
+                      onSubmit={(e) => {
+                        e.preventDefault();
+                        const v = parseFloat(warpLengthInput);
+                        if (!isNaN(v) && v > 0) {
+                          warpLengthMutation.mutate({ length: v, unit: warpLengthUnit });
+                        }
+                      }}
+                    >
+                      <input
+                        type="number"
+                        min={0}
+                        step="0.1"
+                        className="w-24 rounded-md border border-input bg-background px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                        value={warpLengthInput}
+                        onChange={(e) => setWarpLengthInput(e.target.value)}
+                        placeholder="e.g. 500"
+                        autoFocus
+                        required
+                      />
+                      <select
+                        className="rounded-md border border-input bg-background px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                        value={warpLengthUnit}
+                        onChange={(e) => setWarpLengthUnit(e.target.value as "cm" | "in")}
+                      >
+                        <option value="cm">cm</option>
+                        <option value="in">in</option>
+                      </select>
+                      <Button type="submit" size="sm" disabled={warpLengthMutation.isPending}>
+                        {warpLengthMutation.isPending ? "Saving…" : "Save"}
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={() => { setEditingWarpLength(false); setWarpLengthInput(""); }}
+                        disabled={warpLengthMutation.isPending}
+                      >
+                        Cancel
+                      </Button>
+                      {warpLengthMutation.isError && (
+                        <span className="text-xs text-destructive">
+                          {warpLengthMutation.error instanceof Error ? warpLengthMutation.error.message : "Save failed"}
+                        </span>
+                      )}
+                    </form>
+                  ) : (
+                    <div className="flex items-center gap-2 flex-wrap">
+                      {draft.warp_length_cm != null ? (
+                        <>
+                          <span>{formatLength(convertLength(draft.warp_length_cm, "cm", displayUnit), displayUnit)}</span>
+                          {draft.wif_measurements?.warp_length != null && !draft.warp_length_overridden && (
+                            <span className="text-xs text-muted-foreground">
+                              ({draft.wif_measurements.warp_length_original} {draft.wif_measurements.warp_length_unit} in WIF)
+                            </span>
+                          )}
+                          {draft.warp_length_overridden && draft.wif_measurements?.warp_length != null && (
+                            <span className="text-xs text-muted-foreground">
+                              (WIF: {draft.wif_measurements.warp_length_original} {draft.wif_measurements.warp_length_unit}, overridden)
+                            </span>
+                          )}
+                          <button
+                            type="button"
+                            className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+                            onClick={() => {
+                              const v = convertLength(draft.warp_length_cm!, "cm", displayUnit);
+                              setWarpLengthInput(parseFloat(v.toFixed(1)).toString());
+                              setWarpLengthUnit(displayUnit);
+                              setEditingWarpLength(true);
+                            }}
+                          >
+                            Edit
+                          </button>
+                        </>
+                      ) : (
+                        <>
+                          <span className="text-muted-foreground">Not set</span>
+                          <button
+                            type="button"
+                            className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+                            onClick={() => { setWarpLengthInput(""); setWarpLengthUnit(displayUnit); setEditingWarpLength(true); }}
+                          >
+                            Set
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  )}
+                </dd>
+                {draft.warp_length_cm == null && !editingWarpLength && (
+                  <>
+                    <dt />
+                    <dd className="text-xs text-subdued">
+                      Warp calculations unavailable until warp length is set.
+                    </dd>
+                  </>
+                )}
+                <dt className="text-muted-foreground">Weaving width</dt>
+                <dd>
+                  {editingWeavingWidth ? (
+                    <div className="flex items-center gap-1 flex-wrap">
+                      <input
+                        type="number"
+                        min="0"
+                        step="0.1"
+                        className="w-20 rounded border border-border bg-input px-2 py-0.5 text-sm"
+                        value={weavingWidthInput}
+                        onChange={(e) => setWeavingWidthInput(e.target.value)}
+                      />
+                      <select
+                        className="rounded border border-border bg-input px-1 py-0.5 text-sm"
+                        value={weavingWidthUnit}
+                        onChange={(e) => setWeavingWidthUnit(e.target.value as "cm" | "in")}
+                      >
+                        <option value="cm">cm</option>
+                        <option value="in">in</option>
+                      </select>
+                      <button
+                        type="button"
+                        className="text-xs text-accent underline underline-offset-2"
+                        onClick={() => {
+                          const v = parseFloat(weavingWidthInput);
+                          if (!isNaN(v) && v > 0) weavingWidthMutation.mutate({ width: v, unit: weavingWidthUnit });
+                        }}
+                      >Save</button>
+                      <button
+                        type="button"
+                        className="text-xs text-muted-foreground underline underline-offset-2"
+                        onClick={() => { setEditingWeavingWidth(false); setWeavingWidthInput(""); }}
+                      >Cancel</button>
+                    </div>
+                  ) : weavingWidthCm != null ? (
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span>{formatLength(convertLength(weavingWidthCm, "cm", displayUnit), displayUnit)}</span>
+                      {weavingWidthSource === "wif" && draft.wif_measurements?.weft_length_unit !== displayUnit && (
+                        <span className="text-xs text-muted-foreground">
+                          ({draft.wif_measurements!.weft_length_original} {draft.wif_measurements!.weft_length_unit} in WIF)
+                        </span>
+                      )}
+                      {weavingWidthSource === "calculated" && (
+                        <span className="text-xs text-muted-foreground">(thread count × spacing)</span>
+                      )}
+                      {weavingWidthSource === "override" && (
+                        <span className="text-xs text-muted-foreground">(manually set)</span>
+                      )}
+                      <button
+                        type="button"
+                        className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+                        onClick={() => {
+                          setWeavingWidthInput(String(Math.round(convertLength(weavingWidthCm, "cm", displayUnit) * 10) / 10));
+                          setWeavingWidthUnit(displayUnit);
+                          setEditingWeavingWidth(true);
+                        }}
+                      >Edit</button>
+                    </div>
+                  ) : (
+                    <div className="flex items-center gap-2">
+                      <span className="text-muted-foreground">Not set</span>
+                      <button
+                        type="button"
+                        className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+                        onClick={() => { setWeavingWidthInput(""); setWeavingWidthUnit(displayUnit); setEditingWeavingWidth(true); }}
+                      >Set</button>
+                    </div>
+                  )}
+                </dd>
+                <dt className="text-muted-foreground">EPI</dt>
+                <dd>
+                  {editingEpi ? (
+                    <div className="flex items-center gap-1">
+                      <input
+                        type="number"
+                        min="0"
+                        step="0.5"
+                        className="w-20 rounded border border-border bg-input px-2 py-0.5 text-sm"
+                        value={epiInput}
+                        onChange={(e) => setEpiInput(e.target.value)}
+                      />
+                      <span className="text-sm text-muted-foreground">ends/in</span>
+                      <button
+                        type="button"
+                        className="text-xs text-accent underline underline-offset-2"
+                        onClick={() => {
+                          const v = parseFloat(epiInput);
+                          if (!isNaN(v) && v > 0) epiMutation.mutate({ epi: v });
+                        }}
+                      >Save</button>
+                      <button
+                        type="button"
+                        className="text-xs text-muted-foreground underline underline-offset-2"
+                        onClick={() => { setEditingEpi(false); setEpiInput(""); }}
+                      >Cancel</button>
+                    </div>
+                  ) : resolvedEpi != null ? (
+                    <div className="flex items-center gap-2">
+                      <span>{resolvedEpi} ends/in</span>
+                      {epiSource === "calculated" && (
+                        <span className="text-xs text-muted-foreground">(width ÷ thread count)</span>
+                      )}
+                      {epiSource === "spacing" && (
+                        <span className="text-xs text-muted-foreground">(from WIF spacing)</span>
+                      )}
+                      {epiSource === "override" && (
+                        <span className="text-xs text-muted-foreground">(manually set)</span>
+                      )}
+                      <button
+                        type="button"
+                        className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+                        onClick={() => { setEpiInput(String(resolvedEpi)); setEditingEpi(true); }}
+                      >Edit</button>
+                    </div>
+                  ) : (
+                    <div className="flex items-center gap-2">
+                      <span className="text-muted-foreground">Not set</span>
+                      <button
+                        type="button"
+                        className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+                        onClick={() => { setEpiInput(""); setEditingEpi(true); }}
+                      >Set</button>
+                    </div>
+                  )}
+                </dd>
               </dl>
+
+              {draft.wif_colors && draft.wif_colors.length > 0 && (
+                <div className="mt-4 space-y-2">
+                  <h3 className="text-sm font-medium">Color palette</h3>
+                  <div className="flex flex-wrap gap-2">
+                    {draft.wif_colors.map((c) => (
+                      <div key={c.index} className="flex flex-col items-center gap-1 w-16" title={`#${c.index}: RGB(${c.r}, ${c.g}, ${c.b}) — ${c.hex}`}>
+                        <div
+                          className="h-8 w-16 rounded border border-border flex-shrink-0"
+                          style={{ backgroundColor: c.hex }}
+                        />
+                        <span className="text-[10px] text-muted-foreground font-mono leading-none">{c.hex}</span>
+                        <span className="text-[10px] text-subdued leading-none text-center">{nearestColorName(c.hex)}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
             </div>
 
             <div className="space-y-3 border-t pt-4">


### PR DESCRIPTION
## Summary

- **WIF measurement extraction** — warp/weft length and spacing parsed on import, normalized to cm in DB (migrations 0014–0016)
- **Color palette** — extracts only colors referenced in the design (WEFT/WARP COLORS sections), displays swatches with hex value and nearest CSS color name
- **Weaving width** — tri-level resolution: WIF `[WEFT] Length` → `thread count × spacing` → user manual entry; shows source context inline
- **EPI** — tri-level resolution: WIF `[WARP] Spacing` → `width ÷ thread count` → user manual entry; shows source context inline
- **Warp length** — existing WIF extraction; inline edit with unit selector per field (no effect on global preference)
- **CreateProjectModal** — pre-populates finished length from draft warp length; hides warp waste fields and shows banner when warp length not set
- **Reparse task** — Celery task backfills existing drafts with measurements and color data

## Closes

Closes #47, closes #625

## Migrations

Three new migrations (sequential, no breaking changes):
- `0014` — `wif_measurements` (JSONB), `warp_length_cm` (float), `warp_length_overridden` (bool)
- `0015` — `wif_colors` (JSONB)
- `0016` — `weaving_width_override_cm` (float), `epi_override` (float)

## Test plan

- [ ] Upload a WIF with `[WARP] Spacing` set — EPI row should show calculated value with "(from WIF spacing)" note
- [ ] Upload a WIF with `[WARP] Length` set — warp length row should show value; warp length in CreateProjectModal pre-populated
- [ ] Upload a WIF with `[COLOR TABLE]` — only colors referenced in WEFT/WARP COLORS appear in palette; color names shown
- [ ] Draft with no warp length: CreateProjectModal shows banner, hides warp waste fields
- [ ] Manually set weaving width or EPI via inline form — shows "(manually set)"
- [ ] Unit selector per field (cm/in) works independently; doesn't affect other fields or global preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)