### PR TITLE
feat: loading skeleton for draft detail design preview

### DIFF
--- a/frontend/src/components/ui/AuthedImage.tsx
+++ b/frontend/src/components/ui/AuthedImage.tsx
@@ -3,9 +3,10 @@ import { getAuthToken } from "@/api/client";
 
 interface Props extends React.ImgHTMLAttributes<HTMLImageElement> {
   src: string;
+  loadingContent?: React.ReactNode;
 }
 
-export function AuthedImage({ src, ...props }: Props) {
+export function AuthedImage({ src, loadingContent, ...props }: Props) {
   const [blobUrl, setBlobUrl] = useState<string | null>(null);
 
   useEffect(() => {
@@ -35,6 +36,6 @@ export function AuthedImage({ src, ...props }: Props) {
     };
   }, [src]);
 
-  if (!blobUrl) return null;
+  if (!blobUrl) return loadingContent ? <>{loadingContent}</> : null;
   return <img src={blobUrl} {...props} />;
 }

--- a/frontend/src/pages/DraftDetailPage.tsx
+++ b/frontend/src/pages/DraftDetailPage.tsx
@@ -712,6 +712,11 @@ export function DraftDetailPage() {
                   alt={`Draft preview for ${draft.name}`}
                   className="max-w-full group-hover:opacity-90 transition-opacity"
                   data-testid="draft-preview-img"
+                  loadingContent={
+                    <div className="w-full min-h-48 animate-pulse rounded-md bg-muted flex items-center justify-center">
+                      <span className="text-sm text-muted-foreground">Rendering preview…</span>
+                    </div>
+                  }
                 />
                 <p className="mt-1.5 text-xs text-muted-foreground text-center opacity-0 group-hover:opacity-100 transition-opacity">
                   Click to zoom


### PR DESCRIPTION
## Summary
- `AuthedImage` gains an optional `loadingContent?: React.ReactNode` prop — rendered during the authenticated fetch instead of returning `null`; all existing callers unaffected
- `DraftDetailPage` passes a pulsing `bg-muted` skeleton with "Rendering preview…" label so the preview box is never a blank white void while the SVG loads

## Motivation
On mobile, the `/preview/svg` endpoint for large drafts (e.g. Waffle 1) returns 116–189 MB and takes 18–43 s. The preview box was a silent white rectangle the entire time.

## Test plan
- [ ] Open a draft detail page — preview box shows animated skeleton immediately
- [ ] SVG loads and replaces the skeleton cleanly
- [ ] Other `AuthedImage` usages (yarn photo, loom photos, project previews) unchanged — still render `null` while loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)