### PR TITLE
feat: pre-rendered PNG thumbnails for draft drawdown previews (#640)

### DIFF
--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -233,6 +233,19 @@ async def get_preview(
     return Response(content=png, media_type="image/png")
 
 
+@router.get("/{draft_id}/drawdown_preview")
+async def get_drawdown_preview(
+    draft_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    draft = await _get_owned_draft(draft_id, current_user, db)
+    if not draft.drawdown_preview_path or not await storage.afile_exists(draft.drawdown_preview_path):
+        raise HTTPException(status_code=404, detail="Drawdown preview not available")
+    png = await storage.aread_drawdown_preview(draft.drawdown_preview_path)
+    return Response(content=png, media_type="image/png")
+
+
 @router.get("/{draft_id}/preview/svg")
 async def get_preview_svg(
     draft_id: uuid.UUID,

--- a/backend/app/tasks/post_migrate.py
+++ b/backend/app/tasks/post_migrate.py
@@ -49,6 +49,7 @@ _REDIS_KEY_PREFIX = "weftmark:post_migrate:"
 
 
 def _backfill_registry() -> list[dict]:
+    from app.tasks.preview import backfill_all_drawdown_previews
     from app.tasks.reparse import reparse_all_drafts
 
     return [
@@ -59,6 +60,15 @@ def _backfill_registry() -> list[dict]:
                 "SELECT COUNT(*) FROM drafts WHERE wif_colors IS NULL AND wif_path IS NOT NULL AND deleted_at IS NULL"
             ),
             "dispatch": lambda: reparse_all_drafts.delay(),
+        },
+        {
+            "name": "drawdown_preview",
+            "description": "Pre-render drawdown_preview PNG for drafts missing it",
+            "condition": (
+                "SELECT COUNT(*) FROM drafts"
+                " WHERE drawdown_preview_path IS NULL AND wif_path IS NOT NULL AND deleted_at IS NULL"
+            ),
+            "dispatch": lambda: backfill_all_drawdown_previews.delay(),
         },
     ]
 

--- a/backend/app/tasks/preview.py
+++ b/backend/app/tasks/preview.py
@@ -1,4 +1,9 @@
-"""Celery task: pre-generate a reduced-size drawdown preview for a draft."""
+"""Celery tasks: pre-generate draft preview images.
+
+generate_drawdown_preview  — per-draft task dispatched on WIF upload
+backfill_all_drawdown_previews — bulk task dispatched by post_migrate for
+                                  drafts missing drawdown_preview_path
+"""
 
 import asyncio
 import logging
@@ -70,3 +75,55 @@ async def _generate_preview(task: Task, draft_id: uuid.UUID) -> None:
                     pass
     finally:
         await engine.dispose()
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=0,
+    soft_time_limit=300,
+    time_limit=360,
+    name="app.tasks.preview.backfill_all_drawdown_previews",
+)
+def backfill_all_drawdown_previews(self: Task) -> dict:
+    """Dispatch generate_drawdown_preview for every draft missing a thumbnail PNG."""
+    return asyncio.run(_backfill_all_previews())
+
+
+async def _backfill_all_previews() -> dict:
+    from sqlalchemy import select
+
+    from app.config import get_settings
+    from app.models.draft import Draft
+    from app.services import storage
+
+    settings = get_settings()
+    engine = create_async_engine(settings.database_url, echo=False)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    dispatched = skipped = 0
+    try:
+        async with async_session() as db:
+            drafts = (
+                await db.scalars(
+                    select(Draft)
+                    .where(
+                        Draft.deleted_at.is_(None),
+                        Draft.drawdown_preview_path.is_(None),
+                        Draft.wif_path.isnot(None),
+                    )
+                    .order_by(Draft.created_at)
+                )
+            ).all()
+
+            for draft in drafts:
+                if not storage.file_exists(draft.wif_path):
+                    skipped += 1
+                    continue
+                generate_drawdown_preview.delay(str(draft.id))
+                dispatched += 1
+    finally:
+        await engine.dispose()
+
+    result = {"dispatched": dispatched, "skipped": skipped}
+    log.info("backfill_all_drawdown_previews_complete %s", result)
+    return result

--- a/frontend/src/api/drafts.ts
+++ b/frontend/src/api/drafts.ts
@@ -120,6 +120,10 @@ export function previewSvgUrl(id: string): string {
   return `/api/drafts/${id}/preview/svg`;
 }
 
+export function drawdownPreviewUrl(id: string): string {
+  return `/api/drafts/${id}/drawdown_preview`;
+}
+
 export async function generateLiftplan(id: string): Promise<DraftDetail> {
   return req(`/api/drafts/${id}/generate-liftplan`, { method: "POST" });
 }

--- a/frontend/src/components/drafts/DraftCard.tsx
+++ b/frontend/src/components/drafts/DraftCard.tsx
@@ -1,5 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import type { Draft } from "@/api/drafts";
+import { drawdownPreviewUrl } from "@/api/drafts";
+import { AuthedImage } from "@/components/ui/AuthedImage";
 import { AppIcons } from "@/lib/icons";
 
 interface ProjectCounts {
@@ -25,9 +27,19 @@ export function DraftCard({ draft, projectCounts }: Props) {
   return (
     <button
       data-testid="draft-card"
-      className="text-left w-full rounded-lg border bg-background p-4 shadow-sm hover:border-ring transition-colors"
+      className="text-left w-full rounded-lg border bg-background shadow-sm hover:border-ring transition-colors overflow-hidden"
       onClick={() => navigate(`/drafts/${draft.id}`)}
     >
+      {draft.has_drawdown_preview && (
+        <div className="w-full h-20 bg-muted overflow-hidden">
+          <AuthedImage
+            src={drawdownPreviewUrl(draft.id)}
+            alt=""
+            className="w-full h-full object-cover object-top"
+          />
+        </div>
+      )}
+      <div className="p-4">
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
           <h3 className="truncate font-medium">{draft.name}</h3>
@@ -109,6 +121,7 @@ export function DraftCard({ draft, projectCounts }: Props) {
           )}
         </div>
       )}
+      </div>
     </button>
   );
 }

--- a/frontend/src/components/drafts/DraftPreviewModal.tsx
+++ b/frontend/src/components/drafts/DraftPreviewModal.tsx
@@ -7,6 +7,8 @@ import { Button } from "@/components/ui/button";
 interface Props {
   draftId: string;
   draftName: string;
+  warpThreads?: number;
+  weftThreads?: number;
   onClose: () => void;
 }
 
@@ -15,12 +17,18 @@ const ZOOM_MIN = 0.25;
 const ZOOM_MAX = 4;
 const ZOOM_DEFAULT = 1;
 
+// Drafts above this thread-area threshold get a load-confirmation gate.
+// 400k threads ≈ 800 warp × 500 weft — produces a noticeably large SVG.
+const LARGE_DRAFT_THRESHOLD = 400_000;
+
 function parseSvgDimensions(svg: string): { w: number; h: number } {
   const m = svg.match(/width="(\d+(?:\.\d+)?)"[^>]*height="(\d+(?:\.\d+)?)"/);
   return m ? { w: parseFloat(m[1]), h: parseFloat(m[2]) } : { w: 800, h: 600 };
 }
 
-export function DraftPreviewModal({ draftId, draftName, onClose }: Props) {
+export function DraftPreviewModal({ draftId, draftName, warpThreads = 0, weftThreads = 0, onClose }: Props) {
+  const isLarge = warpThreads * weftThreads > LARGE_DRAFT_THRESHOLD;
+  const [confirmed, setConfirmed] = useState(!isLarge);
   const [svgContent, setSvgContent] = useState<string | null>(null);
   const [naturalDims, setNaturalDims] = useState({ w: 0, h: 0 });
   const [zoom, setZoom] = useState(ZOOM_DEFAULT);
@@ -28,6 +36,7 @@ export function DraftPreviewModal({ draftId, draftName, onClose }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    if (!confirmed) return;
     let cancelled = false;
     async function load() {
       try {
@@ -50,7 +59,7 @@ export function DraftPreviewModal({ draftId, draftName, onClose }: Props) {
     }
     load();
     return () => { cancelled = true; };
-  }, [draftId]);
+  }, [draftId, confirmed]);
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -121,13 +130,29 @@ export function DraftPreviewModal({ draftId, draftName, onClose }: Props) {
 
         {/* Content */}
         <div ref={scrollRef} className="flex-1 overflow-auto bg-muted/30 p-4">
-          {error && (
+          {!confirmed && (
+            <div className="flex items-center justify-center h-full">
+              <div className="max-w-sm rounded-lg border bg-card p-6 text-center space-y-4">
+                <p className="text-sm font-medium">Large design</p>
+                <p className="text-sm text-muted-foreground">
+                  This design has {warpThreads.toLocaleString()} warp &times; {weftThreads.toLocaleString()} weft threads.
+                  The interactive preview may be slow to load, especially on mobile.
+                </p>
+                <div className="flex justify-center gap-3">
+                  <Button size="sm" onClick={() => setConfirmed(true)}>Load preview</Button>
+                  <Button size="sm" variant="outline" onClick={onClose}>Cancel</Button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {confirmed && error && (
             <div className="flex items-center justify-center h-full">
               <p className="text-sm text-destructive">{error}</p>
             </div>
           )}
 
-          {!error && !svgContent && (
+          {confirmed && !error && !svgContent && (
             <div className="flex items-center justify-center h-full">
               <p className="text-sm text-muted-foreground">Loading preview…</p>
             </div>

--- a/frontend/src/components/ui/AuthedImage.tsx
+++ b/frontend/src/components/ui/AuthedImage.tsx
@@ -3,9 +3,10 @@ import { getAuthToken } from "@/api/client";
 
 interface Props extends React.ImgHTMLAttributes<HTMLImageElement> {
   src: string;
+  loadingContent?: React.ReactNode;
 }
 
-export function AuthedImage({ src, ...props }: Props) {
+export function AuthedImage({ src, loadingContent, ...props }: Props) {
   const [blobUrl, setBlobUrl] = useState<string | null>(null);
 
   useEffect(() => {
@@ -35,6 +36,6 @@ export function AuthedImage({ src, ...props }: Props) {
     };
   }, [src]);
 
-  if (!blobUrl) return null;
+  if (!blobUrl) return loadingContent ? <>{loadingContent}</> : null;
   return <img src={blobUrl} {...props} />;
 }

--- a/frontend/src/pages/DraftDetailPage.tsx
+++ b/frontend/src/pages/DraftDetailPage.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { AppIcons } from "@/lib/icons";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getDraft, deleteDraft, generateLiftplan, overrideDraftMetadata, setDraftWarpLength, setDraftWeavingWidth, setDraftEpi, previewSvgUrl, downloadWif, downloadWifModified, type ColorStat } from "@/api/drafts";
+import { getDraft, deleteDraft, generateLiftplan, overrideDraftMetadata, setDraftWarpLength, setDraftWeavingWidth, setDraftEpi, previewSvgUrl, drawdownPreviewUrl, downloadWif, downloadWifModified, type ColorStat } from "@/api/drafts";
 import { listProjects } from "@/api/projects";
 import { ProjectSummaryList } from "@/components/projects/ProjectSummaryList";
 import { CreateProjectModal } from "@/components/projects/CreateProjectModal";
@@ -703,12 +703,12 @@ export function DraftDetailPage() {
             {draft.wif_filename ? (
               <button
                 type="button"
-                className="group w-full overflow-auto rounded-lg border bg-card p-2 cursor-zoom-in text-left"
+                className="group w-full overflow-hidden rounded-lg border bg-card p-2 cursor-zoom-in text-left"
                 onClick={() => setShowPreviewModal(true)}
                 title="Click to open interactive preview"
               >
                 <AuthedImage
-                  src={previewSvgUrl(draft.id)}
+                  src={draft.has_drawdown_preview ? drawdownPreviewUrl(draft.id) : previewSvgUrl(draft.id)}
                   alt={`Draft preview for ${draft.name}`}
                   className="max-w-full group-hover:opacity-90 transition-opacity"
                   data-testid="draft-preview-img"
@@ -795,6 +795,8 @@ export function DraftDetailPage() {
         <DraftPreviewModal
           draftId={draft.id}
           draftName={draft.name}
+          warpThreads={draft.warp_threads ?? 0}
+          weftThreads={draft.weft_threads ?? 0}
           onClose={() => setShowPreviewModal(false)}
         />
       )}

--- a/frontend/src/pages/DraftDetailPage.tsx
+++ b/frontend/src/pages/DraftDetailPage.tsx
@@ -712,6 +712,11 @@ export function DraftDetailPage() {
                   alt={`Draft preview for ${draft.name}`}
                   className="max-w-full group-hover:opacity-90 transition-opacity"
                   data-testid="draft-preview-img"
+                  loadingContent={
+                    <div className="w-full min-h-48 animate-pulse rounded-md bg-muted flex items-center justify-center">
+                      <span className="text-sm text-muted-foreground">Rendering preview…</span>
+                    </div>
+                  }
                 />
                 <p className="mt-1.5 text-xs text-muted-foreground text-center opacity-0 group-hover:opacity-100 transition-opacity">
                   Click to zoom


### PR DESCRIPTION
Closes #640

## Summary
- `GET /drafts/{id}/drawdown_preview` — new endpoint serving the existing `drawdown_preview_path` PNG from R2 (already generated on every upload by `generate_drawdown_preview`); instant read, no render cost
- `backfill_all_drawdown_previews` Celery task + post_migrate registry entry — auto-dispatches per-draft preview generation on next worker startup for any drafts missing a thumbnail PNG
- `DraftCard` — 80px thumbnail strip using the PNG when `has_drawdown_preview` is set
- `DraftDetailPage` — thumbnail uses PNG (fast); SVG reserved for the interactive zoom modal only
- `DraftPreviewModal` — confirmation gate for large designs: drafts with warp×weft > 400k threads display thread counts and a "may be slow on mobile" warning before triggering the SVG fetch

## Motivation
Large drafts (e.g. Waffle 1) return 116–189 MB SVGs taking 18–43 s on mobile, locking up the browser. The `drawdown_preview_path` PNG (≤800px wide, drawdown-only) already exists in R2 for every uploaded draft — it just wasn't exposed as a thumbnail endpoint or used in the UI.

## Test plan
- [ ] Draft library cards show thumbnail strip for existing drafts
- [ ] `GET /drafts/{id}/drawdown_preview` returns PNG in < 500 ms
- [ ] Draft detail page thumbnail loads quickly via PNG; clicking opens modal with SVG
- [ ] Modal for a large draft (warp×weft > 400k) shows confirmation gate before loading
- [ ] Modal for small drafts opens immediately with no gate
- [ ] Worker startup triggers drawdown_preview backfill for any drafts missing it

🤖 Generated with [Claude Code](https://claude.com/claude-code)