### PR TITLE
fix: drawdown preview PNG renders gray at scale=1

### DIFF
--- a/backend/app/services/rendering.py
+++ b/backend/app/services/rendering.py
@@ -127,7 +127,9 @@ def render_drawdown_preview(draft: Draft, max_px: int = 800) -> tuple[bytes, int
     """Render a reduced-size drawdown for caching.
 
     Scales down so the image width fits within max_px. Returns (png_bytes, scale_used).
-    Does not apply render_max_* limits — the reduced scale prevents oversized output.
+    Uses render_drawdown_png so colors render correctly even at scale=1 — the
+    ImageRenderer outline approach paints every pixel with the foreground gray at
+    scale=1, obliterating thread colors.
     """
     warp_count = len(draft.warp)
     weft_count = len(draft.weft)
@@ -135,26 +137,14 @@ def render_drawdown_preview(draft: Draft, max_px: int = 800) -> tuple[bytes, int
         raise ValueError("Draft has no drawdown data to render")
 
     scale = max(1, min(DRAWDOWN_SCALE, max_px // warp_count))
-    margin = 20
-    drawdown_w = warp_count * scale
-    drawdown_h = weft_count * scale
-
-    renderer = ImageRenderer(draft, scale=scale, margin_pixels=margin)
     with tracer.start_as_current_span("render.drawdown_preview") as span:
         span.set_attribute("render.scale", scale)
         span.set_attribute("render.warp_threads", warp_count)
         span.set_attribute("render.weft_threads", weft_count)
-        full_im = renderer.make_pil_image()
-        span.set_attribute("render.width_px", drawdown_w)
-        span.set_attribute("render.height_px", drawdown_h)
-
-    offsetx = margin
-    offsety = margin + (6 + len(draft.shafts)) * scale
-    cropped = full_im.crop((offsetx, offsety, offsetx + drawdown_w, offsety + drawdown_h))
-    cropped = cropped.transpose(PILImage.Transpose.FLIP_TOP_BOTTOM)
-    out = io.BytesIO()
-    cropped.save(out, format="PNG")
-    return out.getvalue(), scale
+        png_bytes = render_drawdown_png(draft, scale=scale)
+        span.set_attribute("render.width_px", warp_count * scale)
+        span.set_attribute("render.height_px", weft_count * scale)
+    return png_bytes, scale
 
 
 def render_drawdown_tile(


### PR DESCRIPTION
## Summary

- `ImageRenderer` draws outlined rectangles. At `scale=1` (e.g. 427 warp threads in 800px), the 1px outline covers the entire cell — there is no interior for the fill color — so every drawdown pixel becomes the default foreground gray `(127, 127, 127)`.
- Replaced the `ImageRenderer` crop approach in `render_drawdown_preview` with the existing `render_drawdown_png`, which fills pixel values directly and renders correctly at any scale.

## Affected drafts

Drafts with large warp counts (≥ 800 threads wide at `drawdown_preview_max_px=800`) got `scale=1` and were rendered all-gray. The two confirmed affected drafts on prod are `bccc54d4` (diamond 1) and `1df3ed75` (Waffle 1).

## After merge + deploy

Manually re-dispatch `generate_drawdown_preview` for affected drafts, or set their `drawdown_preview_path=NULL` so the post-migrate backfill picks them up on next worker restart.

## Test plan

- [ ] Upload a draft with > 800 warp threads; confirm thumbnail shows colors, not solid gray
- [ ] Existing drafts with small warp counts still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)