### PR TITLE
feat: show full draft diagram on detail page preview

### DIFF
--- a/frontend/src/pages/DraftDetailPage.tsx
+++ b/frontend/src/pages/DraftDetailPage.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { AppIcons } from "@/lib/icons";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getDraft, deleteDraft, generateLiftplan, overrideDraftMetadata, setDraftWarpLength, setDraftWeavingWidth, setDraftEpi, previewSvgUrl, drawdownPreviewUrl, downloadWif, downloadWifModified, type ColorStat } from "@/api/drafts";
+import { getDraft, deleteDraft, generateLiftplan, overrideDraftMetadata, setDraftWarpLength, setDraftWeavingWidth, setDraftEpi, previewSvgUrl, downloadWif, downloadWifModified, type ColorStat } from "@/api/drafts";
 import { listProjects } from "@/api/projects";
 import { ProjectSummaryList } from "@/components/projects/ProjectSummaryList";
 import { CreateProjectModal } from "@/components/projects/CreateProjectModal";
@@ -708,7 +708,7 @@ export function DraftDetailPage() {
                 title="Click to open interactive preview"
               >
                 <AuthedImage
-                  src={draft.has_drawdown_preview ? drawdownPreviewUrl(draft.id) : previewSvgUrl(draft.id)}
+                  src={previewSvgUrl(draft.id)}
                   alt={`Draft preview for ${draft.name}`}
                   className="max-w-full group-hover:opacity-90 transition-opacity"
                   data-testid="draft-preview-img"


### PR DESCRIPTION
## Summary

- PR #640 switched the detail page Design Preview to the drawdown-only PNG when available. This hid the threading diagram, tie-up grid, treadle columns, and warp color bar.
- This PR switches back to `previewSvgUrl` (full SVG) on the detail page so all sections are visible.
- The drawdown-only PNG thumbnail is kept in `DraftCard` — it's well-suited for the compact card grid.

## Changes

- `DraftDetailPage`: `src` always uses `previewSvgUrl` (full draft SVG — threading + tie-up + drawdown); removes unused `drawdownPreviewUrl` import
- `DraftCard`: unchanged — drawdown PNG thumbnail stays

## Test plan

- [ ] Open a draft detail page — confirm threading, tie-up, treadle, and drawdown sections are all visible in the Design Preview panel
- [ ] Confirm the loading skeleton still shows while the SVG loads
- [ ] Click to open modal — full SVG still renders in the zoom modal
- [ ] Draft library card thumbnails still show the drawdown-only PNG strip

🤖 Generated with [Claude Code](https://claude.com/claude-code)