### PR TITLE
fix: use pre-rendered full PNG on detail page, not on-demand SVG

### DIFF
--- a/frontend/src/pages/DraftDetailPage.tsx
+++ b/frontend/src/pages/DraftDetailPage.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { AppIcons } from "@/lib/icons";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getDraft, deleteDraft, generateLiftplan, overrideDraftMetadata, setDraftWarpLength, setDraftWeavingWidth, setDraftEpi, previewSvgUrl, downloadWif, downloadWifModified, type ColorStat } from "@/api/drafts";
+import { getDraft, deleteDraft, generateLiftplan, overrideDraftMetadata, setDraftWarpLength, setDraftWeavingWidth, setDraftEpi, previewUrl, previewSvgUrl, downloadWif, downloadWifModified, type ColorStat } from "@/api/drafts";
 import { listProjects } from "@/api/projects";
 import { ProjectSummaryList } from "@/components/projects/ProjectSummaryList";
 import { CreateProjectModal } from "@/components/projects/CreateProjectModal";
@@ -708,13 +708,13 @@ export function DraftDetailPage() {
                 title="Click to open interactive preview"
               >
                 <AuthedImage
-                  src={previewSvgUrl(draft.id)}
+                  src={draft.has_preview ? previewUrl(draft.id) : previewSvgUrl(draft.id)}
                   alt={`Draft preview for ${draft.name}`}
                   className="max-w-full group-hover:opacity-90 transition-opacity"
                   data-testid="draft-preview-img"
                   loadingContent={
                     <div className="w-full min-h-48 animate-pulse rounded-md bg-muted flex items-center justify-center">
-                      <span className="text-sm text-muted-foreground">Rendering preview…</span>
+                      <span className="text-sm text-muted-foreground">Loading preview…</span>
                     </div>
                   }
                 />


### PR DESCRIPTION
## Summary

- Follow-up to #645: switching to `previewSvgUrl` broke large drafts. Waffle 1 (1285 warp threads) generates a **189 MB SVG** that takes **19 seconds** and leaves the box white when the browser can't render it.
- `previewUrl` (pre-rendered full PNG — threading + tie-up + drawdown, generated at upload time) serves the same content in under 1 second.
- Falls back to SVG only if no pre-rendered PNG exists. The zoom modal still uses the SVG as before.

## Test plan

- [ ] Open Waffle 1 detail page — preview loads quickly and shows full diagram (threading, tie-up, drawdown)
- [ ] Open a small draft detail page — same behavior
- [ ] Click zoom — modal still loads the interactive SVG

🤖 Generated with [Claude Code](https://claude.com/claude-code)