### PR TITLE
fix: default show_version_numbers to false for all users (#656)

### DIFF
--- a/backend/alembic/versions/0023_default_show_version_numbers_false.py
+++ b/backend/alembic/versions/0023_default_show_version_numbers_false.py
@@ -1,0 +1,22 @@
+"""Default show_version_numbers to false and backfill existing users
+
+Revision ID: 0023
+Revises: 0022
+Create Date: 2026-05-16
+"""
+
+from alembic import op
+
+revision = "e1f2a3b4c5d6"
+down_revision = "d0e1f2a3b4c5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE users SET show_version_numbers = false")
+    op.execute("ALTER TABLE users ALTER COLUMN show_version_numbers SET DEFAULT false")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE users ALTER COLUMN show_version_numbers SET DEFAULT true")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -35,5 +35,5 @@ class User(Base, TimestampMixin, SoftDeleteMixin):
     deletion_state: Mapped[str | None] = mapped_column(String(20), nullable=True, default=None)
     deletion_initiated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, default=None)
     clerk_errored: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
-    show_version_numbers: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    show_version_numbers: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     hide_unused_shafts_treadles: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -102,10 +102,10 @@ class TestUpdateSettings:
         assert resp.status_code == 200
         assert resp.json()["ai_training_consent"] is False
 
-    async def test_show_version_numbers_defaults_true(self, auth_client: AsyncClient):
+    async def test_show_version_numbers_defaults_false(self, auth_client: AsyncClient):
         resp = await auth_client.get("/api/users/me")
         assert resp.status_code == 200
-        assert resp.json()["show_version_numbers"] is True
+        assert resp.json()["show_version_numbers"] is False
 
     async def test_update_show_version_numbers_false(self, auth_client: AsyncClient):
         resp = await auth_client.patch("/api/users/me", json={"show_version_numbers": False})


### PR DESCRIPTION
## Summary
- Alembic migration 0023: bulk-sets all existing users to `show_version_numbers = false` and changes the column default from `true` to `false`
- Updates `User` model default to `False`
- Updates test that asserted the default was `true`

## Test plan
- [ ] Run `alembic upgrade head` — confirm all existing users flipped to false
- [ ] Register a new account — confirm `show_version_numbers` starts as `false`
- [ ] Toggle on/off via user settings — confirm it persists correctly
- [ ] `pytest` passes

Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)