### PR TITLE
feat: dashboard thumbnails — project preview strip and loom photo banner (#658, #659)

### DIFF
--- a/frontend/src/pages/LoomsPage.tsx
+++ b/frontend/src/pages/LoomsPage.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
-import { listLooms, type Loom } from "@/api/looms";
+import { listLooms, loomPhotoUrl, type Loom } from "@/api/looms";
 import { AppIcons } from "@/lib/icons";
+import { AuthedImage } from "@/components/ui/AuthedImage";
 import { listProjects } from "@/api/projects";
 import { NewLoomModal } from "@/components/looms/NewLoomModal";
 import { Button } from "@/components/ui/button";
@@ -18,8 +19,18 @@ function LoomCard({ loom, projectCounts }: { loom: Loom; projectCounts?: LoomPro
   return (
     <Link
       to={`/looms/${loom.id}`}
-      className="rounded-lg border p-5 hover:border-ring transition-colors block"
+      className="rounded-lg border hover:border-ring transition-colors block overflow-hidden"
     >
+      {loom.has_photo && (
+        <div className="w-full h-32 bg-muted overflow-hidden">
+          <AuthedImage
+            src={loomPhotoUrl(loom.id)}
+            alt=""
+            className="w-full h-full object-cover"
+          />
+        </div>
+      )}
+      <div className="p-5">
       <div className="flex items-start justify-between gap-2">
         <div className="flex items-start gap-3">
           <div className="shrink-0 mt-0.5">
@@ -78,6 +89,7 @@ function LoomCard({ loom, projectCounts }: { loom: Loom; projectCounts?: LoomPro
           )}
         </div>
       )}
+      </div>
     </Link>
   );
 }

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { listProjects, PROJECT_TYPE_LABELS, PROJECT_STATUS_LABELS, type ProjectSummary } from "@/api/projects";
+import { listProjects, projectDrawdownPreviewUrl, PROJECT_TYPE_LABELS, PROJECT_STATUS_LABELS, type ProjectSummary } from "@/api/projects";
 import { AppIcons } from "@/lib/icons";
 import { previewUrl } from "@/api/drafts";
 import { AuthedImage } from "@/components/ui/AuthedImage";
@@ -58,7 +58,17 @@ function ProjectCard({ project, onAssign }: {
     : 0;
 
   return (
-    <div className="relative rounded-lg border hover:border-ring transition-colors">
+    <div className="relative rounded-lg border hover:border-ring transition-colors overflow-hidden">
+      {project.has_drawdown_preview && (
+        <div className="w-full h-20 bg-muted overflow-hidden">
+          <AuthedImage
+            src={projectDrawdownPreviewUrl(project.id)}
+            alt=""
+            className="w-full h-full object-cover object-top"
+            style={{ imageRendering: "pixelated" }}
+          />
+        </div>
+      )}
       <Link to={`/projects/${project.id}`} className="block p-4">
         <div className="flex gap-3">
           <div className="shrink-0 mt-0.5">
@@ -145,7 +155,7 @@ function ProjectCard({ project, onAssign }: {
             </button>
             <p className="absolute -top-9 left-0 text-white/70 text-sm truncate max-w-xs">{project.name}</p>
             <AuthedImage
-              src={previewUrl(project.draft_id)}
+              src={project.has_drawdown_preview ? projectDrawdownPreviewUrl(project.id) : previewUrl(project.draft_id)}
               alt="Design preview"
               className="w-full rounded-lg shadow-2xl"
               style={{ imageRendering: "pixelated" }}


### PR DESCRIPTION
## Summary
- **Project dashboard** (`ProjectsPage`): each `ProjectCard` now shows an 80px drawdown preview strip at the top when `has_drawdown_preview` is true, using the stored project PNG (which includes any saved color replacements). The existing fullscreen preview modal also switches to the project-specific URL over the draft generic URL.
- **Equipment dashboard** (`LoomsPage`): each `LoomCard` now shows a 128px profile photo banner at the top when `has_photo` is true, using the authed loom photo endpoint. Cards without a photo are unchanged.

Both fall back gracefully — no thumbnail shown until the image is stored.

No backend changes — all data fields and API helpers were already in place (`has_drawdown_preview`, `projectDrawdownPreviewUrl`, `has_photo`, `loomPhotoUrl`).

## Test plan
- [ ] Project dashboard: cards with a stored preview show the 80px thumbnail strip; cards still rendering show no thumbnail
- [ ] Project dashboard: clicking the preview icon opens the fullscreen modal using the project-specific PNG (with color replacements reflected)
- [ ] Equipment dashboard: looms with a profile photo show the 128px banner; looms without a photo are unchanged
- [ ] Full card (including photo area) is a clickable link to the detail page
- [ ] No regressions on drafts dashboard

Closes #658
Closes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)