### PR TITLE
fix: allow superusers to access /settings/* routes (#653)

### DIFF
--- a/frontend/src/components/layout/ProtectedRoute.tsx
+++ b/frontend/src/components/layout/ProtectedRoute.tsx
@@ -23,8 +23,13 @@ export function ProtectedRoute({ children, requireAdmin = false }: Props) {
     return <Navigate to="/login" replace />;
   }
 
-  // Superusers only use the admin console — redirect any non-admin route to /admin
-  if (user?.is_superuser && !requireAdmin && location.pathname !== "/admin") {
+  // Superusers live in the admin console but can still access personal settings
+  if (
+    user?.is_superuser &&
+    !requireAdmin &&
+    !location.pathname.startsWith("/admin") &&
+    !location.pathname.startsWith("/settings")
+  ) {
     return <Navigate to="/admin" replace />;
   }
 


### PR DESCRIPTION
## Root cause

`ProtectedRoute` redirected superusers to `/admin` for every path that wasn't exactly `/admin`. This included `/settings/appearance`, `/settings/preferences`, etc., making personal settings completely inaccessible to superuser accounts.

## Fix

Added `/settings` to the pass-through condition alongside `/admin`:

```typescript
if (
  user?.is_superuser &&
  !requireAdmin &&
  !location.pathname.startsWith("/admin") &&
  !location.pathname.startsWith("/settings")
) {
  return <Navigate to="/admin" replace />;
}
```

Superusers are still redirected from all regular user routes (`/drafts`, `/projects`, `/looms`, etc.) — only `/settings/*` is now permitted alongside the admin console.

## Test plan
- [ ] Log in as superuser → navigating to `/settings/appearance` loads the settings page (no redirect)
- [ ] Navigating to `/drafts` as superuser still redirects to `/admin`
- [ ] Regular users unaffected — settings and all other routes work normally

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)