### PR TITLE
fix: EULA content unreadable in dark mode (#632)

### DIFF
--- a/frontend/src/components/EulaContent.tsx
+++ b/frontend/src/components/EulaContent.tsx
@@ -5,7 +5,7 @@ interface Props {
 export function EulaContent({ bodyHtml }: Props) {
   return (
     <div
-      className="text-sm leading-relaxed space-y-2"
+      className="eula-content text-sm leading-relaxed space-y-2"
       dangerouslySetInnerHTML={{ __html: bodyHtml }}
     />
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -97,3 +97,10 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* Force light-mode rendering for EULA HTML (always light-authored, may contain inline styles) */
+.eula-content {
+  color-scheme: light;
+  background-color: #ffffff;
+  color: hsl(20 10% 10%);
+}


### PR DESCRIPTION
## Summary

- Adds `.eula-content` CSS class to `index.css` with `color-scheme: light`, white background, and dark text
- Applies the class to the `EulaContent` wrapper div

## Root cause

The prod EULA HTML is always light-mode authored and contains inline `background:#f5f5f5` elements whose `<p>` and `<li>` children have no explicit `color`. In dark mode, those unstyled children inherit the dark-theme foreground (light/white text) — resulting in unreadable light text on a light gray background.

## Fix

Forcing `color-scheme: light` + explicit background/foreground on the `EulaContent` wrapper ensures all child elements that lack an explicit color fall back to dark text, matching the HTML's light-mode intent. This applies consistently to all four render sites: `EulaGate`, `SettingsPage`, `AdminPage` (EULA preview), and `TermsPage`.

## Test plan

- [ ] Switch app to dark mode
- [ ] Navigate to Settings → EULA section — verify text is readable on white/light-gray backgrounds
- [ ] Log out as a new user and accept the EULA via `EulaGate` — verify the "Plain-language summary" box renders readable dark text on light gray
- [ ] Admin → Superuser → EULA tab — verify preview renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)