### PR TITLE
feat: developer note on /about page (#30)

### DIFF
--- a/frontend/src/components/PublicFooter.tsx
+++ b/frontend/src/components/PublicFooter.tsx
@@ -10,7 +10,9 @@ export function PublicFooter() {
           <Link to="/terms" className="hover:text-foreground transition-colors">Terms</Link>
           <span className="text-muted-foreground">Contact</span>
         </nav>
-        <p className="text-xs text-muted-foreground">Built by a weaver, with AI assistance.</p>
+        <Link to="/about" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
+          Built by a hobbyist, with AI assistance.
+        </Link>
       </div>
     </footer>
   );

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -26,6 +26,32 @@ export function AboutPage() {
           </div>
 
           <div className="space-y-3">
+            <h2 className="text-lg font-semibold">A note from the developer</h2>
+            <div className="space-y-3 text-stone-600 leading-relaxed">
+              <p>
+                In the last couple of years, my wife has grown a passion for weaving and I've
+                learned about the process along the way. As she dove into pattern design and WIF
+                files, she asked if I could build a tool to help her track the lifts on her Jane
+                without needing a pencil and paper.
+              </p>
+              <p>
+                I work in industrial automation and although I touch a lot of technology and
+                infrastructure, I'm not an application developer — I'm an integrator.
+              </p>
+              <p>
+                Modern AI tools like Claude have allowed me to play the role of "product owner" by defining
+                architecture, documenting scope, and nudging design with constant feedback; without
+                the demands of learning every framework and toolkit along the way.
+              </p>
+              <p>
+                This is very much a learning experience. I plan to continue posting all code on
+                GitHub and it is open for review and criticism.
+              </p>
+              <p className="text-stone-500">All the best — Derek</p>
+            </div>
+          </div>
+
+          <div className="space-y-3">
             <h2 className="text-lg font-semibold">How it was built</h2>
             <p className="text-stone-600 leading-relaxed">
               weftmark was built with significant assistance from AI tools — specifically Anthropic's
@@ -38,16 +64,6 @@ export function AboutPage() {
               pipeline, and code review are in place to catch errors. The developer is responsible
               for all product decisions and data handling choices.
             </p>
-          </div>
-
-          <div className="space-y-3">
-            <h2 className="text-lg font-semibold">A note from the developer</h2>
-            <div className="rounded-lg border border-stone-200 bg-stone-100 px-5 py-4">
-              <p className="text-sm text-stone-500 italic">
-                [Placeholder — developer-voice content to be written before launch. This section
-                will explain who built this, why, and what weaving means to them personally.]
-              </p>
-            </div>
           </div>
 
           <div className="space-y-3">


### PR DESCRIPTION
## Summary

- Replaces the placeholder in the "A note from the developer" section of `/about` with the real developer note
- Reorders page sections: personal note now leads, followed by the technical "How it was built" disclosure
- Footer blurb updated from a `<p>` to a `<Link to="/about">` so it directs curious visitors to the page

## Content changes

The note covers: origin story (wife's Jane loom), developer background (industrial automation / integrator, not a software engineer), the role AI played, and an invitation to review the source.

## Test plan

- [ ] Visit `/about` — note appears before "How it was built", reads correctly
- [ ] Footer blurb "Built by a hobbyist, with AI assistance." is clickable and navigates to `/about`
- [ ] Page renders correctly in both light and dark contexts (public page — light only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)