### PR TITLE
feat: superuser read-only inspection of any loom, draft, or project (#663)

### DIFF
--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -474,7 +474,7 @@ async def download_wif_modified(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    draft = await _get_owned_draft(draft_id, current_user, db)
+    draft = await _get_owned_draft(draft_id, current_user, db, allow_superuser=True)
     if not draft.wif_modified_path or not await storage.afile_exists(draft.wif_modified_path):
         raise HTTPException(status_code=404, detail="No modified WIF file for this draft")
     wif_bytes = await storage.aread_file(draft.wif_modified_path)

--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -54,6 +54,7 @@ def _content_disposition(filename: str) -> str:
 
 class DraftSummary(BaseModel):
     id: uuid.UUID
+    owner_id: uuid.UUID
     name: str
     description: str | None
     wif_filename: str
@@ -211,7 +212,7 @@ async def get_draft(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> DraftDetail:
-    draft = await _get_owned_draft(draft_id, current_user, db)
+    draft = await _get_owned_draft(draft_id, current_user, db, allow_superuser=True)
     return DraftDetail(**_draft_detail_data(draft))
 
 
@@ -226,7 +227,7 @@ async def get_preview(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    draft = await _get_owned_draft(draft_id, current_user, db)
+    draft = await _get_owned_draft(draft_id, current_user, db, allow_superuser=True)
     if not await storage.afile_exists(draft.preview_path):
         raise HTTPException(status_code=404, detail="Preview not available")
     png = await storage.aread_file(draft.preview_path)  # type: ignore[arg-type]
@@ -239,7 +240,7 @@ async def get_drawdown_preview(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    draft = await _get_owned_draft(draft_id, current_user, db)
+    draft = await _get_owned_draft(draft_id, current_user, db, allow_superuser=True)
     if not draft.drawdown_preview_path or not await storage.afile_exists(draft.drawdown_preview_path):
         raise HTTPException(status_code=404, detail="Drawdown preview not available")
     png = await storage.aread_drawdown_preview(draft.drawdown_preview_path)
@@ -252,7 +253,7 @@ async def get_preview_svg(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    draft = await _get_owned_draft(draft_id, current_user, db)
+    draft = await _get_owned_draft(draft_id, current_user, db, allow_superuser=True)
     if not draft.wif_path:
         raise HTTPException(status_code=404, detail="No WIF file for this draft")
     wif_bytes = await storage.aread_file(draft.wif_path)
@@ -278,7 +279,7 @@ async def get_drawdown(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    draft = await _get_owned_draft(draft_id, current_user, db)
+    draft = await _get_owned_draft(draft_id, current_user, db, allow_superuser=True)
 
     effective_shafts = draft.effective_num_shafts if hide_unused_shafts_treadles else None
     effective_treadles = draft.effective_num_treadles if hide_unused_shafts_treadles else None
@@ -450,7 +451,7 @@ async def download_wif(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    draft = await _get_owned_draft(draft_id, current_user, db)
+    draft = await _get_owned_draft(draft_id, current_user, db, allow_superuser=True)
     if not draft.wif_path or not await storage.afile_exists(draft.wif_path):
         raise HTTPException(status_code=404, detail="WIF file not available for this draft")
     wif_bytes = await storage.aread_file(draft.wif_path)
@@ -687,14 +688,13 @@ def _draft_detail_data(draft: Draft) -> dict:
     return data
 
 
-async def _get_owned_draft(draft_id: uuid.UUID, user: User, db: AsyncSession) -> Draft:
-    draft = await db.scalar(
-        select(Draft).where(
-            Draft.id == draft_id,
-            Draft.owner_id == user.id,
-            Draft.deleted_at.is_(None),
-        )
-    )
+async def _get_owned_draft(
+    draft_id: uuid.UUID, user: User, db: AsyncSession, *, allow_superuser: bool = False
+) -> Draft:
+    stmt = select(Draft).where(Draft.id == draft_id, Draft.deleted_at.is_(None))
+    if not (allow_superuser and user.is_superuser):
+        stmt = stmt.where(Draft.owner_id == user.id)
+    draft = await db.scalar(stmt)
     if draft is None:
         raise HTTPException(status_code=404, detail="Draft not found")
     return draft

--- a/backend/app/routers/looms.py
+++ b/backend/app/routers/looms.py
@@ -145,6 +145,7 @@ class LoomSummary(BaseModel):
 
 class LoomDetail(BaseModel):
     id: uuid.UUID
+    owner_id: uuid.UUID
     loom_type: str
     manufacturer: str
     model_name: str
@@ -167,6 +168,7 @@ class LoomDetail(BaseModel):
     def from_loom(cls, loom: Loom) -> "LoomDetail":
         data = {
             "id": loom.id,
+            "owner_id": loom.owner_id,
             "loom_type": loom.loom_type,
             "manufacturer": loom.manufacturer,
             "model_name": loom.model_name,
@@ -261,10 +263,10 @@ class AddReedRequest(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-async def _get_owned_loom(loom_id: uuid.UUID, user: User, db: AsyncSession) -> Loom:
-    loom = await db.scalar(
+async def _get_owned_loom(loom_id: uuid.UUID, user: User, db: AsyncSession, *, allow_superuser: bool = False) -> Loom:
+    stmt = (
         select(Loom)
-        .where(Loom.id == loom_id, Loom.owner_id == user.id, Loom.deleted_at.is_(None))
+        .where(Loom.id == loom_id, Loom.deleted_at.is_(None))
         .options(
             selectinload(Loom.versions).selectinload(LoomVersion.photos),
             selectinload(Loom.versions).selectinload(LoomVersion.receipts),
@@ -272,15 +274,23 @@ async def _get_owned_loom(loom_id: uuid.UUID, user: User, db: AsyncSession) -> L
             selectinload(Loom.reeds),
         )
     )
+    if not (allow_superuser and user.is_superuser):
+        stmt = stmt.where(Loom.owner_id == user.id)
+    loom = await db.scalar(stmt)
     if loom is None:
         raise HTTPException(status_code=404, detail="Loom not found")
     return loom
 
 
 async def _get_owned_version(
-    loom_id: uuid.UUID, version_id: uuid.UUID, user: User, db: AsyncSession
+    loom_id: uuid.UUID,
+    version_id: uuid.UUID,
+    user: User,
+    db: AsyncSession,
+    *,
+    allow_superuser: bool = False,
 ) -> tuple[Loom, LoomVersion]:
-    loom = await _get_owned_loom(loom_id, user, db)
+    loom = await _get_owned_loom(loom_id, user, db, allow_superuser=allow_superuser)
     version = next((v for v in loom.versions if v.id == version_id), None)
     if version is None:
         raise HTTPException(status_code=404, detail="Version not found")
@@ -376,7 +386,7 @@ async def get_loom(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> LoomDetail:
-    loom = await _get_owned_loom(loom_id, current_user, db)
+    loom = await _get_owned_loom(loom_id, current_user, db, allow_superuser=True)
     return LoomDetail.from_loom(loom)
 
 
@@ -456,7 +466,7 @@ async def get_loom_photo(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    loom = await _get_owned_loom(loom_id, current_user, db)
+    loom = await _get_owned_loom(loom_id, current_user, db, allow_superuser=True)
     if not loom.photo_path or not storage.file_exists(loom.photo_path):
         raise HTTPException(status_code=404, detail="No photo")
     data = storage.read_file(loom.photo_path)
@@ -548,7 +558,7 @@ async def get_version_photo(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    loom, version = await _get_owned_version(loom_id, version_id, current_user, db)
+    loom, version = await _get_owned_version(loom_id, version_id, current_user, db, allow_superuser=True)
     photo = next((p for p in version.photos if p.id == photo_id), None)
     if photo is None or not storage.file_exists(photo.path):
         raise HTTPException(status_code=404, detail="Photo not found")
@@ -617,7 +627,7 @@ async def get_version_receipt(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    loom, version = await _get_owned_version(loom_id, version_id, current_user, db)
+    loom, version = await _get_owned_version(loom_id, version_id, current_user, db, allow_superuser=True)
     receipt = next((r for r in version.receipts if r.id == receipt_id), None)
     if receipt is None or not storage.file_exists(receipt.path):
         raise HTTPException(status_code=404, detail="Receipt not found")

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -51,6 +51,7 @@ class ProjectPhotoSchema(BaseModel):
 
 class ProjectSummary(BaseModel):
     id: uuid.UUID
+    owner_id: uuid.UUID
     draft_id: uuid.UUID
     loom_id: uuid.UUID | None
     loom_version_id: uuid.UUID | None
@@ -239,12 +240,14 @@ async def _get_owned_project(
     db: AsyncSession,
     *,
     with_for_update: bool = False,
+    allow_superuser: bool = False,
 ) -> Project:
     stmt = select(Project).where(
         Project.id == project_id,
-        Project.owner_id == user.id,
         Project.deleted_at.is_(None),
     )
+    if not (allow_superuser and user.is_superuser):
+        stmt = stmt.where(Project.owner_id == user.id)
     if with_for_update:
         stmt = stmt.with_for_update()
     project = await db.scalar(stmt)
@@ -453,7 +456,7 @@ async def get_project_drawdown(
     from app.services import rendering
     from app.services.storage import afile_exists, aproject_tile_exists, aread_file, aread_project_tile
 
-    project = await _get_owned_project(project_id, current_user, db)
+    project = await _get_owned_project(project_id, current_user, db, allow_superuser=True)
 
     draft = await db.scalar(select(Draft).where(Draft.id == project.draft_id, Draft.deleted_at.is_(None)))
     if draft is None:
@@ -565,7 +568,7 @@ async def get_project_drawdown_svg(
     from app.services import rendering
     from app.services.storage import afile_exists, aread_file
 
-    project = await _get_owned_project(project_id, current_user, db)
+    project = await _get_owned_project(project_id, current_user, db, allow_superuser=True)
     draft = await db.scalar(select(Draft).where(Draft.id == project.draft_id, Draft.deleted_at.is_(None)))
     if draft is None:
         raise HTTPException(status_code=404, detail="Draft not found")
@@ -621,7 +624,7 @@ async def get_project_drawdown_preview(
     from app.services import rendering
     from app.services.storage import afile_exists, aread_file
 
-    project = await _get_owned_project(project_id, current_user, db)
+    project = await _get_owned_project(project_id, current_user, db, allow_superuser=True)
     draft = await db.scalar(select(Draft).where(Draft.id == project.draft_id, Draft.deleted_at.is_(None)))
     if draft is None:
         raise HTTPException(status_code=404, detail="Draft not found")
@@ -666,7 +669,7 @@ async def get_project_drawdown_preview_cached(
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     """Return the pre-rendered drawdown thumbnail PNG for a project, or 404 if not yet generated."""
-    project = await _get_owned_project(project_id, current_user, db)
+    project = await _get_owned_project(project_id, current_user, db, allow_superuser=True)
     if not project.drawdown_preview_path:
         raise HTTPException(status_code=404, detail="Preview not yet generated")
     data = await storage.aread_project_drawdown_preview(project.drawdown_preview_path)
@@ -684,7 +687,7 @@ async def get_project_drawdown_svg_cached(
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     """Return the pre-rendered drawdown SVG for a project, or 404 if not yet generated."""
-    project = await _get_owned_project(project_id, current_user, db)
+    project = await _get_owned_project(project_id, current_user, db, allow_superuser=True)
     if not project.drawdown_svg_path:
         raise HTTPException(status_code=404, detail="SVG not yet generated")
     svg_text = await storage.aread_project_drawdown_svg(project.drawdown_svg_path)
@@ -705,7 +708,7 @@ async def get_project_drawdown_data(
     from app.services import rendering
     from app.services.storage import afile_exists, aread_file
 
-    project = await _get_owned_project(project_id, current_user, db)
+    project = await _get_owned_project(project_id, current_user, db, allow_superuser=True)
     draft = await db.scalar(select(Draft).where(Draft.id == project.draft_id, Draft.deleted_at.is_(None)))
     if draft is None:
         raise HTTPException(status_code=404, detail="Draft not found")
@@ -748,11 +751,14 @@ async def get_project(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> ProjectDetail:
-    result = await db.scalars(
+    stmt = (
         select(Project)
-        .where(Project.id == project_id, Project.owner_id == current_user.id, Project.deleted_at.is_(None))
+        .where(Project.id == project_id, Project.deleted_at.is_(None))
         .options(selectinload(Project.photos))
     )
+    if not current_user.is_superuser:
+        stmt = stmt.where(Project.owner_id == current_user.id)
+    result = await db.scalars(stmt)
     project = result.first()
     if project is None:
         raise HTTPException(status_code=404, detail="Project not found")
@@ -1134,7 +1140,7 @@ async def get_project_metrics(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> ProjectMetricsResponse:
-    await _get_owned_project(project_id, current_user, db)
+    await _get_owned_project(project_id, current_user, db, allow_superuser=True)
 
     now = datetime.now(timezone.utc)
 
@@ -1279,7 +1285,7 @@ async def get_project_photo(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    await _get_owned_project(project_id, current_user, db)
+    await _get_owned_project(project_id, current_user, db, allow_superuser=True)
     photo = await db.scalar(
         select(ProjectPhoto).where(ProjectPhoto.id == photo_id, ProjectPhoto.project_id == project_id)
     )
@@ -1314,7 +1320,7 @@ async def get_picks(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> PicksResponse:
-    project = await _get_owned_project(project_id, current_user, db)
+    project = await _get_owned_project(project_id, current_user, db, allow_superuser=True)
     draft = await db.get(Draft, project.draft_id)
     if draft is None:
         raise HTTPException(status_code=404, detail="Draft not found")

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -277,6 +277,7 @@ def _to_detail(
 ) -> ProjectDetail:
     return ProjectDetail(
         id=project.id,
+        owner_id=project.owner_id,
         draft_id=project.draft_id,
         loom_id=project.loom_id,
         loom_version_id=project.loom_version_id,

--- a/frontend/src/api/drafts.ts
+++ b/frontend/src/api/drafts.ts
@@ -32,6 +32,7 @@ export type WeftColorStat = ColorStat;
 
 export interface Draft {
   id: string;
+  owner_id: string;
   name: string;
   description: string | null;
   wif_filename: string;

--- a/frontend/src/api/looms.ts
+++ b/frontend/src/api/looms.ts
@@ -62,6 +62,7 @@ export interface LoomVersion {
 
 export interface Loom {
   id: string;
+  owner_id: string;
   loom_type: LoomType;
   manufacturer: string;
   model_name: string;

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -15,6 +15,7 @@ export const PROJECT_STATUS_LABELS: Record<ProjectStatus, string> = {
 
 export interface ProjectSummary {
   id: string;
+  owner_id: string;
   draft_id: string;
   loom_id: string | null;
   loom_version_id: string | null;

--- a/frontend/src/components/layout/ProtectedRoute.tsx
+++ b/frontend/src/components/layout/ProtectedRoute.tsx
@@ -23,12 +23,16 @@ export function ProtectedRoute({ children, requireAdmin = false }: Props) {
     return <Navigate to="/login" replace />;
   }
 
-  // Superusers live in the admin console but can still access personal settings
+  // Superusers land in the admin console; allow /settings and specific resource
+  // detail pages (/drafts/:id, /looms/:id, /projects/:id) for read-only inspection
   if (
     user?.is_superuser &&
     !requireAdmin &&
     !location.pathname.startsWith("/admin") &&
-    !location.pathname.startsWith("/settings")
+    !location.pathname.startsWith("/settings") &&
+    !location.pathname.startsWith("/drafts/") &&
+    !location.pathname.startsWith("/looms/") &&
+    !location.pathname.startsWith("/projects/")
   ) {
     return <Navigate to="/admin" replace />;
   }

--- a/frontend/src/components/ui/SuperuserInspectionBanner.tsx
+++ b/frontend/src/components/ui/SuperuserInspectionBanner.tsx
@@ -1,0 +1,12 @@
+interface Props {
+  ownerEmail?: string;
+}
+
+export function SuperuserInspectionBanner({ ownerEmail }: Props) {
+  return (
+    <div className="bg-amber-50 border-b border-amber-200 px-4 py-2 text-sm text-amber-900 flex items-center gap-2">
+      <span className="font-semibold">Superuser inspection — read-only</span>
+      {ownerEmail && <span className="text-amber-700">· {ownerEmail}</span>}
+    </div>
+  );
+}

--- a/frontend/src/pages/DraftDetailPage.tsx
+++ b/frontend/src/pages/DraftDetailPage.tsx
@@ -12,6 +12,7 @@ import { AuthedImage } from "@/components/ui/AuthedImage";
 import { useAuthContext } from "@/context/AuthContext";
 import { measurementSystemToUnit, convertLength, formatLength, formatApproxLength } from "@/lib/units";
 import { nearestColorName } from "@/lib/colorName";
+import { SuperuserInspectionBanner } from "@/components/ui/SuperuserInspectionBanner";
 
 export function DraftDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -149,8 +150,12 @@ export function DraftDetailPage() {
     epiFromWidthAndCount != null ? "calculated" :
     null;
 
+  const isReadOnly = !!user?.is_superuser && draft.owner_id !== user.id;
+
   return (
-    <div className="p-6 max-w-5xl mx-auto w-full space-y-6">
+    <div className="max-w-5xl mx-auto w-full">
+      {isReadOnly && <SuperuserInspectionBanner />}
+      <div className="p-6 space-y-6">
       <div className="flex items-center gap-2 text-sm">
         <Link to="/drafts" className="text-muted-foreground hover:text-foreground">Drafts</Link>
         <AppIcons.chevronRight className="h-3.5 w-3.5 text-muted-foreground" />
@@ -687,7 +692,7 @@ export function DraftDetailPage() {
               <div className="flex items-center justify-between mb-4">
                 <h2 className="text-base font-semibold">Projects</h2>
                 <div className="flex items-center gap-3">
-                  <Button size="sm" onClick={() => setShowCreateProject(true)}>New project</Button>
+                  {!isReadOnly && <Button size="sm" onClick={() => setShowCreateProject(true)}>New project</Button>}
                   <Link to="/projects" className="text-xs text-muted-foreground hover:text-foreground">
                     All projects →
                   </Link>
@@ -733,7 +738,7 @@ export function DraftDetailPage() {
         </div>
 
         {/* Danger zone */}
-        <div className="border-t pt-4">
+        {!isReadOnly && <div className="border-t pt-4">
           <button
             type="button"
             onClick={() => setShowDangerZone((v) => !v)}
@@ -776,7 +781,7 @@ export function DraftDetailPage() {
               </div>
             </div>
           )}
-        </div>
+        </div>}
 
       {showCreateProject && (
         <CreateProjectModal
@@ -800,6 +805,7 @@ export function DraftDetailPage() {
           onClose={() => setShowPreviewModal(false)}
         />
       )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/LoomDetailPage.tsx
+++ b/frontend/src/pages/LoomDetailPage.tsx
@@ -23,6 +23,7 @@ import { Button } from "@/components/ui/button";
 import { AuthedImage } from "@/components/ui/AuthedImage";
 import { downloadAuthed } from "@/api/client";
 import { resizeImageToFile, formatBytes } from "@/lib/image-utils";
+import { SuperuserInspectionBanner } from "@/components/ui/SuperuserInspectionBanner";
 
 const PHOTO_MAX_BYTES = 5 * 1024 * 1024; // 5 MB — must match backend MAX_FILE_SIZE
 const MAX_VERSION_PHOTOS = 5;            // must match backend MAX_VERSION_PHOTOS
@@ -64,6 +65,8 @@ function ConfirmInline({
 // ---------------------------------------------------------------------------
 
 function ProfilePhoto({ loom, onChanged }: { loom: LoomDetail; onChanged: () => void }) {
+  const { user } = useAuthContext();
+  const isReadOnly = !!user?.is_superuser && loom.owner_id !== user.id;
   const fileRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
   const [confirmRemove, setConfirmRemove] = useState(false);
@@ -136,21 +139,25 @@ function ProfilePhoto({ loom, onChanged }: { loom: LoomDetail; onChanged: () => 
         </div>
       )}
       <div className="flex flex-col gap-2">
-        <input ref={fileRef} type="file" accept="image/jpeg,image/png,image/webp,image/gif" className="hidden" onChange={handleFileSelected} />
-        <Button size="sm" variant="outline" onClick={() => fileRef.current?.click()} disabled={uploading || !!pendingFile}>
-          {uploading ? "Uploading…" : loom.has_photo ? "Replace photo" : "Upload photo"}
-        </Button>
-        {loom.has_photo && !confirmRemove && (
-          <Button size="sm" variant="outline" onClick={() => setConfirmRemove(true)} disabled={uploading || !!pendingFile}>
-            Remove photo
-          </Button>
-        )}
-        {loom.has_photo && confirmRemove && (
-          <ConfirmInline
-            label="Remove this photo?"
-            onConfirm={handleDelete}
-            onCancel={() => setConfirmRemove(false)}
-          />
+        {!isReadOnly && (
+          <>
+            <input ref={fileRef} type="file" accept="image/jpeg,image/png,image/webp,image/gif" className="hidden" onChange={handleFileSelected} />
+            <Button size="sm" variant="outline" onClick={() => fileRef.current?.click()} disabled={uploading || !!pendingFile}>
+              {uploading ? "Uploading…" : loom.has_photo ? "Replace photo" : "Upload photo"}
+            </Button>
+            {loom.has_photo && !confirmRemove && (
+              <Button size="sm" variant="outline" onClick={() => setConfirmRemove(true)} disabled={uploading || !!pendingFile}>
+                Remove photo
+              </Button>
+            )}
+            {loom.has_photo && confirmRemove && (
+              <ConfirmInline
+                label="Remove this photo?"
+                onConfirm={handleDelete}
+                onCancel={() => setConfirmRemove(false)}
+              />
+            )}
+          </>
         )}
         {pendingFile && (
           <div className="rounded-md border border-copper-subtle bg-copper-subtle px-3 py-2 text-xs">
@@ -616,6 +623,7 @@ function VersionCard({
   onClone: (v: LoomVersion) => void;
 }) {
   const { user } = useAuthContext();
+  const isReadOnly = !!user?.is_superuser && loom.owner_id !== user.id;
   const displayUnit = measurementSystemToUnit(user?.measurement_system ?? "metric");
   const [open, setOpen] = useState(isCurrent);
   const [editing, setEditing] = useState(false);
@@ -758,14 +766,16 @@ function VersionCard({
                     })() : <span className="italic text-muted-foreground">Not set</span>}
                   </dd>
                 </dl>
-                <button
-                  type="button"
-                  onClick={() => setEditing(true)}
-                  className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-                  title="Edit configuration"
-                >
-                  <AppIcons.edit className="h-4 w-4" />
-                </button>
+                {!isReadOnly && (
+                  <button
+                    type="button"
+                    onClick={() => setEditing(true)}
+                    className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+                    title="Edit configuration"
+                  >
+                    <AppIcons.edit className="h-4 w-4" />
+                  </button>
+                )}
               </div>
             )}
           </div>
@@ -780,14 +790,16 @@ function VersionCard({
             <VersionReceipts loom={loom} version={version} onChanged={onChanged} />
           </div>
 
-          <div className="border-t pt-3">
-            <Button size="sm" variant="outline" onClick={() => onClone(version)}>
-              Clone this configuration
-            </Button>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Creates a new configuration pre-filled with {displayName}'s spec and accessories.
-            </p>
-          </div>
+          {!isReadOnly && (
+            <div className="border-t pt-3">
+              <Button size="sm" variant="outline" onClick={() => onClone(version)}>
+                Clone this configuration
+              </Button>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Creates a new configuration pre-filled with {displayName}'s spec and accessories.
+              </p>
+            </div>
+          )}
         </div>
       )}
     </div>
@@ -802,6 +814,7 @@ export function LoomDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { user } = useAuthContext();
   const [showAddVersion, setShowAddVersion] = useState(false);
   const [showEdit, setShowEdit] = useState(false);
   const [cloneSource, setCloneSource] = useState<LoomVersion | null>(null);
@@ -853,9 +866,12 @@ export function LoomDetailPage() {
 
   const sortedVersions = [...loom.versions].sort((a, b) => b.version_number - a.version_number);
   const currentVersionId = loom.current_version?.id;
+  const isReadOnly = !!user?.is_superuser && loom.owner_id !== user.id;
 
   return (
-    <div className="p-6 max-w-3xl mx-auto w-full space-y-8">
+    <div className="max-w-3xl mx-auto w-full">
+      {isReadOnly && <SuperuserInspectionBanner />}
+      <div className="p-6 space-y-8">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2 text-sm">
           <Link to="/looms" className="text-muted-foreground hover:text-foreground">Equipment</Link>
@@ -864,8 +880,8 @@ export function LoomDetailPage() {
           <span className="text-xs text-muted-foreground">{LOOM_TYPE_LABELS[loom.loom_type]}</span>
         </div>
         <div className="flex gap-2">
-          <Button size="sm" variant="outline" onClick={() => setShowEdit(true)}>Edit</Button>
-          <Button size="sm" onClick={() => setShowAddVersion(true)}>Add version</Button>
+          {!isReadOnly && <Button size="sm" variant="outline" onClick={() => setShowEdit(true)}>Edit</Button>}
+          {!isReadOnly && <Button size="sm" onClick={() => setShowAddVersion(true)}>Add version</Button>}
         </div>
       </div>
         {!SUPPORTED_LOOM_TYPES.has(loom.loom_type) && (
@@ -934,38 +950,40 @@ export function LoomDetailPage() {
           <ProjectSummaryList projects={loomProjects} />
         </section>
 
-        <section className="border-t pt-6">
-          <button
-            type="button"
-            className="flex w-full items-center justify-between text-sm font-medium text-destructive hover:text-destructive/80"
-            onClick={() => { setDangerZoneOpen((o) => !o); setConfirmDelete(false); }}
-          >
-            <span>Danger zone</span>
-            <span className="text-xs text-muted-foreground">{dangerZoneOpen ? "▲ collapse" : "▼ expand"}</span>
-          </button>
-          {dangerZoneOpen && (
-            <div className="mt-4 rounded-md border border-destructive/30 px-4 py-4">
-              <div className="flex items-start justify-between gap-4">
-                <div>
-                  <p className="text-sm font-medium">Delete this loom</p>
-                  <p className="mt-0.5 text-xs text-muted-foreground">Permanently removes the loom and all its configurations. This cannot be undone.</p>
-                </div>
-                {!confirmDelete ? (
-                  <Button variant="outline" size="sm" className="shrink-0 border-destructive/50 text-destructive hover:bg-destructive/10" onClick={() => setConfirmDelete(true)}>
-                    Delete loom
-                  </Button>
-                ) : (
-                  <div className="flex shrink-0 items-center gap-2">
-                    <Button variant="outline" size="sm" onClick={() => setConfirmDelete(false)} disabled={deleting}>Cancel</Button>
-                    <Button size="sm" onClick={handleDelete} disabled={deleting} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
-                      {deleting ? "Deleting…" : "Confirm delete"}
-                    </Button>
+        {!isReadOnly && (
+          <section className="border-t pt-6">
+            <button
+              type="button"
+              className="flex w-full items-center justify-between text-sm font-medium text-destructive hover:text-destructive/80"
+              onClick={() => { setDangerZoneOpen((o) => !o); setConfirmDelete(false); }}
+            >
+              <span>Danger zone</span>
+              <span className="text-xs text-muted-foreground">{dangerZoneOpen ? "▲ collapse" : "▼ expand"}</span>
+            </button>
+            {dangerZoneOpen && (
+              <div className="mt-4 rounded-md border border-destructive/30 px-4 py-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <p className="text-sm font-medium">Delete this loom</p>
+                    <p className="mt-0.5 text-xs text-muted-foreground">Permanently removes the loom and all its configurations. This cannot be undone.</p>
                   </div>
-                )}
+                  {!confirmDelete ? (
+                    <Button variant="outline" size="sm" className="shrink-0 border-destructive/50 text-destructive hover:bg-destructive/10" onClick={() => setConfirmDelete(true)}>
+                      Delete loom
+                    </Button>
+                  ) : (
+                    <div className="flex shrink-0 items-center gap-2">
+                      <Button variant="outline" size="sm" onClick={() => setConfirmDelete(false)} disabled={deleting}>Cancel</Button>
+                      <Button size="sm" onClick={handleDelete} disabled={deleting} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
+                        {deleting ? "Deleting…" : "Confirm delete"}
+                      </Button>
+                    </div>
+                  )}
+                </div>
               </div>
-            </div>
-          )}
-        </section>
+            )}
+          </section>
+        )}
 
       {showAddVersion && (
         <AddVersionModal loomId={loom.id} loomType={loom.loom_type} onSuccess={handleVersionAdded} onClose={() => setShowAddVersion(false)} />
@@ -976,6 +994,7 @@ export function LoomDetailPage() {
       {cloneSource && (
         <CloneVersionModal loomId={loom.id} source={cloneSource} onSuccess={handleCloned} onClose={() => setCloneSource(null)} />
       )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -19,6 +19,7 @@ import { getAuthToken } from "@/api/client";
 import { AssignLoomModal } from "@/components/projects/AssignLoomModal";
 import { AuthedImage } from "@/components/ui/AuthedImage";
 import { Button } from "@/components/ui/button";
+import { SuperuserInspectionBanner } from "@/components/ui/SuperuserInspectionBanner";
 
 // ---------------------------------------------------------------------------
 // Color utilities
@@ -704,11 +705,13 @@ function PhotoGrid({
   photos,
   onUploaded,
   onDeleted,
+  readOnly = false,
 }: {
   projectId: string;
   photos: ProjectPhoto[];
   onUploaded: (p: ProjectPhoto) => void;
   onDeleted: (id: string) => void;
+  readOnly?: boolean;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
@@ -743,7 +746,7 @@ function PhotoGrid({
     <div>
       <div className="flex items-center justify-between mb-3">
         <p className="text-sm font-medium">Photos <span className="text-muted-foreground font-normal">({photos.length}/10)</span></p>
-        {photos.length < 10 && (
+        {!readOnly && photos.length < 10 && (
           <button
             type="button"
             onClick={() => inputRef.current?.click()}
@@ -764,14 +767,18 @@ function PhotoGrid({
       </div>
       {error && <p className="mb-2 text-xs text-destructive">{error}</p>}
       {photos.length === 0 ? (
-        <button
-          type="button"
-          onClick={() => inputRef.current?.click()}
-          disabled={uploading}
-          className="w-full rounded-lg border border-dashed p-8 text-sm text-muted-foreground hover:border-ring hover:text-foreground transition-colors disabled:opacity-50"
-        >
-          Add photos to document your work
-        </button>
+        readOnly ? (
+          <p className="text-sm text-muted-foreground/60 italic">No photos.</p>
+        ) : (
+          <button
+            type="button"
+            onClick={() => inputRef.current?.click()}
+            disabled={uploading}
+            className="w-full rounded-lg border border-dashed p-8 text-sm text-muted-foreground hover:border-ring hover:text-foreground transition-colors disabled:opacity-50"
+          >
+            Add photos to document your work
+          </button>
+        )
       ) : (
         <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2">
           {photos.map((p) => (
@@ -782,17 +789,19 @@ function PhotoGrid({
                 className="w-full h-full object-cover rounded-md border cursor-pointer"
                 onClick={() => setLightbox(p.id)}
               />
-              <button
-                type="button"
-                onClick={(e) => { e.stopPropagation(); setConfirmDeleteId(p.id); }}
-                className="absolute top-1 right-1 hidden group-hover:flex h-5 w-5 items-center justify-center rounded-full bg-black/60 text-white text-xs hover:bg-black/80"
-                aria-label="Delete photo"
-              >
-                ✕
-              </button>
+              {!readOnly && (
+                <button
+                  type="button"
+                  onClick={(e) => { e.stopPropagation(); setConfirmDeleteId(p.id); }}
+                  className="absolute top-1 right-1 hidden group-hover:flex h-5 w-5 items-center justify-center rounded-full bg-black/60 text-white text-xs hover:bg-black/80"
+                  aria-label="Delete photo"
+                >
+                  ✕
+                </button>
+              )}
             </div>
           ))}
-          {photos.length < 10 && (
+          {!readOnly && photos.length < 10 && (
             <button
               type="button"
               onClick={() => inputRef.current?.click()}
@@ -1307,6 +1316,8 @@ export function ProjectDetailPage() {
   const isActiveTracking = (project.status === "active" || project.status === "created") && !isPlanning;
   const isAbandoned = project.status === "abandoned";
 
+  const isReadOnly = !!user?.is_superuser && project.owner_id !== user.id;
+
   // Badge for planning vs active
   const badgeClasses = isPlanning
     ? "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200"
@@ -1317,6 +1328,7 @@ export function ProjectDetailPage() {
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
+      {isReadOnly && <SuperuserInspectionBanner />}
       {/* Page header */}
       <div className="shrink-0 border-b border-border bg-card px-6 py-3 flex items-center justify-between">
         <div className="flex items-center gap-3 min-w-0">
@@ -1335,7 +1347,9 @@ export function ProjectDetailPage() {
             <Link to={`/projects/${project.id}`} className="text-muted-foreground hover:text-foreground truncate max-w-[12rem]">{project.name}</Link>
             <AppIcons.chevronRight className="h-3.5 w-3.5 text-muted-foreground" />
           </div>
-          {editingName ? (
+          {isReadOnly ? (
+            <span className="font-semibold truncate">{project.name}</span>
+          ) : editingName ? (
             <form
               onSubmit={async (e) => {
                 e.preventDefault();
@@ -1388,14 +1402,16 @@ export function ProjectDetailPage() {
           >
             View design
           </button>
-          <button
-            onClick={() => setSettingsOpen(true)}
-            className="rounded-md border border-border bg-background px-2.5 py-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            title="View settings"
-            aria-label="Open view settings"
-          >
-            <AppIcons.settings className="h-4 w-4" />
-          </button>
+          {!isReadOnly && (
+            <button
+              onClick={() => setSettingsOpen(true)}
+              className="rounded-md border border-border bg-background px-2.5 py-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              title="View settings"
+              aria-label="Open view settings"
+            >
+              <AppIcons.settings className="h-4 w-4" />
+            </button>
+          )}
           <span className={`rounded px-2 py-0.5 text-xs font-medium ${badgeClasses}`}>
             {badgeLabel}
           </span>
@@ -1575,7 +1591,7 @@ export function ProjectDetailPage() {
 
         {/* Step controls — active tracking and planning */}
         <div className="w-full px-4 pb-6">
-          {(isActiveTracking || isPlanning) && (
+          {!isReadOnly && (isActiveTracking || isPlanning) && (
             <div className="flex flex-col gap-6 lg:grid lg:grid-cols-[1fr_auto_1fr] lg:items-center lg:gap-8 mb-4">
               {/* Left 1/3 on desktop, below step buttons on mobile */}
               <div className="order-2 lg:order-1 lg:flex lg:justify-center">
@@ -1600,7 +1616,7 @@ export function ProjectDetailPage() {
             </div>
           )}
 
-          {(isActiveTracking || isPlanning) && (
+          {!isReadOnly && (isActiveTracking || isPlanning) && (
             <p className="text-center text-sm text-muted-foreground">
               ← → arrow keys or spacebar to navigate picks
             </p>
@@ -1628,11 +1644,12 @@ export function ProjectDetailPage() {
         {panelOpen && (
           <div className="overflow-y-auto max-h-[55dvh] border-t border-border/50">
             <div className="mx-auto max-w-2xl px-8 pb-10 space-y-0">
-          {!isCompleted && (
+          {(!isCompleted || isReadOnly) && (
             <CollapsibleSection title={`Photos (${project.photos.length}/10)`} defaultOpen={isAbandoned}>
               <PhotoGrid
                 projectId={project.id}
                 photos={project.photos}
+                readOnly={isReadOnly}
                 onUploaded={(p) =>
                   queryClient.setQueryData<typeof project>(["project", id], (old) =>
                     old ? { ...old, photos: [...old.photos, p] } : old
@@ -1654,7 +1671,13 @@ export function ProjectDetailPage() {
           )}
 
           <CollapsibleSection title="Notes" defaultOpen={!!project.notes}>
-            {editingNotes ? (
+            {isReadOnly ? (
+              project.notes ? (
+                <p className="whitespace-pre-wrap text-sm text-muted-foreground">{project.notes}</p>
+              ) : (
+                <p className="text-sm text-muted-foreground/60 italic">No notes.</p>
+              )
+            ) : editingNotes ? (
               <textarea
                 autoFocus
                 className="w-full rounded border border-input bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring resize-none"
@@ -1729,7 +1752,7 @@ export function ProjectDetailPage() {
           </CollapsibleSection>
 
           {/* Active tracking: complete / abandon */}
-          {isActiveTracking && (
+          {!isReadOnly && isActiveTracking && (
             <CollapsibleSection title="Actions">
               <div className="flex flex-wrap gap-2">
                 {!confirmComplete && !confirmAbandon && (
@@ -1762,7 +1785,7 @@ export function ProjectDetailPage() {
             </CollapsibleSection>
           )}
 
-          {project.status === "abandoned" && (
+          {!isReadOnly && project.status === "abandoned" && (
             <CollapsibleSection title="Actions">
               <div className="space-y-3">
                 {!confirmRestart && !restartConflict && (
@@ -1800,7 +1823,7 @@ export function ProjectDetailPage() {
             </CollapsibleSection>
           )}
 
-          <CollapsibleSection title="Clone project">
+          {!isReadOnly && <CollapsibleSection title="Clone project">
             <div className="space-y-3">
               <p className="text-xs text-muted-foreground">Create a new project with the same configuration, starting at pick 1.</p>
               {!confirmClone && !cloneConflict && (
@@ -1835,9 +1858,9 @@ export function ProjectDetailPage() {
                 </div>
               )}
             </div>
-          </CollapsibleSection>
+          </CollapsibleSection>}
 
-          <CollapsibleSection title="Danger zone">
+          {!isReadOnly && <CollapsibleSection title="Danger zone">
             {!confirmDelete ? (
               <Button variant="outline" size="sm" onClick={() => setConfirmDelete(true)}>
                 Delete project
@@ -1860,7 +1883,7 @@ export function ProjectDetailPage() {
                 </Button>
               </div>
             )}
-          </CollapsibleSection>
+          </CollapsibleSection>}
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary

- Backend `_get_owned_*` helpers now accept `allow_superuser=True` on all GET endpoints, bypassing `owner_id` filter for superusers
- `owner_id` field added to `DraftSummary`, `LoomDetail`, and `ProjectSummary` schemas (and their TS types)
- `ProtectedRoute` expanded to permit superusers on `/drafts/`, `/looms/`, `/projects/` path prefixes
- New `SuperuserInspectionBanner` component renders an amber read-only indicator when a superuser is viewing another user's resource
- All mutation controls hidden when `isReadOnly` (rename, settings, step controls, actions, clone, delete, photo upload/delete); notes shown read-only

## Test plan

- [ ] Log in as superuser, navigate to another user's draft/loom/project URL — banner appears, no edit controls
- [ ] Log in as superuser, navigate to own draft/loom/project — no banner, full controls
- [ ] All write endpoints still 404 for superuser viewing another user's resource (backend safety layer)
- [ ] `tsc` clean ✅
- [ ] `pytest` passing ✅

Closes #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)