### PR TITLE
feat: copper primary buttons and improved outline contrast (#633)

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -157,7 +157,7 @@ The authenticated app shell (sidebar, pages, modals) uses CSS custom properties 
 | `text-foreground` | `--foreground` | stone-900 | stone-50 |
 | `bg-card` / `text-card-foreground` | `--card` | white | stone-800 |
 | `bg-popover` / `text-popover-foreground` | `--popover` | white | stone-800 |
-| `bg-primary` / `text-primary-foreground` | `--primary` | zinc-800 | amber-500 |
+| `bg-primary` / `text-primary-foreground` | `--primary` | amber-900 | amber-500 |
 | `bg-secondary` / `text-secondary-foreground` | `--secondary` | stone-100 | stone-700 |
 | `bg-muted` / `text-muted-foreground` | `--muted` | stone-100 | stone-700 |
 | `text-accent` / `bg-accent` | `--accent` | amber-600 | amber-500 |
@@ -189,6 +189,41 @@ All authenticated UI adapts automatically when the CSS variables change under `.
 - **Do** use `bg-card` for panel/modal surfaces, `bg-background` for page canvas.
 - **Don't** use raw palette classes (`stone-*`, `amber-*`, `zinc-*`) inside authenticated components — changes to the palette would then require hunting down every hard-coded class.
 - **Don't** add dark mode overrides to public pages (landing, login, register, about, privacy, terms).
+
+---
+
+## Button Conventions (Authenticated App)
+
+Use `<Button>` from `frontend/src/components/ui/button.tsx`. Match intent to variant — do not choose a variant based on aesthetics alone.
+
+| Intent | Variant | When to use |
+| --- | --- | --- |
+| Confirm / save / submit | `default` (no `variant` prop) | The primary positive action in a form or dialog — "Save", "Add", "Submit" |
+| Cancel / dismiss / close | `variant="outline"` | The secondary escape action alongside a confirm button |
+| Delete / ban / irreversible | `variant="destructive"` | Any action that cannot be undone |
+| Secondary neutral | `variant="secondary"` | Second-tier actions that aren't destructive and aren't the primary CTA |
+| Positive outcome / advance | `variant="success"` | Marking a step complete, advancing a project, green-light actions |
+| Toolbar / icon-only | `variant="ghost"` | Icon buttons in toolbars, inline row actions with no border needed |
+
+### Common patterns
+
+```tsx
+// Save / Cancel pair in a form
+<Button type="submit" disabled={saving}>{saving ? "Saving…" : "Save"}</Button>
+<Button type="button" variant="outline" onClick={onCancel} disabled={saving}>Cancel</Button>
+
+// Confirm / Cancel in a destructive dialog
+<Button variant="destructive" onClick={handleDelete}>Delete</Button>
+<Button variant="outline" onClick={() => setConfirm(false)}>Cancel</Button>
+
+// Inline "Add" mini-form (submit = primary action, no cancel present)
+<Button type="submit" size="sm" disabled={saving || !input.trim()}>Add</Button>
+```
+
+### What changed (v0.145+)
+
+- `--primary` in light mode shifted from zinc-800 (cool gray) to amber-900 (dark copper `#78350f`), consistent with the amber-500 copper primary already used in dark mode. All `bg-primary` surfaces — buttons, progress bars, toggles — now read as copper in light mode.
+- `variant="outline"` border changed from `border-input` to `border-foreground/25`, which has better contrast in dark mode where the previous stone-700 border was nearly invisible against the stone-800 card surface.
 
 ---
 

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -13,7 +13,7 @@ const buttonVariants = cva(
         success:
           "bg-green-600 text-white shadow-sm hover:bg-green-700",
         outline:
-          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+          "border border-foreground/25 bg-background text-foreground shadow-sm hover:bg-accent hover:text-accent-foreground",
         secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -39,7 +39,7 @@
     --card-foreground: 20 10% 10%;      /* stone-900 */
     --popover: 0 0% 100%;               /* white     */
     --popover-foreground: 20 10% 10%;   /* stone-900 */
-    --primary: 240 4% 16%;              /* zinc-800  */
+    --primary: 26 72% 26%;               /* amber-900 (dark copper) */
     --primary-foreground: 0 0% 100%;    /* white     */
     --secondary: 60 5% 96%;             /* stone-100 */
     --secondary-foreground: 20 10% 10%; /* stone-900 */

--- a/frontend/src/pages/LoomDetailPage.tsx
+++ b/frontend/src/pages/LoomDetailPage.tsx
@@ -461,7 +461,7 @@ function VersionAccessories({ loom, version, onChanged }: { loom: LoomDetail; ve
           placeholder="e.g. Second warp beam"
           disabled={saving}
         />
-        <Button size="sm" variant="outline" type="submit" disabled={saving || !input.trim()}>
+        <Button size="sm" type="submit" disabled={saving || !input.trim()}>
           Add
         </Button>
       </form>
@@ -594,7 +594,7 @@ function ReedsPanel({ loom, onChanged }: { loom: LoomDetail; onChanged: () => vo
             disabled={saving}
           />
         </div>
-        <Button size="sm" variant="outline" type="submit" disabled={saving || !dentsInput}>
+        <Button size="sm" type="submit" disabled={saving || !dentsInput}>
           Add reed
         </Button>
       </form>


### PR DESCRIPTION
## Summary
- Shifts `--primary` in light mode from zinc-800 (cool gray/"black") to amber-900 (dark copper `#78350f`), matching the existing amber-500 copper primary in dark mode — all `bg-primary` surfaces (buttons, progress bars, toggles, logo) now read as copper in light mode
- Fixes `variant="outline"` border from `border-input` to `border-foreground/25`, which has significantly better contrast in dark mode where stone-700 border on stone-800 card was nearly invisible
- Fixes two inline form submit buttons in `LoomDetailPage` that incorrectly used `variant="outline"` (the "Add" and "Add reed" inline submit buttons); they now use `variant="default"` as the primary action
- Documents the intent-to-variant table and button patterns in `docs/design-system.md`

## Test plan
- [x] tsc clean
- [x] ESLint clean
- [x] Built and deployed to local container — verify copper primary buttons and higher-contrast outline borders
- [x] Check loom detail page: version edit Save/Cancel pair, reed add form, accessories add form
- [x] Check dark mode: outline Cancel buttons should now have a visible border on dark card surfaces

Closes #633

Generated with Claude Code