### PR TITLE
feat: pick step metrics and admin step log viewer (#42)

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -25,7 +25,7 @@ from app.models.eula_version import EulaVersion
 from app.models.invite import Invite
 from app.models.loom import Loom, LoomVersion, LoomVersionPhoto
 from app.models.pending_signup import PendingSignup
-from app.models.project import Project, ProjectPhoto
+from app.models.project import Project, ProjectPhoto, ProjectStep
 from app.models.server_event import ServerEvent
 from app.models.user import User
 from app.models.yarn import Yarn
@@ -2518,3 +2518,38 @@ async def admin_revoke_project_slug(
     project.share_visibility = "private"
     project.share_expires_at = None
     await db.commit()
+
+
+class AdminProjectStepRecord(BaseModel):
+    id: uuid.UUID
+    event_type: str
+    from_pick: int
+    to_pick: int
+    dwell_ms: int | None
+    created_at: datetime
+
+
+@router.get("/project-steps", response_model=list[AdminProjectStepRecord])
+async def admin_list_project_steps(
+    project_id: uuid.UUID,
+    limit: int = 200,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_admin),
+) -> list[AdminProjectStepRecord]:
+    rows = await db.scalars(
+        select(ProjectStep)
+        .where(ProjectStep.project_id == project_id)
+        .order_by(ProjectStep.created_at.desc())
+        .limit(limit)
+    )
+    return [
+        AdminProjectStepRecord(
+            id=s.id,
+            event_type=s.event_type,
+            from_pick=s.from_pick,
+            to_pick=s.to_pick,
+            dwell_ms=s.dwell_ms,
+            created_at=s.created_at,
+        )
+        for s in rows.all()
+    ]

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -217,6 +217,7 @@ class SessionInfo(BaseModel):
     started_at: datetime
     ended_at: datetime | None
     duration_ms: int
+    step_count: int
 
 
 class ProjectMetricsResponse(BaseModel):
@@ -226,6 +227,7 @@ class ProjectMetricsResponse(BaseModel):
     total_advance_steps: int
     total_reverse_steps: int
     total_worked_picks: int
+    avg_pick_dwell_ms: int | None
     sessions: list[SessionInfo]
 
 
@@ -1253,7 +1255,14 @@ async def get_project_metrics(
 
     total_advance = sum(1 for s in steps if s.event_type == "advance")
     total_reverse = sum(1 for s in steps if s.event_type == "reverse")
-    total_worked = sum(1 for s in steps if s.dwell_ms is not None and s.dwell_ms >= _WORKED_PICK_THRESHOLD_MS)
+
+    worked_dwells = [
+        s.dwell_ms
+        for s in steps
+        if s.event_type == "advance" and s.dwell_ms is not None and s.dwell_ms >= _WORKED_PICK_THRESHOLD_MS
+    ]
+    total_worked = len(worked_dwells)
+    avg_pick_dwell_ms = int(sum(worked_dwells) / len(worked_dwells)) if worked_dwells else None
 
     total_session_ms = 0
     session_infos: list[SessionInfo] = []
@@ -1262,8 +1271,15 @@ async def get_project_metrics(
         end = sess.ended_at or now
         duration_ms = int((end - sess.started_at).total_seconds() * 1_000)
         total_session_ms += duration_ms
+        step_count = sum(1 for s in steps if sess.started_at <= s.created_at <= end)
         session_infos.append(
-            SessionInfo(id=sess.id, started_at=sess.started_at, ended_at=sess.ended_at, duration_ms=duration_ms)
+            SessionInfo(
+                id=sess.id,
+                started_at=sess.started_at,
+                ended_at=sess.ended_at,
+                duration_ms=duration_ms,
+                step_count=step_count,
+            )
         )
         if sess.ended_at is None:
             current_session_started_at = sess.started_at
@@ -1275,6 +1291,7 @@ async def get_project_metrics(
         total_advance_steps=total_advance,
         total_reverse_steps=total_reverse,
         total_worked_picks=total_worked,
+        avg_pick_dwell_ms=avg_pick_dwell_ms,
         sessions=session_infos,
     )
 

--- a/backend/tests/routers/test_admin.py
+++ b/backend/tests/routers/test_admin.py
@@ -1398,3 +1398,115 @@ class TestPatchScheduledTask:
         resp = await superuser_client.patch("/api/admin/scheduled-tasks/cve_scan", json={"enabled": True})
         assert resp.json()["cron"] == "0 3 * * *"
         assert resp.json()["enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# GET /api/admin/project-steps
+# ---------------------------------------------------------------------------
+
+
+class TestAdminProjectSteps:
+    async def _insert_project(self, db: AsyncSession, owner: User) -> Project:
+        import uuid as _uuid
+
+        from app.models.draft import Draft as _Draft
+
+        draft = _Draft(
+            id=_uuid.uuid4(),
+            owner_id=owner.id,
+            name="Step Log Test Draft",
+            wif_filename="t.wif",
+            wif_path="drafts/t.wif",
+            has_treadling=True,
+            has_liftplan=True,
+            num_shafts=4,
+            num_treadles=4,
+            weft_threads=2,
+        )
+        db.add(draft)
+        project = Project(
+            owner_id=owner.id,
+            draft_id=draft.id,
+            name="Step Log Test Project",
+            project_type="treadle",
+            status="active",
+            current_pick=3,
+            total_picks=10,
+        )
+        db.add(project)
+        await db.commit()
+        return project
+
+    async def test_returns_200(self, admin_client: AsyncClient, db_session: AsyncSession, admin_user: User):
+        project = await self._insert_project(db_session, admin_user)
+        resp = await admin_client.get(f"/api/admin/project-steps?project_id={project.id}")
+        assert resp.status_code == 200
+
+    async def test_returns_steps_for_project(
+        self, admin_client: AsyncClient, db_session: AsyncSession, admin_user: User
+    ):
+        from app.models.project import ProjectStep
+
+        project = await self._insert_project(db_session, admin_user)
+        db_session.add_all(
+            [
+                ProjectStep(project_id=project.id, event_type="advance", from_pick=1, to_pick=2, dwell_ms=5_000),
+                ProjectStep(project_id=project.id, event_type="advance", from_pick=2, to_pick=3, dwell_ms=6_000),
+            ]
+        )
+        await db_session.commit()
+
+        resp = await admin_client.get(f"/api/admin/project-steps?project_id={project.id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        assert data[0]["event_type"] in ("advance", "reverse")
+        assert "dwell_ms" in data[0]
+        assert "created_at" in data[0]
+
+    async def test_most_recent_first(self, admin_client: AsyncClient, db_session: AsyncSession, admin_user: User):
+        from datetime import datetime, timedelta, timezone
+
+        from app.models.project import ProjectStep
+
+        project = await self._insert_project(db_session, admin_user)
+        now = datetime.now(timezone.utc)
+        db_session.add_all(
+            [
+                ProjectStep(
+                    project_id=project.id,
+                    event_type="advance",
+                    from_pick=1,
+                    to_pick=2,
+                    dwell_ms=5_000,
+                    created_at=now - timedelta(seconds=10),
+                ),
+                ProjectStep(
+                    project_id=project.id,
+                    event_type="advance",
+                    from_pick=2,
+                    to_pick=3,
+                    dwell_ms=6_000,
+                    created_at=now,
+                ),
+            ]
+        )
+        await db_session.commit()
+
+        resp = await admin_client.get(f"/api/admin/project-steps?project_id={project.id}")
+        data = resp.json()
+        assert data[0]["to_pick"] == 3  # most recent first
+
+    async def test_missing_project_id_returns_422(self, admin_client: AsyncClient):
+        resp = await admin_client.get("/api/admin/project-steps")
+        assert resp.status_code == 422
+
+    async def test_non_admin_returns_403(self, auth_client: AsyncClient, db_session: AsyncSession, admin_user: User):
+        project = await self._insert_project(db_session, admin_user)
+        resp = await auth_client.get(f"/api/admin/project-steps?project_id={project.id}")
+        assert resp.status_code == 403
+
+    async def test_unauthenticated_returns_401(self, client: AsyncClient, db_session: AsyncSession, admin_user: User):
+        project = await self._insert_project(db_session, admin_user)
+        resp = await client.get(f"/api/admin/project-steps?project_id={project.id}")
+        assert resp.status_code == 401

--- a/backend/tests/routers/test_projects.py
+++ b/backend/tests/routers/test_projects.py
@@ -2399,6 +2399,103 @@ class TestProjectMetrics:
         resp = await client.get(f"/api/projects/{project.id}/metrics")
         assert resp.status_code == 401
 
+    async def test_avg_pick_dwell_ms_none_when_no_worked_picks(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        body = (await auth_client.get(f"/api/projects/{project.id}/metrics")).json()
+        assert body["avg_pick_dwell_ms"] is None
+
+    async def test_avg_pick_dwell_ms_computed_correctly(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        from app.models.project import ProjectStep
+
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        db_session.add_all(
+            [
+                ProjectStep(project_id=project.id, event_type="advance", from_pick=1, to_pick=2, dwell_ms=6_000),
+                ProjectStep(project_id=project.id, event_type="advance", from_pick=2, to_pick=3, dwell_ms=10_000),
+            ]
+        )
+        await db_session.commit()
+
+        body = (await auth_client.get(f"/api/projects/{project.id}/metrics")).json()
+        assert body["avg_pick_dwell_ms"] == 8_000
+
+    async def test_avg_pick_dwell_ms_excludes_sub_threshold_and_reverse(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        from app.models.project import ProjectStep
+
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        db_session.add_all(
+            [
+                ProjectStep(project_id=project.id, event_type="advance", from_pick=1, to_pick=2, dwell_ms=8_000),
+                ProjectStep(
+                    project_id=project.id, event_type="advance", from_pick=2, to_pick=3, dwell_ms=500
+                ),  # navigation
+                ProjectStep(
+                    project_id=project.id, event_type="reverse", from_pick=3, to_pick=2, dwell_ms=12_000
+                ),  # reverse
+            ]
+        )
+        await db_session.commit()
+
+        body = (await auth_client.get(f"/api/projects/{project.id}/metrics")).json()
+        assert body["avg_pick_dwell_ms"] == 8_000
+
+    async def test_session_step_count(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        from app.models.project import ProjectStep, WeaveSession
+
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+
+        t0 = datetime.now(timezone.utc) - timedelta(minutes=10)
+        t1 = datetime.now(timezone.utc) - timedelta(minutes=5)
+        t2 = datetime.now(timezone.utc) - timedelta(minutes=2)
+
+        sess = WeaveSession(project_id=project.id, started_at=t0, ended_at=t1)
+        db_session.add(sess)
+        await db_session.flush()
+
+        # 3 steps inside the session window, 1 after
+        db_session.add_all(
+            [
+                ProjectStep(
+                    project_id=project.id,
+                    event_type="advance",
+                    from_pick=1,
+                    to_pick=2,
+                    created_at=t0 + timedelta(seconds=10),
+                ),
+                ProjectStep(
+                    project_id=project.id,
+                    event_type="advance",
+                    from_pick=2,
+                    to_pick=3,
+                    created_at=t0 + timedelta(seconds=20),
+                ),
+                ProjectStep(
+                    project_id=project.id,
+                    event_type="reverse",
+                    from_pick=3,
+                    to_pick=2,
+                    created_at=t0 + timedelta(seconds=30),
+                ),
+                ProjectStep(
+                    project_id=project.id, event_type="advance", from_pick=2, to_pick=3, created_at=t2
+                ),  # outside session
+            ]
+        )
+        await db_session.commit()
+
+        body = (await auth_client.get(f"/api/projects/{project.id}/metrics")).json()
+        assert body["sessions"][0]["step_count"] == 3
+
 
 # ---------------------------------------------------------------------------
 # GET /api/projects/{id}/drawdown/svg

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -452,3 +452,15 @@ export interface AdminSlugRecord {
 
 export const listProjectSlugs = () => api.get<AdminSlugRecord[]>("/api/admin/project-slugs");
 export const adminRevokeSlug = (slug: string) => api.delete<void>(`/api/admin/project-slugs/${slug}`);
+
+export interface AdminProjectStep {
+  id: string;
+  event_type: string;
+  from_pick: number;
+  to_pick: number;
+  dwell_ms: number | null;
+  created_at: string;
+}
+
+export const listProjectSteps = (projectId: string, limit = 200) =>
+  api.get<AdminProjectStep[]>(`/api/admin/project-steps?project_id=${projectId}&limit=${limit}`);

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -223,6 +223,7 @@ export interface SessionInfo {
   started_at: string;
   ended_at: string | null;
   duration_ms: number;
+  step_count: number;
 }
 
 export interface ProjectMetrics {
@@ -232,6 +233,7 @@ export interface ProjectMetrics {
   total_advance_steps: number;
   total_reverse_steps: number;
   total_worked_picks: number;
+  avg_pick_dwell_ms: number | null;
   sessions: SessionInfo[];
 }
 

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -45,6 +45,8 @@ import {
   deleteCredential,
   listProjectSlugs,
   adminRevokeSlug,
+  listProjectSteps,
+  type AdminProjectStep,
   type CredentialExpiry,
   type CredentialResource,
   type AdminSlugRecord,
@@ -1669,7 +1671,8 @@ function SlugsTab() {
   }
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-8">
+      <div className="space-y-3">
       <div className="flex items-center justify-between">
         <h2 className="text-base font-semibold">Active share links</h2>
         <span className="text-xs text-muted-foreground">{slugs.length} link{slugs.length !== 1 ? "s" : ""}</span>
@@ -1735,6 +1738,83 @@ function SlugsTab() {
           </tbody>
         </table>
       </div>
+    </div>
+      <StepLogSection />
+    </div>
+  );
+}
+
+function StepLogSection() {
+  const [projectId, setProjectId] = useState("");
+  const [submittedId, setSubmittedId] = useState<string | null>(null);
+
+  const { data: steps, isLoading, isError } = useQuery({
+    queryKey: ["admin", "project-steps", submittedId],
+    queryFn: () => listProjectSteps(submittedId!, 200),
+    enabled: !!submittedId,
+  });
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = projectId.trim();
+    if (trimmed) setSubmittedId(trimmed);
+  }
+
+  function formatDwell(ms: number | null) {
+    if (ms == null) return "—";
+    if (ms < 1000) return `${ms}ms`;
+    return `${(ms / 1000).toFixed(1)}s`;
+  }
+
+  return (
+    <div className="space-y-3 mt-8">
+      <h2 className="text-base font-semibold">Project step log</h2>
+      <form onSubmit={handleSubmit} className="flex gap-2 items-center">
+        <input
+          className="border border-border rounded px-2 py-1 text-sm bg-input flex-1 max-w-sm"
+          placeholder="Project ID (UUID)"
+          value={projectId}
+          onChange={(e) => setProjectId(e.target.value)}
+        />
+        <Button type="submit" size="sm" variant="secondary">Load</Button>
+      </form>
+      {isLoading && <div className="text-sm text-muted-foreground">Loading…</div>}
+      {isError && <div className="text-sm text-destructive">Failed to load steps.</div>}
+      {steps && steps.length === 0 && (
+        <div className="text-sm text-muted-foreground">No steps recorded for this project.</div>
+      )}
+      {steps && steps.length > 0 && (
+        <div className="rounded-lg border border-border overflow-x-auto">
+          <table className="w-full text-sm min-w-[560px]">
+            <thead>
+              <tr className="border-b border-border text-left text-xs text-muted-foreground">
+                <th className="px-3 py-2 font-medium">Timestamp</th>
+                <th className="px-3 py-2 font-medium">Event</th>
+                <th className="px-3 py-2 font-medium">Pick</th>
+                <th className="px-3 py-2 font-medium">Dwell</th>
+              </tr>
+            </thead>
+            <tbody>
+              {steps.map((s: AdminProjectStep) => (
+                <tr key={s.id} className="border-b border-border last:border-0 hover:bg-muted/20">
+                  <td className="px-3 py-1.5 font-mono text-xs text-muted-foreground whitespace-nowrap">
+                    {new Date(s.created_at).toLocaleString()}
+                  </td>
+                  <td className="px-3 py-1.5">
+                    <span className={s.event_type === "advance" ? "text-green-600 dark:text-green-400" : "text-amber-600 dark:text-amber-400"}>
+                      {s.event_type}
+                    </span>
+                  </td>
+                  <td className="px-3 py-1.5 font-mono text-xs">
+                    {s.from_pick} → {s.to_pick}
+                  </td>
+                  <td className="px-3 py-1.5 text-xs text-muted-foreground">{formatDwell(s.dwell_ms)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -91,6 +91,8 @@ function SessionMetricsPanel({ metrics }: { metrics: ProjectMetrics }) {
     return () => clearInterval(id);
   }, [metrics.current_session_started_at]);
 
+  const avgSec = metrics.avg_pick_dwell_ms != null ? (metrics.avg_pick_dwell_ms / 1000).toFixed(1) : null;
+
   return (
     <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
       <dt className="text-muted-foreground">Total woven picks</dt>
@@ -99,6 +101,12 @@ function SessionMetricsPanel({ metrics }: { metrics: ProjectMetrics }) {
       <dd>{metrics.total_advance_steps}</dd>
       <dt className="text-muted-foreground">Reverses</dt>
       <dd>{metrics.total_reverse_steps}</dd>
+      {avgSec != null && (
+        <>
+          <dt className="text-muted-foreground">Avg pick time</dt>
+          <dd>{avgSec}s</dd>
+        </>
+      )}
       <dt className="text-muted-foreground">Sessions</dt>
       <dd>{metrics.total_sessions}</dd>
       <dt className="text-muted-foreground">Total weaving time</dt>


### PR DESCRIPTION
## Summary

- Adds `avg_pick_dwell_ms` to project metrics — computed from advance steps with dwell ≥ 3s (navigation taps excluded), shows as "Avg pick time" in the session metrics panel
- Adds `step_count` per session (steps timestamped within session window)
- New `GET /api/admin/project-steps` endpoint for inspecting a project's raw event log
- Admin Slugs tab now includes a step log viewer: enter a project ID to load and browse all step events with event type, pick transition, and dwell time

Closes #42

## Test plan

- [ ] SessionMetricsPanel shows "Avg pick time" after stepping through picks
- [ ] Avg pick time is blank for projects with no advance steps ≥ 3s
- [ ] Admin → Slugs tab → paste project UUID → step table loads ordered newest first
- [ ] pytest `TestProjectMetrics` and `TestAdminProjectSteps` pass (17 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)