### PR TITLE
feat: in-app feedback forms with GitHub Discussions dispatch (#34)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,14 @@ API_URL=http://localhost:8000
 
 
 # ------------------------------------------------------------
+# GitHub Discussions integration (optional — issue #34)
+# PAT with write:discussion + read:discussion scopes on weftmark/weftmark.
+# Leave blank to store feedback locally only; no error surfaced to users.
+# — injected by Komodo (DEV_GITHUB_FEEDBACK_TOKEN)
+# ------------------------------------------------------------
+GITHUB_FEEDBACK_TOKEN=
+
+# ------------------------------------------------------------
 # Deployment — Docker Compose / Komodo
 # ------------------------------------------------------------
 

--- a/backend/alembic/versions/0025_user_feedback.py
+++ b/backend/alembic/versions/0025_user_feedback.py
@@ -1,0 +1,44 @@
+"""Add user_feedback table for in-app feedback submissions
+
+Revision ID: 0025
+Revises: 0024
+Create Date: 2026-05-17
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+revision = "1c23e69db390"
+down_revision = "f6e5d4c3b2a1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_feedback",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("user_id", UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("submission_type", sa.String(20), nullable=False),
+        sa.Column("is_anonymous", sa.Boolean, nullable=False, server_default="false"),
+        sa.Column("subject", sa.String(200), nullable=True),
+        sa.Column("body", sa.Text, nullable=False),
+        sa.Column("diagnostics", JSONB, nullable=True),
+        sa.Column("github_discussion_url", sa.Text, nullable=True),
+        sa.Column("dispatch_status", sa.String(10), nullable=False, server_default="pending"),
+        sa.Column("dispatch_error", sa.Text, nullable=True),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index("ix_user_feedback_user_id", "user_feedback", ["user_id"])
+    op.create_index("ix_user_feedback_created_at", "user_feedback", ["created_at"])
+    op.create_index("ix_user_feedback_dispatch_status", "user_feedback", ["dispatch_status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_user_feedback_dispatch_status", table_name="user_feedback")
+    op.drop_index("ix_user_feedback_created_at", table_name="user_feedback")
+    op.drop_index("ix_user_feedback_user_id", table_name="user_feedback")
+    op.drop_table("user_feedback")

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -203,3 +203,39 @@ def _run_post_migrate_backfills(sender=None, **kwargs):
         log.info("post_migrate_backfills queued on worker_ready")
     except Exception:
         pass
+
+
+@worker_ready.connect
+def _run_startup_sweeps(sender=None, **kwargs):
+    """Fire recovery sweeps once per deploy on the first worker to start.
+
+    Uses a Redis SETNX lock keyed by VERSION so sweeps run once per deploy
+    regardless of how many worker processes start. Covers work that may have
+    stalled while the worker was down:
+    - retry_failed_feedback: stale pending/failed GitHub Discussion dispatches
+    - retry_failed_previews: drafts missing a drawdown preview
+    """
+    try:
+        import redis as _redis
+
+        settings = get_settings()
+        client = _redis.from_url(settings.redis_url, socket_connect_timeout=2)
+        lock_key = f"weftmark:startup_sweep:{VERSION}"
+        acquired = client.set(lock_key, "1", nx=True, ex=300)
+        client.close()
+        if not acquired:
+            return
+
+        from app.services.task_history import record_queued
+        from app.tasks.feedback_dispatch import retry_failed_feedback
+        from app.tasks.maintenance import retry_failed_previews
+
+        t1 = retry_failed_feedback.delay()
+        record_queued(settings, t1.id, "app.tasks.feedback_dispatch.retry_failed_feedback", "startup:feedback_retry")
+        log.info("startup_sweep feedback_retry task_id=%s", t1.id)
+
+        t2 = retry_failed_previews.delay()
+        record_queued(settings, t2.id, "app.tasks.maintenance.retry_failed_previews", "startup:preview_retry")
+        log.info("startup_sweep preview_retry task_id=%s", t2.id)
+    except Exception:
+        pass

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -23,6 +23,7 @@ def _make_celery() -> Celery:
         include=[
             "app.tasks.deletion",
             "app.tasks.email_task",
+            "app.tasks.feedback_dispatch",
             "app.tasks.geo",
             "app.tasks.maintenance",
             "app.tasks.metrics",

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -227,14 +227,24 @@ def _run_startup_sweeps(sender=None, **kwargs):
             return
 
         from app.services.task_history import record_queued
-        from app.tasks.feedback_dispatch import retry_failed_feedback
-        from app.tasks.maintenance import retry_failed_previews
 
-        t1 = retry_failed_feedback.delay()
+        # send_task dispatches by name without a local registry lookup, avoiding
+        # NotRegistered races during worker_ready when some include modules may not
+        # yet be visible to the signal handler's app instance. countdown=15 gives
+        # pool processes time to finish initializing before executing.
+        t1 = celery_app.send_task(
+            "app.tasks.feedback_dispatch.retry_failed_feedback",
+            kwargs={"limit": 20},
+            countdown=15,
+        )
         record_queued(settings, t1.id, "app.tasks.feedback_dispatch.retry_failed_feedback", "startup:feedback_retry")
         log.info("startup_sweep feedback_retry task_id=%s", t1.id)
 
-        t2 = retry_failed_previews.delay()
+        t2 = celery_app.send_task(
+            "app.tasks.maintenance.retry_failed_previews",
+            kwargs={"limit": 50},
+            countdown=15,
+        )
         record_queued(settings, t2.id, "app.tasks.maintenance.retry_failed_previews", "startup:preview_retry")
         log.info("startup_sweep preview_retry task_id=%s", t2.id)
     except Exception:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -124,6 +124,15 @@ class Settings(BaseSettings):
     maxmind_license_key: str = ""
     geoip_db_path: str = "/app/data/GeoLite2-City.mmdb"
 
+    # GitHub Discussions feedback integration (optional — issue #34)
+    # PAT with write:discussion + read:discussion scopes on the target repo.
+    # Leave empty to store feedback locally only; no error surfaced to users.
+    github_feedback_token: str = ""
+    github_feedback_repo: str = "weftmark/weftmark"
+
+    # Feedback rate limiting
+    feedback_rate_limit_per_hour: int = 5
+
     # Data retention
     soft_delete_retention_days: int = 365
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,4 +1,5 @@
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
 
 from app.config import get_settings
 
@@ -12,6 +13,20 @@ engine = create_async_engine(
 
 AsyncSessionLocal = async_sessionmaker(
     engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+)
+
+# NullPool engine for Celery tasks: each asyncio.run() call creates a new event loop,
+# which invalidates pooled asyncpg connections. NullPool creates a fresh connection
+# per session, avoiding "Future attached to a different loop" errors.
+_celery_engine = create_async_engine(
+    settings.database_url,
+    poolclass=NullPool,
+)
+
+CeleryAsyncSession = async_sessionmaker(
+    _celery_engine,
     class_=AsyncSession,
     expire_on_commit=False,
 )

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -76,6 +76,20 @@ async def get_current_user(
     return user
 
 
+async def get_optional_user(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> User | None:
+    """Like get_current_user but returns None instead of raising for unauthenticated requests."""
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return None
+    try:
+        return await get_current_user(request, db)
+    except HTTPException:
+        return None
+
+
 async def require_admin(current_user: User = Depends(get_current_user)) -> User:
     if not current_user.is_admin:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin required")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,7 +18,20 @@ from app.version import VERSION
 settings = get_settings()
 configure_logging(settings.log_level)
 
-from app.routers import admin, auth, dev, drafts, health, logs, looms, projects, system, users, yarn  # noqa: E402
+from app.routers import (  # noqa: E402
+    admin,
+    auth,
+    dev,
+    drafts,
+    feedback,
+    health,
+    logs,
+    looms,
+    projects,
+    system,
+    users,
+    yarn,
+)
 from app.telemetry import configure_telemetry  # noqa: E402
 
 configure_telemetry(settings)
@@ -221,4 +234,5 @@ app.include_router(looms.router)
 app.include_router(yarn.router)
 app.include_router(projects.router)
 app.include_router(projects.share_router)
+app.include_router(feedback.router)
 app.include_router(admin.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,6 +4,7 @@ from app.models.base import Base
 from app.models.credential_expiry import CredentialExpiry
 from app.models.draft import Draft
 from app.models.eula_version import EulaVersion
+from app.models.feedback import UserFeedback
 from app.models.invite import Invite
 from app.models.loom import (
     Loom,
@@ -27,6 +28,7 @@ __all__ = [
     "AuditLog",
     "CredentialExpiry",
     "User",
+    "UserFeedback",
     "UserIdentity",
     "Invite",
     "PendingSignup",

--- a/backend/app/models/feedback.py
+++ b/backend/app/models/feedback.py
@@ -1,0 +1,31 @@
+import uuid
+
+from sqlalchemy import Boolean, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, SoftDeleteMixin, TimestampMixin
+
+SUBMISSION_TYPES = ("feedback", "feature_request", "bug_report")
+DISPATCH_STATUSES = ("pending", "sent", "failed", "skipped")
+
+
+class UserFeedback(Base, TimestampMixin, SoftDeleteMixin):
+    __tablename__ = "user_feedback"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    # Null when submitted anonymously or by an unauthenticated user
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    submission_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    is_anonymous: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    subject: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    # Auto-collected: environment, page_url, user_agent, app_version, project_id, draft_id
+    diagnostics: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    github_discussion_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    dispatch_status: Mapped[str] = mapped_column(String(10), nullable=False, default="pending")
+    dispatch_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    user: Mapped["User | None"] = relationship("User", foreign_keys=[user_id])  # type: ignore[name-defined]

--- a/backend/app/models/feedback.py
+++ b/backend/app/models/feedback.py
@@ -1,6 +1,6 @@
 import uuid
 
-from sqlalchemy import Boolean, ForeignKey, String, Text
+from sqlalchemy import Boolean, ForeignKey, Index, String, Text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -12,6 +12,10 @@ DISPATCH_STATUSES = ("pending", "sent", "failed", "skipped")
 
 class UserFeedback(Base, TimestampMixin, SoftDeleteMixin):
     __tablename__ = "user_feedback"
+    __table_args__ = (
+        Index("ix_user_feedback_created_at", "created_at"),
+        Index("ix_user_feedback_dispatch_status", "dispatch_status"),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     # Null when submitted anonymously or by an unauthenticated user

--- a/backend/app/routers/feedback.py
+++ b/backend/app/routers/feedback.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, field_validator
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.deps import get_db, get_optional_user, require_admin
+from app.deps import get_current_user, get_db, get_optional_user, require_admin
 from app.models.feedback import SUBMISSION_TYPES, UserFeedback
 from app.models.user import User
 from app.services.rate_limiter import rate_limit
@@ -142,6 +142,26 @@ def _enqueue_dispatch(feedback_id: str) -> None:
 
     t = dispatch_feedback.delay(feedback_id)
     record_queued(settings, t.id, "app.tasks.feedback_dispatch.dispatch_feedback", "feedback")
+
+
+# ---------------------------------------------------------------------------
+# User feedback history
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/feedback/mine")
+async def list_my_feedback(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> list[FeedbackResponse]:
+    q = (
+        select(UserFeedback)
+        .where(UserFeedback.user_id == current_user.id)
+        .where(UserFeedback.deleted_at.is_(None))
+        .order_by(UserFeedback.created_at.desc())
+    )
+    rows = (await db.execute(q)).scalars().all()
+    return [_serialize(r) for r in rows]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/routers/feedback.py
+++ b/backend/app/routers/feedback.py
@@ -1,0 +1,236 @@
+"""In-app feedback submission and admin review endpoints."""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, field_validator
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.deps import get_db, get_optional_user, require_admin
+from app.models.feedback import SUBMISSION_TYPES, UserFeedback
+from app.models.user import User
+from app.services.rate_limiter import rate_limit
+
+router = APIRouter(tags=["feedback"])
+
+_submit_limit = rate_limit("feedback_submit", max_requests=5, window_seconds=3600)
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class DiagnosticsPayload(BaseModel):
+    environment: str | None = None
+    page_url: str | None = None
+    user_agent: str | None = None
+    app_version: str | None = None
+    project_id: str | None = None
+    draft_id: str | None = None
+
+
+class SubmitFeedbackRequest(BaseModel):
+    submission_type: str
+    body: str
+    subject: str | None = None
+    is_anonymous: bool = False
+    diagnostics: DiagnosticsPayload | None = None
+
+    @field_validator("submission_type")
+    @classmethod
+    def _valid_type(cls, v: str) -> str:
+        if v not in SUBMISSION_TYPES:
+            raise ValueError(f"submission_type must be one of: {', '.join(SUBMISSION_TYPES)}")
+        return v
+
+    @field_validator("body")
+    @classmethod
+    def _nonempty_body(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("body must not be blank")
+        return v
+
+
+class FeedbackResponse(BaseModel):
+    id: str
+    submission_type: str
+    subject: str | None
+    body: str
+    is_anonymous: bool
+    diagnostics: dict | None
+    github_discussion_url: str | None
+    dispatch_status: str
+    user_email: str | None
+    deleted_at: str | None
+    created_at: str
+
+    model_config = {"from_attributes": True}
+
+
+class FeedbackPage(BaseModel):
+    items: list[FeedbackResponse]
+    total: int
+    page: int
+    page_size: int
+    pages: int
+
+
+def _serialize(row: UserFeedback, include_user_email: bool = False) -> FeedbackResponse:
+    user_email: str | None = None
+    if include_user_email and not row.is_anonymous and row.user is not None:
+        user_email = row.user.email
+    return FeedbackResponse(
+        id=str(row.id),
+        submission_type=row.submission_type,
+        subject=row.subject,
+        body=row.body,
+        is_anonymous=row.is_anonymous,
+        diagnostics=row.diagnostics,
+        github_discussion_url=row.github_discussion_url,
+        dispatch_status=row.dispatch_status,
+        user_email=user_email,
+        deleted_at=row.deleted_at.isoformat() if row.deleted_at else None,
+        created_at=row.created_at.isoformat(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Submit feedback (auth optional)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/api/feedback", status_code=201)
+async def submit_feedback(
+    body: SubmitFeedbackRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User | None = Depends(get_optional_user),
+    _rl: None = Depends(_submit_limit),
+) -> FeedbackResponse:
+    from app.config import get_settings
+
+    has_token = bool(get_settings().github_feedback_token)
+    row = UserFeedback(
+        id=uuid.uuid4(),
+        user_id=current_user.id if current_user else None,
+        submission_type=body.submission_type,
+        is_anonymous=body.is_anonymous,
+        subject=body.subject,
+        body=body.body,
+        diagnostics=body.diagnostics.model_dump() if body.diagnostics else None,
+        dispatch_status="pending" if has_token else "skipped",
+    )
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+
+    if has_token:
+        _enqueue_dispatch(str(row.id))
+
+    return _serialize(row)
+
+
+def _enqueue_dispatch(feedback_id: str) -> None:
+    from app.config import get_settings
+    from app.services.task_history import record_queued
+
+    settings = get_settings()
+    if not settings.github_feedback_token:
+        return
+    from app.tasks.feedback_dispatch import dispatch_feedback
+
+    t = dispatch_feedback.delay(feedback_id)
+    record_queued(settings, t.id, "app.tasks.feedback_dispatch.dispatch_feedback", "feedback")
+
+
+# ---------------------------------------------------------------------------
+# Admin endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/admin/feedback")
+async def list_feedback(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(25, ge=1, le=100),
+    submission_type: str | None = None,
+    dispatch_status: str | None = None,
+    include_deleted: bool = False,
+    db: AsyncSession = Depends(get_db),
+    _admin: User = Depends(require_admin),
+) -> FeedbackPage:
+    from sqlalchemy.orm import selectinload
+
+    q = select(UserFeedback).options(selectinload(UserFeedback.user))
+    if not include_deleted:
+        q = q.where(UserFeedback.deleted_at.is_(None))
+    if submission_type:
+        q = q.where(UserFeedback.submission_type == submission_type)
+    if dispatch_status:
+        q = q.where(UserFeedback.dispatch_status == dispatch_status)
+
+    total_q = select(func.count()).select_from(q.subquery())
+    total = (await db.execute(total_q)).scalar_one()
+
+    q = q.order_by(UserFeedback.created_at.desc())
+    q = q.offset((page - 1) * page_size).limit(page_size)
+    rows = (await db.execute(q)).scalars().all()
+
+    pages = max(1, (total + page_size - 1) // page_size)
+    return FeedbackPage(
+        items=[_serialize(r, include_user_email=True) for r in rows],
+        total=total,
+        page=page,
+        page_size=page_size,
+        pages=pages,
+    )
+
+
+@router.get("/api/admin/feedback/{feedback_id}")
+async def get_feedback_detail(
+    feedback_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    _admin: User = Depends(require_admin),
+) -> FeedbackResponse:
+    from sqlalchemy.orm import selectinload
+
+    row = (
+        await db.execute(
+            select(UserFeedback).options(selectinload(UserFeedback.user)).where(UserFeedback.id == feedback_id)
+        )
+    ).scalar_one_or_none()
+    if not row:
+        raise HTTPException(status_code=404, detail="Feedback not found")
+    return _serialize(row, include_user_email=True)
+
+
+@router.delete("/api/admin/feedback/{feedback_id}")
+async def soft_delete_feedback(
+    feedback_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    _admin: User = Depends(require_admin),
+) -> FeedbackResponse:
+    row = await db.get(UserFeedback, feedback_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="Feedback not found")
+    row.soft_delete()
+    await db.commit()
+    await db.refresh(row)
+    return _serialize(row)
+
+
+@router.post("/api/admin/feedback/{feedback_id}/recover")
+async def recover_feedback(
+    feedback_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    _admin: User = Depends(require_admin),
+) -> FeedbackResponse:
+    row = await db.get(UserFeedback, feedback_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="Feedback not found")
+    if not row.is_deleted:
+        raise HTTPException(status_code=400, detail="Feedback is not deleted")
+    row.deleted_at = None
+    await db.commit()
+    await db.refresh(row)
+    return _serialize(row)

--- a/backend/app/routers/feedback.py
+++ b/backend/app/routers/feedback.py
@@ -239,6 +239,25 @@ async def soft_delete_feedback(
     return _serialize(row)
 
 
+@router.post("/api/admin/feedback/{feedback_id}/retry-dispatch")
+async def retry_feedback_dispatch(
+    feedback_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    _admin: User = Depends(require_admin),
+) -> FeedbackResponse:
+    row = await db.get(UserFeedback, feedback_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="Feedback not found")
+    if row.dispatch_status not in ("pending", "failed"):
+        raise HTTPException(status_code=400, detail=f"Cannot retry dispatch with status '{row.dispatch_status}'")
+    row.dispatch_status = "pending"
+    row.dispatch_error = None
+    await db.commit()
+    await db.refresh(row)
+    _enqueue_dispatch(str(row.id))
+    return _serialize(row, include_user_email=True)
+
+
 @router.post("/api/admin/feedback/{feedback_id}/recover")
 async def recover_feedback(
     feedback_id: uuid.UUID,

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -393,6 +393,39 @@ def _digest_s3_html(orphaned_count: int | None, scanned_at: str | None) -> str:
     return html
 
 
+async def send_feedback_user_confirmation(to_email: str, type_label: str, discussion_url: str) -> None:
+    settings = get_settings()
+    txt, html = _render(
+        "feedback_user_confirmation",
+        type_label=type_label,
+        discussion_url=discussion_url,
+    )
+    await _send([to_email], f"Your {settings.app_name} {type_label} was received", txt, html)
+
+
+async def send_feedback_admin_alert(
+    admin_emails: list[str],
+    type_label: str,
+    discussion_url: str,
+    subject: str | None,
+) -> None:
+    settings = get_settings()
+    if not settings.smtp_user or not admin_emails:
+        return
+    admin_url = f"{settings.frontend_url}/admin/feedback"
+    subject_row = f'<p style="margin:0 0 16px;"><strong>Subject:</strong> {subject}</p>' if subject else ""
+    subject_line = f"Subject: {subject}\n\n" if subject else ""
+    txt, html = _render(
+        "feedback_admin_alert",
+        type_label=type_label,
+        discussion_url=discussion_url,
+        admin_url=admin_url,
+        subject_row=subject_row,
+        subject_line=subject_line,
+    )
+    await _send(admin_emails, f"[{settings.app_name}] New {type_label} submitted", txt, html)
+
+
 async def send_admin_digest_email(
     admin_emails: list[str],
     week_start: str,

--- a/backend/app/services/github_discussions.py
+++ b/backend/app/services/github_discussions.py
@@ -1,0 +1,154 @@
+"""GitHub Discussions GraphQL client for feedback dispatch."""
+
+import logging
+
+import httpx
+
+log = logging.getLogger(__name__)
+
+_GH_GRAPHQL = "https://api.github.com/graphql"
+
+# Mapping from submission_type → preferred Discussion category name.
+_CATEGORY_MAP = {
+    "feedback": "Feedback",
+    "feature_request": "Ideas",
+    "bug_report": "Bug Reports",
+}
+
+# Fallback order when the preferred category doesn't exist.
+_CATEGORY_FALLBACK = ["General", "Q&A"]
+
+
+async def _graphql(token: str, query: str, variables: dict) -> dict:
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/vnd.github+json",
+    }
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.post(_GH_GRAPHQL, json={"query": query, "variables": variables}, headers=headers)
+        resp.raise_for_status()
+        data = resp.json()
+    if "errors" in data:
+        raise RuntimeError(f"GitHub GraphQL errors: {data['errors']}")
+    return data["data"]
+
+
+async def get_repo_and_category_id(token: str, repo: str, submission_type: str) -> tuple[str, str]:
+    """Return (repositoryId, categoryId) for the given repo and submission type."""
+    owner, name = repo.split("/", 1)
+    query = """
+    query($owner: String!, $name: String!) {
+      repository(owner: $owner, name: $name) {
+        id
+        discussionCategories(first: 20) {
+          nodes { id name }
+        }
+      }
+    }
+    """
+    data = await _graphql(token, query, {"owner": owner, "name": name})
+    repo_id: str = data["repository"]["id"]
+    categories: list[dict] = data["repository"]["discussionCategories"]["nodes"]
+
+    preferred = _CATEGORY_MAP.get(submission_type, "Feedback")
+    candidates = [preferred, *_CATEGORY_FALLBACK]
+    for candidate in candidates:
+        for cat in categories:
+            if cat["name"].lower() == candidate.lower():
+                return repo_id, cat["id"]
+
+    # Last resort: use the first available category
+    if categories:
+        log.warning("No matching Discussion category for %r — using %r", preferred, categories[0]["name"])
+        return repo_id, categories[0]["id"]
+
+    raise RuntimeError(f"No Discussion categories found in repo {repo}")
+
+
+async def create_discussion(
+    token: str,
+    repo: str,
+    submission_type: str,
+    title: str,
+    body: str,
+) -> str:
+    """Create a GitHub Discussion and return its URL."""
+    repo_id, category_id = await get_repo_and_category_id(token, repo, submission_type)
+    mutation = """
+    mutation($input: CreateDiscussionInput!) {
+      createDiscussion(input: $input) {
+        discussion { url }
+      }
+    }
+    """
+    data = await _graphql(
+        token,
+        mutation,
+        {"input": {"repositoryId": repo_id, "categoryId": category_id, "title": title, "body": body}},
+    )
+    return data["createDiscussion"]["discussion"]["url"]
+
+
+def _type_label(submission_type: str) -> str:
+    return {"feedback": "Feedback", "feature_request": "Feature Request", "bug_report": "Bug Report"}.get(
+        submission_type, submission_type.replace("_", " ").title()
+    )
+
+
+def build_discussion_body(
+    submission_type: str,
+    subject: str | None,
+    body: str,
+    diagnostics: dict | None,
+    is_anonymous: bool,
+    user_email: str | None,
+) -> str:
+    """Build the markdown body for the GitHub Discussion."""
+    lines: list[str] = []
+
+    lines.append(body)
+    lines.append("")
+
+    diag = diagnostics or {}
+    has_diag = any(
+        diag.get(k) for k in ("environment", "page_url", "user_agent", "app_version", "project_id", "draft_id")
+    )
+    if has_diag:
+        lines.append("---")
+        lines.append("")
+        lines.append("**Diagnostics**")
+        lines.append("")
+        if diag.get("environment"):
+            lines.append(f"- **Environment:** {diag['environment']}")
+        if diag.get("app_version"):
+            lines.append(f"- **App version:** {diag['app_version']}")
+        if diag.get("page_url"):
+            lines.append(f"- **Page:** `{diag['page_url']}`")
+        if diag.get("project_id"):
+            lines.append(f"- **Project ID:** `{diag['project_id']}`")
+        if diag.get("draft_id"):
+            lines.append(f"- **Draft ID:** `{diag['draft_id']}`")
+        if diag.get("user_agent"):
+            lines.append(f"- **User agent:** `{diag['user_agent']}`")
+        lines.append("")
+
+    if not is_anonymous and user_email:
+        lines.append(f"*Submitted by: {user_email}*")
+    else:
+        lines.append("*Submitted anonymously.*")
+
+    lines.append("")
+    lines.append(
+        "> **Note:** This is a hobby project — responses may be slow. "
+        "You're welcome to attach screenshots or additional context directly to this Discussion thread."
+    )
+
+    return "\n".join(lines)
+
+
+def build_discussion_title(submission_type: str, subject: str | None) -> str:
+    prefix = _type_label(submission_type)
+    if subject and subject.strip():
+        return f"[{prefix}] {subject.strip()}"
+    return f"[{prefix}] User submission"

--- a/backend/app/services/github_discussions.py
+++ b/backend/app/services/github_discussions.py
@@ -102,7 +102,6 @@ def build_discussion_body(
     body: str,
     diagnostics: dict | None,
     is_anonymous: bool,
-    user_email: str | None,
 ) -> str:
     """Build the markdown body for the GitHub Discussion."""
     lines: list[str] = []
@@ -111,9 +110,14 @@ def build_discussion_body(
     lines.append("")
 
     diag = diagnostics or {}
-    has_diag = any(
-        diag.get(k) for k in ("environment", "page_url", "user_agent", "app_version", "project_id", "draft_id")
+    # When anonymous, omit page_url (which often contains a project/draft UUID)
+    # and project_id/draft_id. Environment, version, and user agent are safe.
+    public_diag_keys = (
+        ("environment", "app_version", "user_agent")
+        if is_anonymous
+        else ("environment", "app_version", "page_url", "project_id", "draft_id", "user_agent")
     )
+    has_diag = any(diag.get(k) for k in public_diag_keys)
     if has_diag:
         lines.append("---")
         lines.append("")
@@ -123,19 +127,17 @@ def build_discussion_body(
             lines.append(f"- **Environment:** {diag['environment']}")
         if diag.get("app_version"):
             lines.append(f"- **App version:** {diag['app_version']}")
-        if diag.get("page_url"):
+        if not is_anonymous and diag.get("page_url"):
             lines.append(f"- **Page:** `{diag['page_url']}`")
-        if diag.get("project_id"):
+        if not is_anonymous and diag.get("project_id"):
             lines.append(f"- **Project ID:** `{diag['project_id']}`")
-        if diag.get("draft_id"):
+        if not is_anonymous and diag.get("draft_id"):
             lines.append(f"- **Draft ID:** `{diag['draft_id']}`")
         if diag.get("user_agent"):
             lines.append(f"- **User agent:** `{diag['user_agent']}`")
         lines.append("")
 
-    if not is_anonymous and user_email:
-        lines.append(f"*Submitted by: {user_email}*")
-    else:
+    if is_anonymous:
         lines.append("*Submitted anonymously.*")
 
     lines.append("")

--- a/backend/app/tasks/feedback_dispatch.py
+++ b/backend/app/tasks/feedback_dispatch.py
@@ -56,10 +56,6 @@ async def _dispatch(task, feedback_id: str) -> dict:
             log.warning("feedback_dispatch feedback_id=%s not found", feedback_id)
             return {"status": "not_found"}
 
-        user_email = None
-        if not row.is_anonymous and row.user:
-            user_email = row.user.email
-
         title = build_discussion_title(row.submission_type, row.subject)
         body = build_discussion_body(
             submission_type=row.submission_type,
@@ -67,7 +63,6 @@ async def _dispatch(task, feedback_id: str) -> dict:
             body=row.body,
             diagnostics=row.diagnostics,
             is_anonymous=row.is_anonymous,
-            user_email=user_email,
         )
 
         try:
@@ -94,15 +89,16 @@ async def _dispatch(task, feedback_id: str) -> dict:
 
     # Send emails after successful dispatch (fire and forget; don't retry on email failure)
     try:
-        await _send_emails(feedback_id, url, user_email, settings)
+        await _send_emails(feedback_id, url, settings)
     except Exception:
         log.exception("feedback_dispatch email failed feedback_id=%s — ignoring", feedback_id)
 
     return {"status": "sent", "url": url}
 
 
-async def _send_emails(feedback_id: str, discussion_url: str, user_email: str | None, settings) -> None:
+async def _send_emails(feedback_id: str, discussion_url: str, settings) -> None:
     from sqlalchemy import select
+    from sqlalchemy.orm import selectinload
 
     from app.database import AsyncSessionLocal
     from app.models.feedback import UserFeedback
@@ -111,7 +107,13 @@ async def _send_emails(feedback_id: str, discussion_url: str, user_email: str | 
     from app.services.github_discussions import _type_label
 
     async with AsyncSessionLocal() as db:
-        row = await db.get(UserFeedback, uuid.UUID(feedback_id))
+        row = (
+            await db.execute(
+                select(UserFeedback)
+                .options(selectinload(UserFeedback.user))
+                .where(UserFeedback.id == uuid.UUID(feedback_id))
+            )
+        ).scalar_one_or_none()
         if not row:
             return
         type_label = _type_label(row.submission_type)
@@ -129,9 +131,9 @@ async def _send_emails(feedback_id: str, discussion_url: str, user_email: str | 
         if admin_emails:
             await mail_svc.send_feedback_admin_alert(list(admin_emails), type_label, discussion_url, row.subject)
 
-        # User confirmation (non-anonymous authenticated users only)
-        if user_email and not row.is_anonymous:
-            await mail_svc.send_feedback_user_confirmation(user_email, type_label, discussion_url)
+        # User confirmation (non-anonymous authenticated users only; email from relationship)
+        if not row.is_anonymous and row.user and row.user.email:
+            await mail_svc.send_feedback_user_confirmation(row.user.email, type_label, discussion_url)
 
 
 @celery_app.task(
@@ -147,7 +149,9 @@ def retry_failed_feedback(self, limit: int = 20) -> dict:
 
 
 async def _retry_failed(limit: int) -> dict:
-    from sqlalchemy import select
+    from datetime import datetime, timedelta, timezone
+
+    from sqlalchemy import or_, select
 
     from app.config import get_settings
     from app.database import AsyncSessionLocal
@@ -158,12 +162,20 @@ async def _retry_failed(limit: int) -> dict:
     if not settings.github_feedback_token:
         return {"dispatched": 0, "reason": "no_token"}
 
+    stale_cutoff = datetime.now(timezone.utc) - timedelta(minutes=10)
+
     async with AsyncSessionLocal() as db:
         rows = (
             (
                 await db.execute(
                     select(UserFeedback.id)
-                    .where(UserFeedback.dispatch_status == "failed", UserFeedback.deleted_at.is_(None))
+                    .where(UserFeedback.deleted_at.is_(None))
+                    .where(
+                        or_(
+                            UserFeedback.dispatch_status == "failed",
+                            (UserFeedback.dispatch_status == "pending") & (UserFeedback.created_at < stale_cutoff),
+                        )
+                    )
                     .limit(limit)
                 )
             )

--- a/backend/app/tasks/feedback_dispatch.py
+++ b/backend/app/tasks/feedback_dispatch.py
@@ -26,7 +26,7 @@ async def _dispatch(task, feedback_id: str) -> dict:
     from sqlalchemy.orm import selectinload
 
     from app.config import get_settings
-    from app.database import AsyncSessionLocal
+    from app.database import CeleryAsyncSession
     from app.models.feedback import UserFeedback
     from app.services.github_discussions import (
         build_discussion_body,
@@ -37,14 +37,14 @@ async def _dispatch(task, feedback_id: str) -> dict:
     settings = get_settings()
     if not settings.github_feedback_token:
         log.info("feedback_dispatch skipped — no token feedback_id=%s", feedback_id)
-        async with AsyncSessionLocal() as db:
+        async with CeleryAsyncSession() as db:
             row = await db.get(UserFeedback, uuid.UUID(feedback_id))
             if row:
                 row.dispatch_status = "skipped"
                 await db.commit()
         return {"status": "skipped"}
 
-    async with AsyncSessionLocal() as db:
+    async with CeleryAsyncSession() as db:
         row = (
             await db.execute(
                 select(UserFeedback)
@@ -100,13 +100,13 @@ async def _send_emails(feedback_id: str, discussion_url: str, settings) -> None:
     from sqlalchemy import select
     from sqlalchemy.orm import selectinload
 
-    from app.database import AsyncSessionLocal
+    from app.database import CeleryAsyncSession
     from app.models.feedback import UserFeedback
     from app.models.user import User
     from app.services import email as mail_svc
     from app.services.github_discussions import _type_label
 
-    async with AsyncSessionLocal() as db:
+    async with CeleryAsyncSession() as db:
         row = (
             await db.execute(
                 select(UserFeedback)
@@ -154,7 +154,7 @@ async def _retry_failed(limit: int) -> dict:
     from sqlalchemy import or_, select
 
     from app.config import get_settings
-    from app.database import AsyncSessionLocal
+    from app.database import CeleryAsyncSession
     from app.models.feedback import UserFeedback
     from app.services.task_history import record_queued
 
@@ -164,7 +164,7 @@ async def _retry_failed(limit: int) -> dict:
 
     stale_cutoff = datetime.now(timezone.utc) - timedelta(minutes=10)
 
-    async with AsyncSessionLocal() as db:
+    async with CeleryAsyncSession() as db:
         rows = (
             (
                 await db.execute(
@@ -210,11 +210,11 @@ async def _purge_deleted(retention_days: int) -> dict:
 
     from sqlalchemy import delete
 
-    from app.database import AsyncSessionLocal
+    from app.database import CeleryAsyncSession
     from app.models.feedback import UserFeedback
 
     cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
-    async with AsyncSessionLocal() as db:
+    async with CeleryAsyncSession() as db:
         result = await db.execute(
             delete(UserFeedback).where(
                 UserFeedback.deleted_at.is_not(None),

--- a/backend/app/tasks/feedback_dispatch.py
+++ b/backend/app/tasks/feedback_dispatch.py
@@ -1,0 +1,216 @@
+"""Celery task: dispatch user feedback to GitHub Discussions + send confirmation emails."""
+
+import asyncio
+import logging
+import uuid
+
+from app.celery_app import celery_app
+
+log = logging.getLogger(__name__)
+
+
+@celery_app.task(
+    bind=True,
+    name="app.tasks.feedback_dispatch.dispatch_feedback",
+    max_retries=3,
+    soft_time_limit=60,
+    time_limit=90,
+)
+def dispatch_feedback(self, feedback_id: str) -> dict:
+    """Post feedback to GitHub Discussions and update dispatch_status."""
+    return asyncio.run(_dispatch(self, feedback_id))
+
+
+async def _dispatch(task, feedback_id: str) -> dict:
+    from sqlalchemy import select
+    from sqlalchemy.orm import selectinload
+
+    from app.config import get_settings
+    from app.database import AsyncSessionLocal
+    from app.models.feedback import UserFeedback
+    from app.services.github_discussions import (
+        build_discussion_body,
+        build_discussion_title,
+        create_discussion,
+    )
+
+    settings = get_settings()
+    if not settings.github_feedback_token:
+        log.info("feedback_dispatch skipped — no token feedback_id=%s", feedback_id)
+        async with AsyncSessionLocal() as db:
+            row = await db.get(UserFeedback, uuid.UUID(feedback_id))
+            if row:
+                row.dispatch_status = "skipped"
+                await db.commit()
+        return {"status": "skipped"}
+
+    async with AsyncSessionLocal() as db:
+        row = (
+            await db.execute(
+                select(UserFeedback)
+                .options(selectinload(UserFeedback.user))
+                .where(UserFeedback.id == uuid.UUID(feedback_id))
+            )
+        ).scalar_one_or_none()
+        if not row:
+            log.warning("feedback_dispatch feedback_id=%s not found", feedback_id)
+            return {"status": "not_found"}
+
+        user_email = None
+        if not row.is_anonymous and row.user:
+            user_email = row.user.email
+
+        title = build_discussion_title(row.submission_type, row.subject)
+        body = build_discussion_body(
+            submission_type=row.submission_type,
+            subject=row.subject,
+            body=row.body,
+            diagnostics=row.diagnostics,
+            is_anonymous=row.is_anonymous,
+            user_email=user_email,
+        )
+
+        try:
+            url = await create_discussion(
+                token=settings.github_feedback_token,
+                repo=settings.github_feedback_repo,
+                submission_type=row.submission_type,
+                title=title,
+                body=body,
+            )
+            row.github_discussion_url = url
+            row.dispatch_status = "sent"
+            row.dispatch_error = None
+            await db.commit()
+            log.info("feedback_dispatch sent feedback_id=%s url=%s", feedback_id, url)
+
+        except Exception as exc:
+            row.dispatch_status = "failed"
+            row.dispatch_error = str(exc)[:500]
+            await db.commit()
+            log.exception("feedback_dispatch failed feedback_id=%s", feedback_id)
+            countdown = min(60 * (2**task.request.retries), 1800)
+            raise task.retry(exc=exc, countdown=countdown)
+
+    # Send emails after successful dispatch (fire and forget; don't retry on email failure)
+    try:
+        await _send_emails(feedback_id, url, user_email, settings)
+    except Exception:
+        log.exception("feedback_dispatch email failed feedback_id=%s — ignoring", feedback_id)
+
+    return {"status": "sent", "url": url}
+
+
+async def _send_emails(feedback_id: str, discussion_url: str, user_email: str | None, settings) -> None:
+    from sqlalchemy import select
+
+    from app.database import AsyncSessionLocal
+    from app.models.feedback import UserFeedback
+    from app.models.user import User
+    from app.services import email as mail_svc
+    from app.services.github_discussions import _type_label
+
+    async with AsyncSessionLocal() as db:
+        row = await db.get(UserFeedback, uuid.UUID(feedback_id))
+        if not row:
+            return
+        type_label = _type_label(row.submission_type)
+
+        # Admin alert
+        admin_emails = (
+            (
+                await db.execute(
+                    select(User.email).where(User.is_admin == True, User.is_active == True, User.deleted_at.is_(None))  # noqa: E712
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if admin_emails:
+            await mail_svc.send_feedback_admin_alert(list(admin_emails), type_label, discussion_url, row.subject)
+
+        # User confirmation (non-anonymous authenticated users only)
+        if user_email and not row.is_anonymous:
+            await mail_svc.send_feedback_user_confirmation(user_email, type_label, discussion_url)
+
+
+@celery_app.task(
+    bind=True,
+    name="app.tasks.feedback_dispatch.retry_failed_feedback",
+    max_retries=0,
+    soft_time_limit=120,
+    time_limit=150,
+)
+def retry_failed_feedback(self, limit: int = 20) -> dict:
+    """Re-dispatch feedback submissions that failed to post to GitHub Discussions."""
+    return asyncio.run(_retry_failed(limit))
+
+
+async def _retry_failed(limit: int) -> dict:
+    from sqlalchemy import select
+
+    from app.config import get_settings
+    from app.database import AsyncSessionLocal
+    from app.models.feedback import UserFeedback
+    from app.services.task_history import record_queued
+
+    settings = get_settings()
+    if not settings.github_feedback_token:
+        return {"dispatched": 0, "reason": "no_token"}
+
+    async with AsyncSessionLocal() as db:
+        rows = (
+            (
+                await db.execute(
+                    select(UserFeedback.id)
+                    .where(UserFeedback.dispatch_status == "failed", UserFeedback.deleted_at.is_(None))
+                    .limit(limit)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    dispatched = 0
+    for row_id in rows:
+        t = dispatch_feedback.delay(str(row_id))
+        record_queued(settings, t.id, "app.tasks.feedback_dispatch.dispatch_feedback", "feedback:retry")
+        dispatched += 1
+
+    log.info("retry_failed_feedback dispatched=%d", dispatched)
+    return {"dispatched": dispatched}
+
+
+@celery_app.task(
+    bind=True,
+    name="app.tasks.feedback_dispatch.purge_deleted_feedback",
+    max_retries=0,
+    soft_time_limit=60,
+    time_limit=90,
+)
+def purge_deleted_feedback(self, retention_days: int = 7) -> dict:
+    """Hard-delete feedback that has been soft-deleted for longer than retention_days."""
+    return asyncio.run(_purge_deleted(retention_days))
+
+
+async def _purge_deleted(retention_days: int) -> dict:
+    from datetime import datetime, timedelta, timezone
+
+    from sqlalchemy import delete
+
+    from app.database import AsyncSessionLocal
+    from app.models.feedback import UserFeedback
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(
+            delete(UserFeedback).where(
+                UserFeedback.deleted_at.is_not(None),
+                UserFeedback.deleted_at < cutoff,
+            )
+        )
+        await db.commit()
+
+    deleted = result.rowcount
+    log.info("purge_deleted_feedback deleted=%d retention_days=%d", deleted, retention_days)
+    return {"deleted": deleted}

--- a/backend/app/tasks/scheduler.py
+++ b/backend/app/tasks/scheduler.py
@@ -127,6 +127,24 @@ REGISTRY: dict[str, dict] = {
         "default_cron": "0 6 * * *",
         "default_config": {"inactive_days": 10},
     },
+    "feedback_retry": {
+        "display_name": "Feedback Dispatch Retry",
+        "description": (
+            "Re-dispatches feedback submissions that failed to post to GitHub Discussions. "
+            "No-op when GITHUB_FEEDBACK_TOKEN is not configured."
+        ),
+        "default_cron": "0 7 * * *",
+        "default_config": {"limit": 20},
+    },
+    "feedback_purge": {
+        "display_name": "Feedback Hard Delete",
+        "description": (
+            "Hard-deletes feedback submissions that have been soft-deleted for longer than "
+            "the configured retention window (default 7 days)."
+        ),
+        "default_cron": "30 4 * * *",
+        "default_config": {"retention_days": 7},
+    },
 }
 
 
@@ -251,6 +269,28 @@ def _dispatch_tile_prune(settings, task=None):
     return t
 
 
+def _dispatch_feedback_retry(settings, task=None):
+    from app.services.task_history import record_queued
+    from app.tasks.feedback_dispatch import retry_failed_feedback
+
+    cfg = (task.config or {}) if task else {}
+    limit = int(cfg.get("limit", 20))
+    t = retry_failed_feedback.delay(limit=limit)
+    record_queued(settings, t.id, "app.tasks.feedback_dispatch.retry_failed_feedback", "scheduled:feedback_retry")
+    return t
+
+
+def _dispatch_feedback_purge(settings, task=None):
+    from app.services.task_history import record_queued
+    from app.tasks.feedback_dispatch import purge_deleted_feedback
+
+    cfg = (task.config or {}) if task else {}
+    retention_days = int(cfg.get("retention_days", 7))
+    t = purge_deleted_feedback.delay(retention_days=retention_days)
+    record_queued(settings, t.id, "app.tasks.feedback_dispatch.purge_deleted_feedback", "scheduled:feedback_purge")
+    return t
+
+
 DISPATCH_FNS: dict[str, object] = {
     "cve_scan": _dispatch_cve_scan,
     "s3_audit": _dispatch_s3_audit,
@@ -264,6 +304,8 @@ DISPATCH_FNS: dict[str, object] = {
     "credential_expiry_check": _dispatch_credential_expiry_check,
     "admin_digest": _dispatch_admin_digest,
     "tile_prune": _dispatch_tile_prune,
+    "feedback_retry": _dispatch_feedback_retry,
+    "feedback_purge": _dispatch_feedback_purge,
 }
 
 

--- a/backend/app/templates/email/feedback_admin_alert.html
+++ b/backend/app/templates/email/feedback_admin_alert.html
@@ -1,0 +1,11 @@
+<p style="margin:0 0 16px;font-size:16px;font-weight:bold;color:#1d3557;">New {type_label} Submitted</p>
+<p style="margin:0 0 16px;">A user has submitted a <strong>{type_label}</strong> via the in-app feedback form. A GitHub Discussion has been created automatically.</p>
+{subject_row}
+<table cellpadding="0" cellspacing="0" role="presentation" style="margin:0 0 20px;">
+  <tr>
+    <td style="background:#1d3557;border-radius:6px;">
+      <a href="{discussion_url}" style="display:inline-block;padding:12px 28px;color:#ffffff;font-weight:bold;text-decoration:none;font-size:15px;font-family:Arial,Helvetica,sans-serif;">View Discussion on GitHub</a>
+    </td>
+  </tr>
+</table>
+<p style="margin:0;font-size:14px;color:#6b7280;">You can also review all submissions in the <a href="{admin_url}" style="color:#6b7280;">Admin Console &rarr; Feedback</a> tab.</p>

--- a/backend/app/templates/email/feedback_admin_alert.txt
+++ b/backend/app/templates/email/feedback_admin_alert.txt
@@ -1,0 +1,8 @@
+New {type_label} Submitted
+
+A user has submitted a {type_label} via the in-app feedback form.
+A GitHub Discussion has been created automatically.
+
+{subject_line}View Discussion: {discussion_url}
+
+Review all submissions in the Admin Console: {admin_url}

--- a/backend/app/templates/email/feedback_user_confirmation.html
+++ b/backend/app/templates/email/feedback_user_confirmation.html
@@ -1,0 +1,11 @@
+<p style="margin:0 0 16px;">Thank you for submitting your <strong>{type_label}</strong> to <strong>{app_name}</strong>.</p>
+<p style="margin:0 0 16px;">A Discussion thread has been created on GitHub where you can track any response and attach screenshots or additional context:</p>
+<table cellpadding="0" cellspacing="0" role="presentation" style="margin:0 0 20px;">
+  <tr>
+    <td style="background:#1d3557;border-radius:6px;">
+      <a href="{discussion_url}" style="display:inline-block;padding:12px 28px;color:#ffffff;font-weight:bold;text-decoration:none;font-size:15px;font-family:Arial,Helvetica,sans-serif;">View Discussion on GitHub</a>
+    </td>
+  </tr>
+</table>
+<p style="margin:0 0 16px;font-size:14px;color:#6b7280;"><strong>Please note:</strong> {app_name} is a hobby project, not a business. Responses may be slow or limited. We appreciate your patience and your feedback!</p>
+<p style="margin:0;font-size:14px;color:#6b7280;">If you did not submit this feedback, you can safely ignore this email.</p>

--- a/backend/app/templates/email/feedback_user_confirmation.txt
+++ b/backend/app/templates/email/feedback_user_confirmation.txt
@@ -1,0 +1,9 @@
+Thank you for submitting your {type_label} to {app_name}.
+
+A Discussion thread has been created on GitHub where you can track any response and attach screenshots or additional context:
+
+{discussion_url}
+
+Please note: {app_name} is a hobby project, not a business. Responses may be slow or limited. We appreciate your patience and your feedback!
+
+If you did not submit this feedback, you can safely ignore this email.

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -57,7 +57,7 @@ import app.routers.auth as _auth_mod  # noqa: E402
 
 _auth_mod.load_oidc_metadata = AsyncMock(return_value=None)
 
-from app.deps import get_current_user, get_db  # noqa: E402
+from app.deps import get_current_user, get_db, get_optional_user  # noqa: E402
 from app.main import app  # noqa: E402
 from app.models.base import Base  # noqa: E402
 from app.models.user import User  # noqa: E402
@@ -251,8 +251,12 @@ async def auth_client(db_session: AsyncSession, test_user: User) -> AsyncGenerat
     async def _override_get_current_user() -> User:
         return test_user
 
+    async def _override_get_optional_user() -> User | None:
+        return test_user
+
     app.dependency_overrides[get_db] = _override_get_db
     app.dependency_overrides[get_current_user] = _override_get_current_user
+    app.dependency_overrides[get_optional_user] = _override_get_optional_user
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         yield c
     app.dependency_overrides.clear()
@@ -266,8 +270,12 @@ async def admin_client(db_session: AsyncSession, admin_user: User) -> AsyncGener
     async def _override_get_current_user() -> User:
         return admin_user
 
+    async def _override_get_optional_user() -> User | None:
+        return admin_user
+
     app.dependency_overrides[get_db] = _override_get_db
     app.dependency_overrides[get_current_user] = _override_get_current_user
+    app.dependency_overrides[get_optional_user] = _override_get_optional_user
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         yield c
     app.dependency_overrides.clear()
@@ -350,15 +358,18 @@ def bypass_rate_limits():
     from app.main import app
     from app.routers.auth import _invite_rate_limit
     from app.routers.drafts import _upload_rate_limit
+    from app.routers.feedback import _submit_limit
 
     async def _noop() -> None:
         pass
 
     app.dependency_overrides[_invite_rate_limit] = _noop
     app.dependency_overrides[_upload_rate_limit] = _noop
+    app.dependency_overrides[_submit_limit] = _noop
     yield
     # Client fixtures call dependency_overrides.clear() after each test,
     # so these are cleaned up automatically when a client fixture is used.
     # For tests without a client fixture, clean up here.
     app.dependency_overrides.pop(_invite_rate_limit, None)
     app.dependency_overrides.pop(_upload_rate_limit, None)
+    app.dependency_overrides.pop(_submit_limit, None)

--- a/backend/tests/routers/test_feedback.py
+++ b/backend/tests/routers/test_feedback.py
@@ -1,0 +1,246 @@
+"""Tests for POST /api/feedback and GET /api/admin/feedback endpoints."""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import User
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _feedback_payload(**overrides):
+    return {
+        "submission_type": "feedback",
+        "body": "This is great!",
+        "subject": "General feedback",
+        "is_anonymous": False,
+        "diagnostics": {
+            "environment": "local instance",
+            "page_url": "/projects",
+            "user_agent": "Mozilla/5.0",
+            "app_version": "0.159.0",
+        },
+        **overrides,
+    }
+
+
+# ---------------------------------------------------------------------------
+# POST /api/feedback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestSubmitFeedback:
+    async def test_authenticated_user_can_submit(self, auth_client: AsyncClient):
+        resp = await auth_client.post("/api/feedback", json=_feedback_payload())
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["submission_type"] == "feedback"
+        assert data["dispatch_status"] in ("pending", "skipped")
+        assert "id" in data
+
+    async def test_unauthenticated_user_can_submit(self, client: AsyncClient):
+        resp = await client.post("/api/feedback", json=_feedback_payload())
+        assert resp.status_code == 201
+
+    async def test_missing_body_returns_422(self, client: AsyncClient):
+        resp = await client.post("/api/feedback", json={"submission_type": "feedback"})
+        assert resp.status_code == 422
+
+    async def test_invalid_submission_type_returns_422(self, client: AsyncClient):
+        resp = await client.post("/api/feedback", json=_feedback_payload(submission_type="invalid"))
+        assert resp.status_code == 422
+
+    async def test_all_submission_types_accepted(self, client: AsyncClient):
+        for stype in ("feedback", "feature_request", "bug_report"):
+            resp = await client.post("/api/feedback", json=_feedback_payload(submission_type=stype))
+            assert resp.status_code == 201, f"Expected 201 for type={stype}, got {resp.status_code}"
+
+    async def test_anonymous_flag_stores_correctly(self, auth_client: AsyncClient, db_session: AsyncSession):
+        from app.models.feedback import UserFeedback
+
+        resp = await auth_client.post("/api/feedback", json=_feedback_payload(is_anonymous=True))
+        assert resp.status_code == 201
+        row = await db_session.get(UserFeedback, uuid.UUID(resp.json()["id"]))
+        assert row is not None
+        assert row.is_anonymous is True
+        # user_id still stored in DB even when anonymous (for admin recovery)
+        assert row.user_id is not None
+
+    async def test_user_id_stored_for_authenticated_user(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        from app.models.feedback import UserFeedback
+
+        resp = await auth_client.post("/api/feedback", json=_feedback_payload(is_anonymous=False))
+        assert resp.status_code == 201
+        row = await db_session.get(UserFeedback, uuid.UUID(resp.json()["id"]))
+        assert row is not None
+        assert row.user_id == test_user.id
+
+    async def test_unauthenticated_user_id_is_null(self, client: AsyncClient, db_session: AsyncSession):
+        from app.models.feedback import UserFeedback
+
+        resp = await client.post("/api/feedback", json=_feedback_payload())
+        assert resp.status_code == 201
+        row = await db_session.get(UserFeedback, uuid.UUID(resp.json()["id"]))
+        assert row is not None
+        assert row.user_id is None
+
+    async def test_response_omits_user_email_when_anonymous(self, auth_client: AsyncClient):
+        resp = await auth_client.post("/api/feedback", json=_feedback_payload(is_anonymous=True))
+        assert resp.status_code == 201
+        data = resp.json()
+        assert "user_email" not in data or data.get("user_email") is None
+
+    async def test_discussion_url_null_when_no_token(self, client: AsyncClient):
+        # Without GITHUB_FEEDBACK_TOKEN the dispatch is skipped
+        resp = await client.post("/api/feedback", json=_feedback_payload())
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["github_discussion_url"] is None
+
+
+# ---------------------------------------------------------------------------
+# GET /api/admin/feedback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestAdminListFeedback:
+    async def test_admin_can_list(self, admin_client: AsyncClient):
+        resp = await admin_client.get("/api/admin/feedback")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "items" in data
+        assert "total" in data
+
+    async def test_non_admin_returns_403(self, auth_client: AsyncClient):
+        resp = await auth_client.get("/api/admin/feedback")
+        assert resp.status_code == 403
+
+    async def test_unauthenticated_returns_401(self, client: AsyncClient):
+        resp = await client.get("/api/admin/feedback")
+        assert resp.status_code == 401
+
+    async def test_submission_appears_in_list(self, auth_client: AsyncClient, admin_client: AsyncClient):
+        await auth_client.post("/api/feedback", json=_feedback_payload(body="Test body for list"))
+        resp = await admin_client.get("/api/admin/feedback")
+        items = resp.json()["items"]
+        assert any(item["body"] == "Test body for list" for item in items)
+
+    async def test_soft_deleted_excluded_by_default(self, auth_client: AsyncClient, admin_client: AsyncClient):
+        sub = await auth_client.post("/api/feedback", json=_feedback_payload(body="to be deleted"))
+        fid = sub.json()["id"]
+        await admin_client.delete(f"/api/admin/feedback/{fid}")
+        resp = await admin_client.get("/api/admin/feedback")
+        ids = [i["id"] for i in resp.json()["items"]]
+        assert fid not in ids
+
+    async def test_include_deleted_query_param(self, auth_client: AsyncClient, admin_client: AsyncClient):
+        sub = await auth_client.post("/api/feedback", json=_feedback_payload(body="soft deleted"))
+        fid = sub.json()["id"]
+        await admin_client.delete(f"/api/admin/feedback/{fid}")
+        resp = await admin_client.get("/api/admin/feedback?include_deleted=true")
+        ids = [i["id"] for i in resp.json()["items"]]
+        assert fid in ids
+
+    async def test_filter_by_type(self, auth_client: AsyncClient, admin_client: AsyncClient):
+        await auth_client.post("/api/feedback", json=_feedback_payload(submission_type="bug_report"))
+        resp = await admin_client.get("/api/admin/feedback?submission_type=bug_report")
+        items = resp.json()["items"]
+        assert all(i["submission_type"] == "bug_report" for i in items)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/admin/feedback/{id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestAdminFeedbackDetail:
+    async def test_admin_can_get_detail(self, auth_client: AsyncClient, admin_client: AsyncClient):
+        sub = await auth_client.post("/api/feedback", json=_feedback_payload())
+        fid = sub.json()["id"]
+        resp = await admin_client.get(f"/api/admin/feedback/{fid}")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == fid
+
+    async def test_not_found_returns_404(self, admin_client: AsyncClient):
+        resp = await admin_client.get(f"/api/admin/feedback/{uuid.uuid4()}")
+        assert resp.status_code == 404
+
+    async def test_non_admin_returns_403(self, auth_client: AsyncClient):
+        sub = await auth_client.post("/api/feedback", json=_feedback_payload())
+        fid = sub.json()["id"]
+        resp = await auth_client.get(f"/api/admin/feedback/{fid}")
+        assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/admin/feedback/{id}  (soft delete)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestAdminSoftDeleteFeedback:
+    async def test_soft_delete_sets_deleted_at(
+        self, auth_client: AsyncClient, admin_client: AsyncClient, db_session: AsyncSession
+    ):
+        from app.models.feedback import UserFeedback
+
+        sub = await auth_client.post("/api/feedback", json=_feedback_payload())
+        fid = sub.json()["id"]
+        resp = await admin_client.delete(f"/api/admin/feedback/{fid}")
+        assert resp.status_code == 200
+        await db_session.refresh(await db_session.get(UserFeedback, uuid.UUID(fid)))
+        row = await db_session.get(UserFeedback, uuid.UUID(fid))
+        assert row is not None
+        assert row.deleted_at is not None
+
+    async def test_not_found_returns_404(self, admin_client: AsyncClient):
+        resp = await admin_client.delete(f"/api/admin/feedback/{uuid.uuid4()}")
+        assert resp.status_code == 404
+
+    async def test_non_admin_returns_403(self, auth_client: AsyncClient):
+        sub = await auth_client.post("/api/feedback", json=_feedback_payload())
+        fid = sub.json()["id"]
+        resp = await auth_client.delete(f"/api/admin/feedback/{fid}")
+        assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# POST /api/admin/feedback/{id}/recover
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestAdminRecoverFeedback:
+    async def test_recover_clears_deleted_at(
+        self, auth_client: AsyncClient, admin_client: AsyncClient, db_session: AsyncSession
+    ):
+        from app.models.feedback import UserFeedback
+
+        sub = await auth_client.post("/api/feedback", json=_feedback_payload())
+        fid = sub.json()["id"]
+        await admin_client.delete(f"/api/admin/feedback/{fid}")
+        resp = await admin_client.post(f"/api/admin/feedback/{fid}/recover")
+        assert resp.status_code == 200
+        row = await db_session.get(UserFeedback, uuid.UUID(fid))
+        assert row is not None
+        assert row.deleted_at is None
+
+    async def test_recover_non_deleted_returns_400(self, auth_client: AsyncClient, admin_client: AsyncClient):
+        sub = await auth_client.post("/api/feedback", json=_feedback_payload())
+        fid = sub.json()["id"]
+        resp = await admin_client.post(f"/api/admin/feedback/{fid}/recover")
+        assert resp.status_code == 400
+
+    async def test_not_found_returns_404(self, admin_client: AsyncClient):
+        resp = await admin_client.post(f"/api/admin/feedback/{uuid.uuid4()}/recover")
+        assert resp.status_code == 404

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -35,6 +35,7 @@ x-worker-env: &worker-env
   OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=${APP_ENV}"
   MAXMIND_LICENSE_KEY: ${MAXMIND_LICENSE_KEY:-}
   GEOIP_DB_PATH: ${GEOIP_DB_PATH:-/app/data/GeoLite2-City.mmdb}
+  GITHUB_FEEDBACK_TOKEN: ${GITHUB_FEEDBACK_TOKEN:-}
 
 x-worker: &worker-base
   build:
@@ -159,6 +160,7 @@ services:
       OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=${APP_ENV}"
       MAXMIND_LICENSE_KEY: ${MAXMIND_LICENSE_KEY:-}
       GEOIP_DB_PATH: ${GEOIP_DB_PATH:-/app/data/GeoLite2-City.mmdb}
+      GITHUB_FEEDBACK_TOKEN: ${GITHUB_FEEDBACK_TOKEN:-}
     volumes:
       - uploads:/app/uploads
       - geoip_data:/app/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ x-worker-env: &worker-env
   OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
   OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=${APP_ENV},service.version=${IMAGE_TAG:-dev}"
   OTEL_SERVICE_NAME: weftmark-worker
+  GITHUB_FEEDBACK_TOKEN: ${GITHUB_FEEDBACK_TOKEN:-}
 
 x-worker: &worker-base
   image: ghcr.io/weftmark/weftmark-backend:${IMAGE_TAG:-latest}
@@ -120,6 +121,7 @@ services:
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
       OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=${APP_ENV},service.version=${IMAGE_TAG:-dev}"
       OTEL_SERVICE_NAME: weftmark-api
+      GITHUB_FEEDBACK_TOKEN: ${GITHUB_FEEDBACK_TOKEN:-}
     networks:
       - public
       - internal

--- a/frontend/src/api/feedback.ts
+++ b/frontend/src/api/feedback.ts
@@ -78,3 +78,6 @@ export const softDeleteFeedback = (id: string) =>
 
 export const recoverFeedback = (id: string) =>
   api.post<FeedbackRecord>(`/api/admin/feedback/${id}/recover`, {});
+
+export const retryFeedbackDispatch = (id: string) =>
+  api.post<FeedbackRecord>(`/api/admin/feedback/${id}/retry-dispatch`, {});

--- a/frontend/src/api/feedback.ts
+++ b/frontend/src/api/feedback.ts
@@ -1,0 +1,77 @@
+import { api } from "@/api/client";
+
+export type SubmissionType = "feedback" | "feature_request" | "bug_report";
+
+export const SUBMISSION_TYPE_LABELS: Record<SubmissionType, string> = {
+  feedback: "Feedback",
+  feature_request: "Feature Request",
+  bug_report: "Bug Report",
+};
+
+export interface FeedbackDiagnostics {
+  environment: string;
+  page_url: string;
+  user_agent: string;
+  app_version: string | null;
+  project_id?: string | null;
+  draft_id?: string | null;
+}
+
+export interface SubmitFeedbackPayload {
+  submission_type: SubmissionType;
+  body: string;
+  subject?: string | null;
+  is_anonymous: boolean;
+  diagnostics: FeedbackDiagnostics;
+}
+
+export interface FeedbackRecord {
+  id: string;
+  submission_type: SubmissionType;
+  subject: string | null;
+  body: string;
+  is_anonymous: boolean;
+  diagnostics: Record<string, unknown> | null;
+  github_discussion_url: string | null;
+  dispatch_status: "pending" | "sent" | "failed" | "skipped";
+  user_email: string | null;
+  deleted_at: string | null;
+  created_at: string;
+}
+
+export interface FeedbackPage {
+  items: FeedbackRecord[];
+  total: number;
+  page: number;
+  page_size: number;
+  pages: number;
+}
+
+export const submitFeedback = (payload: SubmitFeedbackPayload) =>
+  api.post<FeedbackRecord>("/api/feedback", payload);
+
+export const listAdminFeedback = (params: {
+  page?: number;
+  page_size?: number;
+  submission_type?: SubmissionType;
+  dispatch_status?: string;
+  include_deleted?: boolean;
+} = {}) => {
+  const qs = new URLSearchParams();
+  if (params.page) qs.set("page", String(params.page));
+  if (params.page_size) qs.set("page_size", String(params.page_size));
+  if (params.submission_type) qs.set("submission_type", params.submission_type);
+  if (params.dispatch_status) qs.set("dispatch_status", params.dispatch_status);
+  if (params.include_deleted) qs.set("include_deleted", "true");
+  const query = qs.toString();
+  return api.get<FeedbackPage>(`/api/admin/feedback${query ? `?${query}` : ""}`);
+};
+
+export const getAdminFeedbackDetail = (id: string) =>
+  api.get<FeedbackRecord>(`/api/admin/feedback/${id}`);
+
+export const softDeleteFeedback = (id: string) =>
+  api.delete<FeedbackRecord>(`/api/admin/feedback/${id}`);
+
+export const recoverFeedback = (id: string) =>
+  api.post<FeedbackRecord>(`/api/admin/feedback/${id}/recover`, {});

--- a/frontend/src/api/feedback.ts
+++ b/frontend/src/api/feedback.ts
@@ -50,6 +50,9 @@ export interface FeedbackPage {
 export const submitFeedback = (payload: SubmitFeedbackPayload) =>
   api.post<FeedbackRecord>("/api/feedback", payload);
 
+export const listMyFeedback = () =>
+  api.get<FeedbackRecord[]>("/api/feedback/mine");
+
 export const listAdminFeedback = (params: {
   page?: number;
   page_size?: number;

--- a/frontend/src/components/FeedbackModal.tsx
+++ b/frontend/src/components/FeedbackModal.tsx
@@ -189,12 +189,11 @@ export function FeedbackModal({ onClose }: Props) {
                   />
                   <span className="text-sm">Submit anonymously</span>
                 </label>
-                {isAnonymous && (
-                  <p className="text-xs text-muted-foreground pl-6">
-                    Anonymous submissions may be closed without action if they lack
-                    enough detail to investigate.
-                  </p>
-                )}
+                <p className="text-xs text-muted-foreground pl-6">
+                  {isAnonymous
+                    ? "Your name won't appear on the GitHub Discussion, but admins can still see who submitted. You'll see this in your feedback history."
+                    : "Your display name will appear on the GitHub Discussion thread."}
+                </p>
               </div>
             )}
 

--- a/frontend/src/components/FeedbackModal.tsx
+++ b/frontend/src/components/FeedbackModal.tsx
@@ -1,0 +1,288 @@
+import { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
+import { useMutation } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { AppIcons } from "@/lib/icons";
+import { useAuth } from "@/hooks/useAuth";
+import {
+  submitFeedback,
+  SUBMISSION_TYPE_LABELS,
+  type SubmissionType,
+  type FeedbackRecord,
+} from "@/api/feedback";
+
+interface Props {
+  onClose: () => void;
+}
+
+const TYPE_PLACEHOLDERS: Record<SubmissionType, string> = {
+  feedback: "Share your thoughts, impressions, or anything you'd like us to know about your experience.",
+  feature_request: "Describe the feature you'd like and how it would help your workflow.",
+  bug_report:
+    "Describe the issue: what happened, what you expected, and how to reproduce it. " +
+    "Include browser and device info if relevant.",
+};
+
+function getEnvironment(hostname: string): string {
+  if (hostname.endsWith(".weftmark.com")) return `https://${hostname}`;
+  return "local instance";
+}
+
+async function getAppVersion(): Promise<string | null> {
+  try {
+    const res = await fetch("/version.json");
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function extractProjectId(pathname: string): string | null {
+  const m = pathname.match(/^\/projects\/([0-9a-f-]{36})/i);
+  return m ? m[1] : null;
+}
+
+function extractDraftId(pathname: string): string | null {
+  const m = pathname.match(/^\/drafts\/([0-9a-f-]{36})/i);
+  return m ? m[1] : null;
+}
+
+export function FeedbackModal({ onClose }: Props) {
+  const { user } = useAuth();
+  const location = useLocation();
+
+  const [type, setType] = useState<SubmissionType>("feedback");
+  const [subject, setSubject] = useState("");
+  const [body, setBody] = useState("");
+  const [isAnonymous, setIsAnonymous] = useState(false);
+  const [includeIds, setIncludeIds] = useState(true);
+  const [submitted, setSubmitted] = useState<FeedbackRecord | null>(null);
+  const [appVersion, setAppVersion] = useState<string | null>(null);
+
+  const detectedProjectId = extractProjectId(location.pathname);
+  const detectedDraftId = extractDraftId(location.pathname);
+
+  useEffect(() => {
+    getAppVersion().then(setAppVersion);
+  }, []);
+
+  // Close on Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  const mutation = useMutation({
+    mutationFn: submitFeedback,
+    onSuccess: (data) => setSubmitted(data),
+  });
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!body.trim()) return;
+
+    const env = getEnvironment(window.location.hostname);
+
+    mutation.mutate({
+      submission_type: type,
+      subject: subject.trim() || null,
+      body: body.trim(),
+      is_anonymous: user ? isAnonymous : false,
+      diagnostics: {
+        environment: env,
+        page_url: location.pathname,
+        user_agent: navigator.userAgent,
+        app_version: appVersion,
+        project_id: includeIds && !isAnonymous ? detectedProjectId : null,
+        draft_id: includeIds && !isAnonymous ? detectedDraftId : null,
+      },
+    });
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 p-4" onClick={onClose}>
+      <div
+        className="w-full max-w-lg rounded-lg border border-border bg-background shadow-xl p-6 space-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <h2 className="text-base font-semibold flex items-center gap-2">
+            <AppIcons.feedback className="h-4 w-4 text-muted-foreground" />
+            Send Feedback
+          </h2>
+          <button
+            onClick={onClose}
+            className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label="Close"
+          >
+            <AppIcons.close className="h-4 w-4" />
+          </button>
+        </div>
+
+        {submitted ? (
+          <SuccessView record={submitted} onClose={onClose} />
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {/* Type selector */}
+            <div>
+              <label className="mb-1.5 block text-sm font-medium">Type</label>
+              <div className="flex gap-2 flex-wrap">
+                {(Object.keys(SUBMISSION_TYPE_LABELS) as SubmissionType[]).map((t) => (
+                  <button
+                    key={t}
+                    type="button"
+                    onClick={() => setType(t)}
+                    className={`rounded-full px-3 py-1 text-sm font-medium border transition-colors ${
+                      type === t
+                        ? "bg-primary text-primary-foreground border-primary"
+                        : "border-border text-muted-foreground hover:border-foreground hover:text-foreground"
+                    }`}
+                  >
+                    {SUBMISSION_TYPE_LABELS[t]}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Subject */}
+            <div>
+              <label className="mb-1 block text-sm font-medium">
+                Subject <span className="text-muted-foreground font-normal">(optional)</span>
+              </label>
+              <input
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                placeholder="Brief summary"
+                value={subject}
+                onChange={(e) => setSubject(e.target.value)}
+                maxLength={200}
+              />
+            </div>
+
+            {/* Body */}
+            <div>
+              <label className="mb-1 block text-sm font-medium">
+                Details <span className="text-destructive">*</span>
+              </label>
+              <textarea
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring resize-none"
+                rows={5}
+                placeholder={TYPE_PLACEHOLDERS[type]}
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+                required
+              />
+            </div>
+
+            {/* Anonymous toggle — logged-in users only */}
+            {user && (
+              <div className="space-y-2">
+                <label className="flex items-center gap-2 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={isAnonymous}
+                    onChange={(e) => setIsAnonymous(e.target.checked)}
+                    className="rounded"
+                  />
+                  <span className="text-sm">Submit anonymously</span>
+                </label>
+                {isAnonymous && (
+                  <p className="text-xs text-muted-foreground pl-6">
+                    Anonymous submissions may be closed without action if they lack
+                    enough detail to investigate.
+                  </p>
+                )}
+              </div>
+            )}
+
+            {/* Include IDs — shown when not anonymous and IDs detected */}
+            {user && !isAnonymous && (detectedProjectId || detectedDraftId) && (
+              <label className="flex items-start gap-2 cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  checked={includeIds}
+                  onChange={(e) => setIncludeIds(e.target.checked)}
+                  className="rounded mt-0.5"
+                />
+                <span className="text-sm text-muted-foreground">
+                  Include{" "}
+                  {[
+                    detectedProjectId && "project ID",
+                    detectedDraftId && "draft ID",
+                  ]
+                    .filter(Boolean)
+                    .join(" and ")}{" "}
+                  to help with troubleshooting
+                </span>
+              </label>
+            )}
+
+            {/* Error */}
+            {mutation.isError && (
+              <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                Failed to submit. Please try again.
+              </p>
+            )}
+
+            {/* Footer note */}
+            <p className="text-xs text-muted-foreground">
+              This is a hobby project — responses may be slow. After submitting, you'll
+              receive a link to a GitHub Discussion thread where you can attach screenshots.
+            </p>
+
+            <div className="flex justify-end gap-2">
+              <Button type="button" variant="outline" onClick={onClose}>Cancel</Button>
+              <Button type="submit" disabled={mutation.isPending || !body.trim()}>
+                {mutation.isPending ? "Sending…" : "Send Feedback"}
+              </Button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SuccessView({ record, onClose }: { record: FeedbackRecord; onClose: () => void }) {
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-foreground">
+        Thank you — your {SUBMISSION_TYPE_LABELS[record.submission_type as SubmissionType] ?? "feedback"} was received.
+      </p>
+
+      {record.github_discussion_url ? (
+        <div className="space-y-2">
+          <p className="text-sm text-muted-foreground">
+            A discussion thread has been created. You can follow progress and attach screenshots there:
+          </p>
+          <a
+            href={record.github_discussion_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+          >
+            <AppIcons.externalLink className="h-3.5 w-3.5" />
+            View on GitHub
+          </a>
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          Your submission is stored and will be reviewed by the team.
+          {record.dispatch_status === "pending" && " A GitHub Discussion link will be emailed to you shortly."}
+        </p>
+      )}
+
+      <p className="text-xs text-muted-foreground border-t border-border pt-3">
+        weftmark is a hobby project, not a business. Response times may be slow or limited.
+        We genuinely appreciate you taking the time to share your feedback.
+      </p>
+
+      <div className="flex justify-end">
+        <Button onClick={onClose}>Close</Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/FeedbackModal.tsx
+++ b/frontend/src/components/FeedbackModal.tsx
@@ -191,8 +191,8 @@ export function FeedbackModal({ onClose }: Props) {
                 </label>
                 <p className="text-xs text-muted-foreground pl-6">
                   {isAnonymous
-                    ? "Your name won't appear on the GitHub Discussion, but admins can still see who submitted. You'll see this in your feedback history."
-                    : "Your display name will appear on the GitHub Discussion thread."}
+                    ? "Page URL and project/draft IDs won't be included in the public Discussion. Admins can still see who submitted, and it will appear in your feedback history."
+                    : "Page URL and project/draft IDs (if opted in below) will appear in the public Discussion."}
                 </p>
               </div>
             )}

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -3,6 +3,7 @@ import { useLocation } from "react-router-dom";
 import { AppIcons } from "@/lib/icons";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { VersionBadge } from "@/components/layout/VersionFooter";
+import { FeedbackModal } from "@/components/FeedbackModal";
 import { useAuth } from "@/hooks/useAuth";
 import type { ReactNode } from "react";
 
@@ -15,6 +16,7 @@ interface Props {
 export function AppLayout({ children }: Props) {
   const { user } = useAuth();
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
   // Track which detail path the user manually expanded the sidebar on.
   // Collapse whenever on a detail page unless this matches the current path.
   const [expandedOnPath, setExpandedOnPath] = useState<string | null>(null);
@@ -34,13 +36,20 @@ export function AppLayout({ children }: Props) {
 
       <div className="flex flex-1 flex-col overflow-hidden">
         {/* Mobile top bar — hidden on lg+ where sidebar is always visible */}
-        <div className="flex h-14 shrink-0 items-center border-b border-border bg-card px-4 lg:hidden">
+        <div className="flex h-14 shrink-0 items-center justify-between border-b border-border bg-card px-4 lg:hidden">
           <button
             onClick={() => setSidebarOpen(true)}
             className="rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
             aria-label="Open navigation"
           >
             <AppIcons.mobileMenu className="h-5 w-5" />
+          </button>
+          <button
+            onClick={() => setFeedbackOpen(true)}
+            className="rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label="Send feedback"
+          >
+            <AppIcons.feedback className="h-5 w-5" />
           </button>
         </div>
 
@@ -51,6 +60,7 @@ export function AppLayout({ children }: Props) {
       </div>
 
       {(user?.show_version_numbers ?? true) && <VersionBadge />}
+      {feedbackOpen && <FeedbackModal onClose={() => setFeedbackOpen(false)} />}
     </div>
   );
 }

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -26,6 +26,7 @@ const SETTINGS_SECTIONS = [
   { id: "privacy", label: "Privacy & data" },
   { id: "terms", label: "Terms" },
   { id: "account", label: "Account" },
+  { id: "feedback-history", label: "Feedback history" },
 ];
 
 const ADMIN_SECTIONS = [

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,8 +1,10 @@
+import { useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { useClerk } from "@clerk/clerk-react";
 import { AppIcons, type LucideIcon } from "@/lib/icons";
 import { WeftmarkLogo } from "@/components/WeftmarkLogo";
 import { useAuth } from "@/hooks/useAuth";
+import { FeedbackModal } from "@/components/FeedbackModal";
 
 interface NavItem {
   label: string;
@@ -34,6 +36,7 @@ const ADMIN_SECTIONS = [
   { id: "services", label: "Services" },
   { id: "deps", label: "Dependencies" },
   { id: "audit", label: "Audit log" },
+  { id: "feedback", label: "Feedback" },
   { id: "credentials", label: "Credentials" },
   { id: "slugs", label: "Share links" },
   { id: "superuser", label: "Superuser", superuserOnly: true },
@@ -50,6 +53,7 @@ export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpa
   const location = useLocation();
   const { user } = useAuth();
   const { signOut } = useClerk();
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
 
   function isActive(href: string, exact = false) {
     if (exact) return location.pathname === href;
@@ -211,6 +215,15 @@ export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpa
           )}
 
           <button
+            onClick={() => setFeedbackOpen(true)}
+            className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground ${desktopCollapsed ? "lg:justify-center lg:px-2" : ""}`}
+            title={desktopCollapsed ? "Send Feedback" : undefined}
+          >
+            <AppIcons.feedback className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} />
+            <span className={desktopCollapsed ? "lg:hidden" : ""}>Send Feedback</span>
+          </button>
+
+          <button
             onClick={() => signOut()}
             className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-subdued transition-colors hover:bg-muted hover:text-foreground ${desktopCollapsed ? "lg:justify-center lg:px-2" : ""}`}
             title={desktopCollapsed ? "Sign out" : undefined}
@@ -228,6 +241,8 @@ export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpa
           </div>
         )}
       </aside>
+
+      {feedbackOpen && <FeedbackModal onClose={() => setFeedbackOpen(false)} />}
     </>
   );
 }

--- a/frontend/src/lib/icons.ts
+++ b/frontend/src/lib/icons.ts
@@ -22,6 +22,7 @@ import {
   LogOut,
   Maximize2,
   Menu,
+  MessageSquare,
   Minimize2,
   Pencil,
   Printer,
@@ -57,6 +58,7 @@ export const AppIcons = {
   settings: Settings,
   admin: ShieldCheck,
   logout: LogOut,
+  feedback: MessageSquare,
 
   // ── UI chrome ─────────────────────────────────────────────────────────────
   edit: Pencil,

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -73,6 +73,7 @@ import {
   listAdminFeedback,
   softDeleteFeedback,
   recoverFeedback,
+  retryFeedbackDispatch,
   SUBMISSION_TYPE_LABELS,
   type FeedbackRecord,
   type SubmissionType,
@@ -1858,6 +1859,14 @@ function FeedbackTab() {
     },
   });
 
+  const retryMutation = useMutation({
+    mutationFn: (id: string) => retryFeedbackDispatch(id),
+    onSuccess: (updated) => {
+      queryClient.invalidateQueries({ queryKey: ["admin", "feedback"] });
+      setDetail(updated);
+    },
+  });
+
   const recoverMutation = useMutation({
     mutationFn: (id: string) => recoverFeedback(id),
     onSuccess: (updated) => {
@@ -1992,7 +2001,18 @@ function FeedbackTab() {
               )}
             </div>
 
-            <div className="flex justify-end gap-2 pt-2">
+            <div className="flex justify-end gap-2 pt-2 flex-wrap">
+              {/* Retry dispatch: shown for failed or pending submissions */}
+              {!detail.deleted_at && (detail.dispatch_status === "failed" || detail.dispatch_status === "pending") && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={retryMutation.isPending}
+                  onClick={() => retryMutation.mutate(detail.id)}
+                >
+                  {retryMutation.isPending ? "Retrying…" : "Retry dispatch"}
+                </Button>
+              )}
               {detail.deleted_at ? (
                 <Button
                   variant="outline"

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -69,12 +69,20 @@ import {
   type WorkerInfo,
   type ServerEvent,
 } from "@/api/admin";
+import {
+  listAdminFeedback,
+  softDeleteFeedback,
+  recoverFeedback,
+  SUBMISSION_TYPE_LABELS,
+  type FeedbackRecord,
+  type SubmissionType,
+} from "@/api/feedback";
 import { getHealthDetailed, type ReadinessResponse, type ReadinessService } from "@/api/health";
 import { EulaContent } from "@/components/EulaContent";
 import { CopyEmail } from "@/components/admin/CopyEmail";
 import { formatBytes } from "@/lib/image-utils";
 
-type Tab = "users" | "invites" | "stats" | "health" | "services" | "deps" | "audit" | "credentials" | "superuser" | "slugs";
+type Tab = "users" | "invites" | "stats" | "health" | "services" | "deps" | "audit" | "credentials" | "superuser" | "slugs" | "feedback";
 
 function formatLastActive(iso: string | null): string {
   if (!iso) return "Never";
@@ -161,6 +169,7 @@ export function AdminPage() {
       {tab === "services" && <ServicesTab />}
       {tab === "deps" && <DepsTab />}
       {tab === "audit" && <AuditLogTab />}
+      {tab === "feedback" && <FeedbackTab />}
       {tab === "credentials" && <CredentialsTab />}
       {tab === "slugs" && <SlugsTab />}
       {tab === "superuser" && <SuperuserTab />}
@@ -1813,6 +1822,202 @@ function StepLogSection() {
               ))}
             </tbody>
           </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Feedback tab
+// ---------------------------------------------------------------------------
+
+function FeedbackTab() {
+  const queryClient = useQueryClient();
+  const [page, setPage] = useState(1);
+  const [typeFilter, setTypeFilter] = useState<SubmissionType | "">("");
+  const [includeDeleted, setIncludeDeleted] = useState(false);
+  const [detail, setDetail] = useState<FeedbackRecord | null>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["admin", "feedback", page, typeFilter, includeDeleted],
+    queryFn: () =>
+      listAdminFeedback({
+        page,
+        page_size: 25,
+        submission_type: typeFilter || undefined,
+        include_deleted: includeDeleted,
+      }),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => softDeleteFeedback(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin", "feedback"] });
+      setDetail(null);
+    },
+  });
+
+  const recoverMutation = useMutation({
+    mutationFn: (id: string) => recoverFeedback(id),
+    onSuccess: (updated) => {
+      queryClient.invalidateQueries({ queryKey: ["admin", "feedback"] });
+      setDetail(updated);
+    },
+  });
+
+  const STATUS_COLORS: Record<string, string> = {
+    sent: "text-green-600 dark:text-green-400",
+    failed: "text-destructive",
+    pending: "text-amber-600 dark:text-amber-400",
+    skipped: "text-muted-foreground",
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <h2 className="text-base font-semibold">Feedback submissions</h2>
+        <div className="flex items-center gap-2 text-sm">
+          <select
+            className="rounded-md border border-border bg-background px-2 py-1 text-sm"
+            value={typeFilter}
+            onChange={(e) => { setTypeFilter(e.target.value as SubmissionType | ""); setPage(1); }}
+          >
+            <option value="">All types</option>
+            {(Object.entries(SUBMISSION_TYPE_LABELS) as [SubmissionType, string][]).map(([k, v]) => (
+              <option key={k} value={k}>{v}</option>
+            ))}
+          </select>
+          <label className="flex items-center gap-1.5 cursor-pointer text-muted-foreground">
+            <input type="checkbox" checked={includeDeleted} onChange={(e) => setIncludeDeleted(e.target.checked)} />
+            Show deleted
+          </label>
+        </div>
+      </div>
+
+      {isLoading && <div className="text-sm text-muted-foreground py-8 text-center">Loading…</div>}
+      {data && data.items.length === 0 && (
+        <div className="text-sm text-muted-foreground py-8 text-center">No submissions found.</div>
+      )}
+      {data && data.items.length > 0 && (
+        <div className="rounded-lg border border-border overflow-x-auto">
+          <table className="w-full text-sm min-w-[600px]">
+            <thead>
+              <tr className="border-b border-border text-left text-xs text-muted-foreground">
+                <th className="px-3 py-2 font-medium">Date</th>
+                <th className="px-3 py-2 font-medium">Type</th>
+                <th className="px-3 py-2 font-medium">Subject</th>
+                <th className="px-3 py-2 font-medium">User</th>
+                <th className="px-3 py-2 font-medium">Status</th>
+                <th className="px-3 py-2 font-medium"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.items.map((item: FeedbackRecord) => (
+                <tr
+                  key={item.id}
+                  className={`border-b border-border last:border-0 hover:bg-muted/20 ${item.deleted_at ? "opacity-50" : ""}`}
+                >
+                  <td className="px-3 py-2 text-xs text-muted-foreground whitespace-nowrap">
+                    {new Date(item.created_at).toLocaleDateString()}
+                  </td>
+                  <td className="px-3 py-2 whitespace-nowrap">
+                    {SUBMISSION_TYPE_LABELS[item.submission_type as SubmissionType] ?? item.submission_type}
+                  </td>
+                  <td className="px-3 py-2 max-w-[200px] truncate text-muted-foreground">
+                    {item.subject ?? item.body.slice(0, 60)}
+                  </td>
+                  <td className="px-3 py-2 text-xs text-muted-foreground">
+                    {item.is_anonymous ? "Anonymous" : (item.user_email ?? "—")}
+                  </td>
+                  <td className={`px-3 py-2 text-xs ${STATUS_COLORS[item.dispatch_status] ?? ""}`}>
+                    {item.dispatch_status}
+                  </td>
+                  <td className="px-3 py-2">
+                    <Button variant="ghost" size="sm" className="h-7 px-2" onClick={() => setDetail(item)}>
+                      View
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Pagination */}
+      {data && data.pages > 1 && (
+        <div className="flex items-center justify-end gap-2 text-sm">
+          <Button variant="outline" size="sm" disabled={page <= 1} onClick={() => setPage(p => p - 1)}>Previous</Button>
+          <span className="text-muted-foreground">{page} / {data.pages}</span>
+          <Button variant="outline" size="sm" disabled={page >= data.pages} onClick={() => setPage(p => p + 1)}>Next</Button>
+        </div>
+      )}
+
+      {/* Detail modal */}
+      {detail && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={() => setDetail(null)}>
+          <div className="w-full max-w-lg rounded-lg border border-border bg-background shadow-xl p-6 space-y-4 max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold">
+                {SUBMISSION_TYPE_LABELS[detail.submission_type as SubmissionType] ?? detail.submission_type}
+              </h3>
+              <button onClick={() => setDetail(null)} className="rounded-md p-1 text-muted-foreground hover:bg-muted">
+                <span className="text-xs">✕</span>
+              </button>
+            </div>
+
+            {detail.subject && <p className="font-medium text-sm">{detail.subject}</p>}
+            <p className="text-sm whitespace-pre-wrap border border-border rounded p-3 bg-muted/30">{detail.body}</p>
+
+            {detail.diagnostics && Object.keys(detail.diagnostics).length > 0 && (
+              <div className="text-xs text-muted-foreground space-y-1">
+                <p className="font-medium text-foreground">Diagnostics</p>
+                {Object.entries(detail.diagnostics).map(([k, v]) =>
+                  v ? <p key={k}><span className="font-mono">{k}:</span> {String(v)}</p> : null
+                )}
+              </div>
+            )}
+
+            <div className="text-xs text-muted-foreground space-y-1">
+              <p>Submitted: {new Date(detail.created_at).toLocaleString()}</p>
+              <p>User: {detail.is_anonymous ? "Anonymous" : (detail.user_email ?? "Unauthenticated")}</p>
+              <p>Dispatch: <span className={STATUS_COLORS[detail.dispatch_status] ?? ""}>{detail.dispatch_status}</span></p>
+              {detail.github_discussion_url && (
+                <p>
+                  <a href={detail.github_discussion_url} target="_blank" rel="noopener noreferrer" className="underline text-primary">
+                    View on GitHub
+                  </a>
+                </p>
+              )}
+            </div>
+
+            <div className="flex justify-end gap-2 pt-2">
+              {detail.deleted_at ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={recoverMutation.isPending}
+                  onClick={() => recoverMutation.mutate(detail.id)}
+                >
+                  {recoverMutation.isPending ? "Recovering…" : "Recover"}
+                </Button>
+              ) : (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-destructive hover:text-destructive"
+                  disabled={deleteMutation.isPending}
+                  onClick={() => {
+                    if (confirm("Soft-delete this submission?")) deleteMutation.mutate(detail.id);
+                  }}
+                >
+                  {deleteMutation.isPending ? "Deleting…" : "Delete"}
+                </Button>
+              )}
+              <Button variant="outline" size="sm" onClick={() => setDetail(null)}>Close</Button>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -553,7 +553,7 @@ function FeedbackHistorySection() {
                   </div>
                 </div>
                 <p className="text-xs text-muted-foreground">
-                  {new Date(s.created_at).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })}
+                  {new Date(s.created_at).toLocaleString(undefined, { year: "numeric", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" })}
                 </p>
               </button>
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -4,10 +4,12 @@ import { useAuth } from "@/hooks/useAuth";
 import { useQuery } from "@tanstack/react-query";
 import { updateSettings, deleteAccount, getDataExport, getCurrentEula } from "@/api/users";
 import { listDrafts } from "@/api/drafts";
+import { listMyFeedback, SUBMISSION_TYPE_LABELS, type FeedbackRecord } from "@/api/feedback";
 import { Button } from "@/components/ui/button";
 import { EulaContent } from "@/components/EulaContent";
+import { AppIcons } from "@/lib/icons";
 
-type Section = "appearance" | "preferences" | "privacy" | "terms" | "account";
+type Section = "appearance" | "preferences" | "privacy" | "terms" | "account" | "feedback-history";
 
 export function SettingsPage() {
   const { user, refetch } = useAuth();
@@ -416,6 +418,9 @@ export function SettingsPage() {
               </Section>
             )}
 
+            {/* ── Feedback history ── */}
+            {activeSection === "feedback-history" && <FeedbackHistorySection />}
+
             {/* ── Account ── */}
             {activeSection === "account" && (
               <Section title="Account management">
@@ -490,6 +495,89 @@ export function SettingsPage() {
             )}
         </div>
     </div>
+  );
+}
+
+const DISPATCH_BADGE: Record<string, string> = {
+  pending: "bg-amber-500/10 text-amber-700 dark:text-amber-400",
+  sent: "bg-green-500/10 text-green-700 dark:text-green-400",
+  skipped: "bg-muted text-muted-foreground",
+  failed: "bg-destructive/10 text-destructive",
+};
+
+function FeedbackHistorySection() {
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  const { data: submissions = [], isLoading } = useQuery({
+    queryKey: ["feedback", "mine"],
+    queryFn: listMyFeedback,
+  });
+
+  return (
+    <Section title="Feedback history">
+      <p className="text-sm text-muted-foreground">
+        Submissions you've sent, including anonymous ones. Only you can see this list.
+      </p>
+
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : submissions.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No submissions yet.</p>
+      ) : (
+        <div className="divide-y divide-border rounded-lg border">
+          {submissions.map((s: FeedbackRecord) => (
+            <div key={s.id} className="px-4 py-3 space-y-1">
+              <button
+                className="w-full text-left space-y-1"
+                onClick={() => setExpanded(expanded === s.id ? null : s.id)}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="text-xs font-medium shrink-0">
+                      {SUBMISSION_TYPE_LABELS[s.submission_type as keyof typeof SUBMISSION_TYPE_LABELS] ?? s.submission_type}
+                    </span>
+                    {s.is_anonymous && (
+                      <span className="text-xs text-muted-foreground shrink-0">(anonymous)</span>
+                    )}
+                    {s.subject && (
+                      <span className="text-sm text-foreground truncate">{s.subject}</span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${DISPATCH_BADGE[s.dispatch_status] ?? ""}`}>
+                      {s.dispatch_status}
+                    </span>
+                    <AppIcons.chevronDown
+                      className={`h-3.5 w-3.5 text-muted-foreground transition-transform ${expanded === s.id ? "rotate-180" : ""}`}
+                    />
+                  </div>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {new Date(s.created_at).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })}
+                </p>
+              </button>
+
+              {expanded === s.id && (
+                <div className="pt-2 space-y-2">
+                  <p className="text-sm whitespace-pre-wrap text-foreground">{s.body}</p>
+                  {s.github_discussion_url && (
+                    <a
+                      href={s.github_discussion_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+                    >
+                      <AppIcons.externalLink className="h-3.5 w-3.5" />
+                      View discussion on GitHub
+                    </a>
+                  )}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </Section>
   );
 }
 


### PR DESCRIPTION
## Summary
- Full feedback submission flow: type selector (Feedback / Feature Request / Bug Report), optional subject, required details, anonymous toggle, auto-detected project/draft IDs
- Backend: UserFeedback model + migration, rate-limited endpoint (5/hr/IP), optional auth so unauthenticated users can also submit
- GitHub Discussions dispatch via Celery task with retry/backoff; admin email alert + user confirmation email on success
- dispatch_status set to skipped immediately when GITHUB_FEEDBACK_TOKEN is absent (was incorrectly left as pending)
- Admin console tab: list/filter by type and status, detail modal, soft-delete, recover
- Scheduler tasks: daily retry of failed dispatches, 7-day hard-delete retention
- Feedback button in sidebar nav (desktop + mobile) and mobile top bar
- 26 tests passing; conftest updated with get_optional_user and _submit_limit dependency overrides

## Test plan
- [ ] Submit feedback as authenticated user -- confirm 201, dispatch_status=pending (if token set) or skipped
- [ ] Submit without logging in -- confirm 201, user_id=null in admin view
- [ ] Submit anonymously -- confirm user_email hidden in admin, ID checkboxes not offered
- [ ] Open admin -> Feedback tab -- verify submissions appear with correct metadata
- [ ] Soft-delete a submission, toggle include-deleted to confirm it reappears, recover it
- [ ] Verify rate limit (5 submissions in quick succession -> 6th returns 429)
- [ ] Confirm feedback button appears in sidebar and mobile top bar
- [ ] Check modal ESC + backdrop close
- [ ] Confirm footer note wording: "After submitting, you'll receive a link..."

Generated with Claude Code