### PR TITLE
feat: global tracker style picker with live preview and user preferences (#684)

### DIFF
--- a/backend/alembic/versions/0026_tracker_prefs.py
+++ b/backend/alembic/versions/0026_tracker_prefs.py
@@ -1,0 +1,30 @@
+"""Add global tracker preference columns to users
+
+Revision ID: 0026
+Revises: 0025
+Create Date: 2026-05-17
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "4a7b2c9d1e3f"
+down_revision = "1c23e69db390"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("tracker_color_mode", sa.String(10), nullable=False, server_default="strip"))
+    op.add_column("users", sa.Column("tracker_show_weft_color", sa.Boolean, nullable=False, server_default="true"))
+    op.add_column("users", sa.Column("tracker_show_drawdown", sa.Boolean, nullable=False, server_default="true"))
+    op.add_column("users", sa.Column("tracker_show_progress", sa.Boolean, nullable=False, server_default="true"))
+    op.add_column("users", sa.Column("tracker_show_pick_cards", sa.Boolean, nullable=False, server_default="true"))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "tracker_show_pick_cards")
+    op.drop_column("users", "tracker_show_progress")
+    op.drop_column("users", "tracker_show_drawdown")
+    op.drop_column("users", "tracker_show_weft_color")
+    op.drop_column("users", "tracker_color_mode")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -37,3 +37,8 @@ class User(Base, TimestampMixin, SoftDeleteMixin):
     clerk_errored: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     show_version_numbers: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     hide_unused_shafts_treadles: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    tracker_color_mode: Mapped[str] = mapped_column(String(10), default="strip", nullable=False)
+    tracker_show_weft_color: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    tracker_show_drawdown: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    tracker_show_progress: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    tracker_show_pick_cards: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -40,6 +40,7 @@ _VALID_THEMES = {"light", "dark", "system"}
 _VALID_MEASUREMENT_SYSTEMS = {"metric", "imperial"}
 _VALID_ACTIVITY_THEMES = {"default", "compact", "high_contrast"}
 _VALID_IDLE_TIMEOUTS = {15, 30, 60, 120}
+_VALID_COLOR_MODES = {"theme", "strip", "filled"}
 
 _SESSION_COOKIE = "session"
 
@@ -58,6 +59,11 @@ class UserSettingsUpdate(BaseModel):
     ai_training_consent: bool | None = None
     show_version_numbers: bool | None = None
     hide_unused_shafts_treadles: bool | None = None
+    tracker_color_mode: str | None = None
+    tracker_show_weft_color: bool | None = None
+    tracker_show_drawdown: bool | None = None
+    tracker_show_progress: bool | None = None
+    tracker_show_pick_cards: bool | None = None
 
 
 class EulaAcceptRequest(BaseModel):
@@ -80,6 +86,11 @@ class UserSettingsResponse(BaseModel):
     ai_training_consent: bool
     show_version_numbers: bool
     hide_unused_shafts_treadles: bool
+    tracker_color_mode: str
+    tracker_show_weft_color: bool
+    tracker_show_drawdown: bool
+    tracker_show_progress: bool
+    tracker_show_pick_cards: bool
     eula_accepted_version: str | None
     current_eula_version: str
 
@@ -109,6 +120,11 @@ def _to_response(user: User, current_eula_version: str) -> UserSettingsResponse:
         ai_training_consent=user.ai_training_consent,
         show_version_numbers=user.show_version_numbers,
         hide_unused_shafts_treadles=user.hide_unused_shafts_treadles,
+        tracker_color_mode=user.tracker_color_mode,
+        tracker_show_weft_color=user.tracker_show_weft_color,
+        tracker_show_drawdown=user.tracker_show_drawdown,
+        tracker_show_progress=user.tracker_show_progress,
+        tracker_show_pick_cards=user.tracker_show_pick_cards,
         eula_accepted_version=user.eula_accepted_version,
         current_eula_version=current_eula_version,
     )
@@ -209,6 +225,26 @@ async def update_settings(
 
     if body.hide_unused_shafts_treadles is not None:
         current_user.hide_unused_shafts_treadles = body.hide_unused_shafts_treadles
+
+    if body.tracker_color_mode is not None:
+        if body.tracker_color_mode not in _VALID_COLOR_MODES:
+            raise HTTPException(
+                status_code=422,
+                detail=f"tracker_color_mode must be one of {sorted(_VALID_COLOR_MODES)}",
+            )
+        current_user.tracker_color_mode = body.tracker_color_mode
+
+    if body.tracker_show_weft_color is not None:
+        current_user.tracker_show_weft_color = body.tracker_show_weft_color
+
+    if body.tracker_show_drawdown is not None:
+        current_user.tracker_show_drawdown = body.tracker_show_drawdown
+
+    if body.tracker_show_progress is not None:
+        current_user.tracker_show_progress = body.tracker_show_progress
+
+    if body.tracker_show_pick_cards is not None:
+        current_user.tracker_show_pick_cards = body.tracker_show_pick_cards
 
     if body.ai_training_consent is not None:
         current_user.ai_training_consent = body.ai_training_consent

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -20,6 +20,11 @@ export interface UserSettingsUpdate {
   ai_training_consent?: boolean;
   show_version_numbers?: boolean;
   hide_unused_shafts_treadles?: boolean;
+  tracker_color_mode?: string;
+  tracker_show_weft_color?: boolean;
+  tracker_show_drawdown?: boolean;
+  tracker_show_progress?: boolean;
+  tracker_show_pick_cards?: boolean;
 }
 
 export async function updateSettings(body: UserSettingsUpdate): Promise<User> {

--- a/frontend/src/components/TrackerStylePreview.tsx
+++ b/frontend/src/components/TrackerStylePreview.tsx
@@ -1,0 +1,302 @@
+export type TrackerStyle = "default" | "compact" | "high_contrast";
+
+// ── Static style-picker preview (small, used in the card selector) ──────────
+
+const DEMO_ACTIVE = [1, 3];
+const DEMO_SHAFTS = 4;
+const DEMO_WEFT = "#b45309";
+const DEMO_PICK = 7;
+const DEMO_TOTAL = 18;
+
+function DemoBox({ n, active, style }: { n: number; active: boolean; style: TrackerStyle }) {
+  const base = "rounded flex items-center justify-center font-bold text-[11px] border-2";
+  if (style === "high_contrast") {
+    return (
+      <div className={`${base} ${active ? "bg-foreground border-foreground text-background" : "border-muted-foreground/50 bg-muted/40 text-muted-foreground"}`}>
+        {n}
+      </div>
+    );
+  }
+  return (
+    <div className={`${base} ${active ? "bg-primary border-primary text-primary-foreground" : "border-border bg-muted/60 text-foreground/70"}`}>
+      {n}
+    </div>
+  );
+}
+
+function DemoPickCard({ compact, style }: { compact?: boolean; style: TrackerStyle }) {
+  const height = compact ? "h-10" : "h-16";
+  const border = style === "high_contrast"
+    ? compact ? "border border-foreground/30" : "border-2 border-foreground/50"
+    : compact ? "border border-primary/20" : "border-2 border-primary/30";
+  const bg = style === "high_contrast" ? "bg-muted/60" : "bg-primary/5 dark:bg-primary/10";
+
+  return (
+    <div className={`rounded-lg ${bg} ${border} ${height} px-2 py-1.5 flex items-stretch gap-2`}>
+      <div className="flex-1 grid gap-0.5" style={{ gridTemplateColumns: `repeat(${DEMO_SHAFTS}, 1fr)` }}>
+        {Array.from({ length: DEMO_SHAFTS }, (_, i) => i + 1).map((n) => (
+          <DemoBox key={n} n={n} active={DEMO_ACTIVE.includes(n)} style={style} />
+        ))}
+      </div>
+      {!compact && <div className="w-4 shrink-0 rounded" style={{ backgroundColor: DEMO_WEFT }} />}
+    </div>
+  );
+}
+
+export function TrackerStylePreview({ style }: { style: TrackerStyle }) {
+  const isCompact = style === "compact";
+  const isHighContrast = style === "high_contrast";
+
+  return (
+    <div className="pointer-events-none select-none space-y-1.5 p-3 rounded-lg bg-muted/30 border border-border/50">
+      <div className="h-1.5 rounded-full bg-muted overflow-hidden">
+        <div className={`h-full rounded-full ${isHighContrast ? "bg-foreground" : "bg-primary"}`} style={{ width: `${(DEMO_PICK / DEMO_TOTAL) * 100}%` }} />
+      </div>
+      <div className={`text-center font-semibold ${isCompact ? "text-[10px]" : "text-xs"} text-muted-foreground`}>
+        Pick {DEMO_PICK} / {DEMO_TOTAL}
+      </div>
+      <div className="grid grid-cols-[1fr_2fr_1fr] gap-1 items-center">
+        <DemoPickCard compact style={style} />
+        <DemoPickCard style={style} />
+        <DemoPickCard compact style={style} />
+      </div>
+      {!isCompact && (
+        <div className="rounded bg-muted/50 p-1 overflow-hidden">
+          <div className="grid gap-px" style={{ gridTemplateColumns: "repeat(4, 1fr)" }}>
+            {Array.from({ length: 4 }, (_, row) =>
+              Array.from({ length: 4 }, (__, col) => {
+                const lit = (row + col) % 2 === 0;
+                return (
+                  <div
+                    key={`${row}-${col}`}
+                    className={`h-2 rounded-sm ${lit ? (isHighContrast ? "bg-foreground/70" : "bg-primary/60") : "bg-muted-foreground/15"}`}
+                  />
+                );
+              })
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Live tracker preview (full-width, reflects current toggle settings) ──────
+
+const LIVE_SHAFTS_ALL = 8;   // total shafts on the loom
+const LIVE_SHAFTS_USED = 4;  // shafts actually used by the design (trailing 4 are "unused")
+const LIVE_ACTIVE = [1, 3];
+const LIVE_WEFT = "#b45309";
+const LIVE_PICK = 12;
+const LIVE_TOTAL = 32;
+const LIVE_PROGRESS = LIVE_PICK / LIVE_TOTAL;
+
+type ColorMode = "theme" | "strip" | "filled";
+
+function LiveBox({
+  n,
+  active,
+  unused,
+  colorMode,
+  style,
+}: {
+  n: number;
+  active: boolean;
+  unused: boolean;
+  colorMode: ColorMode;
+  style: TrackerStyle;
+}) {
+  const base = "rounded-md border-2 flex flex-col items-center justify-center font-bold overflow-hidden";
+  const fontSize = "text-sm";
+
+  // Unused shafts: clearly distinct — dashed border, no background, very faint text
+  if (unused) {
+    return (
+      <div
+        className={`${base} border-dashed ${style === "high_contrast" ? "border-muted-foreground/30 text-muted-foreground/30" : "border-border/40 text-foreground/25"}`}
+        style={{ borderStyle: "dashed" }}
+      >
+        <span className={fontSize}>{n}</span>
+      </div>
+    );
+  }
+
+  if (active && colorMode === "filled") {
+    return (
+      <div className={`${base}`} style={{ backgroundColor: LIVE_WEFT, borderColor: LIVE_WEFT }}>
+        <span className={fontSize} style={{ color: "#fff" }}>{n}</span>
+      </div>
+    );
+  }
+  if (active && colorMode === "strip") {
+    return (
+      <div className={`${base} ${style === "high_contrast" ? "bg-foreground border-foreground" : "bg-primary border-primary"}`}>
+        <span className={`${fontSize} ${style === "high_contrast" ? "text-background" : "text-primary-foreground"} flex-1 flex items-center justify-center w-full`}>{n}</span>
+        <div className="h-[18%] w-full shrink-0" style={{ backgroundColor: LIVE_WEFT }} />
+      </div>
+    );
+  }
+  if (active) {
+    return (
+      <div className={`${base} ${style === "high_contrast" ? "bg-foreground border-foreground text-background" : "bg-primary border-primary text-primary-foreground"}`}>
+        <span className={fontSize}>{n}</span>
+      </div>
+    );
+  }
+  return (
+    <div className={`${base} ${style === "high_contrast" ? "border-muted-foreground/60 bg-muted/50 text-muted-foreground" : "border-border bg-muted/60 text-foreground/60"}`}>
+      <span className={fontSize}>{n}</span>
+    </div>
+  );
+}
+
+function LivePickCard({
+  compact,
+  style,
+  colorMode,
+  showWeftColor,
+  shaftCount,
+}: {
+  compact?: boolean;
+  style: TrackerStyle;
+  colorMode: ColorMode;
+  showWeftColor: boolean;
+  shaftCount: number;
+}) {
+  const height = compact ? "h-14" : "h-24";
+  const border = style === "high_contrast"
+    ? compact ? "border border-foreground/30" : "border-2 border-foreground/40"
+    : compact ? "border border-primary/20" : "border-2 border-primary/30";
+  const bg = style === "high_contrast" ? "bg-muted/60" : "bg-primary/5 dark:bg-primary/10";
+
+  return (
+    <div className={`rounded-xl ${bg} ${border} ${height} px-3 py-2 flex flex-col gap-1.5`}>
+      <div className="flex-1 grid gap-1" style={{ gridTemplateColumns: `repeat(${shaftCount}, 1fr)` }}>
+        {Array.from({ length: shaftCount }, (_, i) => i + 1).map((n) => (
+          <LiveBox
+            key={n}
+            n={n}
+            active={!compact && LIVE_ACTIVE.includes(n)}
+            unused={n > LIVE_SHAFTS_USED}
+            colorMode={compact ? "theme" : colorMode}
+            style={style}
+          />
+        ))}
+      </div>
+      {!compact && showWeftColor && (
+        <div
+          className="h-5 w-full shrink-0 rounded-md flex items-center justify-center text-[10px] font-semibold uppercase tracking-wider"
+          style={{ backgroundColor: LIVE_WEFT, color: "#fff" }}
+        >
+          Weft
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function TrackerLivePreview({
+  style,
+  colorMode,
+  showProgress,
+  showDrawdown,
+  showWeftColor,
+  showPickCards,
+  hideUnusedShafts,
+}: {
+  style: TrackerStyle;
+  colorMode: string;
+  showProgress: boolean;
+  showDrawdown: boolean;
+  showWeftColor: boolean;
+  showPickCards: boolean;
+  hideUnusedShafts: boolean;
+}) {
+  const isHighContrast = style === "high_contrast";
+  const cm = (colorMode as ColorMode) ?? "strip";
+  const shaftCount = hideUnusedShafts ? LIVE_SHAFTS_USED : LIVE_SHAFTS_ALL;
+
+  return (
+    <div className="pointer-events-none select-none rounded-xl border-2 border-dashed border-border bg-background p-4 space-y-3">
+      {/* Header label */}
+      <p className="text-[10px] font-medium uppercase tracking-widest text-muted-foreground/60 text-center">Preview</p>
+
+      {/* Progress bar */}
+      {showProgress && (
+        <div className="space-y-1">
+          <div className="flex justify-between text-[10px] text-muted-foreground">
+            <span>Pick {LIVE_PICK}</span>
+            <span>{LIVE_TOTAL} picks</span>
+          </div>
+          <div className={`h-2 rounded-full ${isHighContrast ? "bg-foreground/20" : "bg-muted"} overflow-hidden`}>
+            <div
+              className={`h-full rounded-full transition-all ${isHighContrast ? "bg-foreground" : "bg-primary"}`}
+              style={{ width: `${LIVE_PROGRESS * 100}%` }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Pick number */}
+      <div className="text-center">
+        <span className={`text-xs font-semibold ${isHighContrast ? "text-foreground" : "text-muted-foreground"}`}>
+          Pick {LIVE_PICK} / {LIVE_TOTAL}
+        </span>
+      </div>
+
+      {/* Pick cards */}
+      {showPickCards ? (
+        <div className="grid grid-cols-[1fr_2fr_1fr] gap-2 items-center">
+          <div>
+            <p className="text-[9px] text-muted-foreground text-center mb-1">← Pick {LIVE_PICK - 1}</p>
+            <LivePickCard compact style={style} colorMode={cm} showWeftColor={false} shaftCount={shaftCount} />
+          </div>
+          <LivePickCard style={style} colorMode={cm} showWeftColor={showWeftColor} shaftCount={shaftCount} />
+          <div>
+            <p className="text-[9px] text-muted-foreground text-center mb-1">Pick {LIVE_PICK + 1} →</p>
+            <LivePickCard compact style={style} colorMode={cm} showWeftColor={false} shaftCount={shaftCount} />
+          </div>
+        </div>
+      ) : (
+        <LivePickCard style={style} colorMode={cm} showWeftColor={showWeftColor} shaftCount={shaftCount} />
+      )}
+
+      {/* Shaft count note when hiding unused */}
+      {hideUnusedShafts && shaftCount < LIVE_SHAFTS_ALL && (
+        <p className="text-[9px] text-muted-foreground text-center">
+          {LIVE_SHAFTS_ALL - shaftCount} unused shaft{LIVE_SHAFTS_ALL - shaftCount !== 1 ? "s" : ""} hidden
+        </p>
+      )}
+
+      {/* Drawdown pattern */}
+      {showDrawdown && (
+        <div className="space-y-1">
+          <p className="text-[9px] text-muted-foreground uppercase tracking-wide">Drawdown</p>
+          <div className="rounded-lg border border-border bg-muted/30 p-2 overflow-hidden">
+            <div className="grid gap-px" style={{ gridTemplateColumns: `repeat(${shaftCount}, 1fr)` }}>
+              {Array.from({ length: 4 }, (_, row) =>
+                Array.from({ length: shaftCount }, (__, col) => {
+                  const shaftNum = col + 1;
+                  const isUnused = shaftNum > LIVE_SHAFTS_USED;
+                  const lit = !isUnused && (row + col) % 2 === 0;
+                  return (
+                    <div
+                      key={`${row}-${col}`}
+                      className={`h-3 rounded-sm ${
+                        isUnused
+                          ? "bg-muted-foreground/8 border border-dashed border-border/30"
+                          : lit
+                            ? (isHighContrast ? "bg-foreground/80" : "bg-primary/70")
+                            : "bg-muted-foreground/15"
+                      }`}
+                    />
+                  );
+                })
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -16,6 +16,11 @@ export interface User {
   ai_training_consent: boolean;
   show_version_numbers: boolean;
   hide_unused_shafts_treadles: boolean;
+  tracker_color_mode: string;
+  tracker_show_weft_color: boolean;
+  tracker_show_drawdown: boolean;
+  tracker_show_progress: boolean;
+  tracker_show_pick_cards: boolean;
   eula_accepted_version: string | null;
   current_eula_version: string;
   storage_used_bytes: number;

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1008,27 +1008,32 @@ export function ProjectDetailPage() {
   const displayUnit = measurementSystemToUnit(user?.measurement_system ?? "metric");
   const [stepping, setStepping] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [colorMode, setColorMode] = useState<ColorMode>(
-    () => (localStorage.getItem("proj-view:colorMode") as ColorMode) ?? "strip"
-  );
-  const [showWeftColor, setShowWeftColor] = useState(
-    () => localStorage.getItem("proj-view:showWeftColor") !== "false"
-  );
-  const [showDrawdown, setShowDrawdown] = useState(
-    () => localStorage.getItem("proj-view:showDrawdown") !== "false"
-  );
+  const [colorMode, setColorMode] = useState<ColorMode>(() => {
+    const stored = localStorage.getItem("proj-view:colorMode");
+    return (stored as ColorMode) ?? (user?.tracker_color_mode as ColorMode) ?? "strip";
+  });
+  const [showWeftColor, setShowWeftColor] = useState(() => {
+    const stored = localStorage.getItem("proj-view:showWeftColor");
+    return stored !== null ? stored !== "false" : (user?.tracker_show_weft_color ?? true);
+  });
+  const [showDrawdown, setShowDrawdown] = useState(() => {
+    const stored = localStorage.getItem("proj-view:showDrawdown");
+    return stored !== null ? stored !== "false" : (user?.tracker_show_drawdown ?? true);
+  });
   const [showPickDisplay] = useState(
     () => localStorage.getItem("proj-view:showPickDisplay") !== "false"
   );
-  const [showProgress, setShowProgress] = useState(
-    () => localStorage.getItem("proj-view:showProgress") !== "false"
-  );
+  const [showProgress, setShowProgress] = useState(() => {
+    const stored = localStorage.getItem("proj-view:showProgress");
+    return stored !== null ? stored !== "false" : (user?.tracker_show_progress ?? true);
+  });
   const [hideTrailingUnused, setHideTrailingUnused] = useState(
     () => localStorage.getItem("proj-view:hideTrailingUnused") === "true"
   );
-  const [showPickCards, setShowPickCards] = useState(
-    () => localStorage.getItem("proj-view:showPickCards") !== "false"
-  );
+  const [showPickCards, setShowPickCards] = useState(() => {
+    const stored = localStorage.getItem("proj-view:showPickCards");
+    return stored !== null ? stored !== "false" : (user?.tracker_show_pick_cards ?? true);
+  });
   const [panelOpen, setPanelOpen] = useState(
     () => localStorage.getItem("proj-view:panelOpen") === "true"
   );

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -8,6 +8,7 @@ import { listMyFeedback, SUBMISSION_TYPE_LABELS, type FeedbackRecord } from "@/a
 import { Button } from "@/components/ui/button";
 import { EulaContent } from "@/components/EulaContent";
 import { AppIcons } from "@/lib/icons";
+import { TrackerStylePreview, TrackerLivePreview } from "@/components/TrackerStylePreview";
 
 type Section = "appearance" | "preferences" | "privacy" | "terms" | "account" | "feedback-history";
 
@@ -34,7 +35,14 @@ export function SettingsPage() {
   // Form state mirrors user fields
   const [displayName, setDisplayName] = useState(user?.display_name ?? "");
   const [theme, setTheme] = useState(user?.theme ?? "light");
-  const [activityTheme, setActivityTheme] = useState(user?.activity_theme ?? "default");
+  const [activityTheme, setActivityTheme] = useState<"default" | "compact" | "high_contrast">(
+    (user?.activity_theme as "default" | "compact" | "high_contrast") ?? "default"
+  );
+  const [trackerColorMode, setTrackerColorMode] = useState(user?.tracker_color_mode ?? "strip");
+  const [trackerShowWeftColor, setTrackerShowWeftColor] = useState(user?.tracker_show_weft_color ?? true);
+  const [trackerShowDrawdown, setTrackerShowDrawdown] = useState(user?.tracker_show_drawdown ?? true);
+  const [trackerShowProgress, setTrackerShowProgress] = useState(user?.tracker_show_progress ?? true);
+  const [trackerShowPickCards, setTrackerShowPickCards] = useState(user?.tracker_show_pick_cards ?? true);
   const [showVersionNumbers, setShowVersionNumbers] = useState(user?.show_version_numbers ?? true);
   const [hideUnusedShaftsTreadles, setHideUnusedShaftsTreadles] = useState(user?.hide_unused_shafts_treadles ?? false);
   const [idleTimeout, setIdleTimeout] = useState(user?.idle_timeout_minutes ?? 30);
@@ -127,6 +135,7 @@ export function SettingsPage() {
 
             {/* ── Appearance ── */}
             {activeSection === "appearance" && (
+              <>
               <Section title="Appearance">
                 <Field label="Theme">
                   <div className="flex gap-2">
@@ -150,48 +159,98 @@ export function SettingsPage() {
                 </Field>
 
                 <Field label="Activity tracker style">
-                  <select
-                    value={activityTheme}
-                    onChange={(e) => {
-                      setActivityTheme(e.target.value);
-                      save({ activity_theme: e.target.value || null });
-                    }}
-                    className="rounded-md border border-border bg-background px-3 py-2 text-sm"
-                  >
-                    <option value="default">Default</option>
-                    <option value="compact">Compact</option>
-                    <option value="high_contrast">High contrast</option>
-                  </select>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Controls the visual density of the pick-by-pick tracker.
+                  <div className="flex flex-col gap-3 mt-1">
+                    {(["default", "compact", "high_contrast"] as const).map((s) => {
+                      const meta: Record<string, { label: string; desc: string }> = {
+                        default: { label: "Default", desc: "Standard layout with full-size pick cards and drawdown preview." },
+                        compact: { label: "Compact", desc: "Denser layout for tracking-heavy sessions with less vertical space." },
+                        high_contrast: { label: "High contrast", desc: "Higher visual contrast for easier reading under bright light or for accessibility." },
+                      };
+                      const selected = activityTheme === s;
+                      return (
+                        <button
+                          key={s}
+                          onClick={() => { setActivityTheme(s); save({ activity_theme: s }); }}
+                          className={`rounded-lg border-2 p-3 text-left transition-colors focus:outline-none focus:ring-2 focus:ring-ring ${
+                            selected ? "border-primary bg-primary/5" : "border-border hover:border-primary/50"
+                          }`}
+                        >
+                          <div className="mb-2">
+                            <p className={`text-sm font-semibold ${selected ? "text-primary" : "text-foreground"}`}>
+                              {meta[s].label}
+                              {selected && <span className="ml-2 text-xs font-normal text-primary/70">— active</span>}
+                            </p>
+                            <p className="text-xs text-muted-foreground mt-0.5">{meta[s].desc}</p>
+                          </div>
+                          <TrackerStylePreview style={s} />
+                        </button>
+                      );
+                    })}
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-2">
+                    Style variants will be visually differentiated in a future update.
                   </p>
                 </Field>
 
-                <Field label="Show version numbers">
-                  <div className="flex items-center gap-3">
-                    <button
-                      role="switch"
-                      aria-checked={showVersionNumbers}
-                      onClick={() => {
-                        const next = !showVersionNumbers;
-                        setShowVersionNumbers(next);
-                        save({ show_version_numbers: next });
-                      }}
-                      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
-                        showVersionNumbers ? "bg-primary" : "bg-input"
-                      }`}
-                    >
-                      <span
-                        className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
-                          showVersionNumbers ? "translate-x-6" : "translate-x-1"
-                        }`}
-                      />
-                    </button>
-                    <span className="text-sm">{showVersionNumbers ? "Visible" : "Hidden"}</span>
-                  </div>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Show or hide the UI, API, and worker version badge in the bottom-right corner.
+                <Field label="Tracker defaults">
+                  <p className="text-xs text-muted-foreground mb-3">
+                    Default view options when opening the activity tracker. You can still override these per-project in the tracker settings panel.
                   </p>
+
+                  {/* Color mode */}
+                  <div className="mb-4">
+                    <p className="text-xs font-medium text-muted-foreground mb-1.5">Color mode</p>
+                    <div className="inline-flex rounded-md border border-input overflow-hidden text-sm">
+                      {(["theme", "strip", "filled"] as const).map((mode) => (
+                        <button
+                          key={mode}
+                          onClick={() => { setTrackerColorMode(mode); save({ tracker_color_mode: mode }); }}
+                          className={`px-3 py-1.5 capitalize transition-colors ${
+                            trackerColorMode === mode
+                              ? "bg-primary text-primary-foreground"
+                              : "bg-background text-muted-foreground hover:bg-muted"
+                          }`}
+                        >
+                          {mode}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* Show/hide toggles */}
+                  <div className="space-y-2.5">
+                    {([
+                      { label: "Progress bar", value: trackerShowProgress, setter: setTrackerShowProgress, key: "tracker_show_progress" as const },
+                      { label: "Drawdown pattern", value: trackerShowDrawdown, setter: setTrackerShowDrawdown, key: "tracker_show_drawdown" as const },
+                      { label: "Weft color bar", value: trackerShowWeftColor, setter: setTrackerShowWeftColor, key: "tracker_show_weft_color" as const },
+                      { label: "Prev/next pick cards", value: trackerShowPickCards, setter: setTrackerShowPickCards, key: "tracker_show_pick_cards" as const },
+                    ] as { label: string; value: boolean; setter: (v: boolean) => void; key: "tracker_show_progress" | "tracker_show_drawdown" | "tracker_show_weft_color" | "tracker_show_pick_cards" }[]).map(({ label, value, setter, key }) => (
+                      <div key={key} className="flex items-center justify-between">
+                        <span className="text-sm">{label}</span>
+                        <button
+                          role="switch"
+                          aria-checked={value}
+                          onClick={() => { setter(!value); save({ [key]: !value }); }}
+                          className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-ring ${value ? "bg-primary" : "bg-input"}`}
+                        >
+                          <span className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform ${value ? "translate-x-4" : "translate-x-1"}`} />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+
+                  {/* Live preview */}
+                  <div className="mt-5">
+                    <TrackerLivePreview
+                      style={activityTheme}
+                      colorMode={trackerColorMode}
+                      showProgress={trackerShowProgress}
+                      showDrawdown={trackerShowDrawdown}
+                      showWeftColor={trackerShowWeftColor}
+                      showPickCards={trackerShowPickCards}
+                      hideUnusedShafts={hideUnusedShaftsTreadles}
+                    />
+                  </div>
                 </Field>
 
                 <Field label="Hide unused shafts and treadles">
@@ -222,6 +281,36 @@ export function SettingsPage() {
                   </p>
                 </Field>
               </Section>
+
+              <Section title="Diagnostics">
+                <Field label="Show version numbers">
+                  <div className="flex items-center gap-3">
+                    <button
+                      role="switch"
+                      aria-checked={showVersionNumbers}
+                      onClick={() => {
+                        const next = !showVersionNumbers;
+                        setShowVersionNumbers(next);
+                        save({ show_version_numbers: next });
+                      }}
+                      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+                        showVersionNumbers ? "bg-primary" : "bg-input"
+                      }`}
+                    >
+                      <span
+                        className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                          showVersionNumbers ? "translate-x-6" : "translate-x-1"
+                        }`}
+                      />
+                    </button>
+                    <span className="text-sm">{showVersionNumbers ? "Visible" : "Hidden"}</span>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Show or hide the UI, API, and worker version badge in the bottom-right corner.
+                  </p>
+                </Field>
+              </Section>
+              </>
             )}
 
             {/* ── Preferences ── */}


### PR DESCRIPTION
## Summary

- Replaces the plain `activity_theme` dropdown with a card-based style picker — each card shows the label, description, and an inline static preview of Default / Compact / High contrast
- Adds a **Tracker defaults** section with color mode (theme / strip / filled) and show/hide toggles for: progress bar, drawdown pattern, weft color bar, prev/next pick cards
- A **live preview** below the toggles reflects all settings in real time, including unused shaft visibility (8-shaft loom, 4-shaft design — unused shafts render as dashed placeholders and collapse when hidden)
- Moves **Show version numbers** to a new **Diagnostics** section at the bottom of Appearance
- Tracker defaults are saved to the user record and used to initialise ProjectDetailPage state, replacing hardcoded `localStorage` fallbacks
- Per-project overrides in the tracker settings panel still work and take priority

## Backend

- 5 new `users` columns: `tracker_color_mode`, `tracker_show_weft_color`, `tracker_show_drawdown`, `tracker_show_progress`, `tracker_show_pick_cards`
- Migration `0026_tracker_prefs` (revision `4a7b2c9d1e3f`)
- `UserSettingsUpdate` / `UserSettingsResponse` / PATCH handler updated

## Test plan

- [ ] Settings → Appearance: style picker shows 3 cards with inline previews; clicking saves and highlights the active card
- [ ] Tracker defaults: each toggle updates the live preview immediately
- [ ] Hide unused shafts: preview collapses from 8 to 4 boxes in both the pick cards and drawdown
- [ ] Color mode selector changes the active box rendering in the preview
- [ ] Diagnostics section visible at the bottom with version numbers toggle
- [ ] Open a project tracker — initial state matches saved defaults
- [ ] Change defaults, reopen tracker — new defaults applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)