### PR TITLE
fix: feedback environment label shows 'local instance' on weftmark.com

### DIFF
--- a/frontend/src/components/FeedbackModal.tsx
+++ b/frontend/src/components/FeedbackModal.tsx
@@ -25,7 +25,7 @@ const TYPE_PLACEHOLDERS: Record<SubmissionType, string> = {
 };
 
 function getEnvironment(hostname: string): string {
-  if (hostname.endsWith(".weftmark.com")) return `https://${hostname}`;
+  if (hostname === "weftmark.com" || hostname.endsWith(".weftmark.com")) return `https://${hostname}`;
   return "local instance";
 }
 


### PR DESCRIPTION
## Summary

`getEnvironment()` checked `hostname.endsWith(".weftmark.com")` which matches subdomains (`app.weftmark.com`, `dev.weftmark.com`) but not the apex domain `weftmark.com` itself — so prod submissions showed "local instance" in diagnostics.

Added an exact-match `hostname === "weftmark.com"` alongside the subdomain check.

## Test plan
- [ ] Submit feedback on weftmark.com → diagnostics show `https://weftmark.com`
- [ ] Submit feedback on dev.weftmark.com → diagnostics show `https://dev.weftmark.com`
- [ ] Submit feedback on localhost → diagnostics show `local instance`

🤖 Generated with [Claude Code](https://claude.com/claude-code)