### PR TITLE
feat: neutral startup banner instead of service failure during backend warmup (#711)

### DIFF
--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Literal
 
 from fastapi import APIRouter
@@ -32,6 +32,8 @@ class ReadinessResponse(BaseModel):
     services: list[ReadinessService]
     checked_at: str | None = None
 
+
+_startup_time: datetime = datetime.now(timezone.utc)
 
 _readiness_cache: ReadinessResponse | None = None  # startup snapshot, never refreshed
 _detailed_cache: ReadinessResponse | None = None  # live, refreshed every 5 min
@@ -87,13 +89,20 @@ async def readiness() -> JSONResponse:
 
 @router.get("/health/detailed")
 async def health_detailed() -> JSONResponse:
-    """Live service health — refreshed every 30 s by a background task.
+    """Live service health — refreshed every 5 min by a background task.
 
     Covers PostgreSQL, S3, Clerk API, SMTP, and the Clerk webhook round-trip.
     Returns the same shape as /health/ready with an added checked_at timestamp.
+    During the initial startup window (before first probe), returns 200 with
+    status "starting" and a next_check_at estimate so clients can show a neutral
+    info banner instead of a failure alert.
     """
     if _detailed_cache is None:
-        return JSONResponse({"status": "starting", "services": [], "checked_at": None}, status_code=503)
+        next_check_at = (_startup_time + timedelta(seconds=DETAILED_REFRESH_INTERVAL_S)).isoformat()
+        return JSONResponse(
+            {"status": "starting", "services": [], "checked_at": None, "next_check_at": next_check_at},
+            status_code=200,
+        )
     return JSONResponse(_detailed_cache.model_dump())
 
 

--- a/backend/tests/routers/test_health.py
+++ b/backend/tests/routers/test_health.py
@@ -74,11 +74,14 @@ class TestHealthReady:
 
 
 class TestHealthDetailed:
-    async def test_returns_503_when_cache_empty(self, client: AsyncClient):
+    async def test_returns_200_with_starting_when_cache_empty(self, client: AsyncClient):
         health_module._detailed_cache = None
         resp = await client.get("/health/detailed")
-        assert resp.status_code == 503
-        assert resp.json()["status"] == "starting"
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "starting"
+        assert "next_check_at" in body
+        assert body["next_check_at"] is not None
 
     async def test_returns_200_when_cache_populated(self, client: AsyncClient):
         health_module._detailed_cache = ReadinessResponse(

--- a/frontend/src/api/health.ts
+++ b/frontend/src/api/health.ts
@@ -10,6 +10,7 @@ export interface ReadinessResponse {
   status: "ok" | "degraded" | "error" | "starting";
   services: ReadinessService[];
   checked_at?: string | null;
+  next_check_at?: string | null;
 }
 
 export async function getHealthReady(): Promise<ReadinessResponse> {

--- a/frontend/src/components/ServiceHealthBanner.tsx
+++ b/frontend/src/components/ServiceHealthBanner.tsx
@@ -20,7 +20,18 @@ export function ServiceHealthBanner() {
     return () => clearInterval(id);
   }, []);
 
-  if (!readiness || readiness.status === "ok" || readiness.status === "starting") return null;
+  if (!readiness || readiness.status === "ok") return null;
+
+  if (readiness.status === "starting") {
+    const expectedTime = readiness.next_check_at
+      ? new Date(readiness.next_check_at).toLocaleTimeString([], { hour: "numeric", minute: "2-digit", second: "2-digit" })
+      : null;
+    return (
+      <div className="w-full bg-muted text-muted-foreground text-center text-xs py-1.5 px-4 select-none">
+        System starting{expectedTime ? ` — first health check expected at ${expectedTime}` : "…"}
+      </div>
+    );
+  }
 
   const failed = readiness.services.filter((s) => !s.ok);
   const webhookFailed = failed.find((s) => s.name === "Clerk Webhook");


### PR DESCRIPTION
## Summary
- `/health/detailed` now returns `200` (not `503`) during the ~5-minute startup window before the first detailed probe fires
- Response includes `next_check_at` (startup time + 5 min) so the frontend can display when to expect real health data
- `ServiceHealthBanner` shows a muted, non-alarming info strip: _"System starting — first health check expected at 10:32:47 AM"_
- Once the first probe completes the banner disappears naturally (status flips to `ok`/`degraded`/`error`)
- Existing failure and degraded states are unchanged

Fixes #711

## Why the 503 caused the red banner
nginx can intercept upstream `503` responses and return its own HTML error page. `res.json()` on HTML throws, falls into the `.catch()` handler, and sets `status: "error"` → red "Service failure" banner.

## Test plan
- [ ] Deploy to dev — observe neutral muted banner during first 5 minutes
- [ ] After ~5 min banner disappears (or shows real health state)
- [ ] Existing degraded/error banners still show correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)