### PR TITLE
fix: require authentication to submit feedback

### DIFF
--- a/backend/app/routers/feedback.py
+++ b/backend/app/routers/feedback.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, field_validator
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.deps import get_current_user, get_db, get_optional_user, require_admin
+from app.deps import get_current_user, get_db, require_admin
 from app.models.feedback import SUBMISSION_TYPES, UserFeedback
 from app.models.user import User
 from app.services.rate_limiter import rate_limit
@@ -97,7 +97,7 @@ def _serialize(row: UserFeedback, include_user_email: bool = False) -> FeedbackR
 
 
 # ---------------------------------------------------------------------------
-# Submit feedback (auth optional)
+# Submit feedback (auth required)
 # ---------------------------------------------------------------------------
 
 
@@ -105,7 +105,7 @@ def _serialize(row: UserFeedback, include_user_email: bool = False) -> FeedbackR
 async def submit_feedback(
     body: SubmitFeedbackRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User | None = Depends(get_optional_user),
+    current_user: User = Depends(get_current_user),
     _rl: None = Depends(_submit_limit),
 ) -> FeedbackResponse:
     from app.config import get_settings
@@ -113,7 +113,7 @@ async def submit_feedback(
     has_token = bool(get_settings().github_feedback_token)
     row = UserFeedback(
         id=uuid.uuid4(),
-        user_id=current_user.id if current_user else None,
+        user_id=current_user.id,
         submission_type=body.submission_type,
         is_anonymous=body.is_anonymous,
         subject=body.subject,

--- a/backend/tests/routers/test_feedback.py
+++ b/backend/tests/routers/test_feedback.py
@@ -44,21 +44,21 @@ class TestSubmitFeedback:
         assert data["dispatch_status"] in ("pending", "skipped")
         assert "id" in data
 
-    async def test_unauthenticated_user_can_submit(self, client: AsyncClient):
+    async def test_unauthenticated_returns_401(self, client: AsyncClient):
         resp = await client.post("/api/feedback", json=_feedback_payload())
-        assert resp.status_code == 201
+        assert resp.status_code == 401
 
-    async def test_missing_body_returns_422(self, client: AsyncClient):
-        resp = await client.post("/api/feedback", json={"submission_type": "feedback"})
+    async def test_missing_body_returns_422(self, auth_client: AsyncClient):
+        resp = await auth_client.post("/api/feedback", json={"submission_type": "feedback"})
         assert resp.status_code == 422
 
-    async def test_invalid_submission_type_returns_422(self, client: AsyncClient):
-        resp = await client.post("/api/feedback", json=_feedback_payload(submission_type="invalid"))
+    async def test_invalid_submission_type_returns_422(self, auth_client: AsyncClient):
+        resp = await auth_client.post("/api/feedback", json=_feedback_payload(submission_type="invalid"))
         assert resp.status_code == 422
 
-    async def test_all_submission_types_accepted(self, client: AsyncClient):
+    async def test_all_submission_types_accepted(self, auth_client: AsyncClient):
         for stype in ("feedback", "feature_request", "bug_report"):
-            resp = await client.post("/api/feedback", json=_feedback_payload(submission_type=stype))
+            resp = await auth_client.post("/api/feedback", json=_feedback_payload(submission_type=stype))
             assert resp.status_code == 201, f"Expected 201 for type={stype}, got {resp.status_code}"
 
     async def test_anonymous_flag_stores_correctly(self, auth_client: AsyncClient, db_session: AsyncSession):
@@ -83,24 +83,15 @@ class TestSubmitFeedback:
         assert row is not None
         assert row.user_id == test_user.id
 
-    async def test_unauthenticated_user_id_is_null(self, client: AsyncClient, db_session: AsyncSession):
-        from app.models.feedback import UserFeedback
-
-        resp = await client.post("/api/feedback", json=_feedback_payload())
-        assert resp.status_code == 201
-        row = await db_session.get(UserFeedback, uuid.UUID(resp.json()["id"]))
-        assert row is not None
-        assert row.user_id is None
-
     async def test_response_omits_user_email_when_anonymous(self, auth_client: AsyncClient):
         resp = await auth_client.post("/api/feedback", json=_feedback_payload(is_anonymous=True))
         assert resp.status_code == 201
         data = resp.json()
         assert "user_email" not in data or data.get("user_email") is None
 
-    async def test_discussion_url_null_when_no_token(self, client: AsyncClient):
+    async def test_discussion_url_null_when_no_token(self, auth_client: AsyncClient):
         # Without GITHUB_FEEDBACK_TOKEN the dispatch is skipped
-        resp = await client.post("/api/feedback", json=_feedback_payload())
+        resp = await auth_client.post("/api/feedback", json=_feedback_payload())
         assert resp.status_code == 201
         data = resp.json()
         assert data["github_discussion_url"] is None

--- a/frontend/src/components/FeedbackModal.tsx
+++ b/frontend/src/components/FeedbackModal.tsx
@@ -126,6 +126,13 @@ export function FeedbackModal({ onClose }: Props) {
 
         {submitted ? (
           <SuccessView record={submitted} onClose={onClose} />
+        ) : !user ? (
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">Please sign in to submit feedback.</p>
+            <div className="flex justify-end">
+              <Button type="button" variant="outline" onClick={onClose}>Close</Button>
+            </div>
+          </div>
         ) : (
           <form onSubmit={handleSubmit} className="space-y-4">
             {/* Type selector */}


### PR DESCRIPTION
## Summary
- `POST /api/feedback` now requires a valid Bearer token — unauthenticated requests return 401
- Removes `get_optional_user` dependency; `user_id` is always set (no more nullable path)
- `FeedbackModal` shows a "Please sign in" message if somehow opened without a session (shouldn't normally occur since the button is sidebar-gated)
- Updated all tests that were using the unauthenticated `client` fixture to use `auth_client`

## Test plan
- [ ] Authenticated user can submit feedback (201)
- [ ] Unauthenticated POST to `/api/feedback` returns 401
- [ ] All submission types still accepted for auth'd users

🤖 Generated with [Claude Code](https://claude.com/claude-code)