### PR TITLE
feat: running costs transparency page with support link (#690)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { LandingPage } from "@/pages/LandingPage";
 import { AboutPage } from "@/pages/AboutPage";
 import { PrivacyPage } from "@/pages/PrivacyPage";
 import { TermsPage } from "@/pages/TermsPage";
+import { CostsPage } from "@/pages/CostsPage";
 import { DraftsPage } from "@/pages/DraftsPage";
 import { DraftDetailPage } from "@/pages/DraftDetailPage";
 import { LoomsPage } from "@/pages/LoomsPage";
@@ -96,6 +97,7 @@ export default function App() {
                   <Route path="/about" element={<AboutPage />} />
                   <Route path="/privacy" element={<PrivacyPage />} />
                   <Route path="/terms" element={<TermsPage />} />
+                  <Route path="/costs" element={<CostsPage />} />
                   <Route path="/" element={<RootRoute />} />
                   <Route path="/home" element={<AuthRoute><DashboardPage /></AuthRoute>} />
                   <Route path="/drafts" element={<AuthRoute><DraftsPage /></AuthRoute>} />

--- a/frontend/src/components/PublicFooter.tsx
+++ b/frontend/src/components/PublicFooter.tsx
@@ -4,14 +4,15 @@ export function PublicFooter() {
   return (
     <footer className="border-t border-border bg-muted py-4 px-6">
       <div className="mx-auto flex max-w-4xl flex-col items-center gap-2 sm:flex-row sm:justify-between">
-        <nav className="flex gap-4 text-sm text-subdued">
+        <nav className="flex flex-wrap gap-4 text-sm text-subdued">
           <Link to="/about" className="hover:text-foreground transition-colors">About</Link>
           <Link to="/privacy" className="hover:text-foreground transition-colors">Privacy</Link>
           <Link to="/terms" className="hover:text-foreground transition-colors">Terms</Link>
+          <Link to="/costs" className="hover:text-foreground transition-colors">Running costs</Link>
           <span className="text-muted-foreground">Contact</span>
         </nav>
-        <Link to="/about" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
-          Built by a hobbyist, with AI assistance.
+        <Link to="/costs" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
+          ♥ Support WeftMark
         </Link>
       </div>
     </footer>

--- a/frontend/src/components/PublicFooter.tsx
+++ b/frontend/src/components/PublicFooter.tsx
@@ -12,7 +12,7 @@ export function PublicFooter() {
           <span className="text-muted-foreground">Contact</span>
         </nav>
         <Link to="/costs" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
-          ♥ Support WeftMark
+          ♥ Support weftmark
         </Link>
       </div>
     </footer>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -232,6 +232,16 @@ export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpa
             <span className={desktopCollapsed ? "lg:hidden" : ""}>Send Feedback</span>
           </button>
 
+          <Link
+            to="/costs"
+            onClick={onClose}
+            className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground ${desktopCollapsed ? "lg:justify-center lg:px-2" : ""}`}
+            title={desktopCollapsed ? "Support WeftMark" : undefined}
+          >
+            <AppIcons.support className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} />
+            <span className={desktopCollapsed ? "lg:hidden" : ""}>Support WeftMark</span>
+          </Link>
+
           <button
             onClick={() => signOut()}
             className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-subdued transition-colors hover:bg-muted hover:text-foreground ${desktopCollapsed ? "lg:justify-center lg:px-2" : ""}`}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -236,10 +236,10 @@ export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpa
             to="/costs"
             onClick={onClose}
             className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground ${desktopCollapsed ? "lg:justify-center lg:px-2" : ""}`}
-            title={desktopCollapsed ? "Support WeftMark" : undefined}
+            title={desktopCollapsed ? "Support weftmark" : undefined}
           >
             <AppIcons.support className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} />
-            <span className={desktopCollapsed ? "lg:hidden" : ""}>Support WeftMark</span>
+            <span className={desktopCollapsed ? "lg:hidden" : ""}>Support weftmark</span>
           </Link>
 
           <button

--- a/frontend/src/lib/icons.ts
+++ b/frontend/src/lib/icons.ts
@@ -17,6 +17,7 @@ import {
   FileDown,
   FolderOpen,
   Footprints,
+  Heart,
   LayoutDashboard,
   Layers,
   Loader2,
@@ -61,6 +62,7 @@ export const AppIcons = {
   logout: LogOut,
   feedback: MessageSquare,
   onboarding: ListChecks,
+  support: Heart,
 
   // ── UI chrome ─────────────────────────────────────────────────────────────
   edit: Pencil,

--- a/frontend/src/pages/CostsPage.tsx
+++ b/frontend/src/pages/CostsPage.tsx
@@ -1,0 +1,197 @@
+import { Link } from "react-router-dom";
+import { WeftmarkLogo } from "@/components/WeftmarkLogo";
+import { PublicFooter } from "@/components/PublicFooter";
+import { AppIcons } from "@/lib/icons";
+
+interface CostRow {
+  service: string;
+  description: string;
+  tier: string;
+  monthlyCost: string;
+  status: "free" | "paid" | "donation";
+}
+
+const COSTS: CostRow[] = [
+  {
+    service: "Hosting / Infrastructure",
+    description: "Servers, networking, and operating environment for all services.",
+    tier: "Equipment owner donation",
+    monthlyCost: "$0",
+    status: "donation",
+  },
+  {
+    service: "Claude Max ×5",
+    description: "AI-assisted development — the primary tool used to build and maintain weftmark.",
+    tier: "Max ×5 subscription",
+    monthlyCost: "~$100",
+    status: "paid",
+  },
+  {
+    service: "Claude API",
+    description: "AI agents used for market research and automated analysis tasks.",
+    tier: "Pay-as-you-go",
+    monthlyCost: "~$20",
+    status: "paid",
+  },
+  {
+    service: "Neon (PostgreSQL)",
+    description: "Managed PostgreSQL database — stores all your drafts, projects, and settings.",
+    tier: "Free (100 CU-hr/mo, 0.5 GB)",
+    monthlyCost: "$0",
+    status: "free",
+  },
+  {
+    service: "SMTP2Go (Email)",
+    description: "Transactional email delivery — account notifications and admin alerts.",
+    tier: "Free (1,000 emails/mo)",
+    monthlyCost: "$0",
+    status: "free",
+  },
+  {
+    service: "Cloudflare R2 (Storage)",
+    description: "Object storage for drawdown images, WIF files, and project photos.",
+    tier: "Free (10 GB, 10M reads/mo)",
+    monthlyCost: "$0",
+    status: "free",
+  },
+  {
+    service: "Clerk (Authentication)",
+    description: "Secure sign-in, account management, and session handling.",
+    tier: "Free (50,000 MAU)",
+    monthlyCost: "$0",
+    status: "free",
+  },
+];
+
+const STATUS_BADGE: Record<CostRow["status"], string> = {
+  free: "bg-green-100 text-green-800",
+  paid: "bg-amber-100 text-amber-800",
+  donation: "bg-blue-100 text-blue-800",
+};
+
+const STATUS_LABEL: Record<CostRow["status"], string> = {
+  free: "Free tier",
+  paid: "Paid",
+  donation: "Donated",
+};
+
+// Replace with the actual GitHub Sponsors URL once approved.
+const GITHUB_SPONSORS_URL: string | null = null;
+
+export function CostsPage() {
+  return (
+    <div className="flex min-h-screen flex-col bg-stone-50 text-stone-900">
+      <header className="border-b border-stone-200 bg-stone-50 px-6 py-4">
+        <div className="mx-auto flex max-w-4xl items-center gap-3">
+          <Link to="/" className="flex items-center gap-3 hover:opacity-80 transition-opacity">
+            <WeftmarkLogo className="h-8 w-auto text-amber-800" />
+            <span className="text-lg font-semibold tracking-tight" style={{ fontFamily: '"Segoe UI", system-ui, sans-serif' }}>weftmark</span>
+          </Link>
+        </div>
+      </header>
+
+      <main className="flex-1 px-6 py-16">
+        <div className="mx-auto max-w-3xl space-y-12">
+
+          {/* Intro */}
+          <div className="space-y-4">
+            <h1 className="text-3xl font-bold tracking-tight">Running costs</h1>
+            <p className="text-stone-600 leading-relaxed">
+              weftmark is a personal project, not a commercial product. In the spirit of transparency,
+              here's exactly what it costs to keep the lights on — and why.
+            </p>
+            <p className="text-stone-600 leading-relaxed">
+              Almost all infrastructure runs on free tiers. The meaningful recurring cost is the Claude
+              subscription used to build and maintain the platform — AI assistance is the only way a
+              solo developer can ship features at a pace that keeps the app useful.
+            </p>
+            <div className="inline-flex items-center gap-2 rounded-full bg-amber-100 px-4 py-1.5 text-sm font-medium text-amber-900">
+              Approximate monthly cost: ~$120 / month
+            </div>
+          </div>
+
+          {/* Cost table */}
+          <div className="space-y-3">
+            <h2 className="text-lg font-semibold">Service breakdown</h2>
+            <div className="overflow-x-auto rounded-xl border border-stone-200">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-stone-200 bg-stone-100 text-left text-xs uppercase tracking-wide text-stone-500">
+                    <th className="px-4 py-3">Service</th>
+                    <th className="px-4 py-3 hidden sm:table-cell">What it does</th>
+                    <th className="px-4 py-3">Tier</th>
+                    <th className="px-4 py-3 text-right">Cost / mo</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {COSTS.map((row) => (
+                    <tr key={row.service} className="border-b border-stone-200 last:border-0">
+                      <td className="px-4 py-3 font-medium align-top">
+                        <div>{row.service}</div>
+                        <div className="mt-1 sm:hidden text-xs text-stone-500 font-normal">{row.description}</div>
+                        <span className={`mt-1.5 inline-block rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_BADGE[row.status]}`}>
+                          {STATUS_LABEL[row.status]}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-stone-600 hidden sm:table-cell align-top">{row.description}</td>
+                      <td className="px-4 py-3 text-stone-600 align-top">{row.tier}</td>
+                      <td className="px-4 py-3 text-right font-mono font-semibold align-top">{row.monthlyCost}</td>
+                    </tr>
+                  ))}
+                </tbody>
+                <tfoot>
+                  <tr className="border-t-2 border-stone-300 bg-stone-50">
+                    <td colSpan={3} className="px-4 py-3 text-sm font-medium text-right hidden sm:table-cell">Total (approximate)</td>
+                    <td colSpan={2} className="px-4 py-3 text-sm font-medium sm:hidden">Total</td>
+                    <td className="px-4 py-3 text-right font-mono font-bold">~$120 / mo</td>
+                  </tr>
+                </tfoot>
+              </table>
+            </div>
+          </div>
+
+          {/* Support CTA */}
+          <div className="rounded-xl border border-stone-200 bg-white p-6 space-y-4">
+            <div className="flex items-center gap-2">
+              <AppIcons.support className="h-5 w-5 text-amber-600" />
+              <h2 className="text-lg font-semibold">Support this project</h2>
+            </div>
+            <p className="text-stone-600 leading-relaxed">
+              weftmark is free to use and always will be. If it saves you time, prevents treadling
+              errors, or just makes weaving a little more enjoyable — and you'd like to help keep it
+              running — a small contribution goes a long way toward the monthly Claude bill.
+            </p>
+            {GITHUB_SPONSORS_URL ? (
+              <a
+                href={GITHUB_SPONSORS_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 rounded-lg bg-amber-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-amber-700 transition-colors"
+              >
+                <AppIcons.support className="h-4 w-4" />
+                Sponsor on GitHub
+              </a>
+            ) : (
+              <div className="rounded-lg border border-dashed border-stone-300 bg-stone-50 px-4 py-3 text-sm text-stone-500">
+                GitHub Sponsors profile pending approval — check back soon.
+              </div>
+            )}
+          </div>
+
+          {/* Free tiers note */}
+          <div className="space-y-2">
+            <h2 className="text-lg font-semibold">What happens if limits are hit?</h2>
+            <p className="text-stone-600 leading-relaxed">
+              All infrastructure services are well within their free tiers today. If weftmark grows
+              to the point where paid tiers are needed, costs will be re-evaluated and this page will
+              be updated. No features will be paywalled — the platform stays free to use.
+            </p>
+          </div>
+
+        </div>
+      </main>
+
+      <PublicFooter />
+    </div>
+  );
+}

--- a/frontend/src/pages/CostsPage.tsx
+++ b/frontend/src/pages/CostsPage.tsx
@@ -21,7 +21,7 @@ const COSTS: CostRow[] = [
   },
   {
     service: "Claude Max ×5",
-    description: "AI-assisted development — the primary tool used to build and maintain weftmark.",
+    description: "AI-assisted development — makes it possible for one person to manage system complexity and ship features alongside a full-time job and family.",
     tier: "Max ×5 subscription",
     monthlyCost: "~$100",
     status: "paid",
@@ -102,8 +102,10 @@ export function CostsPage() {
             </p>
             <p className="text-stone-600 leading-relaxed">
               Almost all infrastructure runs on free tiers. The meaningful recurring cost is the Claude
-              subscription used to build and maintain the platform — AI assistance is the only way a
-              solo developer can ship features at a pace that keeps the app useful.
+              subscription used to build and maintain the platform. weftmark is built and maintained
+              by one person, around a full-time job and family — AI assistance is what makes it
+              possible to manage the complexity of the system, keep up with bugs, and ship new
+              features without it becoming a second job in itself.
             </p>
             <div className="inline-flex items-center gap-2 rounded-full bg-amber-100 px-4 py-1.5 text-sm font-medium text-amber-900">
               Approximate monthly cost: ~$120 / month

--- a/frontend/src/pages/CostsPage.tsx
+++ b/frontend/src/pages/CostsPage.tsx
@@ -138,7 +138,8 @@ export function CostsPage() {
                   <tr className="border-b border-stone-200 bg-stone-100 text-left text-xs uppercase tracking-wide text-stone-500">
                     <th className="px-4 py-3">Service</th>
                     <th className="px-4 py-3 hidden sm:table-cell">What it does</th>
-                    <th className="px-4 py-3">Tier</th>
+                    <th className="px-4 py-3">Current tier</th>
+                    <th className="px-4 py-3 hidden md:table-cell">Next tier</th>
                     <th className="px-4 py-3 text-right">Cost / mo</th>
                   </tr>
                 </thead>
@@ -157,13 +158,9 @@ export function CostsPage() {
                         <div>{row.description}</div>
                         {row.note && <div className="mt-1 text-xs text-stone-400 italic">{row.note}</div>}
                       </td>
-                      <td className="px-4 py-3 text-stone-600 align-top">
-                        <div>{row.tier}</div>
-                        {row.nextTier && (
-                          <div className="mt-1 text-xs text-stone-400">
-                            Next: {row.nextTier}
-                          </div>
-                        )}
+                      <td className="px-4 py-3 text-stone-600 align-top">{row.tier}</td>
+                      <td className="px-4 py-3 text-stone-500 hidden md:table-cell align-top">
+                        {row.nextTier ?? <span className="text-stone-300">—</span>}
                       </td>
                       <td className="px-4 py-3 text-right font-mono font-semibold align-top">{row.monthlyCost}</td>
                     </tr>
@@ -171,7 +168,8 @@ export function CostsPage() {
                 </tbody>
                 <tfoot>
                   <tr className="border-t-2 border-stone-300 bg-stone-50">
-                    <td colSpan={3} className="px-4 py-3 text-sm font-medium text-right hidden sm:table-cell">Total (approximate)</td>
+                    <td colSpan={4} className="px-4 py-3 text-sm font-medium text-right hidden md:table-cell">Total (approximate)</td>
+                    <td colSpan={3} className="px-4 py-3 text-sm font-medium text-right hidden sm:table-cell md:hidden">Total (approximate)</td>
                     <td colSpan={2} className="px-4 py-3 text-sm font-medium sm:hidden">Total</td>
                     <td className="px-4 py-3 text-right font-mono font-bold">~$121 / mo</td>
                   </tr>

--- a/frontend/src/pages/CostsPage.tsx
+++ b/frontend/src/pages/CostsPage.tsx
@@ -8,7 +8,9 @@ interface CostRow {
   description: string;
   tier: string;
   monthlyCost: string;
-  status: "free" | "paid" | "donation";
+  status: "free" | "paid" | "donation" | "goal";
+  nextTier?: string;
+  note?: string;
 }
 
 const COSTS: CostRow[] = [
@@ -18,6 +20,15 @@ const COSTS: CostRow[] = [
     tier: "Equipment owner donation",
     monthlyCost: "$0",
     status: "donation",
+    note: "Goal: donate $100/yr to the hosting owner as a thank-you.",
+  },
+  {
+    service: "Domain registration",
+    description: "weftmark.com domain name — annual renewal.",
+    tier: "Annual renewal",
+    monthlyCost: "~$1",
+    status: "paid",
+    note: "Billed ~$12/yr.",
   },
   {
     service: "Claude Max ×5",
@@ -39,6 +50,7 @@ const COSTS: CostRow[] = [
     tier: "Free (100 CU-hr/mo, 0.5 GB)",
     monthlyCost: "$0",
     status: "free",
+    nextTier: "Launch plan: ~$19/mo",
   },
   {
     service: "SMTP2Go (Email)",
@@ -46,13 +58,15 @@ const COSTS: CostRow[] = [
     tier: "Free (1,000 emails/mo)",
     monthlyCost: "$0",
     status: "free",
+    nextTier: "Starter: $10/mo (10k emails/mo)",
   },
   {
     service: "Cloudflare R2 (Storage)",
     description: "Object storage for drawdown images, WIF files, and project photos.",
-    tier: "Free (10 GB, 10M reads/mo)",
+    tier: "Free (10 GB, 1M writes, 10M reads/mo)",
     monthlyCost: "$0",
     status: "free",
+    nextTier: "$0.015/GB + $4.50/M write ops above free tier",
   },
   {
     service: "Clerk (Authentication)",
@@ -60,6 +74,7 @@ const COSTS: CostRow[] = [
     tier: "Free (50,000 MAU)",
     monthlyCost: "$0",
     status: "free",
+    nextTier: "Pro: $20/mo + $0.02/MAU over limit",
   },
 ];
 
@@ -67,12 +82,14 @@ const STATUS_BADGE: Record<CostRow["status"], string> = {
   free: "bg-green-100 text-green-800",
   paid: "bg-amber-100 text-amber-800",
   donation: "bg-blue-100 text-blue-800",
+  goal: "bg-purple-100 text-purple-800",
 };
 
 const STATUS_LABEL: Record<CostRow["status"], string> = {
   free: "Free tier",
   paid: "Paid",
   donation: "Donated",
+  goal: "Goal",
 };
 
 // Replace with the actual GitHub Sponsors URL once approved.
@@ -108,7 +125,7 @@ export function CostsPage() {
               features without it becoming a second job in itself.
             </p>
             <div className="inline-flex items-center gap-2 rounded-full bg-amber-100 px-4 py-1.5 text-sm font-medium text-amber-900">
-              Approximate monthly cost: ~$120 / month
+              Approximate monthly cost: ~$121 / month
             </div>
           </div>
 
@@ -131,12 +148,23 @@ export function CostsPage() {
                       <td className="px-4 py-3 font-medium align-top">
                         <div>{row.service}</div>
                         <div className="mt-1 sm:hidden text-xs text-stone-500 font-normal">{row.description}</div>
+                        {row.note && <div className="mt-1 sm:hidden text-xs text-stone-400 italic">{row.note}</div>}
                         <span className={`mt-1.5 inline-block rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_BADGE[row.status]}`}>
                           {STATUS_LABEL[row.status]}
                         </span>
                       </td>
-                      <td className="px-4 py-3 text-stone-600 hidden sm:table-cell align-top">{row.description}</td>
-                      <td className="px-4 py-3 text-stone-600 align-top">{row.tier}</td>
+                      <td className="px-4 py-3 text-stone-600 hidden sm:table-cell align-top">
+                        <div>{row.description}</div>
+                        {row.note && <div className="mt-1 text-xs text-stone-400 italic">{row.note}</div>}
+                      </td>
+                      <td className="px-4 py-3 text-stone-600 align-top">
+                        <div>{row.tier}</div>
+                        {row.nextTier && (
+                          <div className="mt-1 text-xs text-stone-400">
+                            Next: {row.nextTier}
+                          </div>
+                        )}
+                      </td>
                       <td className="px-4 py-3 text-right font-mono font-semibold align-top">{row.monthlyCost}</td>
                     </tr>
                   ))}
@@ -145,7 +173,7 @@ export function CostsPage() {
                   <tr className="border-t-2 border-stone-300 bg-stone-50">
                     <td colSpan={3} className="px-4 py-3 text-sm font-medium text-right hidden sm:table-cell">Total (approximate)</td>
                     <td colSpan={2} className="px-4 py-3 text-sm font-medium sm:hidden">Total</td>
-                    <td className="px-4 py-3 text-right font-mono font-bold">~$120 / mo</td>
+                    <td className="px-4 py-3 text-right font-mono font-bold">~$121 / mo</td>
                   </tr>
                 </tfoot>
               </table>

--- a/frontend/src/pages/CostsPage.tsx
+++ b/frontend/src/pages/CostsPage.tsx
@@ -214,7 +214,9 @@ export function CostsPage() {
             <p className="text-stone-600 leading-relaxed">
               All infrastructure services are well within their free tiers today. If weftmark grows
               to the point where paid tiers are needed, costs will be re-evaluated and this page will
-              be updated. No features will be paywalled — the platform stays free to use.
+              be updated. weftmark is free to use and is intended to stay that way — the long-term
+              goal is for the platform to be community-supported through voluntary donations rather
+              than subscriptions or feature gates.
             </p>
           </div>
 

--- a/frontend/src/pages/CostsPage.tsx
+++ b/frontend/src/pages/CostsPage.tsx
@@ -24,11 +24,11 @@ const COSTS: CostRow[] = [
   },
   {
     service: "Domain registration",
-    description: "weftmark.com domain name — annual renewal.",
-    tier: "Annual renewal",
+    description: "weftmark.com domain name — registered and renewed through Cloudflare Registrar at cost.",
+    tier: "Cloudflare Registrar",
     monthlyCost: "~$1",
     status: "paid",
-    note: "Billed ~$12/yr.",
+    note: "Billed ~$9.15/yr (at-cost, no Cloudflare markup).",
   },
   {
     service: "Claude Max ×5",


### PR DESCRIPTION
## Summary

- New public `/costs` page with a service breakdown table showing every infrastructure component, its current tier, and monthly cost (~$120/mo total — all Claude subscription)
- GitHub Sponsors CTA rendered as a placeholder banner ("pending approval") until the profile goes live — swap `GITHUB_SPONSORS_URL` from `null` to the URL when approved
- **App sidebar**: "Support WeftMark" link (Heart icon) added below "Send Feedback"
- **Public footer**: "Running costs" nav link + "♥ Support WeftMark" right-side link added to all public pages (Landing, About, Privacy, Terms, SharedProject)
- No backend changes; no auth required for `/costs`

## Wiring up GitHub Sponsors (when approved)

In [`frontend/src/pages/CostsPage.tsx`](frontend/src/pages/CostsPage.tsx), update:
```ts
const GITHUB_SPONSORS_URL: string | null = null;
// → change to:
const GITHUB_SPONSORS_URL = "https://github.com/sponsors/weftmark";
```

## Test plan

- [ ] Navigate to `/costs` — verify table renders, placeholder banner shows, no auth wall
- [ ] App sidebar: "Support WeftMark" appears below Send Feedback, links to `/costs`
- [ ] Public footer on landing page, about, privacy, terms: "Running costs" and "♥ Support WeftMark" links present

Closes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)