### PR TITLE
feat: increase backend test coverage from 75.5% to 84.6%

### DIFF
--- a/backend/tests/routers/test_feedback.py
+++ b/backend/tests/routers/test_feedback.py
@@ -235,3 +235,134 @@ class TestAdminRecoverFeedback:
     async def test_not_found_returns_404(self, admin_client: AsyncClient):
         resp = await admin_client.post(f"/api/admin/feedback/{uuid.uuid4()}/recover")
         assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /api/feedback/mine
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestListMyFeedback:
+    async def test_returns_own_submissions(self, auth_client: AsyncClient):
+        await auth_client.post("/api/feedback", json=_feedback_payload(body="my own post"))
+        resp = await auth_client.get("/api/feedback/mine")
+        assert resp.status_code == 200
+        items = resp.json()
+        assert isinstance(items, list)
+        assert any(i["body"] == "my own post" for i in items)
+
+    async def test_empty_list_when_no_submissions(self, auth_client: AsyncClient):
+        resp = await auth_client.get("/api/feedback/mine")
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+
+    async def test_unauthenticated_returns_401(self, client: AsyncClient):
+        resp = await client.get("/api/feedback/mine")
+        assert resp.status_code == 401
+
+    async def test_excludes_soft_deleted(self, auth_client: AsyncClient, admin_client: AsyncClient):
+        sub = await auth_client.post("/api/feedback", json=_feedback_payload(body="to delete"))
+        fid = sub.json()["id"]
+        await admin_client.delete(f"/api/admin/feedback/{fid}")
+        resp = await auth_client.get("/api/feedback/mine")
+        ids = [i["id"] for i in resp.json()]
+        assert fid not in ids
+
+
+# ---------------------------------------------------------------------------
+# GET /api/feedback/{id}/status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestFeedbackStatus:
+    async def test_returns_status_for_own_submission(self, auth_client: AsyncClient):
+        sub = await auth_client.post("/api/feedback", json=_feedback_payload())
+        fid = sub.json()["id"]
+        resp = await auth_client.get(f"/api/feedback/{fid}/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "dispatch_status" in data
+        assert "github_discussion_url" in data
+
+    async def test_not_found_when_wrong_user(self, admin_client: AsyncClient, db_session, test_user):
+        from app.models.feedback import UserFeedback
+
+        # Create feedback owned by test_user (not admin_user who admin_client uses)
+        row = UserFeedback(
+            id=uuid.uuid4(),
+            user_id=test_user.id,
+            submission_type="feedback",
+            body="other user's feedback",
+            dispatch_status="skipped",
+        )
+        db_session.add(row)
+        await db_session.commit()
+
+        resp = await admin_client.get(f"/api/feedback/{row.id}/status")
+        assert resp.status_code == 404
+
+    async def test_not_found_for_unknown_id(self, auth_client: AsyncClient):
+        resp = await auth_client.get(f"/api/feedback/{uuid.uuid4()}/status")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /api/admin/feedback/{id}/retry-dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestAdminRetryDispatch:
+    async def test_retry_resets_status_to_pending(
+        self, auth_client: AsyncClient, admin_client: AsyncClient, db_session
+    ):
+        from unittest.mock import patch
+
+        from app.models.feedback import UserFeedback
+
+        sub = await auth_client.post("/api/feedback", json=_feedback_payload())
+        fid = sub.json()["id"]
+
+        row = await db_session.get(UserFeedback, uuid.UUID(fid))
+        row.dispatch_status = "failed"
+        await db_session.commit()
+
+        with patch("app.routers.feedback._enqueue_dispatch"):
+            resp = await admin_client.post(f"/api/admin/feedback/{fid}/retry-dispatch")
+
+        assert resp.status_code == 200
+        assert resp.json()["dispatch_status"] == "pending"
+
+    async def test_retry_skipped_status_returns_400(self, admin_client: AsyncClient, db_session, admin_user):
+        from app.models.feedback import UserFeedback
+
+        row = UserFeedback(
+            id=uuid.uuid4(),
+            user_id=admin_user.id,
+            submission_type="feedback",
+            body="skipped dispatch",
+            dispatch_status="skipped",
+        )
+        db_session.add(row)
+        await db_session.commit()
+
+        resp = await admin_client.post(f"/api/admin/feedback/{row.id}/retry-dispatch")
+        assert resp.status_code == 400
+
+    async def test_not_found_returns_404(self, admin_client: AsyncClient):
+        resp = await admin_client.post(f"/api/admin/feedback/{uuid.uuid4()}/retry-dispatch")
+        assert resp.status_code == 404
+
+    async def test_filter_by_dispatch_status(self, auth_client: AsyncClient, admin_client: AsyncClient):
+        await auth_client.post("/api/feedback", json=_feedback_payload(body="skipped-dispatch"))
+        resp = await admin_client.get("/api/admin/feedback?dispatch_status=skipped")
+        items = resp.json()["items"]
+        assert all(i["dispatch_status"] == "skipped" for i in items)
+
+    async def test_non_admin_returns_403(self, auth_client: AsyncClient):
+        sub = await auth_client.post("/api/feedback", json=_feedback_payload())
+        fid = sub.json()["id"]
+        resp = await auth_client.post(f"/api/admin/feedback/{fid}/retry-dispatch")
+        assert resp.status_code == 403

--- a/backend/tests/services/test_email.py
+++ b/backend/tests/services/test_email.py
@@ -12,9 +12,22 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.services.email import (
+    _digest_cve_html,
+    _digest_cve_txt,
+    _digest_s3_html,
+    _digest_s3_txt,
+    _format_uptime,
     send_account_approved_email,
     send_account_denied_email,
+    send_admin_digest_email,
     send_approval_confirmation_to_admins,
+    send_credential_expiring_admin,
+    send_credential_expiring_superuser,
+    send_deletion_completed_admin,
+    send_deletion_created_admin,
+    send_deletion_stalled_superuser,
+    send_feedback_admin_alert,
+    send_feedback_user_confirmation,
     send_health_degraded_alert,
     send_health_recovered_alert,
     send_invite_email,
@@ -877,3 +890,584 @@ class TestSendHealthRecoveredAlert:
         mock = await self._call()
         combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
         assert "{" not in combined
+
+
+# ---------------------------------------------------------------------------
+# _format_uptime
+# ---------------------------------------------------------------------------
+
+
+class TestFormatUptime:
+    def test_seconds_only(self):
+        assert _format_uptime(45) == "45s"
+
+    def test_minutes_and_seconds(self):
+        result = _format_uptime(90)
+        assert "m" in result
+        assert "s" in result
+
+    def test_hours_minutes_seconds(self):
+        result = _format_uptime(3661)
+        assert "h" in result
+        assert "m" in result
+
+    def test_zero(self):
+        assert _format_uptime(0) == "0s"
+
+    def test_exactly_one_hour(self):
+        assert _format_uptime(3600) == "1h 00m 00s"
+
+    def test_exactly_one_minute(self):
+        assert _format_uptime(60) == "1m 00s"
+
+
+# ---------------------------------------------------------------------------
+# _digest_cve_txt / _digest_cve_html
+# ---------------------------------------------------------------------------
+
+
+class TestDigestCveTxt:
+    def test_none_returns_no_data(self):
+        assert _digest_cve_txt(None, None) == "No scan data available"
+
+    def test_zero_findings(self):
+        result = _digest_cve_txt(0, None)
+        assert "0" in result
+
+    def test_one_finding_singular(self):
+        result = _digest_cve_txt(1, None)
+        assert "finding" in result
+        assert "findings" not in result
+
+    def test_multiple_findings_plural(self):
+        result = _digest_cve_txt(5, None)
+        assert "findings" in result
+
+    def test_scanned_at_included(self):
+        result = _digest_cve_txt(3, "2026-05-01T00:00:00")
+        assert "2026-05-01" in result
+
+    def test_scanned_at_none_not_present(self):
+        result = _digest_cve_txt(2, None)
+        assert "scanned" not in result
+
+
+class TestDigestCveHtml:
+    def test_none_returns_no_data_html(self):
+        result = _digest_cve_html(None, None)
+        assert "No scan data" in result
+
+    def test_zero_findings_green(self):
+        result = _digest_cve_html(0, None)
+        assert "#16a34a" in result
+
+    def test_nonzero_findings_red(self):
+        result = _digest_cve_html(3, None)
+        assert "#dc2626" in result
+
+    def test_scanned_at_included(self):
+        result = _digest_cve_html(1, "2026-05-01T00:00:00")
+        assert "2026-05-01" in result
+
+
+# ---------------------------------------------------------------------------
+# _digest_s3_txt / _digest_s3_html
+# ---------------------------------------------------------------------------
+
+
+class TestDigestS3Txt:
+    def test_none_returns_no_data(self):
+        assert _digest_s3_txt(None, None) == "No scan data available"
+
+    def test_zero_orphaned(self):
+        result = _digest_s3_txt(0, None)
+        assert "0" in result
+
+    def test_one_orphaned_singular(self):
+        result = _digest_s3_txt(1, None)
+        assert "orphaned file" in result
+        assert "files" not in result
+
+    def test_multiple_orphaned_plural(self):
+        result = _digest_s3_txt(4, None)
+        assert "files" in result
+
+    def test_scanned_at_included(self):
+        result = _digest_s3_txt(2, "2026-04-01T00:00:00")
+        assert "2026-04-01" in result
+
+
+class TestDigestS3Html:
+    def test_none_returns_no_data_html(self):
+        result = _digest_s3_html(None, None)
+        assert "No scan data" in result
+
+    def test_zero_orphaned_green(self):
+        result = _digest_s3_html(0, None)
+        assert "#16a34a" in result
+
+    def test_nonzero_orphaned_red(self):
+        result = _digest_s3_html(5, None)
+        assert "#dc2626" in result
+
+
+# ---------------------------------------------------------------------------
+# send_deletion_created_admin
+# ---------------------------------------------------------------------------
+
+
+class TestSendDeletionCreatedAdmin:
+    async def _call(self, admin_emails=None, display_name="Alice", email="alice@test.com"):
+        if admin_emails is None:
+            admin_emails = ["admin@example.com"]
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
+            await send_deletion_created_admin(admin_emails, display_name, email)
+        return mock_delay
+
+    async def test_delay_called_once(self):
+        mock = await self._call()
+        mock.assert_called_once()
+
+    async def test_subject_contains_display_name(self):
+        mock = await self._call(display_name="Alice Loom")
+        assert "Alice Loom" in _kwargs(mock)["subject"]
+
+    async def test_body_contains_email(self):
+        mock = await self._call(email="delete@test.com")
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
+        assert "delete@test.com" in combined
+
+    async def test_body_has_no_unfilled_placeholders(self):
+        mock = await self._call()
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
+        assert "{" not in combined
+
+
+# ---------------------------------------------------------------------------
+# send_deletion_completed_admin
+# ---------------------------------------------------------------------------
+
+
+class TestSendDeletionCompletedAdmin:
+    async def _call(self, admin_emails=None, display_name="Bob", email="bob@test.com"):
+        if admin_emails is None:
+            admin_emails = ["admin@example.com"]
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
+            await send_deletion_completed_admin(admin_emails, display_name, email)
+        return mock_delay
+
+    async def test_delay_called_once(self):
+        mock = await self._call()
+        mock.assert_called_once()
+
+    async def test_subject_contains_display_name(self):
+        mock = await self._call(display_name="Bob Weave")
+        assert "Bob Weave" in _kwargs(mock)["subject"]
+
+    async def test_body_has_no_unfilled_placeholders(self):
+        mock = await self._call()
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
+        assert "{" not in combined
+
+
+# ---------------------------------------------------------------------------
+# send_deletion_stalled_superuser
+# ---------------------------------------------------------------------------
+
+
+class TestSendDeletionStalledSuperuser:
+    async def _call(
+        self,
+        superuser_emails=None,
+        display_name="Carol",
+        email="carol@test.com",
+        user_id="usr_abc123",
+    ):
+        if superuser_emails is None:
+            superuser_emails = ["su@example.com"]
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
+            await send_deletion_stalled_superuser(superuser_emails, display_name, email, user_id)
+        return mock_delay
+
+    async def test_delay_called_once(self):
+        mock = await self._call()
+        mock.assert_called_once()
+
+    async def test_subject_contains_display_name(self):
+        mock = await self._call(display_name="Carol Yarn")
+        assert "Carol Yarn" in _kwargs(mock)["subject"]
+
+    async def test_body_contains_user_id(self):
+        mock = await self._call(user_id="usr_xyz789")
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
+        assert "usr_xyz789" in combined
+
+    async def test_body_has_no_unfilled_placeholders(self):
+        mock = await self._call()
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
+        assert "{" not in combined
+
+
+# ---------------------------------------------------------------------------
+# send_credential_expiring_superuser
+# ---------------------------------------------------------------------------
+
+
+class TestSendCredentialExpiringSuperuser:
+    async def _call(
+        self,
+        emails=None,
+        credential_name="SMTP Password",
+        resource="SMTP2Go",
+        days_remaining=5,
+        expires_on="2026-06-01",
+    ):
+        if emails is None:
+            emails = ["su@example.com"]
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
+            await send_credential_expiring_superuser(emails, credential_name, resource, days_remaining, expires_on)
+        return mock_delay
+
+    async def test_delay_called_once(self):
+        mock = await self._call()
+        mock.assert_called_once()
+
+    async def test_no_delay_when_smtp_unconfigured(self, monkeypatch):
+        from app.config import get_settings
+
+        monkeypatch.setattr(get_settings(), "smtp_user", "")
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
+            await send_credential_expiring_superuser(["su@example.com"], "k", "r", 5, "2026-06-01")
+        mock_delay.assert_not_called()
+
+    async def test_no_delay_when_no_recipients(self):
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
+            await send_credential_expiring_superuser([], "k", "r", 5, "2026-06-01")
+        mock_delay.assert_not_called()
+
+    async def test_subject_contains_credential_name(self):
+        mock = await self._call(credential_name="API Key")
+        assert "API Key" in _kwargs(mock)["subject"]
+
+    async def test_subject_singular_day(self):
+        mock = await self._call(days_remaining=1)
+        assert "day" in _kwargs(mock)["subject"]
+        assert "days" not in _kwargs(mock)["subject"]
+
+    async def test_subject_plural_days(self):
+        mock = await self._call(days_remaining=7)
+        assert "days" in _kwargs(mock)["subject"]
+
+    async def test_body_has_no_unfilled_placeholders(self):
+        mock = await self._call()
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
+        assert "{" not in combined
+
+
+# ---------------------------------------------------------------------------
+# send_credential_expiring_admin
+# ---------------------------------------------------------------------------
+
+
+class TestSendCredentialExpiringAdmin:
+    async def _call(
+        self,
+        emails=None,
+        credential_name="R2 Token",
+        resource="Cloudflare R2",
+        days_remaining=14,
+        expires_on="2026-07-01",
+    ):
+        if emails is None:
+            emails = ["admin@example.com"]
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
+            await send_credential_expiring_admin(emails, credential_name, resource, days_remaining, expires_on)
+        return mock_delay
+
+    async def test_delay_called_once(self):
+        mock = await self._call()
+        mock.assert_called_once()
+
+    async def test_no_delay_when_smtp_unconfigured(self, monkeypatch):
+        from app.config import get_settings
+
+        monkeypatch.setattr(get_settings(), "smtp_user", "")
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
+            await send_credential_expiring_admin(["a@example.com"], "k", "r", 14, "2026-07-01")
+        mock_delay.assert_not_called()
+
+    async def test_no_delay_when_no_recipients(self):
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
+            await send_credential_expiring_admin([], "k", "r", 14, "2026-07-01")
+        mock_delay.assert_not_called()
+
+    async def test_body_contains_credential_name(self):
+        mock = await self._call(credential_name="R2 Token")
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
+        assert "R2 Token" in combined
+
+    async def test_body_has_no_unfilled_placeholders(self):
+        mock = await self._call()
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
+        assert "{" not in combined
+
+
+# ---------------------------------------------------------------------------
+# send_feedback_user_confirmation
+# ---------------------------------------------------------------------------
+
+
+class TestSendFeedbackUserConfirmation:
+    async def _call(self, to="user@test.com", type_label="bug report", discussion_url="https://github.com/d/1"):
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
+            await send_feedback_user_confirmation(to, type_label, discussion_url)
+        return mock_delay
+
+    async def test_delay_called_once(self):
+        mock = await self._call()
+        mock.assert_called_once()
+
+    async def test_recipient_is_user(self):
+        mock = await self._call(to="specific@test.com")
+        assert "specific@test.com" in _kwargs(mock)["to"]
+
+    async def test_subject_contains_type_label(self):
+        mock = await self._call(type_label="feature request")
+        assert "feature request" in _kwargs(mock)["subject"]
+
+    async def test_body_contains_discussion_url(self):
+        mock = await self._call(discussion_url="https://github.com/discussions/42")
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
+        assert "https://github.com/discussions/42" in combined
+
+    async def test_body_has_no_unfilled_placeholders(self):
+        mock = await self._call()
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
+        assert "{" not in combined
+
+
+# ---------------------------------------------------------------------------
+# send_feedback_admin_alert
+# ---------------------------------------------------------------------------
+
+
+class TestSendFeedbackAdminAlert:
+    async def _call(
+        self,
+        admin_emails=None,
+        type_label="bug report",
+        discussion_url="https://github.com/d/1",
+        subject=None,
+    ):
+        if admin_emails is None:
+            admin_emails = ["admin@example.com"]
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
+            await send_feedback_admin_alert(admin_emails, type_label, discussion_url, subject)
+        return mock_delay
+
+    async def test_delay_called_once(self):
+        mock = await self._call()
+        mock.assert_called_once()
+
+    async def test_no_delay_when_smtp_unconfigured(self, monkeypatch):
+        from app.config import get_settings
+
+        monkeypatch.setattr(get_settings(), "smtp_user", "")
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
+            await send_feedback_admin_alert(["a@example.com"], "bug", "https://g.com/1", None)
+        mock_delay.assert_not_called()
+
+    async def test_no_delay_when_no_recipients(self):
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
+            await send_feedback_admin_alert([], "bug", "https://g.com/1", None)
+        mock_delay.assert_not_called()
+
+    async def test_subject_email_contains_type_label(self):
+        mock = await self._call(type_label="feature request")
+        assert "feature request" in _kwargs(mock)["subject"]
+
+    async def test_body_with_subject_contains_it(self):
+        mock = await self._call(subject="Dark mode please")
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
+        assert "Dark mode please" in combined
+
+    async def test_body_without_subject_has_no_unfilled_placeholders(self):
+        mock = await self._call(subject=None)
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
+        assert "{" not in combined
+
+
+# ---------------------------------------------------------------------------
+# send_admin_digest_email
+# ---------------------------------------------------------------------------
+
+
+class TestSendAdminDigestEmail:
+    async def _call(
+        self,
+        admin_emails=None,
+        week_start="2026-05-11",
+        week_end="2026-05-17",
+        new_users=3,
+        pending_signups=1,
+        new_drafts=10,
+        new_projects=5,
+        new_looms=2,
+        storage_str="1.2 GB",
+        storage_delta_str="+50 MB",
+        cve_finding_count=0,
+        cve_scanned_at="2026-05-17T02:00:00",
+        s3_orphaned_count=0,
+        s3_scanned_at="2026-05-17T03:00:00",
+    ):
+        if admin_emails is None:
+            admin_emails = ["admin@example.com"]
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
+            await send_admin_digest_email(
+                admin_emails=admin_emails,
+                week_start=week_start,
+                week_end=week_end,
+                new_users=new_users,
+                pending_signups=pending_signups,
+                new_drafts=new_drafts,
+                new_projects=new_projects,
+                new_looms=new_looms,
+                storage_str=storage_str,
+                storage_delta_str=storage_delta_str,
+                cve_finding_count=cve_finding_count,
+                cve_scanned_at=cve_scanned_at,
+                s3_orphaned_count=s3_orphaned_count,
+                s3_scanned_at=s3_scanned_at,
+            )
+        return mock_delay
+
+    async def test_delay_called_once(self):
+        mock = await self._call()
+        mock.assert_called_once()
+
+    async def test_no_delay_when_smtp_unconfigured(self, monkeypatch):
+        from app.config import get_settings
+
+        monkeypatch.setattr(get_settings(), "smtp_user", "")
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
+            await send_admin_digest_email(
+                admin_emails=["a@example.com"],
+                week_start="2026-05-11",
+                week_end="2026-05-17",
+                new_users=0,
+                pending_signups=0,
+                new_drafts=0,
+                new_projects=0,
+                new_looms=0,
+                storage_str="0 B",
+                storage_delta_str=None,
+                cve_finding_count=None,
+                cve_scanned_at=None,
+                s3_orphaned_count=None,
+                s3_scanned_at=None,
+            )
+        mock_delay.assert_not_called()
+
+    async def test_no_delay_when_no_recipients(self):
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
+            await send_admin_digest_email(
+                admin_emails=[],
+                week_start="2026-05-11",
+                week_end="2026-05-17",
+                new_users=0,
+                pending_signups=0,
+                new_drafts=0,
+                new_projects=0,
+                new_looms=0,
+                storage_str="0 B",
+                storage_delta_str=None,
+                cve_finding_count=None,
+                cve_scanned_at=None,
+                s3_orphaned_count=None,
+                s3_scanned_at=None,
+            )
+        mock_delay.assert_not_called()
+
+    async def test_subject_contains_week_range(self):
+        mock = await self._call(week_start="2026-05-11", week_end="2026-05-17")
+        subj = _kwargs(mock)["subject"]
+        assert "2026-05-11" in subj
+        assert "2026-05-17" in subj
+
+    async def test_body_contains_storage_str(self):
+        mock = await self._call(storage_str="2.4 GB")
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
+        assert "2.4 GB" in combined
+
+    async def test_body_contains_storage_delta(self):
+        mock = await self._call(storage_delta_str="+100 MB")
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
+        assert "+100 MB" in combined
+
+    async def test_body_no_delta_shows_first_run_indicator(self):
+        mock = await self._call(storage_delta_str=None)
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
+        assert "—" in combined or "First run" in combined or "no prior" in combined.lower()
+
+    async def test_body_cve_none_shows_no_data(self):
+        mock = await self._call(cve_finding_count=None, cve_scanned_at=None)
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
+        assert "No scan data" in combined
+
+    async def test_body_has_no_unfilled_placeholders(self):
+        mock = await self._call()
+        combined = _kwargs(mock)["txt"] + " " + _kwargs(mock)["html"]
+        assert "{" not in combined
+
+
+# ---------------------------------------------------------------------------
+# DEV environment banner (_send branch)
+# ---------------------------------------------------------------------------
+
+
+class TestDevEnvironmentBanner:
+    async def test_dev_prefix_added_to_subject(self, monkeypatch):
+        from app.config import get_settings
+
+        monkeypatch.setattr(get_settings(), "app_env", "dev")
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
+            await send_test_email("a@test.com")
+        subj = _kwargs(mock_delay)["subject"]
+        assert subj.startswith("[DEV]")
+
+    async def test_dev_banner_added_to_txt(self, monkeypatch):
+        from app.config import get_settings
+
+        monkeypatch.setattr(get_settings(), "app_env", "dev")
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
+            await send_test_email("a@test.com")
+        txt = _kwargs(mock_delay)["txt"]
+        assert "DEV ENVIRONMENT" in txt
+
+    async def test_non_dev_removes_dev_banner_comment(self, monkeypatch):
+        from app.config import get_settings
+
+        monkeypatch.setattr(get_settings(), "app_env", "test")
+        mock_delay = MagicMock()
+        with patch("app.tasks.email_task.send_email.delay", mock_delay):
+            await send_test_email("a@test.com")
+        html = _kwargs(mock_delay)["html"]
+        assert "<!-- DEV_BANNER -->" not in html

--- a/backend/tests/services/test_github_discussions.py
+++ b/backend/tests/services/test_github_discussions.py
@@ -1,0 +1,292 @@
+"""Tests for app.services.github_discussions."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.github_discussions import (
+    _graphql,
+    _type_label,
+    build_discussion_body,
+    build_discussion_title,
+    create_discussion,
+    get_repo_and_category_id,
+)
+
+# ---------------------------------------------------------------------------
+# _type_label — pure dict lookup
+# ---------------------------------------------------------------------------
+
+
+class TestTypeLabel:
+    def test_feedback(self):
+        assert _type_label("feedback") == "Feedback"
+
+    def test_feature_request(self):
+        assert _type_label("feature_request") == "Feature Request"
+
+    def test_bug_report(self):
+        assert _type_label("bug_report") == "Bug Report"
+
+    def test_unknown_falls_back_to_title_case(self):
+        assert _type_label("my_custom_type") == "My Custom Type"
+
+    def test_unknown_single_word(self):
+        assert _type_label("general") == "General"
+
+
+# ---------------------------------------------------------------------------
+# build_discussion_title — pure string builder
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDiscussionTitle:
+    def test_with_subject(self):
+        result = build_discussion_title("feedback", "My bug")
+        assert result == "[Feedback] My bug"
+
+    def test_without_subject(self):
+        result = build_discussion_title("feedback", None)
+        assert result == "[Feedback] User submission"
+
+    def test_whitespace_only_subject(self):
+        result = build_discussion_title("bug_report", "   ")
+        assert result == "[Bug Report] User submission"
+
+    def test_subject_is_stripped(self):
+        result = build_discussion_title("feature_request", "  My idea  ")
+        assert result == "[Feature Request] My idea"
+
+    def test_empty_string_subject(self):
+        result = build_discussion_title("feedback", "")
+        assert result == "[Feedback] User submission"
+
+
+# ---------------------------------------------------------------------------
+# build_discussion_body — pure markdown builder
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDiscussionBody:
+    def test_minimal_body_included(self):
+        result = build_discussion_body("feedback", None, "Hello world", None, False)
+        assert "Hello world" in result
+
+    def test_no_diagnostics_skips_section(self):
+        result = build_discussion_body("feedback", None, "Hello", None, False)
+        assert "Diagnostics" not in result
+
+    def test_with_environment_diagnostic(self):
+        diag = {"environment": "production"}
+        result = build_discussion_body("feedback", None, "Hello", diag, False)
+        assert "Diagnostics" in result
+        assert "production" in result
+
+    def test_with_app_version_diagnostic(self):
+        diag = {"app_version": "1.2.3"}
+        result = build_discussion_body("feedback", None, "Hello", diag, False)
+        assert "1.2.3" in result
+
+    def test_non_anonymous_includes_page_url(self):
+        diag = {"page_url": "/projects/abc", "environment": "prod"}
+        result = build_discussion_body("feedback", None, "Hello", diag, False)
+        assert "/projects/abc" in result
+
+    def test_non_anonymous_includes_project_id(self):
+        diag = {"project_id": "proj-123", "environment": "prod"}
+        result = build_discussion_body("feedback", None, "Hello", diag, False)
+        assert "proj-123" in result
+
+    def test_non_anonymous_includes_draft_id(self):
+        diag = {"draft_id": "draft-456", "environment": "prod"}
+        result = build_discussion_body("feedback", None, "Hello", diag, False)
+        assert "draft-456" in result
+
+    def test_anonymous_omits_page_url(self):
+        diag = {"page_url": "/projects/secret-uuid", "environment": "prod"}
+        result = build_discussion_body("feedback", None, "Hello", diag, True)
+        assert "/projects/secret-uuid" not in result
+
+    def test_anonymous_omits_project_id(self):
+        diag = {"project_id": "proj-secret", "environment": "prod"}
+        result = build_discussion_body("feedback", None, "Hello", diag, True)
+        assert "proj-secret" not in result
+
+    def test_anonymous_omits_draft_id(self):
+        diag = {"draft_id": "draft-secret", "environment": "prod"}
+        result = build_discussion_body("feedback", None, "Hello", diag, True)
+        assert "draft-secret" not in result
+
+    def test_anonymous_includes_user_agent(self):
+        diag = {"user_agent": "Mozilla/5.0", "environment": "prod"}
+        result = build_discussion_body("feedback", None, "Hello", diag, True)
+        assert "Mozilla/5.0" in result
+
+    def test_anonymous_appends_anonymously_note(self):
+        result = build_discussion_body("feedback", None, "Hello", None, True)
+        assert "anonymously" in result
+
+    def test_non_anonymous_no_anonymously_note(self):
+        result = build_discussion_body("feedback", None, "Hello", None, False)
+        assert "anonymously" not in result
+
+    def test_note_always_appended(self):
+        result = build_discussion_body("feedback", None, "Hello", None, False)
+        assert "hobby project" in result
+
+    def test_empty_diagnostics_dict_skips_section(self):
+        result = build_discussion_body("feedback", None, "Hello", {}, False)
+        assert "Diagnostics" not in result
+
+    def test_diagnostics_with_only_falsy_values_skips_section(self):
+        diag = {"environment": "", "app_version": None}
+        result = build_discussion_body("feedback", None, "Hello", diag, False)
+        assert "Diagnostics" not in result
+
+
+# ---------------------------------------------------------------------------
+# _graphql — async HTTP call
+# ---------------------------------------------------------------------------
+
+
+def _mock_httpx_client(json_response: dict):
+    """Return (mock_cls, mock_response) for patching httpx.AsyncClient."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = json_response
+
+    mock_client_instance = AsyncMock()
+    mock_client_instance.post = AsyncMock(return_value=mock_response)
+
+    mock_cls = MagicMock()
+    mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
+    mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    return mock_cls, mock_client_instance
+
+
+class TestGraphql:
+    @pytest.mark.asyncio
+    async def test_returns_data_on_success(self):
+        mock_cls, _ = _mock_httpx_client({"data": {"result": "ok"}})
+        with patch("httpx.AsyncClient", mock_cls):
+            result = await _graphql("token", "query {}", {})
+        assert result == {"result": "ok"}
+
+    @pytest.mark.asyncio
+    async def test_raises_on_errors_key(self):
+        mock_cls, _ = _mock_httpx_client({"errors": [{"message": "bad query"}]})
+        with patch("httpx.AsyncClient", mock_cls):
+            with pytest.raises(RuntimeError, match="GraphQL errors"):
+                await _graphql("token", "query {}", {})
+
+    @pytest.mark.asyncio
+    async def test_passes_bearer_header(self):
+        mock_cls, mock_client = _mock_httpx_client({"data": {}})
+        with patch("httpx.AsyncClient", mock_cls):
+            await _graphql("my-token", "query {}", {})
+
+        call_kwargs = mock_client.post.call_args[1]
+        assert "Bearer my-token" in call_kwargs["headers"]["Authorization"]
+
+    @pytest.mark.asyncio
+    async def test_posts_query_and_variables(self):
+        mock_cls, mock_client = _mock_httpx_client({"data": {}})
+        variables = {"owner": "acme", "name": "repo"}
+        with patch("httpx.AsyncClient", mock_cls):
+            await _graphql("token", "query Q($owner: String!) {}", variables)
+
+        call_kwargs = mock_client.post.call_args[1]
+        assert call_kwargs["json"]["variables"] == variables
+
+
+# ---------------------------------------------------------------------------
+# get_repo_and_category_id — wraps _graphql
+# ---------------------------------------------------------------------------
+
+
+def _graphql_mock(repo_id: str, categories: list[dict]):
+    return AsyncMock(
+        return_value={
+            "repository": {
+                "id": repo_id,
+                "discussionCategories": {"nodes": categories},
+            }
+        }
+    )
+
+
+class TestGetRepoAndCategoryId:
+    @pytest.mark.asyncio
+    async def test_returns_preferred_category(self):
+        categories = [{"id": "C_1", "name": "Feedback"}, {"id": "C_2", "name": "General"}]
+        with patch("app.services.github_discussions._graphql", _graphql_mock("R_abc", categories)):
+            repo_id, cat_id = await get_repo_and_category_id("token", "owner/repo", "feedback")
+        assert repo_id == "R_abc"
+        assert cat_id == "C_1"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_general_when_preferred_missing(self):
+        categories = [{"id": "C_gen", "name": "General"}, {"id": "C_qa", "name": "Q&A"}]
+        with patch("app.services.github_discussions._graphql", _graphql_mock("R_x", categories)):
+            _, cat_id = await get_repo_and_category_id("token", "owner/repo", "feature_request")
+        assert cat_id == "C_gen"
+
+    @pytest.mark.asyncio
+    async def test_uses_first_category_as_last_resort(self):
+        categories = [{"id": "C_first", "name": "Unrelated"}]
+        with patch("app.services.github_discussions._graphql", _graphql_mock("R_y", categories)):
+            _, cat_id = await get_repo_and_category_id("token", "owner/repo", "feedback")
+        assert cat_id == "C_first"
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_categories(self):
+        with patch("app.services.github_discussions._graphql", _graphql_mock("R_z", [])):
+            with pytest.raises(RuntimeError, match="No Discussion categories"):
+                await get_repo_and_category_id("token", "owner/repo", "feedback")
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive_category_match(self):
+        categories = [{"id": "C_fb", "name": "feedback"}]
+        with patch("app.services.github_discussions._graphql", _graphql_mock("R_ci", categories)):
+            _, cat_id = await get_repo_and_category_id("token", "owner/repo", "feedback")
+        assert cat_id == "C_fb"
+
+
+# ---------------------------------------------------------------------------
+# create_discussion — wraps get_repo_and_category_id + _graphql
+# ---------------------------------------------------------------------------
+
+
+class TestCreateDiscussion:
+    @pytest.mark.asyncio
+    async def test_returns_discussion_url(self):
+        expected_url = "https://github.com/owner/repo/discussions/42"
+
+        with patch(
+            "app.services.github_discussions.get_repo_and_category_id",
+            new=AsyncMock(return_value=("R_repo", "C_cat")),
+        ):
+            mock_data = {"createDiscussion": {"discussion": {"url": expected_url}}}
+            with patch(
+                "app.services.github_discussions._graphql",
+                new=AsyncMock(return_value=mock_data),
+            ):
+                url = await create_discussion("token", "owner/repo", "feedback", "My title", "My body")
+
+        assert url == expected_url
+
+    @pytest.mark.asyncio
+    async def test_passes_title_and_body_to_mutation(self):
+        with patch(
+            "app.services.github_discussions.get_repo_and_category_id",
+            new=AsyncMock(return_value=("R_r", "C_c")),
+        ):
+            mock_graphql = AsyncMock(return_value={"createDiscussion": {"discussion": {"url": "https://example.com"}}})
+            with patch("app.services.github_discussions._graphql", new=mock_graphql):
+                await create_discussion("token", "owner/repo", "feedback", "Test title", "Test body")
+
+        call_args = mock_graphql.call_args
+        variables = call_args[0][2]
+        assert variables["input"]["title"] == "Test title"
+        assert variables["input"]["body"] == "Test body"

--- a/backend/tests/services/test_storage.py
+++ b/backend/tests/services/test_storage.py
@@ -453,3 +453,340 @@ class TestAsyncWrappers:
         data = b"\x89PNG\r\n\x1a\n"
         key = await storage.asave_drawdown_preview(data)
         assert storage.read_drawdown_preview(key) == data
+
+
+# ---------------------------------------------------------------------------
+# Local backend primitives — cover lines 50-52, 59, 67-69, 83
+# ---------------------------------------------------------------------------
+
+
+class TestLocalBackendPrimitives:
+    @pytest.fixture(autouse=True)
+    def _local_mode(self, monkeypatch):
+        monkeypatch.setattr(storage.settings, "storage_backend", "local")
+
+    def test_put_writes_bytes_to_disk(self, tmp_path):
+        result = _real_put("test/file.wif", b"hello local")
+        assert result == "test/file.wif"
+        assert (tmp_path / "test" / "file.wif").read_bytes() == b"hello local"
+
+    def test_put_creates_missing_parent_dirs(self, tmp_path):
+        _real_put("a/b/c/deep.wif", b"deep")
+        assert (tmp_path / "a" / "b" / "c" / "deep.wif").exists()
+
+    def test_get_reads_bytes_from_disk(self, tmp_path):
+        (tmp_path / "read_me.txt").write_bytes(b"file content")
+        assert _real_get("read_me.txt") == b"file content"
+
+    def test_delete_removes_existing_file(self, tmp_path):
+        (tmp_path / "remove_me.wif").write_bytes(b"x")
+        _real_delete("remove_me.wif")
+        assert not (tmp_path / "remove_me.wif").exists()
+
+    def test_delete_missing_file_is_silent(self):
+        _real_delete("not/there/file.wif")
+
+    def test_exists_returns_true_for_existing_file(self, tmp_path):
+        (tmp_path / "present.wif").write_bytes(b"y")
+        assert _real_exists("present.wif") is True
+
+    def test_exists_returns_false_for_missing_file(self):
+        assert _real_exists("absent/file.wif") is False
+
+
+# ---------------------------------------------------------------------------
+# Drawdown tile functions — cover lines 138, 142, 146, 150, 154
+# ---------------------------------------------------------------------------
+
+
+class TestDrawdownTileFunctions:
+    @pytest.fixture(autouse=True)
+    def _local_mode(self, monkeypatch):
+        monkeypatch.setattr(storage.settings, "storage_backend", "local")
+
+    def test_drawdown_tile_path_format(self):
+        did = _pid()
+        path = storage.drawdown_tile_path(did, 2, 100)
+        assert path == f"drafts/{did}/tiles/s2/t100.png"
+
+    def test_save_and_tile_exists_true(self):
+        did = _pid()
+        storage.save_drawdown_tile(did, 1, 0, b"PNG")
+        assert storage.drawdown_tile_exists(did, 1, 0) is True
+
+    def test_tile_not_exists_before_save(self):
+        assert storage.drawdown_tile_exists(_pid(), 1, 0) is False
+
+    def test_save_and_read_round_trip(self):
+        did = _pid()
+        storage.save_drawdown_tile(did, 2, 50, b"TILE DATA")
+        assert storage.read_drawdown_tile(did, 2, 50) == b"TILE DATA"
+
+    async def test_adrawdown_tile_exists_true(self):
+        did = _pid()
+        storage.save_drawdown_tile(did, 1, 0, b"PNG")
+        assert await storage.adrawdown_tile_exists(did, 1, 0) is True
+
+    async def test_adrawdown_tile_exists_false(self):
+        assert await storage.adrawdown_tile_exists(_pid(), 1, 0) is False
+
+    async def test_aread_drawdown_tile_round_trip(self):
+        did = _pid()
+        storage.save_drawdown_tile(did, 1, 0, b"ASYNC READ")
+        assert await storage.aread_drawdown_tile(did, 1, 0) == b"ASYNC READ"
+
+    async def test_asave_drawdown_tile_round_trip(self):
+        did = _pid()
+        await storage.asave_drawdown_tile(did, 1, 0, b"ASYNC SAVE")
+        assert storage.read_drawdown_tile(did, 1, 0) == b"ASYNC SAVE"
+
+
+# ---------------------------------------------------------------------------
+# Project tile functions — cover lines 170-187
+# ---------------------------------------------------------------------------
+
+
+class TestProjectTileFunctions:
+    @pytest.fixture(autouse=True)
+    def _local_mode(self, monkeypatch):
+        monkeypatch.setattr(storage.settings, "storage_backend", "local")
+
+    def test_project_tile_path_format(self):
+        pid = _pid()
+        path = storage.project_tile_path(pid, 2, 100)
+        assert path == f"projects/{pid}/tiles/s2/r100.png"
+
+    def test_save_and_tile_exists_true(self):
+        pid = _pid()
+        storage.save_project_tile(pid, 1, 0, b"PNG")
+        assert storage.project_tile_exists(pid, 1, 0) is True
+
+    def test_tile_not_exists_before_save(self):
+        assert storage.project_tile_exists(_pid(), 1, 0) is False
+
+    def test_save_and_read_round_trip(self):
+        pid = _pid()
+        storage.save_project_tile(pid, 2, 50, b"TILE DATA")
+        assert storage.read_project_tile(pid, 2, 50) == b"TILE DATA"
+
+    async def test_aproject_tile_exists_true(self):
+        pid = _pid()
+        storage.save_project_tile(pid, 1, 0, b"PNG")
+        assert await storage.aproject_tile_exists(pid, 1, 0) is True
+
+    async def test_aproject_tile_exists_false(self):
+        assert await storage.aproject_tile_exists(_pid(), 1, 0) is False
+
+    async def test_aread_project_tile_round_trip(self):
+        pid = _pid()
+        storage.save_project_tile(pid, 1, 0, b"ASYNC READ")
+        assert await storage.aread_project_tile(pid, 1, 0) == b"ASYNC READ"
+
+    async def test_asave_project_tile_round_trip(self):
+        pid = _pid()
+        await storage.asave_project_tile(pid, 1, 0, b"ASYNC SAVE")
+        assert storage.read_project_tile(pid, 1, 0) == b"ASYNC SAVE"
+
+
+# ---------------------------------------------------------------------------
+# Project drawdown preview and SVG — cover lines 190-211
+# ---------------------------------------------------------------------------
+
+
+class TestProjectDrawdownAndSvg:
+    @pytest.fixture(autouse=True)
+    def _local_mode(self, monkeypatch):
+        monkeypatch.setattr(storage.settings, "storage_backend", "local")
+
+    def test_save_project_drawdown_preview_returns_path(self):
+        rel = storage.save_project_drawdown_preview(b"\x89PNG")
+        assert rel.startswith("projects/") and rel.endswith(".png")
+
+    def test_project_drawdown_preview_round_trip(self):
+        data = b"\x89PNG\r\n\x1a\n"
+        rel = storage.save_project_drawdown_preview(data)
+        assert storage.read_project_drawdown_preview(rel) == data
+
+    def test_project_drawdown_preview_exists_true(self):
+        rel = storage.save_project_drawdown_preview(b"img")
+        assert storage.project_drawdown_preview_exists(rel) is True
+
+    def test_project_drawdown_preview_exists_false_for_none(self):
+        assert storage.project_drawdown_preview_exists(None) is False
+
+    def test_project_drawdown_preview_exists_false_for_missing(self):
+        assert storage.project_drawdown_preview_exists("projects/no.png") is False
+
+    def test_save_project_drawdown_svg_returns_path(self):
+        rel = storage.save_project_drawdown_svg("<svg/>")
+        assert rel.startswith("projects/") and rel.endswith(".svg")
+
+    def test_project_drawdown_svg_round_trip(self):
+        data = "<svg><rect/></svg>"
+        rel = storage.save_project_drawdown_svg(data)
+        assert storage.read_project_drawdown_svg(rel) == data
+
+    def test_project_drawdown_svg_exists_true(self):
+        rel = storage.save_project_drawdown_svg("<svg/>")
+        assert storage.project_drawdown_svg_exists(rel) is True
+
+    def test_project_drawdown_svg_exists_false_for_none(self):
+        assert storage.project_drawdown_svg_exists(None) is False
+
+
+# ---------------------------------------------------------------------------
+# delete_project_tiles — cover lines 216-236
+#
+# Note: conftest mock_storage replaces _put/_get/_delete/_exists with an
+# in-memory dict, so delete_project_tiles (which checks the real filesystem
+# in local mode) must be seeded with _real_put (captured before the mock runs).
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteProjectTiles:
+    @pytest.fixture(autouse=True)
+    def _local_mode(self, monkeypatch):
+        monkeypatch.setattr(storage.settings, "storage_backend", "local")
+
+    def test_local_returns_zero_when_no_tiles(self):
+        assert storage.delete_project_tiles(_pid()) == 0
+
+    def test_local_deletes_tiles_and_returns_count(self):
+        pid = _pid()
+        _real_put(storage.project_tile_path(pid, 1, 0), b"a")
+        _real_put(storage.project_tile_path(pid, 1, 50), b"b")
+        _real_put(storage.project_tile_path(pid, 2, 0), b"c")
+        count = storage.delete_project_tiles(pid)
+        assert count == 3
+
+    def test_local_only_deletes_target_project_tiles(self, tmp_path):
+        pid1, pid2 = _pid(), _pid()
+        _real_put(storage.project_tile_path(pid1, 1, 0), b"p1")
+        _real_put(storage.project_tile_path(pid2, 1, 0), b"p2")
+        storage.delete_project_tiles(pid1)
+        assert (tmp_path / storage.project_tile_path(pid2, 1, 0)).exists()
+
+    def test_s3_path_uses_paginator_and_delete_objects(self, monkeypatch):
+        mock_client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [{"Contents": [{"Key": "projects/x/tiles/s1/r0.png"}]}]
+        mock_client.get_paginator.return_value = paginator
+        monkeypatch.setattr(storage, "_s3_client", mock_client)
+        monkeypatch.setattr(storage.settings, "storage_backend", "s3")
+        monkeypatch.setattr(storage.settings, "s3_bucket_name", "test-bucket")
+
+        count = storage.delete_project_tiles(_pid())
+        assert count == 1
+        mock_client.delete_objects.assert_called_once()
+
+    def test_s3_empty_page_skips_delete_objects(self, monkeypatch):
+        mock_client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [{}]
+        mock_client.get_paginator.return_value = paginator
+        monkeypatch.setattr(storage, "_s3_client", mock_client)
+        monkeypatch.setattr(storage.settings, "storage_backend", "s3")
+        monkeypatch.setattr(storage.settings, "s3_bucket_name", "test-bucket")
+
+        count = storage.delete_project_tiles(_pid())
+        assert count == 0
+        mock_client.delete_objects.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# copy_file — cover lines 321-322
+# ---------------------------------------------------------------------------
+
+
+class TestCopyFile:
+    @pytest.fixture(autouse=True)
+    def _local_mode(self, monkeypatch):
+        monkeypatch.setattr(storage.settings, "storage_backend", "local")
+
+    def test_copy_creates_new_key_with_same_content(self):
+        pid = _pid()
+        old_key = storage.save_wif(pid, "original.wif", b"COPY ME")
+        new_key = f"drafts/{uuid.uuid4()}.wif"
+        result = storage.copy_file(old_key, new_key)
+        assert result == new_key
+        assert storage.read_wif(new_key) == b"COPY ME"
+
+    def test_copy_does_not_remove_original(self):
+        pid = _pid()
+        old_key = storage.save_wif(pid, "original.wif", b"ORIGINAL")
+        storage.copy_file(old_key, f"drafts/{uuid.uuid4()}.wif")
+        assert storage.read_wif(old_key) == b"ORIGINAL"
+
+
+# ---------------------------------------------------------------------------
+# Additional async wrappers — cover lines 345, 365, 369, 375, 379, 385, 389,
+# 393, 397, 401, 405, 409, 413, 417, 421
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncWrappersExtended:
+    @pytest.fixture(autouse=True)
+    def _local_mode(self, monkeypatch):
+        monkeypatch.setattr(storage.settings, "storage_backend", "local")
+
+    async def test_asave_preview_creates_file(self):
+        key = await storage.asave_preview(_pid(), b"\x89PNG")
+        assert storage.preview_exists(key) is True
+
+    async def test_asave_loom_photo_round_trip(self):
+        key = await storage.asave_loom_photo(_pid(), ".jpg", b"JPEG")
+        assert storage.file_exists(key) is True
+
+    async def test_adelete_loom_photo_removes_file(self):
+        key = await storage.asave_loom_photo(_pid(), ".jpg", b"JPEG")
+        await storage.adelete_loom_photo(key)
+        assert storage.file_exists(key) is False
+
+    async def test_asave_version_photo_round_trip(self):
+        key = await storage.asave_version_photo(_pid(), _pid(), _pid(), ".jpg", b"PHOTO")
+        assert storage.file_exists(key) is True
+
+    async def test_adelete_version_photo_removes_file(self):
+        key = await storage.asave_version_photo(_pid(), _pid(), _pid(), ".jpg", b"PHOTO")
+        await storage.adelete_version_photo(key)
+        assert storage.file_exists(key) is False
+
+    async def test_asave_version_receipt_round_trip(self):
+        key = await storage.asave_version_receipt(_pid(), _pid(), _pid(), ".pdf", b"PDF")
+        assert storage.file_exists(key) is True
+
+    async def test_adelete_version_receipt_removes_file(self):
+        key = await storage.asave_version_receipt(_pid(), _pid(), _pid(), ".pdf", b"PDF")
+        await storage.adelete_version_receipt(key)
+        assert storage.file_exists(key) is False
+
+    async def test_asave_yarn_photo_round_trip(self):
+        key = await storage.asave_yarn_photo(_pid(), ".jpg", b"YARN")
+        assert storage.file_exists(key) is True
+
+    async def test_adelete_yarn_photo_removes_file(self):
+        key = await storage.asave_yarn_photo(_pid(), ".jpg", b"YARN")
+        await storage.adelete_yarn_photo(key)
+        assert storage.file_exists(key) is False
+
+    async def test_asave_project_drawdown_preview_round_trip(self):
+        key = await storage.asave_project_drawdown_preview(b"\x89PNG")
+        assert await storage.aread_project_drawdown_preview(key) == b"\x89PNG"
+
+    async def test_aproject_drawdown_preview_exists_true(self):
+        key = await storage.asave_project_drawdown_preview(b"img")
+        assert await storage.aproject_drawdown_preview_exists(key) is True
+
+    async def test_aproject_drawdown_preview_exists_false_for_none(self):
+        assert await storage.aproject_drawdown_preview_exists(None) is False
+
+    async def test_asave_project_drawdown_svg_round_trip(self):
+        key = await storage.asave_project_drawdown_svg("<svg/>")
+        assert await storage.aread_project_drawdown_svg(key) == "<svg/>"
+
+    async def test_aproject_drawdown_svg_exists_true(self):
+        key = await storage.asave_project_drawdown_svg("<svg/>")
+        assert await storage.aproject_drawdown_svg_exists(key) is True
+
+    async def test_aproject_drawdown_svg_exists_false_for_none(self):
+        assert await storage.aproject_drawdown_svg_exists(None) is False

--- a/backend/tests/services/test_storage_quota.py
+++ b/backend/tests/services/test_storage_quota.py
@@ -1,12 +1,12 @@
 """Tests for app.services.storage_quota."""
 
 import uuid
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 
-from app.services.storage_quota import MAX_USER_STORAGE_BYTES, check_storage_quota
+from app.services.storage_quota import MAX_USER_STORAGE_BYTES, _s3_head, check_storage_quota, get_user_files_report
 
 
 class TestCheckStorageQuota:
@@ -48,3 +48,158 @@ class TestCheckStorageQuota:
             with pytest.raises(HTTPException) as exc_info:
                 await check_storage_quota(user_id, db=None, incoming_bytes=MAX_USER_STORAGE_BYTES)
         assert "300 MB" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# _s3_head — local filesystem backend
+# ---------------------------------------------------------------------------
+
+
+class TestS3HeadLocalBackend:
+    def test_missing_key_returns_false(self, tmp_path, monkeypatch):
+        from app.config import get_settings
+
+        monkeypatch.setattr(get_settings(), "storage_backend", "local")
+        monkeypatch.setattr(get_settings(), "upload_dir", str(tmp_path))
+        exists, size = _s3_head("drafts/nonexistent.wif")
+        assert exists is False
+        assert size is None
+
+    def test_existing_key_returns_true_with_size(self, tmp_path, monkeypatch):
+        from app.config import get_settings
+
+        monkeypatch.setattr(get_settings(), "storage_backend", "local")
+        monkeypatch.setattr(get_settings(), "upload_dir", str(tmp_path))
+        (tmp_path / "test.wif").write_bytes(b"hello")
+        exists, size = _s3_head("test.wif")
+        assert exists is True
+        assert size == 5
+
+
+class TestS3HeadS3Backend:
+    def test_existing_key_returns_true(self, monkeypatch):
+        from app.config import get_settings
+
+        monkeypatch.setattr(get_settings(), "storage_backend", "s3")
+        monkeypatch.setattr(get_settings(), "s3_bucket_name", "test-bucket")
+        mock_client = MagicMock()
+        mock_client.head_object.return_value = {"ContentLength": 1024}
+        with patch("app.services.storage._s3", return_value=mock_client):
+            exists, size = _s3_head("drafts/file.wif")
+        assert exists is True
+        assert size == 1024
+
+    def test_missing_key_returns_false(self, monkeypatch):
+        from botocore.exceptions import ClientError
+
+        from app.config import get_settings
+
+        monkeypatch.setattr(get_settings(), "storage_backend", "s3")
+        monkeypatch.setattr(get_settings(), "s3_bucket_name", "test-bucket")
+        mock_client = MagicMock()
+        mock_client.head_object.side_effect = ClientError({"Error": {"Code": "404"}}, "HeadObject")
+        with patch("app.services.storage._s3", return_value=mock_client):
+            exists, size = _s3_head("drafts/missing.wif")
+        assert exists is False
+        assert size is None
+
+
+# ---------------------------------------------------------------------------
+# get_user_files_report — optional path branches
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserFilesReport:
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_user_with_no_files(self, db_session, test_user):
+        result = await get_user_files_report(db_session, test_user.id)
+        assert isinstance(result, list)
+
+    @pytest.mark.asyncio
+    async def test_draft_wif_modified_path_included(self, db_session, test_user):
+        import app.services.storage as storage
+        from app.models.draft import Draft
+
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Test Draft",
+            wif_filename="test.wif",
+            wif_path=storage.save_wif(uuid.uuid4(), "test.wif", b"[WIF]"),
+            wif_modified_path=storage.save_wif(uuid.uuid4(), "test_modified.wif", b"[WIF]"),
+        )
+        db_session.add(draft)
+        await db_session.commit()
+
+        result = await get_user_files_report(db_session, test_user.id)
+        types = [f["entity_type"] for f in result]
+        assert "draft_wif_modified" in types
+
+    @pytest.mark.asyncio
+    async def test_draft_preview_path_included(self, db_session, test_user):
+        import app.services.storage as storage
+        from app.models.draft import Draft
+
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Test Draft 2",
+            wif_filename="test.wif",
+            wif_path=storage.save_wif(uuid.uuid4(), "test.wif", b"[WIF]"),
+            preview_path="previews/fake_preview.svg",
+            drawdown_preview_path="drawdown-previews/fake.png",
+        )
+        db_session.add(draft)
+        await db_session.commit()
+
+        result = await get_user_files_report(db_session, test_user.id)
+        types = [f["entity_type"] for f in result]
+        assert "draft_preview" in types
+        assert "draft_drawdown_preview" in types
+
+    @pytest.mark.asyncio
+    async def test_verify_s3_true_populates_s3_fields(self, db_session, test_user):
+        import app.services.storage as storage
+        from app.models.draft import Draft
+
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Verify Draft",
+            wif_filename="test.wif",
+            wif_path=storage.save_wif(uuid.uuid4(), "test.wif", b"[WIF]"),
+        )
+        db_session.add(draft)
+        await db_session.commit()
+
+        with patch("app.services.storage_quota._s3_head", return_value=(True, 42)):
+            result = await get_user_files_report(db_session, test_user.id, verify_s3=True)
+
+        assert len(result) >= 1
+        for f in result:
+            assert f["s3_verified"] is True
+            assert f["exists_in_s3"] is True
+            assert f["size_bytes"] == 42
+
+    @pytest.mark.asyncio
+    async def test_verify_s3_missing_file_marks_not_existing(self, db_session, test_user):
+        import app.services.storage as storage
+        from app.models.draft import Draft
+
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Missing Verify Draft",
+            wif_filename="test.wif",
+            wif_path=storage.save_wif(uuid.uuid4(), "test.wif", b"[WIF]"),
+        )
+        db_session.add(draft)
+        await db_session.commit()
+
+        with patch("app.services.storage_quota._s3_head", return_value=(False, None)):
+            result = await get_user_files_report(db_session, test_user.id, verify_s3=True)
+
+        assert len(result) >= 1
+        for f in result:
+            assert f["s3_verified"] is True
+            assert f["exists_in_s3"] is False

--- a/backend/tests/tasks/test_cve_scan.py
+++ b/backend/tests/tasks/test_cve_scan.py
@@ -1,0 +1,219 @@
+"""Tests for app.tasks.cve_scan._do_scan, _run_pip_audit, _scan_npm_osv, _store_summary."""
+
+import json
+import subprocess
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.tasks.cve_scan import CVE_SUMMARY_KEY, _do_scan, _run_pip_audit, _scan_npm_osv, _store_summary
+
+# ---------------------------------------------------------------------------
+# TestRunPipAudit — subprocess-backed pip-audit wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestRunPipAudit:
+    def _mock_run(self, stdout: str, returncode: int = 0):
+        r = MagicMock()
+        r.stdout = stdout
+        r.returncode = returncode
+        return r
+
+    def test_returns_empty_list_when_no_vulns(self):
+        pkg_json = json.dumps([{"name": "requests", "version": "2.28.0", "vulns": []}])
+        with patch("subprocess.run", return_value=self._mock_run(pkg_json)):
+            result = _run_pip_audit()
+        assert result == []
+
+    def test_returns_finding_for_vulnerable_package(self):
+        vuln = {
+            "id": "GHSA-xxxx",
+            "aliases": ["CVE-2023-0001"],
+            "fix_versions": ["2.29.0"],
+            "description": "A test vulnerability",
+        }
+        pkg_json = json.dumps([{"name": "requests", "version": "2.28.0", "vulns": [vuln]}])
+        with patch("subprocess.run", return_value=self._mock_run(pkg_json)):
+            result = _run_pip_audit()
+        assert len(result) == 1
+        assert result[0]["name"] == "requests"
+        assert len(result[0]["vulns"]) == 1
+
+    def test_returns_empty_list_when_pip_audit_missing(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError()):
+            result = _run_pip_audit()
+        assert result == []
+
+    def test_returns_empty_list_on_subprocess_error(self):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("pip-audit", 120)):
+            result = _run_pip_audit()
+        assert result == []
+
+    def test_handles_empty_stdout(self):
+        with patch("subprocess.run", return_value=self._mock_run("")):
+            result = _run_pip_audit()
+        assert result == []
+
+    def test_filters_packages_without_vulns(self):
+        pkg_json = json.dumps(
+            [
+                {"name": "safe-pkg", "version": "1.0.0", "vulns": []},
+                {"name": "bad-pkg", "version": "1.0.0", "vulns": [{"id": "CVE-1", "aliases": [], "fix_versions": []}]},
+            ]
+        )
+        with patch("subprocess.run", return_value=self._mock_run(pkg_json)):
+            result = _run_pip_audit()
+        assert len(result) == 1
+        assert result[0]["name"] == "bad-pkg"
+
+
+# ---------------------------------------------------------------------------
+# TestScanNpmOsv — async OSV.dev API scan
+# ---------------------------------------------------------------------------
+
+
+class TestScanNpmOsv:
+    async def test_returns_empty_list_for_empty_deps(self):
+        result = await _scan_npm_osv({})
+        assert result == []
+
+    async def test_returns_empty_list_on_http_error(self):
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=Exception("network error"))
+        mock_cls = MagicMock()
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("httpx.AsyncClient", mock_cls):
+            result = await _scan_npm_osv({"react": "18.0.0"})
+        assert result == []
+
+    async def test_returns_findings_for_vulnerable_npm_package(self):
+        osv_response = {
+            "results": [{"vulns": [{"id": "GHSA-npm-1", "aliases": [], "summary": "npm vuln", "details": ""}]}]
+        }
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = osv_response
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_cls = MagicMock()
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("httpx.AsyncClient", mock_cls):
+            result = await _scan_npm_osv({"vulnerable-pkg": "1.0.0"})
+
+        assert len(result) == 1
+        assert result[0]["name"] == "vulnerable-pkg"
+
+    async def test_returns_empty_for_packages_with_no_vulns(self):
+        osv_response = {"results": [{"vulns": []}]}
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = osv_response
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_cls = MagicMock()
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("httpx.AsyncClient", mock_cls):
+            result = await _scan_npm_osv({"safe-pkg": "1.0.0"})
+
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# TestStoreSummary — Redis summary write
+# ---------------------------------------------------------------------------
+
+
+class TestCveStoreSummary:
+    def test_writes_to_correct_redis_key(self):
+        mock_settings = MagicMock()
+        mock_settings.redis_url = "redis://localhost:6379/0"
+        mock_client = MagicMock()
+
+        with patch("redis.from_url", return_value=mock_client):
+            _store_summary(mock_settings, 3, "2026-01-01T00:00:00+00:00")
+
+        key = mock_client.set.call_args[0][0]
+        assert key == CVE_SUMMARY_KEY
+
+    def test_stores_finding_count(self):
+        mock_settings = MagicMock()
+        mock_settings.redis_url = "redis://localhost:6379/0"
+        mock_client = MagicMock()
+
+        with patch("redis.from_url", return_value=mock_client):
+            _store_summary(mock_settings, 7, "2026-01-01T00:00:00+00:00")
+
+        _key, value = mock_client.set.call_args[0]
+        data = json.loads(value)
+        assert data["finding_count"] == 7
+
+    def test_swallows_redis_exception(self):
+        mock_settings = MagicMock()
+        mock_settings.redis_url = "redis://localhost:6379/0"
+
+        with patch("redis.from_url", side_effect=Exception("redis down")):
+            _store_summary(mock_settings, 0, "2026-01-01T00:00:00+00:00")  # must not raise
+
+    def test_stores_scanned_at(self):
+        mock_settings = MagicMock()
+        mock_settings.redis_url = "redis://localhost:6379/0"
+        mock_client = MagicMock()
+        ts = "2026-05-18T10:00:00+00:00"
+
+        with patch("redis.from_url", return_value=mock_client):
+            _store_summary(mock_settings, 0, ts)
+
+        _key, value = mock_client.set.call_args[0]
+        data = json.loads(value)
+        assert data["scanned_at"] == ts
+
+
+# ---------------------------------------------------------------------------
+# TestDoScan — integration of the above
+# ---------------------------------------------------------------------------
+
+
+class TestDoScan:
+    async def test_returns_expected_keys(self):
+        with (
+            patch("app.tasks.cve_scan._run_pip_audit", return_value=[]),
+            patch("app.tasks.cve_scan._scan_npm_osv", new=AsyncMock(return_value=[])),
+            patch("app.tasks.cve_scan._store_summary"),
+            patch("app.config.get_settings", return_value=MagicMock()),
+        ):
+            result = await _do_scan({})
+
+        for key in ("backend_findings", "frontend_findings", "scanned_at", "total_findings"):
+            assert key in result
+
+    async def test_total_findings_sums_both_sources(self):
+        backend = [{"name": "pkg", "version": "1.0", "vulns": [{"id": "CVE-1"}]}]
+        frontend = [{"name": "npm-pkg", "version": "1.0", "vulns": [{"id": "CVE-2"}, {"id": "CVE-3"}]}]
+
+        with (
+            patch("app.tasks.cve_scan._run_pip_audit", return_value=backend),
+            patch("app.tasks.cve_scan._scan_npm_osv", new=AsyncMock(return_value=frontend)),
+            patch("app.tasks.cve_scan._store_summary"),
+            patch("app.config.get_settings", return_value=MagicMock()),
+        ):
+            result = await _do_scan({})
+
+        assert result["total_findings"] == 3
+
+    async def test_calls_store_summary(self):
+        with (
+            patch("app.tasks.cve_scan._run_pip_audit", return_value=[]),
+            patch("app.tasks.cve_scan._scan_npm_osv", new=AsyncMock(return_value=[])),
+            patch("app.tasks.cve_scan._store_summary") as mock_store,
+            patch("app.config.get_settings", return_value=MagicMock()),
+        ):
+            await _do_scan({})
+
+        mock_store.assert_called_once()

--- a/backend/tests/tasks/test_deletion_helpers.py
+++ b/backend/tests/tasks/test_deletion_helpers.py
@@ -1,0 +1,249 @@
+"""Tests for app.tasks.deletion helper functions.
+
+Kept separate from test_deletion_task.py because that file defines a local
+mock_storage fixture that shadows the conftest autouse mock_storage and patches
+_purge_storage for all tests in the file. These helpers need the real
+_purge_storage, so they live here.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# TestSafeDelete — _safe_delete helper
+# ---------------------------------------------------------------------------
+
+
+class TestSafeDelete:
+    def test_calls_storage_delete(self):
+        from app.tasks.deletion import _safe_delete
+
+        mock_storage = MagicMock()
+        _safe_delete(mock_storage, "drafts/file.wif")
+        mock_storage._delete.assert_called_once_with("drafts/file.wif")
+
+    def test_swallows_exceptions(self):
+        from app.tasks.deletion import _safe_delete
+
+        mock_storage = MagicMock()
+        mock_storage._delete.side_effect = Exception("storage gone")
+        _safe_delete(mock_storage, "drafts/file.wif")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# TestGetAdminAndSuperuserEmails — DB query helpers
+# ---------------------------------------------------------------------------
+
+
+class TestGetAdminEmails:
+    async def test_returns_admin_email(self, db_session, admin_user):
+        from app.tasks.deletion import _get_admin_emails
+
+        result = await _get_admin_emails(db_session)
+        assert admin_user.email in result
+
+    async def test_excludes_regular_user(self, db_session, test_user):
+        from app.tasks.deletion import _get_admin_emails
+
+        result = await _get_admin_emails(db_session)
+        assert test_user.email not in result
+
+    async def test_returns_list(self, db_session):
+        from app.tasks.deletion import _get_admin_emails
+
+        result = await _get_admin_emails(db_session)
+        assert isinstance(result, list)
+
+
+class TestGetSuperuserEmails:
+    async def test_returns_superuser_email(self, db_session, superuser_user):
+        from app.tasks.deletion import _get_superuser_emails
+
+        result = await _get_superuser_emails(db_session)
+        assert superuser_user.email in result
+
+    async def test_excludes_regular_admin(self, db_session, admin_user):
+        from app.tasks.deletion import _get_superuser_emails
+
+        result = await _get_superuser_emails(db_session)
+        assert admin_user.email not in result
+
+
+# ---------------------------------------------------------------------------
+# TestPurgeStorage — _purge_storage with real DB data
+# ---------------------------------------------------------------------------
+
+
+class TestPurgeStorage:
+    async def test_no_data_runs_cleanly(self, db_session, test_user):
+        from app.tasks.deletion import _purge_storage
+
+        mock_storage = MagicMock()
+        mock_storage.delete_project_tiles = MagicMock(return_value=0)
+        await _purge_storage(db_session, test_user.id, mock_storage)
+
+    async def test_deletes_draft_wif_path(self, db_session, test_user):
+        from app.models.draft import Draft
+        from app.tasks.deletion import _purge_storage
+
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Storage Draft",
+            wif_filename="storage.wif",
+            wif_path="drafts/storage.wif",
+        )
+        db_session.add(draft)
+        await db_session.commit()
+
+        mock_storage = MagicMock()
+        mock_storage.delete_project_tiles = MagicMock(return_value=0)
+        await _purge_storage(db_session, test_user.id, mock_storage)
+
+        mock_storage._delete.assert_any_call("drafts/storage.wif")
+
+    async def test_deletes_draft_preview_path(self, db_session, test_user):
+        from app.models.draft import Draft
+        from app.tasks.deletion import _purge_storage
+
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Preview Storage Draft",
+            wif_filename="pvstorage.wif",
+            wif_path="drafts/pvstorage.wif",
+            preview_path="previews/pvstorage.svg",
+        )
+        db_session.add(draft)
+        await db_session.commit()
+
+        mock_storage = MagicMock()
+        mock_storage.delete_project_tiles = MagicMock(return_value=0)
+        await _purge_storage(db_session, test_user.id, mock_storage)
+
+        called_paths = [c.args[0] for c in mock_storage._delete.call_args_list]
+        assert "previews/pvstorage.svg" in called_paths
+
+    async def test_deletes_yarn_photo(self, db_session, test_user):
+        from app.models.yarn import Yarn
+        from app.tasks.deletion import _purge_storage
+
+        yarn = Yarn(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            brand="TestBrand",
+            name="TestYarn",
+            photo_path="yarn-photos/test.jpg",
+        )
+        db_session.add(yarn)
+        await db_session.commit()
+
+        mock_storage = MagicMock()
+        mock_storage.delete_project_tiles = MagicMock(return_value=0)
+        await _purge_storage(db_session, test_user.id, mock_storage)
+
+        called_paths = [c.args[0] for c in mock_storage._delete.call_args_list]
+        assert "yarn-photos/test.jpg" in called_paths
+
+    async def test_deletes_loom_photo(self, db_session, test_user):
+        from app.models.loom import Loom
+        from app.tasks.deletion import _purge_storage
+
+        loom = Loom(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            loom_type="floor",
+            manufacturer="Acme",
+            model_name="TestLoom",
+            photo_path="loom-photos/test.jpg",
+        )
+        db_session.add(loom)
+        await db_session.commit()
+
+        mock_storage = MagicMock()
+        mock_storage.delete_project_tiles = MagicMock(return_value=0)
+        await _purge_storage(db_session, test_user.id, mock_storage)
+
+        called_paths = [c.args[0] for c in mock_storage._delete.call_args_list]
+        assert "loom-photos/test.jpg" in called_paths
+
+    async def test_skips_yarn_without_photo(self, db_session, test_user):
+        from app.models.yarn import Yarn
+        from app.tasks.deletion import _purge_storage
+
+        yarn = Yarn(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            brand="NoPic",
+            name="PlainYarn",
+        )
+        db_session.add(yarn)
+        await db_session.commit()
+
+        mock_storage = MagicMock()
+        mock_storage.delete_project_tiles = MagicMock(return_value=0)
+        await _purge_storage(db_session, test_user.id, mock_storage)
+        mock_storage._delete.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestNotifyHelpers — _notify_admins_complete / _notify_stalled
+# ---------------------------------------------------------------------------
+
+
+class TestNotifyAdminsComplete:
+    async def test_calls_email_when_admins_exist(self, db_session, admin_user):
+        from app.tasks.deletion import _notify_admins_complete
+
+        with patch("app.services.email.send_deletion_completed_admin", new_callable=AsyncMock) as mock_email:
+            await _notify_admins_complete(db_session, "user@example.com", "User Name")
+
+        mock_email.assert_called_once()
+        assert admin_user.email in mock_email.call_args[0][0]
+
+    async def test_no_call_when_no_admins(self, db_session, test_user):
+        from app.tasks.deletion import _notify_admins_complete
+
+        with patch("app.services.email.send_deletion_completed_admin", new_callable=AsyncMock) as mock_email:
+            await _notify_admins_complete(db_session, "user@example.com", "User Name")
+
+        mock_email.assert_not_called()
+
+    async def test_swallows_email_exception(self, db_session, admin_user):
+        from app.tasks.deletion import _notify_admins_complete
+
+        with patch(
+            "app.services.email.send_deletion_completed_admin",
+            new_callable=AsyncMock,
+            side_effect=Exception("smtp error"),
+        ):
+            await _notify_admins_complete(db_session, "user@example.com", "User Name")
+
+
+class TestNotifyStalled:
+    async def test_calls_email_when_superusers_exist(self, db_session, superuser_user):
+        from app.tasks.deletion import _notify_stalled
+
+        with patch("app.services.email.send_deletion_stalled_superuser", new_callable=AsyncMock) as mock_email:
+            await _notify_stalled(db_session, uuid.uuid4(), "user@example.com", "User Name")
+
+        mock_email.assert_called_once()
+        assert superuser_user.email in mock_email.call_args[0][0]
+
+    async def test_no_call_when_no_superusers(self, db_session, test_user):
+        from app.tasks.deletion import _notify_stalled
+
+        with patch("app.services.email.send_deletion_stalled_superuser", new_callable=AsyncMock) as mock_email:
+            await _notify_stalled(db_session, uuid.uuid4(), "user@example.com", "User Name")
+
+        mock_email.assert_not_called()
+
+    async def test_swallows_email_exception(self, db_session, superuser_user):
+        from app.tasks.deletion import _notify_stalled
+
+        with patch(
+            "app.services.email.send_deletion_stalled_superuser",
+            new_callable=AsyncMock,
+            side_effect=Exception("smtp error"),
+        ):
+            await _notify_stalled(db_session, uuid.uuid4(), "user@example.com", "User Name")

--- a/backend/tests/tasks/test_dispatch.py
+++ b/backend/tests/tasks/test_dispatch.py
@@ -1,0 +1,330 @@
+"""Tests for app.tasks.feedback_dispatch._dispatch and _send_emails."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.tasks.feedback_dispatch import _dispatch, _send_emails
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _celery_session_ctx(db_session):
+    """Return a CeleryAsyncSession-compatible factory that yields db_session."""
+
+    class _Ctx:
+        async def __aenter__(self):
+            return db_session
+
+        async def __aexit__(self, *args):
+            pass
+
+    class _Factory:
+        def __call__(self):
+            return _Ctx()
+
+    return _Factory()
+
+
+def _task_mock(retries: int = 0):
+    t = MagicMock()
+    t.request = MagicMock()
+    t.request.retries = retries
+    t.max_retries = 3
+    return t
+
+
+def _settings_mock(token="fake-github-token"):
+    m = MagicMock()
+    m.github_feedback_token = token
+    m.github_feedback_repo = "owner/repo"
+    return m
+
+
+# ---------------------------------------------------------------------------
+# TestDispatchNoToken — skips when no token configured
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchNoToken:
+    async def test_no_token_returns_skipped(self, db_session):
+        from app.models.feedback import UserFeedback
+
+        row = UserFeedback(id=uuid.uuid4(), submission_type="feedback", body="Hello!")
+        db_session.add(row)
+        await db_session.commit()
+
+        with (
+            patch("app.database.CeleryAsyncSession", _celery_session_ctx(db_session)),
+            patch("app.config.get_settings", return_value=_settings_mock(token=None)),
+        ):
+            result = await _dispatch(_task_mock(), str(row.id))
+
+        assert result["status"] == "skipped"
+
+    async def test_no_token_sets_skipped_status_in_db(self, db_session):
+        from app.models.feedback import UserFeedback
+
+        row = UserFeedback(id=uuid.uuid4(), submission_type="feedback", body="Hello!")
+        db_session.add(row)
+        await db_session.commit()
+
+        with (
+            patch("app.database.CeleryAsyncSession", _celery_session_ctx(db_session)),
+            patch("app.config.get_settings", return_value=_settings_mock(token=None)),
+        ):
+            await _dispatch(_task_mock(), str(row.id))
+
+        await db_session.refresh(row)
+        assert row.dispatch_status == "skipped"
+
+    async def test_no_token_row_not_in_db_still_returns_skipped(self, db_session):
+        with (
+            patch("app.database.CeleryAsyncSession", _celery_session_ctx(db_session)),
+            patch("app.config.get_settings", return_value=_settings_mock(token=None)),
+        ):
+            result = await _dispatch(_task_mock(), str(uuid.uuid4()))
+
+        assert result["status"] == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# TestDispatchNotFound — row missing from DB
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchNotFound:
+    async def test_returns_not_found_when_row_absent(self, db_session):
+        with (
+            patch("app.database.CeleryAsyncSession", _celery_session_ctx(db_session)),
+            patch("app.config.get_settings", return_value=_settings_mock()),
+        ):
+            result = await _dispatch(_task_mock(), str(uuid.uuid4()))
+
+        assert result["status"] == "not_found"
+
+
+# ---------------------------------------------------------------------------
+# TestDispatchSuccess — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchSuccess:
+    async def _feedback_row(self, db_session):
+        from app.models.feedback import UserFeedback
+
+        row = UserFeedback(id=uuid.uuid4(), submission_type="feedback", body="Test body")
+        db_session.add(row)
+        await db_session.commit()
+        return row
+
+    async def test_sets_dispatch_status_sent(self, db_session):
+        row = await self._feedback_row(db_session)
+        expected_url = "https://github.com/owner/repo/discussions/1"
+
+        with (
+            patch("app.database.CeleryAsyncSession", _celery_session_ctx(db_session)),
+            patch("app.config.get_settings", return_value=_settings_mock()),
+            patch("app.services.github_discussions.create_discussion", new=AsyncMock(return_value=expected_url)),
+            patch("app.tasks.feedback_dispatch._send_emails", new=AsyncMock()),
+        ):
+            result = await _dispatch(_task_mock(), str(row.id))
+
+        assert result["status"] == "sent"
+        await db_session.refresh(row)
+        assert row.dispatch_status == "sent"
+
+    async def test_returns_discussion_url(self, db_session):
+        row = await self._feedback_row(db_session)
+        expected_url = "https://github.com/owner/repo/discussions/99"
+
+        with (
+            patch("app.database.CeleryAsyncSession", _celery_session_ctx(db_session)),
+            patch("app.config.get_settings", return_value=_settings_mock()),
+            patch("app.services.github_discussions.create_discussion", new=AsyncMock(return_value=expected_url)),
+            patch("app.tasks.feedback_dispatch._send_emails", new=AsyncMock()),
+        ):
+            result = await _dispatch(_task_mock(), str(row.id))
+
+        assert result["url"] == expected_url
+
+    async def test_stores_discussion_url_in_db(self, db_session):
+        row = await self._feedback_row(db_session)
+        expected_url = "https://github.com/discussions/42"
+
+        with (
+            patch("app.database.CeleryAsyncSession", _celery_session_ctx(db_session)),
+            patch("app.config.get_settings", return_value=_settings_mock()),
+            patch("app.services.github_discussions.create_discussion", new=AsyncMock(return_value=expected_url)),
+            patch("app.tasks.feedback_dispatch._send_emails", new=AsyncMock()),
+        ):
+            await _dispatch(_task_mock(), str(row.id))
+
+        await db_session.refresh(row)
+        assert row.github_discussion_url == expected_url
+
+
+# ---------------------------------------------------------------------------
+# TestDispatchFailure — exception in create_discussion
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchFailure:
+    async def _feedback_row(self, db_session):
+        from app.models.feedback import UserFeedback
+
+        row = UserFeedback(id=uuid.uuid4(), submission_type="feedback", body="Test")
+        db_session.add(row)
+        await db_session.commit()
+        return row
+
+    async def test_sets_dispatch_status_failed_on_exception(self, db_session):
+        row = await self._feedback_row(db_session)
+
+        task = _task_mock()
+        task.retry = MagicMock(return_value=RuntimeError("retry scheduled"))
+
+        with (
+            patch("app.database.CeleryAsyncSession", _celery_session_ctx(db_session)),
+            patch("app.config.get_settings", return_value=_settings_mock()),
+            patch(
+                "app.services.github_discussions.create_discussion",
+                new=AsyncMock(side_effect=RuntimeError("API error")),
+            ),
+        ):
+            with pytest.raises(RuntimeError):
+                await _dispatch(task, str(row.id))
+
+        await db_session.refresh(row)
+        assert row.dispatch_status == "failed"
+
+    async def test_stores_error_message_on_failure(self, db_session):
+        row = await self._feedback_row(db_session)
+
+        task = _task_mock()
+        task.retry = MagicMock(return_value=RuntimeError("retry"))
+
+        with (
+            patch("app.database.CeleryAsyncSession", _celery_session_ctx(db_session)),
+            patch("app.config.get_settings", return_value=_settings_mock()),
+            patch(
+                "app.services.github_discussions.create_discussion",
+                new=AsyncMock(side_effect=RuntimeError("API error")),
+            ),
+        ):
+            with pytest.raises(RuntimeError):
+                await _dispatch(task, str(row.id))
+
+        await db_session.refresh(row)
+        assert row.dispatch_error is not None
+
+    async def test_calls_task_retry_on_exception(self, db_session):
+        row = await self._feedback_row(db_session)
+
+        task = _task_mock(retries=0)
+        task.retry = MagicMock(return_value=RuntimeError("retry"))
+
+        with (
+            patch("app.database.CeleryAsyncSession", _celery_session_ctx(db_session)),
+            patch("app.config.get_settings", return_value=_settings_mock()),
+            patch(
+                "app.services.github_discussions.create_discussion",
+                new=AsyncMock(side_effect=RuntimeError("API error")),
+            ),
+        ):
+            with pytest.raises(RuntimeError):
+                await _dispatch(task, str(row.id))
+
+        task.retry.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TestSendEmails — _send_emails helper
+# ---------------------------------------------------------------------------
+
+
+class TestSendEmails:
+    async def _feedback_row(self, db_session, *, user_id=None, is_anonymous=False):
+        from app.models.feedback import UserFeedback
+
+        row = UserFeedback(
+            id=uuid.uuid4(),
+            submission_type="feedback",
+            body="Hello",
+            is_anonymous=is_anonymous,
+            user_id=user_id,
+        )
+        db_session.add(row)
+        await db_session.commit()
+        return row
+
+    async def test_calls_admin_alert_when_admins_exist(self, db_session, admin_user):
+        row = await self._feedback_row(db_session)
+
+        with (
+            patch("app.database.CeleryAsyncSession", _celery_session_ctx(db_session)),
+            patch("app.services.email.send_feedback_admin_alert", new=AsyncMock()) as mock_alert,
+            patch("app.services.email.send_feedback_user_confirmation", new=AsyncMock()),
+        ):
+            await _send_emails(str(row.id), "https://github.com/d/1", _settings_mock())
+
+        mock_alert.assert_called_once()
+
+    async def test_no_admin_alert_when_no_admins(self, db_session, test_user):
+        row = await self._feedback_row(db_session)
+
+        with (
+            patch("app.database.CeleryAsyncSession", _celery_session_ctx(db_session)),
+            patch("app.services.email.send_feedback_admin_alert", new=AsyncMock()) as mock_alert,
+            patch("app.services.email.send_feedback_user_confirmation", new=AsyncMock()),
+        ):
+            await _send_emails(str(row.id), "https://github.com/d/1", _settings_mock())
+
+        mock_alert.assert_not_called()
+
+    async def test_sends_user_confirmation_for_non_anonymous_user(self, db_session, test_user):
+        row = await self._feedback_row(db_session, user_id=test_user.id, is_anonymous=False)
+
+        with (
+            patch("app.database.CeleryAsyncSession", _celery_session_ctx(db_session)),
+            patch("app.services.email.send_feedback_admin_alert", new=AsyncMock()),
+            patch("app.services.email.send_feedback_user_confirmation", new=AsyncMock()) as mock_confirm,
+        ):
+            await _send_emails(str(row.id), "https://github.com/d/1", _settings_mock())
+
+        mock_confirm.assert_called_once()
+
+    async def test_skips_user_confirmation_for_anonymous(self, db_session, test_user):
+        row = await self._feedback_row(db_session, user_id=test_user.id, is_anonymous=True)
+
+        with (
+            patch("app.database.CeleryAsyncSession", _celery_session_ctx(db_session)),
+            patch("app.services.email.send_feedback_admin_alert", new=AsyncMock()),
+            patch("app.services.email.send_feedback_user_confirmation", new=AsyncMock()) as mock_confirm,
+        ):
+            await _send_emails(str(row.id), "https://github.com/d/1", _settings_mock())
+
+        mock_confirm.assert_not_called()
+
+    async def test_skips_confirmation_when_no_user_id(self, db_session):
+        row = await self._feedback_row(db_session, user_id=None, is_anonymous=False)
+
+        with (
+            patch("app.database.CeleryAsyncSession", _celery_session_ctx(db_session)),
+            patch("app.services.email.send_feedback_admin_alert", new=AsyncMock()),
+            patch("app.services.email.send_feedback_user_confirmation", new=AsyncMock()) as mock_confirm,
+        ):
+            await _send_emails(str(row.id), "https://github.com/d/1", _settings_mock())
+
+        mock_confirm.assert_not_called()
+
+    async def test_returns_silently_when_row_not_found(self, db_session):
+        with (
+            patch("app.database.CeleryAsyncSession", _celery_session_ctx(db_session)),
+            patch("app.services.email.send_feedback_admin_alert", new=AsyncMock()),
+            patch("app.services.email.send_feedback_user_confirmation", new=AsyncMock()),
+        ):
+            await _send_emails(str(uuid.uuid4()), "https://github.com/d/1", _settings_mock())

--- a/backend/tests/tasks/test_feedback_dispatch.py
+++ b/backend/tests/tasks/test_feedback_dispatch.py
@@ -1,0 +1,268 @@
+"""Tests for app.tasks.feedback_dispatch async inner functions.
+
+_dispatch, _retry_failed, and _purge_deleted are tested by calling them
+directly (bypassing the Celery task wrapper) with CeleryAsyncSession
+redirected to the test db_session.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _ago(**kwargs) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(**kwargs)
+
+
+def _session_ctx(db_session):
+    """Return an async context manager that yields db_session."""
+
+    class _Ctx:
+        async def __aenter__(self):
+            return db_session
+
+        async def __aexit__(self, *args):
+            pass
+
+    class _Factory:
+        def __call__(self):
+            return _Ctx()
+
+    return _Factory()
+
+
+# ---------------------------------------------------------------------------
+# _retry_failed — no-token early exit path
+# ---------------------------------------------------------------------------
+
+
+class TestRetryFailedNoToken:
+    @pytest.mark.asyncio
+    async def test_returns_no_token_reason_when_token_missing(self, monkeypatch):
+        from app.config import get_settings
+        from app.tasks.feedback_dispatch import _retry_failed
+
+        monkeypatch.setattr(get_settings(), "github_feedback_token", "")
+
+        with patch("app.database.CeleryAsyncSession", _session_ctx(None)):
+            result = await _retry_failed(limit=20)
+
+        assert result.get("reason") == "no_token"
+        assert result["dispatched"] == 0
+
+    @pytest.mark.asyncio
+    async def test_no_dispatches_when_token_missing(self, monkeypatch):
+        from app.config import get_settings
+        from app.tasks.feedback_dispatch import _retry_failed
+
+        monkeypatch.setattr(get_settings(), "github_feedback_token", "")
+
+        mock_dispatch = MagicMock()
+        with patch("app.tasks.feedback_dispatch.dispatch_feedback", mock_dispatch):
+            await _retry_failed(limit=20)
+
+        mock_dispatch.delay.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _purge_deleted — deletes soft-deleted feedback past retention window
+# ---------------------------------------------------------------------------
+
+
+class TestPurgeDeleted:
+    @pytest.mark.asyncio
+    async def test_returns_deleted_key(self, db_session):
+        from app.tasks.feedback_dispatch import _purge_deleted
+
+        with patch("app.database.CeleryAsyncSession", _session_ctx(db_session)):
+            result = await _purge_deleted(retention_days=7)
+
+        assert "deleted" in result
+        assert isinstance(result["deleted"], int)
+
+    @pytest.mark.asyncio
+    async def test_zero_when_nothing_deleted(self, db_session):
+        from app.tasks.feedback_dispatch import _purge_deleted
+
+        with patch("app.database.CeleryAsyncSession", _session_ctx(db_session)):
+            result = await _purge_deleted(retention_days=7)
+
+        assert result["deleted"] == 0
+
+    @pytest.mark.asyncio
+    async def test_hard_deletes_old_soft_deleted_feedback(self, db_session, test_user):
+        from sqlalchemy import select
+
+        from app.models.feedback import UserFeedback
+        from app.tasks.feedback_dispatch import _purge_deleted
+
+        old_deleted = UserFeedback(
+            id=uuid.uuid4(),
+            user_id=test_user.id,
+            submission_type="bug",
+            body="old deleted feedback",
+            deleted_at=_ago(days=30),
+        )
+        db_session.add(old_deleted)
+        await db_session.commit()
+
+        with patch("app.database.CeleryAsyncSession", _session_ctx(db_session)):
+            result = await _purge_deleted(retention_days=7)
+
+        assert result["deleted"] >= 1
+
+        remaining = (await db_session.scalars(select(UserFeedback))).all()
+        assert all(str(f.id) != str(old_deleted.id) for f in remaining)
+
+    @pytest.mark.asyncio
+    async def test_keeps_recently_soft_deleted_feedback(self, db_session, test_user):
+        from sqlalchemy import select
+
+        from app.models.feedback import UserFeedback
+        from app.tasks.feedback_dispatch import _purge_deleted
+
+        recent_deleted = UserFeedback(
+            id=uuid.uuid4(),
+            user_id=test_user.id,
+            submission_type="bug",
+            body="recently deleted feedback",
+            deleted_at=_ago(days=1),
+        )
+        db_session.add(recent_deleted)
+        await db_session.commit()
+
+        with patch("app.database.CeleryAsyncSession", _session_ctx(db_session)):
+            result = await _purge_deleted(retention_days=7)
+
+        assert result["deleted"] == 0
+
+        remaining = (await db_session.scalars(select(UserFeedback))).all()
+        assert any(str(f.id) == str(recent_deleted.id) for f in remaining)
+
+    @pytest.mark.asyncio
+    async def test_keeps_non_deleted_feedback(self, db_session, test_user):
+        from sqlalchemy import select
+
+        from app.models.feedback import UserFeedback
+        from app.tasks.feedback_dispatch import _purge_deleted
+
+        active = UserFeedback(
+            id=uuid.uuid4(),
+            user_id=test_user.id,
+            submission_type="feature",
+            body="active feedback",
+        )
+        db_session.add(active)
+        await db_session.commit()
+
+        with patch("app.database.CeleryAsyncSession", _session_ctx(db_session)):
+            result = await _purge_deleted(retention_days=7)
+
+        assert result["deleted"] == 0
+
+        remaining = (await db_session.scalars(select(UserFeedback))).all()
+        assert any(str(f.id) == str(active.id) for f in remaining)
+
+
+# ---------------------------------------------------------------------------
+# _retry_failed — with-token path (dispatches for failed/stale feedback)
+# ---------------------------------------------------------------------------
+
+
+class TestRetryFailedWithToken:
+    @pytest.mark.asyncio
+    async def test_dispatches_for_failed_feedback(self, db_session, test_user, monkeypatch):
+        from app.config import get_settings
+        from app.models.feedback import UserFeedback
+        from app.tasks.feedback_dispatch import _retry_failed
+
+        monkeypatch.setattr(get_settings(), "github_feedback_token", "ghp_faketoken")
+
+        failed_fb = UserFeedback(
+            id=uuid.uuid4(),
+            user_id=test_user.id,
+            submission_type="bug",
+            body="failed feedback",
+            dispatch_status="failed",
+        )
+        db_session.add(failed_fb)
+        await db_session.commit()
+
+        mock_dispatch = MagicMock()
+        mock_dispatch.delay.return_value = MagicMock(id="task-123")
+
+        with (
+            patch("app.database.CeleryAsyncSession", _session_ctx(db_session)),
+            patch("app.tasks.feedback_dispatch.dispatch_feedback", mock_dispatch),
+            patch("app.services.task_history.record_queued"),
+        ):
+            result = await _retry_failed(limit=20)
+
+        assert result["dispatched"] >= 1
+        mock_dispatch.delay.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_respects_limit(self, db_session, test_user, monkeypatch):
+        from app.config import get_settings
+        from app.models.feedback import UserFeedback
+        from app.tasks.feedback_dispatch import _retry_failed
+
+        monkeypatch.setattr(get_settings(), "github_feedback_token", "ghp_faketoken")
+
+        for _ in range(5):
+            fb = UserFeedback(
+                id=uuid.uuid4(),
+                user_id=test_user.id,
+                submission_type="bug",
+                body="failed feedback",
+                dispatch_status="failed",
+            )
+            db_session.add(fb)
+        await db_session.commit()
+
+        mock_dispatch = MagicMock()
+        mock_dispatch.delay.return_value = MagicMock(id="task-123")
+
+        with (
+            patch("app.database.CeleryAsyncSession", _session_ctx(db_session)),
+            patch("app.tasks.feedback_dispatch.dispatch_feedback", mock_dispatch),
+            patch("app.services.task_history.record_queued"),
+        ):
+            result = await _retry_failed(limit=2)
+
+        assert result["dispatched"] == 2
+        assert mock_dispatch.delay.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_skips_pending_recent_feedback(self, db_session, test_user, monkeypatch):
+        from app.config import get_settings
+        from app.models.feedback import UserFeedback
+        from app.tasks.feedback_dispatch import _retry_failed
+
+        monkeypatch.setattr(get_settings(), "github_feedback_token", "ghp_faketoken")
+
+        recent_pending = UserFeedback(
+            id=uuid.uuid4(),
+            user_id=test_user.id,
+            submission_type="bug",
+            body="recent pending",
+            dispatch_status="pending",
+        )
+        db_session.add(recent_pending)
+        await db_session.commit()
+
+        mock_dispatch = MagicMock()
+        mock_dispatch.delay.return_value = MagicMock(id="task-123")
+
+        with (
+            patch("app.database.CeleryAsyncSession", _session_ctx(db_session)),
+            patch("app.tasks.feedback_dispatch.dispatch_feedback", mock_dispatch),
+            patch("app.services.task_history.record_queued"),
+        ):
+            result = await _retry_failed(limit=20)
+
+        # recent pending (< 10 min old) should be skipped
+        assert result["dispatched"] == 0
+        mock_dispatch.delay.assert_not_called()

--- a/backend/tests/tasks/test_maintenance.py
+++ b/backend/tests/tasks/test_maintenance.py
@@ -1020,3 +1020,431 @@ class TestPruneInactiveProjectTiles:
 
         mock_del.assert_called_once_with(project.id)
         assert result["pruned_projects"] == 1
+
+
+# ---------------------------------------------------------------------------
+# prune_server_event_log
+# ---------------------------------------------------------------------------
+
+
+class TestPruneServerEventLog:
+    def test_returns_result_keys(self):
+        from app.tasks.maintenance import prune_server_event_log
+
+        result = prune_server_event_log.run.__func__(_make_task(), max_age_days=9999, max_entries=1000)
+        assert "deleted_age" in result
+        assert "deleted_overflow" in result
+
+    def test_zero_when_nothing_old(self):
+        from app.tasks.maintenance import prune_server_event_log
+
+        result = prune_server_event_log.run.__func__(_make_task(), max_age_days=9999, max_entries=9999)
+        assert result["deleted_age"] == 0
+        assert result["deleted_overflow"] == 0
+
+    @pytest.mark.asyncio
+    async def test_deletes_old_events(self, db_session):
+        from sqlalchemy import select
+
+        from app.models.server_event import ServerEvent
+        from app.tasks.maintenance import prune_server_event_log
+
+        old_evt = ServerEvent(
+            event_type="health.check",
+            severity="info",
+            status="closed",
+            started_at=_ago(days=60),
+            ended_at=_ago(days=60),
+            app_version="0.0.1",
+            message="old event",
+            details={},
+        )
+        db_session.add(old_evt)
+        await db_session.commit()
+
+        result = prune_server_event_log.run.__func__(_make_task(), max_age_days=30, max_entries=9999)
+        assert result["deleted_age"] >= 1
+
+        remaining = (await db_session.scalars(select(ServerEvent))).all()
+        assert all(e.message != "old event" for e in remaining)
+
+    @pytest.mark.asyncio
+    async def test_keeps_recent_events(self, db_session):
+        from sqlalchemy import select
+
+        from app.models.server_event import ServerEvent
+        from app.tasks.maintenance import prune_server_event_log
+
+        recent = ServerEvent(
+            event_type="health.check",
+            severity="info",
+            status="closed",
+            started_at=_ago(hours=1),
+            ended_at=_ago(hours=1),
+            app_version="0.0.1",
+            message="recent event",
+            details={},
+        )
+        db_session.add(recent)
+        await db_session.commit()
+
+        result = prune_server_event_log.run.__func__(_make_task(), max_age_days=30, max_entries=9999)
+        assert result["deleted_age"] == 0
+
+        remaining = (await db_session.scalars(select(ServerEvent))).all()
+        assert any(e.message == "recent event" for e in remaining)
+
+    @pytest.mark.asyncio
+    async def test_overflow_prunes_oldest_first(self, db_session):
+        from sqlalchemy import select
+
+        from app.models.server_event import ServerEvent
+        from app.tasks.maintenance import prune_server_event_log
+
+        for i in range(5):
+            evt = ServerEvent(
+                event_type="health.check",
+                severity="info",
+                status="closed",
+                started_at=_ago(hours=5 - i),
+                ended_at=_ago(hours=5 - i),
+                app_version="0.0.1",
+                message=f"overflow_event_{i}",
+                details={},
+            )
+            db_session.add(evt)
+        await db_session.commit()
+
+        result = prune_server_event_log.run.__func__(_make_task(), max_age_days=9999, max_entries=3)
+        assert result["deleted_overflow"] == 2
+
+        remaining = (await db_session.scalars(select(ServerEvent))).all()
+        assert len(remaining) == 3
+
+
+# ---------------------------------------------------------------------------
+# _fmt_bytes and _fmt_delta
+# ---------------------------------------------------------------------------
+
+
+class TestFmtBytes:
+    def test_bytes(self):
+        from app.tasks.maintenance import _fmt_bytes
+
+        assert _fmt_bytes(500) == "500 B"
+
+    def test_kilobytes(self):
+        from app.tasks.maintenance import _fmt_bytes
+
+        assert "KB" in _fmt_bytes(2048)
+
+    def test_megabytes(self):
+        from app.tasks.maintenance import _fmt_bytes
+
+        assert "MB" in _fmt_bytes(2 * 1024 * 1024)
+
+    def test_gigabytes(self):
+        from app.tasks.maintenance import _fmt_bytes
+
+        assert "GB" in _fmt_bytes(2 * 1024 * 1024 * 1024)
+
+
+class TestFmtDelta:
+    def test_positive_delta(self):
+        from app.tasks.maintenance import _fmt_delta
+
+        result = _fmt_delta(1024)
+        assert result.startswith("+")
+
+    def test_negative_delta(self):
+        from app.tasks.maintenance import _fmt_delta
+
+        result = _fmt_delta(-1024)
+        assert result.startswith("-")
+
+
+# ---------------------------------------------------------------------------
+# _send_credential_alerts (the inner async helper)
+# ---------------------------------------------------------------------------
+
+
+class TestSendCredentialAlerts:
+    @pytest.mark.asyncio
+    async def test_sends_to_superusers_and_admins(self):
+        from unittest.mock import AsyncMock, patch
+
+        from app.tasks.maintenance import _send_credential_alerts
+
+        with (
+            patch("app.services.email.send_credential_expiring_superuser", new_callable=AsyncMock) as mock_su,
+            patch("app.services.email.send_credential_expiring_admin", new_callable=AsyncMock) as mock_adm,
+        ):
+            await _send_credential_alerts(
+                superuser_emails=["su@test.com"],
+                admin_emails=["admin@test.com"],
+                credential_name="Test Cred",
+                resource="test-resource",
+                days_remaining=5,
+                expires_on="2026-06-01",
+            )
+
+        mock_su.assert_called_once()
+        mock_adm.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_passes_correct_credential_name(self):
+        from unittest.mock import AsyncMock, patch
+
+        from app.tasks.maintenance import _send_credential_alerts
+
+        with (
+            patch("app.services.email.send_credential_expiring_superuser", new_callable=AsyncMock) as mock_su,
+            patch("app.services.email.send_credential_expiring_admin", new_callable=AsyncMock),
+        ):
+            await _send_credential_alerts(
+                superuser_emails=["su@test.com"],
+                admin_emails=[],
+                credential_name="My API Key",
+                resource="some-service",
+                days_remaining=3,
+                expires_on="2026-07-01",
+            )
+        call_kwargs = mock_su.call_args.kwargs
+        assert call_kwargs["credential_name"] == "My API Key"
+
+
+# ---------------------------------------------------------------------------
+# send_admin_digest — Redis-populated CVE/S3 branches
+# ---------------------------------------------------------------------------
+
+
+class TestSendAdminDigestRedisBranches:
+    @pytest.mark.asyncio
+    async def test_cve_data_from_redis_used(self, db_session):
+        import json
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from app.models.user import User
+        from app.tasks.cve_scan import CVE_SUMMARY_KEY
+        from app.tasks.maintenance import send_admin_digest
+
+        admin = User(
+            id=uuid.uuid4(),
+            email=f"admin-{uuid.uuid4().hex[:8]}@example.test",
+            display_name="Admin",
+            is_admin=True,
+            is_active=True,
+        )
+        db_session.add(admin)
+        await db_session.commit()
+
+        cve_data = json.dumps({"finding_count": 3, "scanned_at": "2026-05-18T02:00:00"})
+
+        mock_client = MagicMock()
+
+        def _redis_get(key):
+            if key == CVE_SUMMARY_KEY:
+                return cve_data.encode()
+            return None
+
+        mock_client.get.side_effect = _redis_get
+
+        with (
+            patch("app.tasks.maintenance._send_admin_digest_email", new_callable=AsyncMock) as mock_send,
+            patch("redis.from_url", return_value=mock_client),
+        ):
+            result = send_admin_digest.run.__func__(_make_task())
+
+        assert result["sent"] == 1
+        call_kwargs = mock_send.call_args.kwargs
+        assert call_kwargs["cve_finding_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_s3_data_from_redis_used(self, db_session):
+        import json
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from app.models.user import User
+        from app.tasks.maintenance import send_admin_digest
+        from app.tasks.s3_audit import S3_AUDIT_SUMMARY_KEY
+
+        admin = User(
+            id=uuid.uuid4(),
+            email=f"admin-{uuid.uuid4().hex[:8]}@example.test",
+            display_name="Admin",
+            is_admin=True,
+            is_active=True,
+        )
+        db_session.add(admin)
+        await db_session.commit()
+
+        s3_data = json.dumps({"orphaned_count": 5, "scanned_at": "2026-05-18T03:00:00", "not_applicable": False})
+
+        mock_client = MagicMock()
+
+        def _redis_get(key):
+            if key == S3_AUDIT_SUMMARY_KEY:
+                return s3_data.encode()
+            return None
+
+        mock_client.get.side_effect = _redis_get
+
+        with (
+            patch("app.tasks.maintenance._send_admin_digest_email", new_callable=AsyncMock) as mock_send,
+            patch("redis.from_url", return_value=mock_client),
+        ):
+            result = send_admin_digest.run.__func__(_make_task())
+
+        assert result["sent"] == 1
+        call_kwargs = mock_send.call_args.kwargs
+        assert call_kwargs["s3_orphaned_count"] == 5
+
+
+# ---------------------------------------------------------------------------
+# _send_admin_digest_email — async email helper
+# ---------------------------------------------------------------------------
+
+
+class TestSendAdminDigestEmail:
+    @pytest.mark.asyncio
+    async def test_calls_email_service(self):
+        from app.tasks.maintenance import _send_admin_digest_email
+
+        with patch("app.services.email.send_admin_digest_email", new=AsyncMock()) as mock_send:
+            await _send_admin_digest_email(
+                admin_emails=["admin@test.com"],
+                week_start="2026-01-01",
+                week_end="2026-01-07",
+                new_users=5,
+                pending_signups=2,
+                new_drafts=10,
+                new_projects=3,
+                new_looms=1,
+                storage_str="1.5 GB",
+                storage_delta_str="+100 MB",
+                cve_finding_count=0,
+                cve_scanned_at=None,
+                s3_orphaned_count=None,
+                s3_scanned_at=None,
+            )
+
+        mock_send.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_passes_admin_emails_through(self):
+        from app.tasks.maintenance import _send_admin_digest_email
+
+        with patch("app.services.email.send_admin_digest_email", new=AsyncMock()) as mock_send:
+            await _send_admin_digest_email(
+                admin_emails=["a@test.com", "b@test.com"],
+                week_start="2026-01-01",
+                week_end="2026-01-07",
+                new_users=0,
+                pending_signups=0,
+                new_drafts=0,
+                new_projects=0,
+                new_looms=0,
+                storage_str="0 B",
+                storage_delta_str=None,
+                cve_finding_count=None,
+                cve_scanned_at=None,
+                s3_orphaned_count=None,
+                s3_scanned_at=None,
+            )
+
+        call_kwargs = mock_send.call_args.kwargs
+        assert call_kwargs["admin_emails"] == ["a@test.com", "b@test.com"]
+
+
+# ---------------------------------------------------------------------------
+# expire_project_slugs — revoke expired share slugs
+# ---------------------------------------------------------------------------
+
+
+class TestExpireProjectSlugs:
+    def test_returns_revoked_key(self):
+        from app.tasks.maintenance import expire_project_slugs
+
+        result = expire_project_slugs.run.__func__(_make_task())
+        assert "revoked" in result
+
+    def test_zero_when_no_expired_slugs(self):
+        from app.tasks.maintenance import expire_project_slugs
+
+        result = expire_project_slugs.run.__func__(_make_task())
+        assert result["revoked"] == 0
+
+    @pytest.mark.asyncio
+    async def test_revokes_expired_project_slug(self, db_session, test_user):
+
+        from app.models.draft import Draft
+        from app.models.project import Project
+        from app.tasks.maintenance import expire_project_slugs
+
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Slug Draft",
+            wif_filename="slug.wif",
+            wif_path="drafts/slug.wif",
+        )
+        db_session.add(draft)
+        await db_session.flush()
+
+        project = Project(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="Shared Project",
+            project_type="weave",
+            total_picks=4,
+            share_slug="test-slug-expired",
+            share_visibility="public",
+            share_expires_at=_ago(days=1),
+        )
+        db_session.add(project)
+        await db_session.commit()
+
+        result = expire_project_slugs.run.__func__(_make_task())
+        assert result["revoked"] >= 1
+
+        await db_session.refresh(project)
+        assert project.share_slug is None
+        assert project.share_visibility == "private"
+
+    @pytest.mark.asyncio
+    async def test_preserves_non_expired_slug(self, db_session, test_user):
+        from app.models.draft import Draft
+        from app.models.project import Project
+        from app.tasks.maintenance import expire_project_slugs
+
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Future Draft",
+            wif_filename="future.wif",
+            wif_path="drafts/future.wif",
+        )
+        db_session.add(draft)
+        await db_session.flush()
+
+        future_time = datetime.now(timezone.utc) + timedelta(days=7)
+        project = Project(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="Future Shared",
+            project_type="weave",
+            total_picks=4,
+            share_slug="not-yet-expired",
+            share_visibility="public",
+            share_expires_at=future_time,
+        )
+        db_session.add(project)
+        await db_session.commit()
+
+        result = expire_project_slugs.run.__func__(_make_task())
+        assert result["revoked"] == 0
+
+        await db_session.refresh(project)
+        assert project.share_slug == "not-yet-expired"

--- a/backend/tests/tasks/test_purge.py
+++ b/backend/tests/tasks/test_purge.py
@@ -1,0 +1,541 @@
+"""Tests for app.tasks.purge._purge and _safe_delete.
+
+_purge creates its own DB engine via local imports of create_async_engine /
+sessionmaker, so we patch those at the sqlalchemy module level and redirect
+them to the test db_session.  This lets us exercise the real SQL logic without
+a separate connection.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.tasks.purge import _purge, _safe_delete
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ago(**kwargs) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(**kwargs)
+
+
+def _session_factory(db: AsyncSession):
+    """Return a sessionmaker-compatible callable that yields db as the session."""
+
+    class _Ctx:
+        async def __aenter__(self):
+            return db
+
+        async def __aexit__(self, *args):
+            pass
+
+    class _Factory:
+        def __call__(self, *args, **kwargs):
+            return _Ctx()
+
+    return _Factory()
+
+
+@pytest.fixture()
+def mock_engine_and_session(db_session: AsyncSession):
+    """Patch engine/session creation so _purge runs against db_session."""
+    fake_engine = MagicMock()
+    fake_engine.dispose = AsyncMock()
+    with (
+        patch("sqlalchemy.ext.asyncio.create_async_engine", return_value=fake_engine),
+        patch("sqlalchemy.orm.sessionmaker", return_value=_session_factory(db_session)),
+    ):
+        yield fake_engine
+
+
+# ---------------------------------------------------------------------------
+# TestSafeDelete
+# ---------------------------------------------------------------------------
+
+
+class TestSafeDelete:
+    def test_calls_storage_delete(self):
+        mock_storage = MagicMock()
+        _safe_delete(mock_storage, "drafts/some.wif")
+        mock_storage._delete.assert_called_once_with("drafts/some.wif")
+
+    def test_swallows_exceptions(self):
+        mock_storage = MagicMock()
+        mock_storage._delete.side_effect = Exception("storage unavailable")
+        _safe_delete(mock_storage, "drafts/some.wif")  # must not raise
+
+    def test_logs_on_exception(self, caplog):
+        import logging
+
+        mock_storage = MagicMock()
+        mock_storage._delete.side_effect = RuntimeError("boom")
+        with caplog.at_level(logging.WARNING, logger="app.tasks.purge"):
+            _safe_delete(mock_storage, "bad/path.wif")
+        assert "purge_storage_error" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# TestPurgeEmpty — no deleted records; covers main control flow
+# ---------------------------------------------------------------------------
+
+
+class TestPurgeEmpty:
+    @pytest.mark.asyncio
+    async def test_returns_expected_keys(self, db_session, mock_engine_and_session):
+        result = await _purge(7)
+        assert "projects" in result
+        assert "yarn" in result
+        assert "looms" in result
+        assert "drafts" in result
+        assert "total" in result
+        assert "retention_days" in result
+
+    @pytest.mark.asyncio
+    async def test_all_counts_zero_when_no_deleted_records(self, db_session, mock_engine_and_session):
+        result = await _purge(7)
+        assert result["projects"] == 0
+        assert result["yarn"] == 0
+        assert result["looms"] == 0
+        assert result["drafts"] == 0
+        assert result["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_retention_days_echoed(self, db_session, mock_engine_and_session):
+        result = await _purge(30)
+        assert result["retention_days"] == 30
+
+    @pytest.mark.asyncio
+    async def test_engine_disposed(self, db_session, mock_engine_and_session):
+        await _purge(7)
+        mock_engine_and_session.dispose.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TestPurgeDrafts — with actual soft-deleted draft records
+# ---------------------------------------------------------------------------
+
+
+class TestPurgeDrafts:
+    @pytest.mark.asyncio
+    async def test_deletes_old_soft_deleted_draft(self, db_session, test_user, mock_engine_and_session):
+        from sqlalchemy import select
+
+        from app.models.draft import Draft
+
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Old Draft",
+            wif_filename="old.wif",
+            wif_path="drafts/old.wif",
+            deleted_at=_ago(days=30),
+        )
+        db_session.add(draft)
+        await db_session.commit()
+
+        result = await _purge(7)
+
+        assert result["drafts"] >= 1
+        remaining = (await db_session.scalars(select(Draft))).all()
+        assert all(str(d.id) != str(draft.id) for d in remaining)
+
+    @pytest.mark.asyncio
+    async def test_keeps_recently_soft_deleted_draft(self, db_session, test_user, mock_engine_and_session):
+        from sqlalchemy import select
+
+        from app.models.draft import Draft
+
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Recent Draft",
+            wif_filename="recent.wif",
+            wif_path="drafts/recent.wif",
+            deleted_at=_ago(days=1),
+        )
+        db_session.add(draft)
+        await db_session.commit()
+
+        result = await _purge(7)
+
+        assert result["drafts"] == 0
+        remaining = (await db_session.scalars(select(Draft))).all()
+        assert any(str(d.id) == str(draft.id) for d in remaining)
+
+    @pytest.mark.asyncio
+    async def test_keeps_non_deleted_draft(self, db_session, test_user, mock_engine_and_session):
+        from sqlalchemy import select
+
+        from app.models.draft import Draft
+
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Active Draft",
+            wif_filename="active.wif",
+            wif_path="drafts/active.wif",
+        )
+        db_session.add(draft)
+        await db_session.commit()
+
+        result = await _purge(7)
+
+        assert result["drafts"] == 0
+        remaining = (await db_session.scalars(select(Draft))).all()
+        assert any(str(d.id) == str(draft.id) for d in remaining)
+
+    @pytest.mark.asyncio
+    async def test_deletes_preview_storage_path(self, db_session, test_user, mock_engine_and_session):
+        from app.models.draft import Draft
+
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Preview Draft",
+            wif_filename="preview.wif",
+            wif_path="drafts/preview.wif",
+            preview_path="previews/preview.svg",
+            drawdown_preview_path="drawdown-previews/preview.png",
+            deleted_at=_ago(days=30),
+        )
+        db_session.add(draft)
+        await db_session.commit()
+
+        result = await _purge(7)
+        assert result["drafts"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# TestPurgeYarn — with actual soft-deleted yarn records
+# ---------------------------------------------------------------------------
+
+
+class TestPurgeYarn:
+    @pytest.mark.asyncio
+    async def test_deletes_old_soft_deleted_yarn(self, db_session, test_user, mock_engine_and_session):
+        from sqlalchemy import select
+
+        from app.models.yarn import Yarn
+
+        yarn = Yarn(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            brand="OldBrand",
+            name="OldYarn",
+            deleted_at=_ago(days=30),
+        )
+        db_session.add(yarn)
+        await db_session.commit()
+
+        result = await _purge(7)
+
+        assert result["yarn"] >= 1
+        remaining = (await db_session.scalars(select(Yarn))).all()
+        assert all(str(y.id) != str(yarn.id) for y in remaining)
+
+    @pytest.mark.asyncio
+    async def test_keeps_recently_deleted_yarn(self, db_session, test_user, mock_engine_and_session):
+        from sqlalchemy import select
+
+        from app.models.yarn import Yarn
+
+        yarn = Yarn(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            brand="NewBrand",
+            name="NewYarn",
+            deleted_at=_ago(days=1),
+        )
+        db_session.add(yarn)
+        await db_session.commit()
+
+        result = await _purge(7)
+
+        assert result["yarn"] == 0
+        remaining = (await db_session.scalars(select(Yarn))).all()
+        assert any(str(y.id) == str(yarn.id) for y in remaining)
+
+
+# ---------------------------------------------------------------------------
+# TestPurgeLooms — with actual soft-deleted loom records
+# ---------------------------------------------------------------------------
+
+
+class TestPurgeLooms:
+    @pytest.mark.asyncio
+    async def test_deletes_old_soft_deleted_loom(self, db_session, test_user, mock_engine_and_session):
+        from sqlalchemy import select
+
+        from app.models.loom import Loom
+
+        loom = Loom(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            loom_type="floor",
+            manufacturer="Acme",
+            model_name="OldLoom",
+            deleted_at=_ago(days=30),
+        )
+        db_session.add(loom)
+        await db_session.commit()
+
+        result = await _purge(7)
+
+        assert result["looms"] >= 1
+        remaining = (await db_session.scalars(select(Loom))).all()
+        assert all(str(lm.id) != str(loom.id) for lm in remaining)
+
+    @pytest.mark.asyncio
+    async def test_keeps_recently_deleted_loom(self, db_session, test_user, mock_engine_and_session):
+        from sqlalchemy import select
+
+        from app.models.loom import Loom
+
+        loom = Loom(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            loom_type="table",
+            manufacturer="BrandX",
+            model_name="RecentLoom",
+            deleted_at=_ago(days=1),
+        )
+        db_session.add(loom)
+        await db_session.commit()
+
+        result = await _purge(7)
+
+        assert result["looms"] == 0
+        remaining = (await db_session.scalars(select(Loom))).all()
+        assert any(str(lm.id) == str(loom.id) for lm in remaining)
+
+
+# ---------------------------------------------------------------------------
+# TestPurgeProjects — with actual soft-deleted project records and photos
+# ---------------------------------------------------------------------------
+
+
+class TestPurgeProjects:
+    async def _make_draft(self, db_session, test_user, suffix=""):
+        from app.models.draft import Draft
+
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name=f"ProjDraft{suffix}",
+            wif_filename=f"proj{suffix}.wif",
+            wif_path=f"drafts/proj{suffix}.wif",
+        )
+        db_session.add(draft)
+        await db_session.flush()
+        return draft
+
+    @pytest.mark.asyncio
+    async def test_deletes_old_soft_deleted_project(self, db_session, test_user, mock_engine_and_session):
+        from sqlalchemy import select
+
+        from app.models.project import Project
+
+        draft = await self._make_draft(db_session, test_user, suffix="-del")
+        project = Project(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="Old Project",
+            project_type="treadle",
+            total_picks=4,
+            deleted_at=_ago(days=30),
+        )
+        db_session.add(project)
+        await db_session.commit()
+
+        result = await _purge(7)
+
+        assert result["projects"] >= 1
+        remaining = (await db_session.scalars(select(Project))).all()
+        assert all(str(p.id) != str(project.id) for p in remaining)
+
+    @pytest.mark.asyncio
+    async def test_deletes_project_photos_before_project(self, db_session, test_user, mock_engine_and_session):
+        from sqlalchemy import select
+
+        from app.models.project import Project, ProjectPhoto
+
+        draft = await self._make_draft(db_session, test_user, suffix="-photo")
+        project = Project(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="Photo Project",
+            project_type="treadle",
+            total_picks=4,
+            deleted_at=_ago(days=30),
+        )
+        db_session.add(project)
+        await db_session.flush()
+
+        photo = ProjectPhoto(
+            id=uuid.uuid4(),
+            project_id=project.id,
+            file_path="projects/photo.jpg",
+            filename="photo.jpg",
+        )
+        db_session.add(photo)
+        await db_session.commit()
+
+        result = await _purge(7)
+
+        assert result["projects"] >= 1
+        remaining_photos = (await db_session.scalars(select(ProjectPhoto))).all()
+        assert all(str(p.id) != str(photo.id) for p in remaining_photos)
+
+    @pytest.mark.asyncio
+    async def test_keeps_recently_deleted_project(self, db_session, test_user, mock_engine_and_session):
+        from sqlalchemy import select
+
+        from app.models.project import Project
+
+        draft = await self._make_draft(db_session, test_user, suffix="-recent")
+        project = Project(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="Recent Project",
+            project_type="treadle",
+            total_picks=4,
+            deleted_at=_ago(days=1),
+        )
+        db_session.add(project)
+        await db_session.commit()
+
+        result = await _purge(7)
+
+        assert result["projects"] == 0
+        remaining = (await db_session.scalars(select(Project))).all()
+        assert any(str(p.id) == str(project.id) for p in remaining)
+
+
+# ---------------------------------------------------------------------------
+# TestPurgeYarnWithPhoto — yarn deletion with photo_path storage cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestPurgeYarnWithPhoto:
+    @pytest.mark.asyncio
+    async def test_deletes_yarn_with_photo_path(self, db_session, test_user, mock_engine_and_session):
+        from sqlalchemy import select
+
+        from app.models.yarn import Yarn
+
+        yarn = Yarn(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            brand="PhotoBrand",
+            name="PhotoYarn",
+            photo_path="yarn/photo.jpg",
+            deleted_at=_ago(days=30),
+        )
+        db_session.add(yarn)
+        await db_session.commit()
+
+        result = await _purge(7)
+
+        assert result["yarn"] >= 1
+        remaining = (await db_session.scalars(select(Yarn))).all()
+        assert all(str(y.id) != str(yarn.id) for y in remaining)
+
+
+# ---------------------------------------------------------------------------
+# TestPurgeLoomsWithPhoto — loom deletion with photo_path storage cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestPurgeLoomsWithPhoto:
+    @pytest.mark.asyncio
+    async def test_deletes_loom_with_photo_path(self, db_session, test_user, mock_engine_and_session):
+        from sqlalchemy import select
+
+        from app.models.loom import Loom
+
+        loom = Loom(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            loom_type="floor_loom",
+            manufacturer="PhotoMaker",
+            model_name="PhotoLoom",
+            photo_path="looms/photo.jpg",
+            deleted_at=_ago(days=30),
+        )
+        db_session.add(loom)
+        await db_session.commit()
+
+        result = await _purge(7)
+
+        assert result["looms"] >= 1
+        remaining = (await db_session.scalars(select(Loom))).all()
+        assert all(str(lm.id) != str(loom.id) for lm in remaining)
+
+
+# ---------------------------------------------------------------------------
+# TestPurgeLoomsWithVersions — loom version attachment cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestPurgeLoomsWithVersions:
+    @pytest.mark.asyncio
+    async def test_deletes_loom_versions_and_photos(self, db_session, test_user, mock_engine_and_session):
+        from datetime import date
+
+        from sqlalchemy import select
+
+        from app.models.loom import Loom, LoomVersion, LoomVersionPhoto, LoomVersionReceipt
+
+        loom = Loom(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            loom_type="floor_loom",
+            manufacturer="VersionMaker",
+            model_name="VersionLoom",
+            deleted_at=_ago(days=30),
+        )
+        db_session.add(loom)
+        await db_session.flush()
+
+        version = LoomVersion(
+            id=uuid.uuid4(),
+            loom_id=loom.id,
+            version_number=1,
+            effective_date=date.today(),
+        )
+        db_session.add(version)
+        await db_session.flush()
+
+        photo = LoomVersionPhoto(
+            id=uuid.uuid4(),
+            loom_version_id=version.id,
+            filename="loom-photo.jpg",
+            path="loom-versions/photo.jpg",
+        )
+        receipt = LoomVersionReceipt(
+            id=uuid.uuid4(),
+            loom_version_id=version.id,
+            filename="receipt.pdf",
+            path="loom-versions/receipt.pdf",
+        )
+        db_session.add(photo)
+        db_session.add(receipt)
+        await db_session.commit()
+
+        result = await _purge(7)
+
+        assert result["looms"] >= 1
+        remaining_versions = (await db_session.scalars(select(LoomVersion))).all()
+        assert all(str(v.id) != str(version.id) for v in remaining_versions)
+        remaining_photos = (await db_session.scalars(select(LoomVersionPhoto))).all()
+        assert all(str(p.id) != str(photo.id) for p in remaining_photos)
+        remaining_receipts = (await db_session.scalars(select(LoomVersionReceipt))).all()
+        assert all(str(r.id) != str(receipt.id) for r in remaining_receipts)

--- a/backend/tests/tasks/test_reparse.py
+++ b/backend/tests/tasks/test_reparse.py
@@ -1,0 +1,203 @@
+"""Tests for app.tasks.reparse._reparse_all."""
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+MINIMAL_WIF = b"""[WIF]
+Version=1.1
+Date=April 2024
+Source Program=TestSuite
+
+[CONTENTS]
+THREADING=true
+TIEUP=true
+TREADLING=true
+COLOR TABLE=true
+COLOR PALETTE=true
+
+[WEAVING]
+Shafts=4
+Treadles=4
+Rising Shed=true
+
+[WARP]
+Threads=4
+Units=Inches
+Color=1
+
+[WEFT]
+Threads=4
+Units=Inches
+Color=2
+
+[COLOR PALETTE]
+Range=0,255
+Form=Decimal
+
+[COLOR TABLE]
+1=200,50,50
+2=50,50,200
+
+[THREADING]
+1=1
+2=2
+3=3
+4=4
+
+[TIEUP]
+1=1
+2=2
+3=3
+4=4
+
+[TREADLING]
+1=1
+2=2
+3=3
+4=4
+"""
+
+
+def _session_factory(db: AsyncSession):
+    class _Ctx:
+        async def __aenter__(self):
+            return db
+
+        async def __aexit__(self, *args):
+            pass
+
+    class _Factory:
+        def __call__(self, *args, **kwargs):
+            return _Ctx()
+
+    return _Factory()
+
+
+@pytest.fixture()
+def mock_engine_and_session(db_session: AsyncSession):
+    fake_engine = MagicMock()
+    fake_engine.dispose = AsyncMock()
+    with (
+        patch("app.tasks.reparse.create_async_engine", return_value=fake_engine),
+        patch("app.tasks.reparse.sessionmaker", return_value=_session_factory(db_session)),
+    ):
+        yield fake_engine
+
+
+# ---------------------------------------------------------------------------
+# TestReparseAll
+# ---------------------------------------------------------------------------
+
+
+class TestReparseAll:
+    async def test_returns_expected_keys(self, db_session, mock_engine_and_session):
+        from app.tasks.reparse import _reparse_all
+
+        result = await _reparse_all()
+        assert "updated" in result
+        assert "skipped" in result
+        assert "errors" in result
+
+    async def test_empty_database_returns_zeros(self, db_session, mock_engine_and_session):
+        from app.tasks.reparse import _reparse_all
+
+        result = await _reparse_all()
+        assert result["updated"] == 0
+        assert result["skipped"] == 0
+        assert result["errors"] == 0
+
+    async def test_engine_disposed(self, db_session, mock_engine_and_session):
+        from app.tasks.reparse import _reparse_all
+
+        await _reparse_all()
+        mock_engine_and_session.dispose.assert_called_once()
+
+    async def test_draft_without_wif_path_is_skipped(self, db_session, test_user, mock_engine_and_session):
+        from app.models.draft import Draft
+        from app.tasks.reparse import _reparse_all
+
+        # wif_path is NOT NULL in the schema; use a non-existing path so
+        # file_exists() returns False and the draft is counted as skipped.
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name="No WIF",
+            wif_filename="nope.wif",
+            wif_path="drafts/nope-not-here.wif",
+        )
+        db_session.add(draft)
+        await db_session.commit()
+
+        result = await _reparse_all()
+        assert result["skipped"] >= 1
+        assert result["updated"] == 0
+
+    async def test_draft_with_wif_path_but_file_missing_is_skipped(
+        self, db_session, test_user, mock_engine_and_session
+    ):
+        from app.models.draft import Draft
+        from app.tasks.reparse import _reparse_all
+
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Missing File",
+            wif_filename="missing.wif",
+            wif_path="drafts/no-such-file.wif",
+        )
+        db_session.add(draft)
+        await db_session.commit()
+
+        result = await _reparse_all()
+        assert result["skipped"] >= 1
+        assert result["updated"] == 0
+
+    async def test_draft_with_valid_wif_is_updated(self, db_session, test_user, mock_engine_and_session):
+        import app.services.storage as _storage
+        from app.models.draft import Draft
+        from app.tasks.reparse import _reparse_all
+
+        wif_key = f"drafts/reparse-{uuid.uuid4().hex}.wif"
+        _storage._put(wif_key, MINIMAL_WIF)
+
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Valid WIF",
+            wif_filename="valid.wif",
+            wif_path=wif_key,
+        )
+        db_session.add(draft)
+        await db_session.commit()
+
+        result = await _reparse_all()
+        assert result["updated"] >= 1
+        assert result["skipped"] == 0
+
+    async def test_deleted_draft_excluded(self, db_session, test_user, mock_engine_and_session):
+        import app.services.storage as _storage
+        from app.models.draft import Draft
+        from app.tasks.reparse import _reparse_all
+
+        wif_key = f"drafts/deleted-{uuid.uuid4().hex}.wif"
+        _storage._put(wif_key, MINIMAL_WIF)
+
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Deleted Draft",
+            wif_filename="deleted.wif",
+            wif_path=wif_key,
+            deleted_at=datetime.now(timezone.utc),
+        )
+        db_session.add(draft)
+        await db_session.commit()
+
+        result = await _reparse_all()
+        # Deleted drafts are excluded by the WHERE clause
+        assert result["updated"] == 0
+        assert result["skipped"] == 0

--- a/backend/tests/tasks/test_s3_audit.py
+++ b/backend/tests/tasks/test_s3_audit.py
@@ -1,0 +1,314 @@
+"""Tests for app.tasks.s3_audit._do_scan and _store_s3_summary."""
+
+import json
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.tasks.s3_audit import S3_AUDIT_SUMMARY_KEY, _do_scan, _store_s3_summary
+
+# ---------------------------------------------------------------------------
+# Helpers for redirecting DB engine/session to test db_session
+# ---------------------------------------------------------------------------
+
+
+def _session_factory(db: AsyncSession):
+    class _Ctx:
+        async def __aenter__(self):
+            return db
+
+        async def __aexit__(self, *args):
+            pass
+
+    class _Factory:
+        def __call__(self, *args, **kwargs):
+            return _Ctx()
+
+    return _Factory()
+
+
+@pytest.fixture()
+def mock_engine_and_session(db_session: AsyncSession):
+    fake_engine = MagicMock()
+    fake_engine.dispose = AsyncMock()
+    with (
+        patch("sqlalchemy.ext.asyncio.create_async_engine", return_value=fake_engine),
+        patch("sqlalchemy.orm.sessionmaker", return_value=_session_factory(db_session)),
+    ):
+        yield fake_engine
+
+
+# ---------------------------------------------------------------------------
+# TestDoScanNotApplicable — non-S3 backend takes the fast early-return path
+# ---------------------------------------------------------------------------
+
+
+class TestDoScanNotApplicable:
+    async def test_returns_not_applicable_flag(self):
+        mock_settings = MagicMock()
+        mock_settings.storage_backend = "local"
+        mock_settings.redis_url = "redis://localhost:6379/0"
+
+        with (
+            patch("app.config.get_settings", return_value=mock_settings),
+            patch("redis.from_url", return_value=MagicMock()),
+        ):
+            result = await _do_scan()
+
+        assert result["not_applicable"] is True
+
+    async def test_returns_zero_counts(self):
+        mock_settings = MagicMock()
+        mock_settings.storage_backend = "local"
+        mock_settings.redis_url = "redis://localhost:6379/0"
+
+        with (
+            patch("app.config.get_settings", return_value=mock_settings),
+            patch("redis.from_url", return_value=MagicMock()),
+        ):
+            result = await _do_scan()
+
+        assert result["orphaned_count"] == 0
+        assert result["total_s3_keys"] == 0
+        assert result["total_db_paths"] == 0
+
+    async def test_returns_expected_keys(self):
+        mock_settings = MagicMock()
+        mock_settings.storage_backend = "local"
+        mock_settings.redis_url = "redis://localhost:6379/0"
+
+        with (
+            patch("app.config.get_settings", return_value=mock_settings),
+            patch("redis.from_url", return_value=MagicMock()),
+        ):
+            result = await _do_scan()
+
+        for key in ("total_s3_keys", "total_db_paths", "orphaned_count", "orphaned_files", "not_applicable"):
+            assert key in result
+
+    async def test_stores_summary_to_redis(self):
+        mock_settings = MagicMock()
+        mock_settings.storage_backend = "local"
+        mock_settings.redis_url = "redis://localhost:6379/0"
+
+        mock_client = MagicMock()
+        with (
+            patch("app.config.get_settings", return_value=mock_settings),
+            patch("redis.from_url", return_value=mock_client),
+        ):
+            await _do_scan()
+
+        mock_client.set.assert_called_once()
+        _key, stored_json = mock_client.set.call_args[0]
+        stored = json.loads(stored_json)
+        assert stored["not_applicable"] is True
+
+
+# ---------------------------------------------------------------------------
+# TestStoreSummary — _store_s3_summary Redis writes
+# ---------------------------------------------------------------------------
+
+
+class TestStoreSummary:
+    def test_writes_to_correct_redis_key(self):
+        mock_settings = MagicMock()
+        mock_settings.redis_url = "redis://localhost:6379/0"
+        mock_client = MagicMock()
+
+        with patch("redis.from_url", return_value=mock_client):
+            _store_s3_summary(mock_settings, 5)
+
+        mock_client.set.assert_called_once()
+        key = mock_client.set.call_args[0][0]
+        assert key == S3_AUDIT_SUMMARY_KEY
+
+    def test_stores_orphaned_count(self):
+        mock_settings = MagicMock()
+        mock_settings.redis_url = "redis://localhost:6379/0"
+        mock_client = MagicMock()
+
+        with patch("redis.from_url", return_value=mock_client):
+            _store_s3_summary(mock_settings, 7)
+
+        _key, value = mock_client.set.call_args[0]
+        data = json.loads(value)
+        assert data["orphaned_count"] == 7
+
+    def test_stores_not_applicable_flag(self):
+        mock_settings = MagicMock()
+        mock_settings.redis_url = "redis://localhost:6379/0"
+        mock_client = MagicMock()
+
+        with patch("redis.from_url", return_value=mock_client):
+            _store_s3_summary(mock_settings, 0, not_applicable=True)
+
+        _key, value = mock_client.set.call_args[0]
+        data = json.loads(value)
+        assert data["not_applicable"] is True
+
+    def test_stores_scanned_at_timestamp(self):
+        mock_settings = MagicMock()
+        mock_settings.redis_url = "redis://localhost:6379/0"
+        mock_client = MagicMock()
+
+        with patch("redis.from_url", return_value=mock_client):
+            _store_s3_summary(mock_settings, 3)
+
+        _key, value = mock_client.set.call_args[0]
+        data = json.loads(value)
+        assert "scanned_at" in data
+
+    def test_swallows_redis_exception(self):
+        mock_settings = MagicMock()
+        mock_settings.redis_url = "redis://localhost:6379/0"
+
+        with patch("redis.from_url", side_effect=Exception("redis down")):
+            _store_s3_summary(mock_settings, 0)  # must not raise
+
+    def test_closes_redis_client(self):
+        mock_settings = MagicMock()
+        mock_settings.redis_url = "redis://localhost:6379/0"
+        mock_client = MagicMock()
+
+        with patch("redis.from_url", return_value=mock_client):
+            _store_s3_summary(mock_settings, 0)
+
+        mock_client.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TestDoScanS3Path — full boto3 S3 scan path (storage_backend=s3)
+# ---------------------------------------------------------------------------
+
+
+def _s3_settings(**overrides):
+    s = MagicMock()
+    s.storage_backend = "s3"
+    s.s3_bucket_name = "test-bucket"
+    s.s3_endpoint_url = "https://s3.example.com"
+    s.s3_access_key_id = "AKID"
+    s.s3_secret_access_key = "secret"
+    s.s3_region = "us-east-1"
+    s.redis_url = "redis://localhost:6379/0"
+    for k, v in overrides.items():
+        setattr(s, k, v)
+    return s
+
+
+def _mock_s3(pages: list[dict]):
+    paginator = MagicMock()
+    paginator.paginate.return_value = iter(pages)
+    client = MagicMock()
+    client.get_paginator.return_value = paginator
+    return client
+
+
+class TestDoScanS3Path:
+    async def test_returns_not_applicable_false(self, db_session, mock_engine_and_session):
+        s3 = _mock_s3([{"Contents": []}])
+        with (
+            patch("app.config.get_settings", return_value=_s3_settings()),
+            patch("boto3.client", return_value=s3),
+            patch("redis.from_url", return_value=MagicMock()),
+        ):
+            result = await _do_scan()
+
+        assert result["not_applicable"] is False
+
+    async def test_returns_expected_keys(self, db_session, mock_engine_and_session):
+        s3 = _mock_s3([{"Contents": []}])
+        with (
+            patch("app.config.get_settings", return_value=_s3_settings()),
+            patch("boto3.client", return_value=s3),
+            patch("redis.from_url", return_value=MagicMock()),
+        ):
+            result = await _do_scan()
+
+        for key in ("total_s3_keys", "total_db_paths", "orphaned_count", "orphaned_files", "not_applicable"):
+            assert key in result
+
+    async def test_empty_bucket_produces_zero_orphans(self, db_session, mock_engine_and_session):
+        s3 = _mock_s3([{}])  # page with no Contents key
+        with (
+            patch("app.config.get_settings", return_value=_s3_settings()),
+            patch("boto3.client", return_value=s3),
+            patch("redis.from_url", return_value=MagicMock()),
+        ):
+            result = await _do_scan()
+
+        assert result["orphaned_count"] == 0
+        assert result["total_s3_keys"] == 0
+
+    async def test_detects_orphaned_file(self, db_session, mock_engine_and_session):
+        orphan_key = "drafts/orphaned-file.wif"
+        page = {"Contents": [{"Key": orphan_key, "Size": 512, "LastModified": datetime.now(timezone.utc)}]}
+        s3 = _mock_s3([page])
+
+        with (
+            patch("app.config.get_settings", return_value=_s3_settings()),
+            patch("boto3.client", return_value=s3),
+            patch("redis.from_url", return_value=MagicMock()),
+        ):
+            result = await _do_scan()
+
+        assert result["orphaned_count"] >= 1
+        assert any(f["key"] == orphan_key for f in result["orphaned_files"])
+
+    async def test_known_db_path_not_orphaned(self, db_session, test_user, mock_engine_and_session):
+        import app.services.storage as _storage
+        from app.models.draft import Draft
+
+        wif_key = f"drafts/known-{uuid.uuid4().hex}.wif"
+        _storage._put(wif_key, b"WIF content")
+
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Known Draft",
+            wif_filename="known.wif",
+            wif_path=wif_key,
+        )
+        db_session.add(draft)
+        await db_session.commit()
+
+        page = {"Contents": [{"Key": wif_key, "Size": 11, "LastModified": datetime.now(timezone.utc)}]}
+        s3 = _mock_s3([page])
+
+        with (
+            patch("app.config.get_settings", return_value=_s3_settings()),
+            patch("boto3.client", return_value=s3),
+            patch("redis.from_url", return_value=MagicMock()),
+        ):
+            result = await _do_scan()
+
+        assert result["orphaned_count"] == 0
+        assert result["total_s3_keys"] == 1
+
+    async def test_calls_store_summary_with_orphan_count(self, db_session, mock_engine_and_session):
+        orphan_key = "stale/file.jpg"
+        page = {"Contents": [{"Key": orphan_key, "Size": 100, "LastModified": datetime.now(timezone.utc)}]}
+        s3 = _mock_s3([page])
+
+        with (
+            patch("app.config.get_settings", return_value=_s3_settings()),
+            patch("boto3.client", return_value=s3),
+            patch("redis.from_url", return_value=MagicMock()) as mock_redis,
+        ):
+            result = await _do_scan()
+
+        assert result["orphaned_count"] >= 1
+        mock_redis.assert_called()
+
+    async def test_disposes_engine(self, db_session, mock_engine_and_session):
+        s3 = _mock_s3([{"Contents": []}])
+        with (
+            patch("app.config.get_settings", return_value=_s3_settings()),
+            patch("boto3.client", return_value=s3),
+            patch("redis.from_url", return_value=MagicMock()),
+        ):
+            await _do_scan()
+
+        mock_engine_and_session.dispose.assert_called_once()

--- a/backend/tests/tasks/test_scheduler.py
+++ b/backend/tests/tasks/test_scheduler.py
@@ -1,0 +1,527 @@
+"""Tests for app.tasks.scheduler dispatch functions.
+
+Each _dispatch_* function is tested by mocking the Celery task's .delay()
+method and record_queued so no real Celery worker or DB connection is needed.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from app.tasks.scheduler import (
+    DISPATCH_FNS,
+    REGISTRY,
+    _dispatch_admin_digest,
+    _dispatch_audit_log_pruning,
+    _dispatch_credential_expiry_check,
+    _dispatch_cve_scan,
+    _dispatch_daily_health_check,
+    _dispatch_feedback_purge,
+    _dispatch_feedback_retry,
+    _dispatch_heartbeat,
+    _dispatch_invite_pruning,
+    _dispatch_preview_retry,
+    _dispatch_s3_audit,
+    _dispatch_server_event_log_pruning,
+    _dispatch_stale_signup_dismissal,
+    _dispatch_tile_prune,
+)
+
+
+def _fake_settings():
+    from app.config import get_settings
+
+    return get_settings()
+
+
+def _mock_task():
+    """Return a mock task object with a mock .delay() that returns a stub result."""
+    m = MagicMock()
+    m.delay.return_value = MagicMock(id="task-id-123")
+    return m
+
+
+# ---------------------------------------------------------------------------
+# REGISTRY sanity
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_all_registry_keys_have_dispatch_fn(self):
+        for slug in REGISTRY:
+            assert slug in DISPATCH_FNS, f"no dispatch function for registry slug: {slug}"
+
+    def test_all_dispatch_fns_in_registry(self):
+        for slug in DISPATCH_FNS:
+            assert slug in REGISTRY, f"dispatch function '{slug}' not in REGISTRY"
+
+    def test_each_registry_entry_has_required_fields(self):
+        for slug, entry in REGISTRY.items():
+            assert "display_name" in entry, slug
+            assert "default_cron" in entry, slug
+            assert "default_config" in entry, slug
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_cve_scan
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchCveScan:
+    def test_calls_delay(self):
+        mock_task = _mock_task()
+        with (
+            patch("app.tasks.cve_scan.run_cve_scan", mock_task),
+            patch("app.services.task_history.record_queued"),
+        ):
+            result = _dispatch_cve_scan(_fake_settings())
+        mock_task.delay.assert_called_once()
+        assert result is mock_task.delay.return_value
+
+    def test_records_queued(self):
+        mock_task = _mock_task()
+        with (
+            patch("app.tasks.cve_scan.run_cve_scan", mock_task),
+            patch("app.services.task_history.record_queued") as mock_rq,
+        ):
+            _dispatch_cve_scan(_fake_settings())
+        mock_rq.assert_called_once()
+        args = mock_rq.call_args[0]
+        assert "cve_scan" in args[2]
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_s3_audit
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchS3Audit:
+    def test_calls_delay(self):
+        mock_task = _mock_task()
+        with (
+            patch("app.tasks.s3_audit.run_s3_orphan_scan", mock_task),
+            patch("app.services.task_history.record_queued"),
+        ):
+            result = _dispatch_s3_audit(_fake_settings())
+        mock_task.delay.assert_called_once()
+        assert result is mock_task.delay.return_value
+
+    def test_records_queued(self):
+        mock_task = _mock_task()
+        with (
+            patch("app.tasks.s3_audit.run_s3_orphan_scan", mock_task),
+            patch("app.services.task_history.record_queued") as mock_rq,
+        ):
+            _dispatch_s3_audit(_fake_settings())
+        mock_rq.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_stale_signup_dismissal
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchStaleSignupDismissal:
+    def test_calls_delay_with_default_days(self):
+        mock_task = _mock_task()
+        with (
+            patch("app.tasks.maintenance.dismiss_stale_signups", mock_task),
+            patch("app.services.task_history.record_queued"),
+        ):
+            _dispatch_stale_signup_dismissal(_fake_settings(), task=None)
+        mock_task.delay.assert_called_once_with(days=30)
+
+    def test_reads_config_days(self):
+        mock_task = _mock_task()
+        fake_task = MagicMock()
+        fake_task.config = {"days": "45"}
+        with (
+            patch("app.tasks.maintenance.dismiss_stale_signups", mock_task),
+            patch("app.services.task_history.record_queued"),
+        ):
+            _dispatch_stale_signup_dismissal(_fake_settings(), task=fake_task)
+        mock_task.delay.assert_called_once_with(days=45)
+
+    def test_records_queued(self):
+        mock_task = _mock_task()
+        with (
+            patch("app.tasks.maintenance.dismiss_stale_signups", mock_task),
+            patch("app.services.task_history.record_queued") as mock_rq,
+        ):
+            _dispatch_stale_signup_dismissal(_fake_settings())
+        mock_rq.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_invite_pruning
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchInvitePruning:
+    def test_calls_delay_with_default_retention(self):
+        mock_task = _mock_task()
+        with (
+            patch("app.tasks.maintenance.prune_expired_invites", mock_task),
+            patch("app.services.task_history.record_queued"),
+        ):
+            _dispatch_invite_pruning(_fake_settings(), task=None)
+        mock_task.delay.assert_called_once_with(retention_days=90)
+
+    def test_reads_config_retention_days(self):
+        mock_task = _mock_task()
+        fake_task = MagicMock()
+        fake_task.config = {"retention_days": "60"}
+        with (
+            patch("app.tasks.maintenance.prune_expired_invites", mock_task),
+            patch("app.services.task_history.record_queued"),
+        ):
+            _dispatch_invite_pruning(_fake_settings(), task=fake_task)
+        mock_task.delay.assert_called_once_with(retention_days=60)
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_audit_log_pruning
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchAuditLogPruning:
+    def test_calls_delay_with_default_retention(self):
+        mock_task = _mock_task()
+        with (
+            patch("app.tasks.maintenance.prune_audit_log", mock_task),
+            patch("app.services.task_history.record_queued"),
+        ):
+            _dispatch_audit_log_pruning(_fake_settings(), task=None)
+        mock_task.delay.assert_called_once_with(retention_days=90)
+
+    def test_reads_config(self):
+        mock_task = _mock_task()
+        fake_task = MagicMock()
+        fake_task.config = {"retention_days": "30"}
+        with (
+            patch("app.tasks.maintenance.prune_audit_log", mock_task),
+            patch("app.services.task_history.record_queued"),
+        ):
+            _dispatch_audit_log_pruning(_fake_settings(), task=fake_task)
+        mock_task.delay.assert_called_once_with(retention_days=30)
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_heartbeat
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchHeartbeat:
+    def test_calls_delay(self):
+        mock_task = _mock_task()
+        with (
+            patch("app.tasks.maintenance.worker_heartbeat", mock_task),
+            patch("app.services.task_history.record_queued"),
+        ):
+            result = _dispatch_heartbeat(_fake_settings())
+        mock_task.delay.assert_called_once()
+        assert result is mock_task.delay.return_value
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_preview_retry
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchPreviewRetry:
+    def test_calls_delay_with_default_limit(self):
+        mock_task = _mock_task()
+        with (
+            patch("app.tasks.maintenance.retry_failed_previews", mock_task),
+            patch("app.services.task_history.record_queued"),
+        ):
+            _dispatch_preview_retry(_fake_settings(), task=None)
+        mock_task.delay.assert_called_once_with(limit=50)
+
+    def test_reads_config_limit(self):
+        mock_task = _mock_task()
+        fake_task = MagicMock()
+        fake_task.config = {"limit": "25"}
+        with (
+            patch("app.tasks.maintenance.retry_failed_previews", mock_task),
+            patch("app.services.task_history.record_queued"),
+        ):
+            _dispatch_preview_retry(_fake_settings(), task=fake_task)
+        mock_task.delay.assert_called_once_with(limit=25)
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_daily_health_check
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchDailyHealthCheck:
+    def test_calls_delay(self):
+        mock_task = _mock_task()
+        with (
+            patch("app.tasks.maintenance.daily_health_check", mock_task),
+            patch("app.services.task_history.record_queued"),
+        ):
+            result = _dispatch_daily_health_check(_fake_settings())
+        mock_task.delay.assert_called_once()
+        assert result is mock_task.delay.return_value
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_server_event_log_pruning
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchServerEventLogPruning:
+    def test_calls_delay_with_defaults(self):
+        mock_task = _mock_task()
+        with (
+            patch("app.tasks.maintenance.prune_server_event_log", mock_task),
+            patch("app.services.task_history.record_queued"),
+        ):
+            _dispatch_server_event_log_pruning(_fake_settings(), task=None)
+        mock_task.delay.assert_called_once_with(max_age_days=28, max_entries=1000)
+
+    def test_reads_config(self):
+        mock_task = _mock_task()
+        fake_task = MagicMock()
+        fake_task.config = {"max_age_days": "14", "max_entries": "500"}
+        with (
+            patch("app.tasks.maintenance.prune_server_event_log", mock_task),
+            patch("app.services.task_history.record_queued"),
+        ):
+            _dispatch_server_event_log_pruning(_fake_settings(), task=fake_task)
+        mock_task.delay.assert_called_once_with(max_age_days=14, max_entries=500)
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_credential_expiry_check
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchCredentialExpiryCheck:
+    def test_calls_delay(self):
+        mock_task = _mock_task()
+        with (
+            patch("app.tasks.maintenance.check_credential_expiry", mock_task),
+            patch("app.services.task_history.record_queued"),
+        ):
+            result = _dispatch_credential_expiry_check(_fake_settings())
+        mock_task.delay.assert_called_once()
+        assert result is mock_task.delay.return_value
+
+    def test_records_queued(self):
+        mock_task = _mock_task()
+        with (
+            patch("app.tasks.maintenance.check_credential_expiry", mock_task),
+            patch("app.services.task_history.record_queued") as mock_rq,
+        ):
+            _dispatch_credential_expiry_check(_fake_settings())
+        mock_rq.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_admin_digest
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchAdminDigest:
+    def test_calls_delay(self):
+        mock_task = _mock_task()
+        with (
+            patch("app.tasks.maintenance.send_admin_digest", mock_task),
+            patch("app.services.task_history.record_queued"),
+        ):
+            result = _dispatch_admin_digest(_fake_settings())
+        mock_task.delay.assert_called_once()
+        assert result is mock_task.delay.return_value
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_tile_prune
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchTilePrune:
+    def test_calls_delay_with_default_inactive_days(self):
+        mock_task = _mock_task()
+        with (
+            patch("app.tasks.maintenance.prune_inactive_project_tiles", mock_task),
+            patch("app.services.task_history.record_queued"),
+        ):
+            _dispatch_tile_prune(_fake_settings(), task=None)
+        mock_task.delay.assert_called_once_with(inactive_days=10)
+
+    def test_reads_config_inactive_days(self):
+        mock_task = _mock_task()
+        fake_task = MagicMock()
+        fake_task.config = {"inactive_days": "5"}
+        with (
+            patch("app.tasks.maintenance.prune_inactive_project_tiles", mock_task),
+            patch("app.services.task_history.record_queued"),
+        ):
+            _dispatch_tile_prune(_fake_settings(), task=fake_task)
+        mock_task.delay.assert_called_once_with(inactive_days=5)
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_feedback_retry
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchFeedbackRetry:
+    def test_calls_delay_with_default_limit(self):
+        mock_task = _mock_task()
+        with (
+            patch("app.tasks.feedback_dispatch.retry_failed_feedback", mock_task),
+            patch("app.services.task_history.record_queued"),
+        ):
+            _dispatch_feedback_retry(_fake_settings(), task=None)
+        mock_task.delay.assert_called_once_with(limit=20)
+
+    def test_reads_config_limit(self):
+        mock_task = _mock_task()
+        fake_task = MagicMock()
+        fake_task.config = {"limit": "10"}
+        with (
+            patch("app.tasks.feedback_dispatch.retry_failed_feedback", mock_task),
+            patch("app.services.task_history.record_queued"),
+        ):
+            _dispatch_feedback_retry(_fake_settings(), task=fake_task)
+        mock_task.delay.assert_called_once_with(limit=10)
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_feedback_purge
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchFeedbackPurge:
+    def test_calls_delay_with_default_retention(self):
+        mock_task = _mock_task()
+        with (
+            patch("app.tasks.feedback_dispatch.purge_deleted_feedback", mock_task),
+            patch("app.services.task_history.record_queued"),
+        ):
+            _dispatch_feedback_purge(_fake_settings(), task=None)
+        mock_task.delay.assert_called_once_with(retention_days=7)
+
+    def test_reads_config_retention_days(self):
+        mock_task = _mock_task()
+        fake_task = MagicMock()
+        fake_task.config = {"retention_days": "14"}
+        with (
+            patch("app.tasks.feedback_dispatch.purge_deleted_feedback", mock_task),
+            patch("app.services.task_history.record_queued"),
+        ):
+            _dispatch_feedback_purge(_fake_settings(), task=fake_task)
+        mock_task.delay.assert_called_once_with(retention_days=14)
+
+
+# ---------------------------------------------------------------------------
+# TestRunScheduledTasks — the main orchestrator task
+# ---------------------------------------------------------------------------
+
+
+def _mock_sync_session(tasks=None):
+    db = MagicMock()
+    db.scalars.return_value.all.return_value = tasks or []
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=db)
+    ctx.__exit__ = MagicMock(return_value=False)
+    Session_cls = MagicMock(return_value=ctx)
+    engine = MagicMock()
+    engine.dispose = MagicMock()
+    create_engine = MagicMock(return_value=engine)
+    return create_engine, Session_cls, engine, db
+
+
+class TestRunScheduledTasks:
+    def test_runs_cleanly_with_no_tasks(self):
+        from app.tasks.scheduler import run_scheduled_tasks
+
+        create_engine, Session_cls, engine, _db = _mock_sync_session([])
+        settings = MagicMock()
+        settings.database_url_sync = "postgresql://test/test"
+
+        with (
+            patch("sqlalchemy.create_engine", create_engine),
+            patch("sqlalchemy.orm.Session", Session_cls),
+            patch("app.config.get_settings", return_value=settings),
+        ):
+            run_scheduled_tasks()
+
+        engine.dispose.assert_called_once()
+
+    def test_does_not_raise_when_db_unavailable(self):
+        from app.tasks.scheduler import run_scheduled_tasks
+
+        settings = MagicMock()
+        settings.database_url_sync = "postgresql://test/test"
+
+        with (
+            patch("sqlalchemy.create_engine", side_effect=Exception("db unreachable")),
+            patch("app.config.get_settings", return_value=settings),
+        ):
+            run_scheduled_tasks()  # exception is swallowed
+
+    def test_fires_enabled_task_within_window(self):
+        from app.tasks.scheduler import run_scheduled_tasks
+
+        task_obj = MagicMock()
+        task_obj.name = "heartbeat"
+        task_obj.cron = "* * * * *"  # every minute — always in the 70-sec window
+
+        dispatch_fn = MagicMock()
+        create_engine, Session_cls, engine, _db = _mock_sync_session([task_obj])
+        settings = MagicMock()
+        settings.database_url_sync = "postgresql://test/test"
+
+        with (
+            patch("sqlalchemy.create_engine", create_engine),
+            patch("sqlalchemy.orm.Session", Session_cls),
+            patch("app.config.get_settings", return_value=settings),
+            patch("app.tasks.scheduler.DISPATCH_FNS", {"heartbeat": dispatch_fn}),
+        ):
+            run_scheduled_tasks()
+
+        dispatch_fn.assert_called_once()
+
+    def test_commits_when_tasks_fired(self):
+        from app.tasks.scheduler import run_scheduled_tasks
+
+        task_obj = MagicMock()
+        task_obj.name = "heartbeat"
+        task_obj.cron = "* * * * *"
+
+        dispatch_fn = MagicMock()
+        create_engine, Session_cls, engine, db = _mock_sync_session([task_obj])
+        settings = MagicMock()
+        settings.database_url_sync = "postgresql://test/test"
+
+        with (
+            patch("sqlalchemy.create_engine", create_engine),
+            patch("sqlalchemy.orm.Session", Session_cls),
+            patch("app.config.get_settings", return_value=settings),
+            patch("app.tasks.scheduler.DISPATCH_FNS", {"heartbeat": dispatch_fn}),
+        ):
+            run_scheduled_tasks()
+
+        db.commit.assert_called_once()
+
+    def test_handles_unknown_task_name_gracefully(self):
+        from app.tasks.scheduler import run_scheduled_tasks
+
+        task_obj = MagicMock()
+        task_obj.name = "unknown_task"
+        task_obj.cron = "* * * * *"
+
+        create_engine, Session_cls, engine, _db = _mock_sync_session([task_obj])
+        settings = MagicMock()
+        settings.database_url_sync = "postgresql://test/test"
+
+        with (
+            patch("sqlalchemy.create_engine", create_engine),
+            patch("sqlalchemy.orm.Session", Session_cls),
+            patch("app.config.get_settings", return_value=settings),
+            patch("app.tasks.scheduler.DISPATCH_FNS", {}),
+        ):
+            run_scheduled_tasks()  # must not raise

--- a/backend/tests/tasks/test_tiles.py
+++ b/backend/tests/tasks/test_tiles.py
@@ -1,0 +1,406 @@
+"""Tests for app.tasks.tiles._render_and_store_tiles, _prerender_draft, _prerender_project.
+
+The tile rendering pipeline (_render_and_store_tiles) is a pure synchronous function
+that takes all its dependencies as parameters and can be exercised without any DB or
+storage fixtures.
+
+The prerender functions (_prerender_draft, _prerender_project) create their own DB
+engine and session; we redirect them to the test db_session using the same sqlalchemy-
+level patch as test_purge.py.
+"""
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.tasks.tiles import _render_and_store_tiles
+
+MINIMAL_WIF = b"""[WIF]
+Version=1.1
+Date=April 2024
+Source Program=TestSuite
+
+[CONTENTS]
+THREADING=true
+TIEUP=true
+TREADLING=true
+COLOR TABLE=true
+COLOR PALETTE=true
+
+[WEAVING]
+Shafts=4
+Treadles=4
+Rising Shed=true
+
+[WARP]
+Threads=4
+Units=Inches
+Color=1
+
+[WEFT]
+Threads=4
+Units=Inches
+Color=2
+
+[COLOR PALETTE]
+Range=0,255
+Form=Decimal
+
+[COLOR TABLE]
+1=200,50,50
+2=50,50,200
+
+[THREADING]
+1=1
+2=2
+3=3
+4=4
+
+[TIEUP]
+1=1
+2=2
+3=3
+4=4
+
+[TREADLING]
+1=1
+2=2
+3=3
+4=4
+"""
+
+
+def _settings(tile_row_count: int = 50, render_max_width: int = 16000):
+    m = MagicMock()
+    m.render_max_width = render_max_width
+    m.tile_row_count = tile_row_count
+    return m
+
+
+def _render(wif_bytes=MINIMAL_WIF, save_fn=None, tile_row_count=50, color_replacements=None):
+    from PIL import Image as PILImage
+
+    from app.services import rendering
+    from app.services.rendering import ImageRenderer
+
+    if save_fn is None:
+        save_fn = MagicMock()
+    return _render_and_store_tiles(
+        wif_bytes,
+        _settings(tile_row_count=tile_row_count),
+        rendering,
+        ImageRenderer,
+        PILImage,
+        save_fn,
+        entity_id=uuid.uuid4(),
+        entity_label="draft_id",
+        color_replacements=color_replacements,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestRenderAndStoreTiles
+# ---------------------------------------------------------------------------
+
+
+class TestRenderAndStoreTiles:
+    def test_returns_positive_tile_count(self):
+        count = _render()
+        assert count >= 1
+
+    def test_calls_save_fn_once_per_tile(self):
+        save_fn = MagicMock()
+        count = _render(save_fn=save_fn)
+        assert save_fn.call_count == count
+
+    def test_save_fn_receives_bytes(self):
+        save_fn = MagicMock()
+        _render(save_fn=save_fn)
+        # Last arg to save_fn is PNG bytes
+        _entity_id, scale, start, data = save_fn.call_args[0]
+        assert isinstance(data, bytes)
+        assert data[:4] == b"\x89PNG"  # PNG magic
+
+    def test_save_fn_tile_start_is_zero_for_first_tile(self):
+        save_fn = MagicMock()
+        _render(save_fn=save_fn)
+        first_call = save_fn.call_args_list[0]
+        _entity_id, scale, start, _data = first_call[0]
+        assert start == 0
+
+    def test_smaller_tile_row_count_produces_more_tiles(self):
+        count_big = _render(tile_row_count=100)
+        count_small = _render(tile_row_count=1)
+        # 4-thread draft: tile_row_count=100 → 1 tile; tile_row_count=1 → 4 tiles
+        assert count_small >= count_big
+
+    def test_entity_id_passed_to_save_fn(self):
+        entity_id = uuid.uuid4()
+        save_fn = MagicMock()
+
+        from PIL import Image as PILImage
+
+        from app.services import rendering
+        from app.services.rendering import ImageRenderer
+
+        _render_and_store_tiles(
+            MINIMAL_WIF,
+            _settings(),
+            rendering,
+            ImageRenderer,
+            PILImage,
+            save_fn,
+            entity_id=entity_id,
+            entity_label="draft_id",
+        )
+        first_call_entity_id = save_fn.call_args_list[0][0][0]
+        assert first_call_entity_id == entity_id
+
+    def test_no_color_replacements_renders_successfully(self):
+        count = _render(color_replacements=None)
+        assert count >= 1
+
+    def test_empty_color_replacements_renders_successfully(self):
+        count = _render(color_replacements={})
+        assert count >= 1
+
+    def test_render_returns_zero_for_too_wide_draft(self):
+        # render_max_width=1 forces effective_scale < 1 → returns 0
+        from PIL import Image as PILImage
+
+        from app.services import rendering
+        from app.services.rendering import ImageRenderer
+
+        save_fn = MagicMock()
+        count = _render_and_store_tiles(
+            MINIMAL_WIF,
+            _settings(render_max_width=1),
+            rendering,
+            ImageRenderer,
+            PILImage,
+            save_fn,
+            entity_id=uuid.uuid4(),
+            entity_label="draft_id",
+        )
+        assert count == 0
+        save_fn.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by prerender tests
+# ---------------------------------------------------------------------------
+
+
+def _session_factory(db: AsyncSession):
+    class _Ctx:
+        async def __aenter__(self):
+            return db
+
+        async def __aexit__(self, *args):
+            pass
+
+    class _Factory:
+        def __call__(self, *args, **kwargs):
+            return _Ctx()
+
+    return _Factory()
+
+
+@pytest.fixture()
+def mock_engine_and_session(db_session: AsyncSession):
+    """Patch engine/session creation so prerender tasks run against db_session."""
+    fake_engine = MagicMock()
+    fake_engine.dispose = AsyncMock()
+    with (
+        patch("sqlalchemy.ext.asyncio.create_async_engine", return_value=fake_engine),
+        patch("sqlalchemy.orm.sessionmaker", return_value=_session_factory(db_session)),
+    ):
+        yield fake_engine
+
+
+def _task_mock():
+    t = MagicMock()
+    t.MaxRetriesExceededError = Exception
+    t.retry = MagicMock(side_effect=Exception("retry"))
+    return t
+
+
+# ---------------------------------------------------------------------------
+# TestPrerendeerDraft — _prerender_draft early-return paths
+# ---------------------------------------------------------------------------
+
+
+class TestPrerendeerDraft:
+    async def test_draft_not_found_returns_cleanly(self, db_session, mock_engine_and_session):
+        from app.tasks.tiles import _prerender_draft
+
+        await _prerender_draft(_task_mock(), uuid.uuid4())
+        mock_engine_and_session.dispose.assert_called_once()
+
+    async def test_deleted_draft_returns_cleanly(self, db_session, test_user, mock_engine_and_session):
+        from app.models.draft import Draft
+        from app.tasks.tiles import _prerender_draft
+
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Deleted",
+            wif_filename="del.wif",
+            wif_path="drafts/del.wif",
+            deleted_at=datetime.now(timezone.utc),
+        )
+        db_session.add(draft)
+        await db_session.commit()
+
+        await _prerender_draft(_task_mock(), draft.id)
+        mock_engine_and_session.dispose.assert_called_once()
+
+    async def test_missing_wif_file_returns_cleanly(self, db_session, test_user, mock_engine_and_session):
+        from app.models.draft import Draft
+        from app.tasks.tiles import _prerender_draft
+
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Missing",
+            wif_filename="missing.wif",
+            wif_path="drafts/no-such-file.wif",  # not in mock storage
+        )
+        db_session.add(draft)
+        await db_session.commit()
+
+        await _prerender_draft(_task_mock(), draft.id)
+        mock_engine_and_session.dispose.assert_called_once()
+
+    async def test_valid_draft_runs_to_completion(self, db_session, test_user, mock_engine_and_session):
+        import app.services.storage as _storage
+        from app.models.draft import Draft
+        from app.tasks.tiles import _prerender_draft
+
+        wif_key = f"drafts/prerender-draft-{uuid.uuid4().hex}.wif"
+        _storage._put(wif_key, MINIMAL_WIF)
+
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Valid",
+            wif_filename="valid.wif",
+            wif_path=wif_key,
+        )
+        db_session.add(draft)
+        await db_session.commit()
+
+        await _prerender_draft(_task_mock(), draft.id)
+        mock_engine_and_session.dispose.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TestPrerenderProject — _prerender_project early-return paths
+# ---------------------------------------------------------------------------
+
+
+class TestPrerenderProject:
+    async def _make_draft(self, db_session, test_user, *, wif_key="drafts/proj.wif"):
+        from app.models.draft import Draft
+
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Proj Draft",
+            wif_filename="proj.wif",
+            wif_path=wif_key,
+        )
+        db_session.add(draft)
+        await db_session.flush()
+        return draft
+
+    async def test_project_not_found_returns_cleanly(self, db_session, mock_engine_and_session):
+        from app.tasks.tiles import _prerender_project
+
+        await _prerender_project(_task_mock(), uuid.uuid4())
+        mock_engine_and_session.dispose.assert_called_once()
+
+    async def test_deleted_project_returns_cleanly(self, db_session, test_user, mock_engine_and_session):
+        from app.models.project import Project
+        from app.tasks.tiles import _prerender_project
+
+        draft = await self._make_draft(db_session, test_user)
+        project = Project(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="Deleted Project",
+            project_type="weave",
+            total_picks=4,
+            deleted_at=datetime.now(timezone.utc),
+        )
+        db_session.add(project)
+        await db_session.commit()
+
+        await _prerender_project(_task_mock(), project.id)
+        mock_engine_and_session.dispose.assert_called_once()
+
+    async def test_project_with_deleted_draft_returns_cleanly(self, db_session, test_user, mock_engine_and_session):
+        from app.models.project import Project
+        from app.tasks.tiles import _prerender_project
+
+        draft = await self._make_draft(db_session, test_user)
+        draft.deleted_at = datetime.now(timezone.utc)
+        project = Project(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="Draft Deleted",
+            project_type="weave",
+            total_picks=4,
+        )
+        db_session.add(project)
+        await db_session.commit()
+
+        await _prerender_project(_task_mock(), project.id)
+        mock_engine_and_session.dispose.assert_called_once()
+
+    async def test_project_with_missing_wif_returns_cleanly(self, db_session, test_user, mock_engine_and_session):
+        from app.models.project import Project
+        from app.tasks.tiles import _prerender_project
+
+        draft = await self._make_draft(db_session, test_user, wif_key="drafts/not-stored.wif")
+        project = Project(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="Missing WIF",
+            project_type="weave",
+            total_picks=4,
+        )
+        db_session.add(project)
+        await db_session.commit()
+
+        await _prerender_project(_task_mock(), project.id)
+        mock_engine_and_session.dispose.assert_called_once()
+
+    async def test_valid_project_runs_to_completion(self, db_session, test_user, mock_engine_and_session):
+        import app.services.storage as _storage
+        from app.models.project import Project
+        from app.tasks.tiles import _prerender_project
+
+        wif_key = f"drafts/proj-{uuid.uuid4().hex}.wif"
+        _storage._put(wif_key, MINIMAL_WIF)
+
+        draft = await self._make_draft(db_session, test_user, wif_key=wif_key)
+        project = Project(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="Valid Project",
+            project_type="weave",
+            total_picks=4,
+        )
+        db_session.add(project)
+        await db_session.commit()
+
+        await _prerender_project(_task_mock(), project.id)
+        mock_engine_and_session.dispose.assert_called_once()

--- a/backend/tests/weaving/test_generators.py
+++ b/backend/tests/weaving/test_generators.py
@@ -1,0 +1,90 @@
+"""Tests for app.weaving.generators.twill and app.weaving.generators.tartan."""
+
+from app.weaving import Draft
+from app.weaving.generators.tartan import tartan
+from app.weaving.generators.twill import twill
+
+# ---------------------------------------------------------------------------
+# TestTwill
+# ---------------------------------------------------------------------------
+
+
+class TestTwill:
+    def test_returns_draft(self):
+        draft = twill()
+        assert isinstance(draft, Draft)
+
+    def test_default_size_2_shafts(self):
+        draft = twill(size=2)
+        assert len(draft.shafts) == 4
+        assert len(draft.treadles) == 4
+
+    def test_size_3_shafts(self):
+        draft = twill(size=3)
+        assert len(draft.shafts) == 6
+        assert len(draft.treadles) == 6
+
+    def test_thread_count_size_2(self):
+        draft = twill(size=2)
+        assert len(draft.warp) == 16  # 8 * size
+        assert len(draft.weft) == 16
+
+    def test_thread_count_size_3(self):
+        draft = twill(size=3)
+        assert len(draft.warp) == 24  # 8 * size
+        assert len(draft.weft) == 24
+
+    def test_custom_warp_color(self):
+        draft = twill(warp_color=(255, 0, 0))
+        assert draft.warp[0].color.rgb == (255, 0, 0)
+
+    def test_custom_weft_color(self):
+        draft = twill(weft_color=(0, 255, 0))
+        assert draft.weft[0].color.rgb == (0, 255, 0)
+
+    def test_treadles_have_shafts_assigned(self):
+        draft = twill(size=2)
+        for treadle in draft.treadles:
+            assert len(treadle.shafts) > 0
+
+
+# ---------------------------------------------------------------------------
+# TestTartan
+# ---------------------------------------------------------------------------
+
+
+class TestTartan:
+    def test_returns_draft(self):
+        draft = tartan("B24, K4, G36")
+        assert isinstance(draft, Draft)
+
+    def test_always_4_shafts(self):
+        draft = tartan("B24, K4")
+        assert len(draft.shafts) == 4
+        assert len(draft.treadles) == 4
+
+    def test_thread_count_single_color(self):
+        # "B24" → colors list is [B24] + reversed([B24]) = [B24, B24] = 48 threads
+        draft = tartan("B24")
+        assert len(draft.warp) == 48
+        assert len(draft.weft) == 48
+
+    def test_thread_count_two_colors(self):
+        # "B24, K4" → [B24, K4] + [K4, B24] → 2*(24+4) = 56
+        draft = tartan("B24, K4")
+        assert len(draft.warp) == 56
+
+    def test_repeats_doubles_threads(self):
+        single = tartan("B24", repeats=1)
+        double = tartan("B24", repeats=2)
+        assert len(double.warp) == 2 * len(single.warp)
+
+    def test_treadles_assigned(self):
+        draft = tartan("B24, K4")
+        for treadle in draft.treadles:
+            assert len(treadle.shafts) == 2
+
+    def test_known_colors_parse_without_error(self):
+        # Smoke test: all colour letters used in _COLOR_MAP
+        draft = tartan("A2, G2, B2, K2, W2, Y2, R2, P2")
+        assert len(draft.warp) > 0


### PR DESCRIPTION
## Summary

- Increases backend test coverage from 75.5% → **84.6%** (goal was 85%; within rounding of 0.4%)
- Adds 16 new/expanded test files across tasks, services, routers, and weaving generators
- All 2110 tests pass, 0 failures

## New test coverage

**Tasks:**
- `test_purge`: project photos, yarn photo paths, loom photo paths, loom version + attachment purge paths
- `test_s3_audit`: full boto3 S3 scan path with mock paginator and DB session redirect  
- `test_tiles`: `_render_and_store_tiles`, `_prerender_draft`, `_prerender_project`
- `test_cve_scan`: pip-audit subprocess, npm OSV API, store summary, full do_scan integration
- `test_reparse`: `_reparse_all` with real DB — skip/update/deleted-excluded paths
- `test_scheduler`: `run_scheduled_tasks` sync mock, dispatch window/cron logic
- `test_maintenance`: `_send_admin_digest_email`, `expire_project_slugs`
- `test_dispatch`, `test_feedback_dispatch`: feedback dispatch task integration and retry paths
- `test_deletion_helpers`: helper function coverage

**Routers:**
- `test_feedback`: `GET /mine`, `GET /{id}/status`, `POST /{id}/retry-dispatch`, admin filter by dispatch_status

**Services:**
- `test_email`, `test_storage`, `test_storage_quota`, `test_github_discussions`

**Weaving:**
- `test_generators`: `twill()` and `tartan()` generator functions

## Test plan

- [x] pytest full suite passes (2110 passed, 2 skipped, 0 failed)
- [x] Coverage: 84.6% (meets 65% CI gate, near 85% target)
- [x] `ruff` lint passes (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)