### PR TITLE
test: clerk service, WIF I/O edge cases, deletion task coverage (#746 #747 #748)

### DIFF
--- a/backend/tests/services/test_clerk.py
+++ b/backend/tests/services/test_clerk.py
@@ -1,0 +1,237 @@
+"""Tests for app.services.clerk — Clerk management API client."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _clerk_user(uid="user_123", email="user@example.com", first="Test", last="User"):
+    return {
+        "id": uid,
+        "email_addresses": [{"email_address": email}],
+        "first_name": first,
+        "last_name": last,
+    }
+
+
+def _mock_client(method: str, response: MagicMock):
+    """Return a context-manager-compatible AsyncMock wired to return response."""
+    client = AsyncMock()
+    getattr(client, method).return_value = response
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=client)
+    ctx.__aexit__ = AsyncMock(return_value=None)
+    return ctx, client
+
+
+def _ok_response(body: dict | list):
+    r = MagicMock()
+    r.status_code = 200
+    r.json.return_value = body
+    r.raise_for_status = MagicMock()
+    return r
+
+
+# ---------------------------------------------------------------------------
+# TestParseClerkUser — internal helper (imported directly)
+# ---------------------------------------------------------------------------
+
+
+class TestParseClerkUser:
+    def test_parses_id_email_display_name(self):
+        from app.services.clerk import _parse_clerk_user
+
+        result = _parse_clerk_user(_clerk_user())
+        assert result["id"] == "user_123"
+        assert result["email"] == "user@example.com"
+        assert result["display_name"] == "Test User"
+
+    def test_falls_back_to_email_when_no_name(self):
+        from app.services.clerk import _parse_clerk_user
+
+        u = _clerk_user(first="", last="")
+        result = _parse_clerk_user(u)
+        assert result["display_name"] == u["email_addresses"][0]["email_address"]
+
+    def test_handles_empty_email_addresses(self):
+        from app.services.clerk import _parse_clerk_user
+
+        u = {"id": "u1", "email_addresses": [], "first_name": "A", "last_name": "B"}
+        result = _parse_clerk_user(u)
+        assert result["email"] == ""
+        assert result["display_name"] == "A B"
+
+
+# ---------------------------------------------------------------------------
+# TestGetClerkUser
+# ---------------------------------------------------------------------------
+
+
+class TestGetClerkUser:
+    async def test_returns_user_dict_on_200(self):
+        from app.services.clerk import get_clerk_user
+
+        response = _ok_response(_clerk_user())
+        ctx, client = _mock_client("get", response)
+        with patch("httpx.AsyncClient", return_value=ctx):
+            result = await get_clerk_user("user_123")
+
+        assert result is not None
+        assert result["id"] == "user_123"
+        assert result["email"] == "user@example.com"
+
+    async def test_returns_none_on_404(self):
+        from app.services.clerk import get_clerk_user
+
+        response = MagicMock()
+        response.status_code = 404
+        ctx, client = _mock_client("get", response)
+        with patch("httpx.AsyncClient", return_value=ctx):
+            result = await get_clerk_user("missing_user")
+
+        assert result is None
+
+    async def test_returns_none_on_exception(self):
+        from app.services.clerk import get_clerk_user
+
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(side_effect=Exception("network error"))
+        ctx.__aexit__ = AsyncMock(return_value=None)
+        with patch("httpx.AsyncClient", return_value=ctx):
+            result = await get_clerk_user("user_123")
+
+        assert result is None
+
+    async def test_calls_correct_endpoint(self):
+        from app.services.clerk import get_clerk_user
+
+        response = _ok_response(_clerk_user())
+        ctx, client = _mock_client("get", response)
+        with patch("httpx.AsyncClient", return_value=ctx):
+            await get_clerk_user("user_abc")
+
+        call_url = client.get.call_args[0][0]
+        assert "user_abc" in call_url
+
+
+# ---------------------------------------------------------------------------
+# TestListClerkUsers
+# ---------------------------------------------------------------------------
+
+
+class TestListClerkUsers:
+    async def test_returns_list_of_user_dicts(self):
+        from app.services.clerk import list_clerk_users
+
+        batch = [_clerk_user("u1", "a@x.com"), _clerk_user("u2", "b@x.com")]
+        response = _ok_response(batch)
+        ctx, client = _mock_client("get", response)
+        with patch("httpx.AsyncClient", return_value=ctx):
+            result = await list_clerk_users()
+
+        assert len(result) == 2
+        assert result[0]["id"] == "u1"
+
+    async def test_paginates_until_partial_batch(self):
+        from app.services.clerk import list_clerk_users
+
+        # First call returns 500 items (full batch), second returns 1 (stop)
+        full_batch = [_clerk_user(f"u{i}", f"u{i}@x.com") for i in range(500)]
+        partial_batch = [_clerk_user("u500", "u500@x.com")]
+
+        responses = [_ok_response(full_batch), _ok_response(partial_batch)]
+        client = AsyncMock()
+        client.get.side_effect = responses
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=client)
+        ctx.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("httpx.AsyncClient", return_value=ctx):
+            result = await list_clerk_users()
+
+        assert len(result) == 501
+        assert client.get.call_count == 2
+
+    async def test_returns_empty_list_when_no_users(self):
+        from app.services.clerk import list_clerk_users
+
+        response = _ok_response([])
+        ctx, client = _mock_client("get", response)
+        with patch("httpx.AsyncClient", return_value=ctx):
+            result = await list_clerk_users()
+
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# TestSetUserMetadata
+# ---------------------------------------------------------------------------
+
+
+class TestSetUserMetadata:
+    async def test_calls_patch_endpoint(self):
+        from app.services.clerk import set_user_metadata
+
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        ctx, client = _mock_client("patch", response)
+        with patch("httpx.AsyncClient", return_value=ctx):
+            await set_user_metadata("user_abc", {"approved": True})
+
+        assert client.patch.called
+        call_url = client.patch.call_args[0][0]
+        assert "user_abc" in call_url
+
+    async def test_swallows_exception_on_failure(self):
+        from app.services.clerk import set_user_metadata
+
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(side_effect=Exception("timeout"))
+        ctx.__aexit__ = AsyncMock(return_value=None)
+        with patch("httpx.AsyncClient", return_value=ctx):
+            await set_user_metadata("user_abc", {"approved": True})  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# TestBanClerkUser / TestUnbanClerkUser
+# ---------------------------------------------------------------------------
+
+
+class TestBanClerkUser:
+    async def test_calls_ban_endpoint(self):
+        from app.services.clerk import ban_clerk_user
+
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        ctx, client = _mock_client("post", response)
+        with patch("httpx.AsyncClient", return_value=ctx):
+            await ban_clerk_user("user_abc")
+
+        call_url = client.post.call_args[0][0]
+        assert "user_abc" in call_url
+        assert "ban" in call_url
+
+    async def test_raises_on_http_error(self):
+        from app.services.clerk import ban_clerk_user
+
+        response = MagicMock()
+        response.raise_for_status.side_effect = Exception("403 Forbidden")
+        ctx, client = _mock_client("post", response)
+        with patch("httpx.AsyncClient", return_value=ctx):
+            with pytest.raises(Exception):
+                await ban_clerk_user("user_abc")
+
+
+class TestUnbanClerkUser:
+    async def test_calls_unban_endpoint(self):
+        from app.services.clerk import unban_clerk_user
+
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        ctx, client = _mock_client("post", response)
+        with patch("httpx.AsyncClient", return_value=ctx):
+            await unban_clerk_user("user_abc")
+
+        call_url = client.post.call_args[0][0]
+        assert "user_abc" in call_url
+        assert "unban" in call_url

--- a/backend/tests/tasks/test_deletion_helpers.py
+++ b/backend/tests/tasks/test_deletion_helpers.py
@@ -185,6 +185,127 @@ class TestPurgeStorage:
         await _purge_storage(db_session, test_user.id, mock_storage)
         mock_storage._delete.assert_not_called()
 
+    async def test_deletes_project_photo(self, db_session, test_user):
+        from app.models.draft import Draft
+        from app.models.project import Project, ProjectPhoto
+        from app.tasks.deletion import _purge_storage
+
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Photo Draft",
+            wif_filename="photo.wif",
+            wif_path="drafts/photo.wif",
+        )
+        db_session.add(draft)
+        await db_session.flush()
+
+        project = Project(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="Photo Project",
+            project_type="treadle",
+            total_picks=4,
+        )
+        db_session.add(project)
+        await db_session.flush()
+
+        photo = ProjectPhoto(
+            id=uuid.uuid4(),
+            project_id=project.id,
+            file_path="projects/photo.jpg",
+            filename="photo.jpg",
+        )
+        db_session.add(photo)
+        await db_session.commit()
+
+        mock_storage = MagicMock()
+        mock_storage.delete_project_tiles = MagicMock(return_value=0)
+        await _purge_storage(db_session, test_user.id, mock_storage)
+
+        called_paths = [c.args[0] for c in mock_storage._delete.call_args_list]
+        assert "projects/photo.jpg" in called_paths
+
+    async def test_delete_project_tiles_exception_swallowed(self, db_session, test_user):
+        from app.models.draft import Draft
+        from app.models.project import Project
+        from app.tasks.deletion import _purge_storage
+
+        draft = Draft(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            name="Tiles Draft",
+            wif_filename="tiles.wif",
+            wif_path="drafts/tiles.wif",
+        )
+        db_session.add(draft)
+        await db_session.flush()
+
+        project = Project(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="Tiles Project",
+            project_type="treadle",
+            total_picks=4,
+        )
+        db_session.add(project)
+        await db_session.commit()
+
+        mock_storage = MagicMock()
+        mock_storage.delete_project_tiles = MagicMock(side_effect=RuntimeError("s3 gone"))
+        await _purge_storage(db_session, test_user.id, mock_storage)  # must not raise
+
+    async def test_deletes_loom_version_photo_and_receipt(self, db_session, test_user):
+        from datetime import date
+
+        from app.models.loom import Loom, LoomVersion, LoomVersionPhoto, LoomVersionReceipt
+        from app.tasks.deletion import _purge_storage
+
+        loom = Loom(
+            id=uuid.uuid4(),
+            owner_id=test_user.id,
+            loom_type="floor",
+            manufacturer="Acme",
+            model_name="VersionedLoom",
+        )
+        db_session.add(loom)
+        await db_session.flush()
+
+        version = LoomVersion(
+            id=uuid.uuid4(),
+            loom_id=loom.id,
+            version_number=1,
+            effective_date=date.today(),
+        )
+        db_session.add(version)
+        await db_session.flush()
+
+        photo = LoomVersionPhoto(
+            id=uuid.uuid4(),
+            loom_version_id=version.id,
+            filename="loom.jpg",
+            path="loom-versions/loom.jpg",
+        )
+        receipt = LoomVersionReceipt(
+            id=uuid.uuid4(),
+            loom_version_id=version.id,
+            filename="receipt.pdf",
+            path="loom-versions/receipt.pdf",
+        )
+        db_session.add(photo)
+        db_session.add(receipt)
+        await db_session.commit()
+
+        mock_storage = MagicMock()
+        mock_storage.delete_project_tiles = MagicMock(return_value=0)
+        await _purge_storage(db_session, test_user.id, mock_storage)
+
+        called_paths = [c.args[0] for c in mock_storage._delete.call_args_list]
+        assert "loom-versions/loom.jpg" in called_paths
+        assert "loom-versions/receipt.pdf" in called_paths
+
 
 # ---------------------------------------------------------------------------
 # TestNotifyHelpers — _notify_admins_complete / _notify_stalled

--- a/backend/tests/tasks/test_deletion_task.py
+++ b/backend/tests/tasks/test_deletion_task.py
@@ -133,6 +133,37 @@ class TestDeleteUserHappyPath:
 
         assert await db_session.scalar(select(Loom).where(Loom.owner_id == user.id)) is None
 
+    async def test_deletes_pending_signup_for_clerk_user_id(self, db_session, mock_db, mock_storage, mock_emails):
+        from sqlalchemy import select
+
+        from app.models.pending_signup import PendingSignup
+
+        clerk_id = f"clerk_{uuid.uuid4().hex[:12]}"
+        user = User(
+            email=f"clerk-{uuid.uuid4().hex[:6]}@test.com",
+            display_name="Clerk User",
+            oidc_sub=f"clerk-sub-{uuid.uuid4().hex}",
+            clerk_user_id=clerk_id,
+            deletion_state="pending",
+        )
+        user.soft_delete()
+        db_session.add(user)
+        await db_session.flush()
+
+        signup = PendingSignup(
+            clerk_user_id=clerk_id,
+            email="clerk-pending@test.com",
+            display_name="Pending",
+        )
+        db_session.add(signup)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        await _delete_user(_task_mock(), user.id)
+
+        remaining = (await db_session.scalars(select(PendingSignup))).all()
+        assert all(s.clerk_user_id != clerk_id for s in remaining)
+
     async def test_notifies_admins_on_complete(self, db_session, mock_db, mock_storage):
         admin = User(
             email="task-notify-admin@test.com",
@@ -243,6 +274,15 @@ class TestDeleteUserErrorPaths:
                 await _delete_user(task, user.id)
 
         task.retry.assert_called_once()
+
+    def test_run_user_deletion_calls_asyncio_run(self):
+        from app.tasks.deletion import run_user_deletion
+
+        user_id = str(uuid.uuid4())
+        with patch("app.tasks.deletion.asyncio") as mock_asyncio:
+            mock_asyncio.run = MagicMock()
+            run_user_deletion.run(user_id)
+        mock_asyncio.run.assert_called_once()
 
     async def test_stalled_notifies_superusers(self, db_session, mock_db):
         superuser = User(

--- a/backend/tests/weaving/test_wif_io.py
+++ b/backend/tests/weaving/test_wif_io.py
@@ -6,6 +6,7 @@ No WeftMark fixtures, database, or Celery stack required.
 
 import os
 import tempfile
+from configparser import RawConfigParser
 from pathlib import Path
 
 from app.weaving import Draft
@@ -95,3 +96,254 @@ class TestWIFWriter:
         d = self._make_draft()
         restored = self._round_trip(d)
         assert restored.all_threads_attached()
+
+
+def _write_temp_wif(content: str) -> str:
+    """Write WIF content to a temp file and return its path."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".wif", delete=False, encoding="utf-8") as f:
+        f.write(content)
+        return f.name
+
+
+# ---------------------------------------------------------------------------
+# TestWIFReaderEdgeCases — cover paths not exercised by the plain_weave fixture
+# ---------------------------------------------------------------------------
+
+
+_WIF_NO_PER_THREAD_COLORS = """\
+[WIF]
+Version=1.1
+Date=Jan 01, 2024
+
+[CONTENTS]
+COLOR TABLE=1
+WARP=1
+WEFT=1
+THREADING=1
+TREADLING=1
+TIEUP=1
+WEAVING=1
+
+[COLOR TABLE]
+1=0,0,0
+2=255,255,255
+
+[WEAVING]
+Rising Shed=true
+Shafts=4
+Treadles=2
+
+[WARP]
+Threads=2
+Units=Inches
+Color=1
+
+[WEFT]
+Threads=2
+Units=Inches
+Color=2
+
+[THREADING]
+1=1
+2=2
+
+[TREADLING]
+1=1
+2=2
+
+[TIEUP]
+1=1
+2=2
+"""
+
+_WIF_LIFTPLAN = """\
+[WIF]
+Version=1.1
+Date=Jan 01, 2024
+
+[CONTENTS]
+COLOR TABLE=1
+WARP=1
+WEFT=1
+THREADING=1
+LIFTPLAN=1
+WEAVING=1
+
+[COLOR TABLE]
+1=0,0,0
+2=255,255,255
+
+[WEAVING]
+Rising Shed=true
+Shafts=4
+Treadles=0
+
+[WARP]
+Threads=2
+Units=Inches
+Color=1
+
+[WEFT]
+Threads=2
+Units=Inches
+Color=2
+
+[THREADING]
+1=1
+2=2
+
+[LIFTPLAN]
+1=1,3
+2=2,4
+"""
+
+_WIF_NO_COLOR_PALETTE = """\
+[WIF]
+Version=1.1
+Date=Jan 01, 2024
+
+[CONTENTS]
+COLOR TABLE=1
+WARP=1
+WEFT=1
+THREADING=1
+TREADLING=1
+TIEUP=1
+WEAVING=1
+
+[COLOR TABLE]
+1=0,0,0
+2=255,255,255
+
+[WEAVING]
+Rising Shed=true
+Shafts=2
+Treadles=2
+
+[WARP]
+Threads=2
+Units=Inches
+Color=1
+
+[WEFT]
+Threads=2
+Units=Inches
+Color=2
+
+[THREADING]
+1=1
+2=2
+
+[TREADLING]
+1=1
+2=2
+
+[TIEUP]
+1=1
+2=2
+"""
+
+
+class TestWIFReaderEdgeCases:
+    def test_reads_without_per_thread_colors(self):
+        path = _write_temp_wif(_WIF_NO_PER_THREAD_COLORS)
+        try:
+            draft = WIFReader(path).read()
+            assert len(draft.warp) == 2
+            assert draft.warp[0].color is not None
+        finally:
+            os.unlink(path)
+
+    def test_reads_liftplan_draft(self):
+        path = _write_temp_wif(_WIF_LIFTPLAN)
+        try:
+            draft = WIFReader(path).read()
+            assert draft.liftplan is True
+            assert len(draft.weft) == 2
+            assert len(draft.weft[0].shafts) > 0
+        finally:
+            os.unlink(path)
+
+    def test_reads_without_color_palette_section(self):
+        path = _write_temp_wif(_WIF_NO_COLOR_PALETTE)
+        try:
+            draft = WIFReader(path).read()
+            assert len(draft.warp) == 2
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# TestWIFWriterEdgeCases — cover write_liftplan, notes, and liftplan roundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestWIFWriterEdgeCases:
+    def _make_liftplan_draft(self) -> Draft:
+        d = Draft(num_shafts=4, num_treadles=0)
+        for ii in range(4):
+            d.add_warp_thread(color=(0, 0, 0), shaft=ii % 4)
+            d.add_weft_thread(color=(255, 255, 255), shafts=[ii % 4])
+        return d
+
+    def test_writes_liftplan_draft(self):
+        d = self._make_liftplan_draft()
+        with tempfile.NamedTemporaryFile(suffix=".wif", delete=False) as f:
+            path = f.name
+        try:
+            WIFWriter(d).write(path)
+            config = RawConfigParser()
+            config.read(path)
+            assert config.has_section("LIFTPLAN")
+        finally:
+            os.unlink(path)
+
+    def test_liftplan_roundtrip_weft_count(self):
+        d = self._make_liftplan_draft()
+        with tempfile.NamedTemporaryFile(suffix=".wif", delete=False) as f:
+            path = f.name
+        try:
+            WIFWriter(d).write(path)
+            restored = WIFReader(path).read()
+            assert len(restored.weft) == len(d.weft)
+        finally:
+            os.unlink(path)
+
+    def test_writes_notes_when_set(self):
+        d = Draft(num_shafts=4, num_treadles=2)
+        d.notes = "Line one\nLine two"
+        d.treadles[0].shafts = {d.shafts[0]}
+        d.treadles[1].shafts = {d.shafts[1]}
+        for ii in range(2):
+            d.add_warp_thread(color=(0, 0, 0), shaft=ii % 2)
+            d.add_weft_thread(color=(255, 255, 255), treadles=[ii % 2])
+
+        with tempfile.NamedTemporaryFile(suffix=".wif", delete=False) as f:
+            path = f.name
+        try:
+            WIFWriter(d).write(path)
+            config = RawConfigParser()
+            config.read(path)
+            assert config.has_section("NOTES")
+        finally:
+            os.unlink(path)
+
+    def test_explicit_liftplan_flag_uses_liftplan_section(self):
+        """write(liftplan=True) on a treadle draft still emits LIFTPLAN."""
+        d = Draft(num_shafts=4, num_treadles=2)
+        d.treadles[0].shafts = {d.shafts[0], d.shafts[2]}
+        d.treadles[1].shafts = {d.shafts[1], d.shafts[3]}
+        for ii in range(4):
+            d.add_warp_thread(color=(0, 0, 0), shaft=ii % 4)
+            d.add_weft_thread(color=(255, 255, 255), treadles=[ii % 2])
+
+        with tempfile.NamedTemporaryFile(suffix=".wif", delete=False) as f:
+            path = f.name
+        try:
+            WIFWriter(d).write(path, liftplan=True)
+            config = RawConfigParser()
+            config.read(path)
+            assert config.has_section("LIFTPLAN")
+            assert not config.has_section("TREADLING")
+        finally:
+            os.unlink(path)


### PR DESCRIPTION
## Summary

- **#746 (clerk.py):** New `test_clerk.py` covering all five management API functions (`_parse_clerk_user`, `get_clerk_user`, `list_clerk_users`, `set_user_metadata`, `ban_clerk_user`, `unban_clerk_user`) with mocked httpx. Covers the 404/exception/pagination paths. Coverage: 23% → ~85%.

- **#747 (_wif.py):** Extended `test_wif_io.py` with edge-case WIF files: no-per-thread-colors read path, liftplan read/write roundtrip, missing COLOR PALETTE section, notes metadata write, explicit `liftplan=True` flag. Coverage: 90% → 98% (4 lines remain: the default-color fallback and a treadling ValueError edge case).

- **#748 (deletion.py):** Extended `test_deletion_helpers.py` with project photo deletion (line 138), `delete_project_tiles` exception swallowed (lines 142–145), and loom version photo+receipt deletion (lines 163–168). Extended `test_deletion_task.py` with PendingSignup cleared for clerk_user_id (line 99) and asyncio.run entry-point (line 31). Coverage: 91% → ~99%.

## Test plan

- [ ] 2137 tests pass, 0 failures (confirmed locally via docker exec)
- [ ] Overall coverage: 84.85% (up from 84.61%)
- [ ] CI full suite passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)