### PR TITLE
test: health and projects router coverage (#745 #749)

### DIFF
--- a/backend/tests/routers/test_health.py
+++ b/backend/tests/routers/test_health.py
@@ -1,11 +1,12 @@
 import asyncio
-from unittest.mock import MagicMock
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import AsyncClient
 
 import app.routers.health as health_module
-from app.routers.health import ReadinessResponse, ReadinessService, _build_readiness_from_results
+from app.routers.health import ReadinessResponse, ReadinessService, _build_readiness_from_results, set_readiness
 from app.version import VERSION
 
 
@@ -15,6 +16,10 @@ def reset_health_state():
     original_detailed = health_module._detailed_cache
     original_readiness = health_module._readiness_cache
     original_task = health_module._detailed_task
+    original_open_event = health_module._open_health_event_id
+    original_last_alert = health_module._last_alert_status
+    original_email_cache = health_module._superuser_email_cache
+    original_failures = health_module._consecutive_failures
     yield
     # Cancel any task created during the test before restoring
     if health_module._detailed_task is not None and health_module._detailed_task is not original_task:
@@ -22,6 +27,10 @@ def reset_health_state():
     health_module._detailed_cache = original_detailed
     health_module._readiness_cache = original_readiness
     health_module._detailed_task = original_task
+    health_module._open_health_event_id = original_open_event
+    health_module._last_alert_status = original_last_alert
+    health_module._superuser_email_cache = original_email_cache
+    health_module._consecutive_failures = original_failures
 
 
 class TestHealth:
@@ -234,3 +243,584 @@ class TestBuildReadinessFromResults:
         ]
         result = _build_readiness_from_results(results, webhook_result=None, checked_at="2026-01-01T00:00:00+00:00")
         assert len(result.services) == 4
+
+
+# ---------------------------------------------------------------------------
+# TestSetReadiness — set_readiness helper
+# ---------------------------------------------------------------------------
+
+
+class TestSetReadiness:
+    def test_sets_cache(self):
+        health_module._readiness_cache = None
+        r = ReadinessResponse(status="ok", services=[])
+        set_readiness(r)
+        assert health_module._readiness_cache is r
+
+    def test_overwrites_existing(self):
+        health_module._readiness_cache = ReadinessResponse(status="error", services=[])
+        r = ReadinessResponse(status="ok", services=[])
+        set_readiness(r)
+        assert health_module._readiness_cache.status == "ok"
+
+
+# ---------------------------------------------------------------------------
+# TestGetWorkerVersion — _get_worker_version Redis helper
+# ---------------------------------------------------------------------------
+
+
+class TestGetWorkerVersion:
+    async def test_returns_none_when_redis_unavailable(self):
+        from app.routers.health import _get_worker_version
+
+        with patch("redis.asyncio.from_url", side_effect=Exception("connection refused")):
+            result = await _get_worker_version()
+        assert result is None
+
+    async def test_returns_decoded_value_when_key_exists(self):
+        from app.routers.health import _get_worker_version
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=b"0.170.0")
+        mock_client.aclose = AsyncMock()
+
+        with patch("redis.asyncio.from_url", return_value=mock_client):
+            result = await _get_worker_version()
+
+        assert result == "0.170.0"
+
+    async def test_returns_none_when_key_missing(self):
+        from app.routers.health import _get_worker_version
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=None)
+        mock_client.aclose = AsyncMock()
+
+        with patch("redis.asyncio.from_url", return_value=mock_client):
+            result = await _get_worker_version()
+
+        assert result is None
+
+    async def test_health_endpoint_includes_worker_version(self, client: AsyncClient):
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=b"1.2.3")
+        mock_client.aclose = AsyncMock()
+
+        with patch("redis.asyncio.from_url", return_value=mock_client):
+            resp = await client.get("/api/health")
+
+        assert resp.status_code == 200
+        assert resp.json()["worker_version"] == "1.2.3"
+
+    async def test_health_endpoint_worker_version_none_on_error(self, client: AsyncClient):
+        with patch("redis.asyncio.from_url", side_effect=Exception("down")):
+            resp = await client.get("/api/health")
+
+        assert resp.status_code == 200
+        assert resp.json()["worker_version"] is None
+
+
+# ---------------------------------------------------------------------------
+# TestRefreshSuperuserEmailCache
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshSuperuserEmailCache:
+    async def test_populates_cache(self, db_session, superuser_user):
+        from app.routers.health import _refresh_superuser_email_cache
+
+        health_module._superuser_email_cache = []
+
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=db_session)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        with patch("app.database.AsyncSessionLocal", return_value=ctx):
+            await _refresh_superuser_email_cache()
+
+        assert superuser_user.email in health_module._superuser_email_cache
+
+    async def test_swallows_exceptions(self):
+        from app.routers.health import _refresh_superuser_email_cache
+
+        with patch("app.database.AsyncSessionLocal", side_effect=Exception("db down")):
+            await _refresh_superuser_email_cache()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# TestDispatchHealthAlert
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchHealthAlert:
+    async def test_no_op_when_alerts_disabled(self):
+        from app.routers.health import _dispatch_health_alert
+
+        result = ReadinessResponse(status="error", services=[ReadinessService(name="PG", ok=False, critical=True)])
+
+        with patch("app.routers.health.get_settings") as mock_settings:
+            mock_settings.return_value.stack_alert_emails_enabled = False
+            with patch("app.services.email.send_health_degraded_alert", new_callable=AsyncMock) as mock_email:
+                await _dispatch_health_alert(result, is_recovery=False)
+
+        mock_email.assert_not_called()
+
+    async def test_no_op_when_email_cache_empty(self):
+        from app.routers.health import _dispatch_health_alert
+
+        health_module._superuser_email_cache = []
+        result = ReadinessResponse(status="error", services=[])
+
+        with patch("app.routers.health.get_settings") as mock_settings:
+            mock_settings.return_value.stack_alert_emails_enabled = True
+            mock_settings.return_value.app_env = "test"
+            mock_settings.return_value.app_base_url = "http://localhost"
+            mock_settings.return_value.frontend_url = "http://localhost"
+            await _dispatch_health_alert(result, is_recovery=False)
+
+    async def test_swallows_email_exception(self):
+        from app.routers.health import _dispatch_health_alert
+
+        health_module._superuser_email_cache = ["admin@test.com"]
+        result = ReadinessResponse(status="error", services=[])
+
+        with patch("app.routers.health.get_settings") as mock_settings:
+            mock_settings.return_value.stack_alert_emails_enabled = True
+            mock_settings.return_value.app_env = "test"
+            mock_settings.return_value.app_base_url = "http://localhost"
+            mock_settings.return_value.frontend_url = "http://localhost"
+            with patch(
+                "app.services.email.send_health_degraded_alert",
+                new_callable=AsyncMock,
+                side_effect=Exception("smtp down"),
+            ):
+                await _dispatch_health_alert(result, is_recovery=False)  # must not raise
+
+    async def test_calls_recovery_email_when_is_recovery(self):
+        from app.routers.health import _dispatch_health_alert
+
+        health_module._superuser_email_cache = ["admin@test.com"]
+        result = ReadinessResponse(status="ok", services=[])
+
+        with patch("app.routers.health.get_settings") as mock_settings:
+            mock_settings.return_value.stack_alert_emails_enabled = True
+            mock_settings.return_value.app_env = "test"
+            mock_settings.return_value.app_base_url = "http://localhost"
+            mock_settings.return_value.frontend_url = "http://localhost"
+            with patch("app.services.email.send_health_recovered_alert", new_callable=AsyncMock) as mock_recovery:
+                with patch("app.services.email.send_health_degraded_alert", new_callable=AsyncMock):
+                    await _dispatch_health_alert(result, is_recovery=True)
+
+        mock_recovery.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TestRecordHealthTransition
+# ---------------------------------------------------------------------------
+
+
+class TestRecordHealthTransition:
+    async def test_no_op_when_status_unchanged(self):
+        from app.routers.health import _record_health_transition
+
+        result = ReadinessResponse(status="ok", services=[])
+        # Same status → early return before any DB access; must not raise
+        await _record_health_transition("ok", result)
+
+    async def test_swallows_db_exception(self):
+        from app.routers.health import _record_health_transition
+
+        result = ReadinessResponse(status="error", services=[ReadinessService(name="PG", ok=False, critical=True)])
+        with patch("app.database.AsyncSessionLocal", side_effect=Exception("db down")):
+            await _record_health_transition("ok", result)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# TestRunStartupProbes
+# ---------------------------------------------------------------------------
+
+
+class TestRunStartupProbes:
+    async def test_returns_readiness_response(self):
+        from app.routers.health import run_startup_probes
+
+        ok_result = MagicMock()
+        ok_result.service = "PostgreSQL"
+        ok_result.status = "ok"
+        ok_result.message = "ok"
+        ok_result.checks = []
+
+        ctx = MagicMock()
+        mock_db = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=mock_db)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        with patch("app.database.AsyncSessionLocal", return_value=ctx):
+            with patch("app.routers.admin._probe_postgres", return_value=ok_result):
+                with patch("app.routers.admin._probe_s3", return_value=ok_result):
+                    with patch("app.routers.admin._probe_clerk", return_value=ok_result):
+                        with patch("app.routers.admin._probe_smtp", return_value=ok_result):
+                            with patch("app.routers.admin._probe_config", return_value=ok_result):
+                                result = await run_startup_probes()
+
+        assert isinstance(result, ReadinessResponse)
+
+    async def test_returns_error_on_db_connect_failure(self):
+        from app.routers.health import run_startup_probes
+
+        with patch("app.database.AsyncSessionLocal", side_effect=Exception("connection refused")):
+            result = await run_startup_probes()
+
+        assert result.status == "error"
+
+
+# ---------------------------------------------------------------------------
+# TestRunDetailedProbes — _run_detailed_probes
+# ---------------------------------------------------------------------------
+
+
+class TestRunDetailedProbes:
+    async def test_returns_readiness_response_when_all_ok(self):
+        from app.routers.health import _run_detailed_probes
+
+        ok_result = MagicMock()
+        ok_result.service = "PostgreSQL"
+        ok_result.status = "ok"
+        ok_result.message = "All good"
+        ok_result.checks = []
+
+        ctx = MagicMock()
+        mock_db = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=mock_db)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.database.AsyncSessionLocal", return_value=ctx):
+            with patch("app.routers.admin._probe_postgres", new_callable=AsyncMock, return_value=ok_result):
+                with patch("app.routers.admin._probe_s3", new_callable=AsyncMock, return_value=ok_result):
+                    with patch("app.routers.admin._probe_clerk", new_callable=AsyncMock, return_value=ok_result):
+                        with patch("app.routers.admin._probe_smtp", new_callable=AsyncMock, return_value=ok_result):
+                            with patch(
+                                "app.routers.admin._probe_config", new_callable=AsyncMock, return_value=ok_result
+                            ):
+                                with patch(
+                                    "app.services.clerk_webhook_probe.run_webhook_probe",
+                                    new_callable=AsyncMock,
+                                    return_value=None,
+                                ):
+                                    result = await _run_detailed_probes()
+
+        assert isinstance(result, ReadinessResponse)
+
+    async def test_returns_error_on_db_exception(self):
+        from app.routers.health import _run_detailed_probes
+
+        with patch("app.database.AsyncSessionLocal", side_effect=Exception("db down")):
+            result = await _run_detailed_probes()
+
+        assert result.status == "error"
+        assert result.services[0].ok is False
+
+
+# ---------------------------------------------------------------------------
+# TestRecordHealthTransitionDBPaths — DB write paths
+# ---------------------------------------------------------------------------
+
+
+class TestRecordHealthTransitionDBPaths:
+    def _make_db_ctx(self, mock_db: AsyncMock):
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=mock_db)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        return ctx
+
+    async def test_opens_event_when_going_to_error(self):
+        from app.routers.health import _record_health_transition
+
+        health_module._open_health_event_id = None
+        result = ReadinessResponse(
+            status="error",
+            services=[ReadinessService(name="PG", ok=False, critical=True)],
+        )
+
+        mock_evt = MagicMock()
+        mock_evt.id = uuid.uuid4()
+
+        mock_db = AsyncMock()
+        mock_db.commit = AsyncMock()
+        mock_db.refresh = AsyncMock()
+
+        with patch("app.database.AsyncSessionLocal", return_value=self._make_db_ctx(mock_db)):
+            with patch(
+                "app.services.server_events.write_event", new_callable=AsyncMock, return_value=mock_evt
+            ) as mock_write:
+                await _record_health_transition("ok", result)
+
+        mock_write.assert_called_once()
+        assert health_module._open_health_event_id == mock_evt.id
+
+    async def test_opens_event_when_going_to_degraded(self):
+        from app.routers.health import _record_health_transition
+
+        health_module._open_health_event_id = None
+        result = ReadinessResponse(
+            status="degraded",
+            services=[ReadinessService(name="S3", ok=False, critical=False)],
+        )
+
+        mock_evt = MagicMock()
+        mock_evt.id = uuid.uuid4()
+
+        mock_db = AsyncMock()
+        mock_db.commit = AsyncMock()
+        mock_db.refresh = AsyncMock()
+
+        with patch("app.database.AsyncSessionLocal", return_value=self._make_db_ctx(mock_db)):
+            with patch("app.services.server_events.write_event", new_callable=AsyncMock, return_value=mock_evt):
+                await _record_health_transition("ok", result)
+
+        assert health_module._open_health_event_id == mock_evt.id
+
+    async def test_closes_event_on_recovery(self):
+        from app.routers.health import _record_health_transition
+
+        event_id = uuid.uuid4()
+        health_module._open_health_event_id = event_id
+        result = ReadinessResponse(status="ok", services=[])
+
+        mock_evt = MagicMock()
+        mock_evt.status = "open"
+
+        mock_db = AsyncMock()
+        mock_db.scalar = AsyncMock(return_value=mock_evt)
+        mock_db.commit = AsyncMock()
+
+        with patch("app.database.AsyncSessionLocal", return_value=self._make_db_ctx(mock_db)):
+            with patch("app.services.server_events.close_event", new_callable=AsyncMock) as mock_close:
+                await _record_health_transition("error", result)
+
+        mock_close.assert_called_once()
+        assert health_module._open_health_event_id is None
+
+    async def test_recovery_clears_id_even_when_event_not_found(self):
+        from app.routers.health import _record_health_transition
+
+        health_module._open_health_event_id = uuid.uuid4()
+        result = ReadinessResponse(status="ok", services=[])
+
+        mock_db = AsyncMock()
+        mock_db.scalar = AsyncMock(return_value=None)
+        mock_db.commit = AsyncMock()
+
+        with patch("app.database.AsyncSessionLocal", return_value=self._make_db_ctx(mock_db)):
+            with patch("app.services.server_events.close_event", new_callable=AsyncMock) as mock_close:
+                await _record_health_transition("error", result)
+
+        mock_close.assert_not_called()
+        assert health_module._open_health_event_id is None
+
+    async def test_already_closed_event_not_closed_again(self):
+        from app.routers.health import _record_health_transition
+
+        health_module._open_health_event_id = uuid.uuid4()
+        result = ReadinessResponse(status="ok", services=[])
+
+        mock_evt = MagicMock()
+        mock_evt.status = "closed"
+
+        mock_db = AsyncMock()
+        mock_db.scalar = AsyncMock(return_value=mock_evt)
+        mock_db.commit = AsyncMock()
+
+        with patch("app.database.AsyncSessionLocal", return_value=self._make_db_ctx(mock_db)):
+            with patch("app.services.server_events.close_event", new_callable=AsyncMock) as mock_close:
+                await _record_health_transition("error", result)
+
+        mock_close.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestStartStopDetailedRefresh — lifecycle helpers
+# ---------------------------------------------------------------------------
+
+
+class TestStartStopDetailedRefresh:
+    def test_start_creates_background_task(self):
+        from app.routers.health import start_detailed_refresh
+
+        health_module._detailed_task = None
+        mock_task = MagicMock()
+        with patch("app.routers.health.asyncio") as mock_asyncio:
+            mock_asyncio.create_task.return_value = mock_task
+            start_detailed_refresh()
+
+        mock_asyncio.create_task.assert_called_once()
+        assert health_module._detailed_task is mock_task
+
+    def test_start_sets_initial_status(self):
+        from app.routers.health import start_detailed_refresh
+
+        health_module._last_alert_status = None
+        with patch("app.routers.health.asyncio") as mock_asyncio:
+            mock_asyncio.create_task.return_value = MagicMock()
+            start_detailed_refresh(initial_status="ok")
+
+        assert health_module._last_alert_status == "ok"
+
+    def test_start_without_initial_status_leaves_it_unchanged(self):
+        from app.routers.health import start_detailed_refresh
+
+        health_module._last_alert_status = "degraded"
+        with patch("app.routers.health.asyncio") as mock_asyncio:
+            mock_asyncio.create_task.return_value = MagicMock()
+            start_detailed_refresh()
+
+        assert health_module._last_alert_status == "degraded"
+
+    def test_stop_cancels_task_and_clears_reference(self):
+        from app.routers.health import stop_detailed_refresh
+
+        mock_task = MagicMock()
+        mock_task.cancel = MagicMock()
+        health_module._detailed_task = mock_task
+
+        stop_detailed_refresh()
+
+        mock_task.cancel.assert_called_once()
+        assert health_module._detailed_task is None
+
+    def test_stop_noop_when_no_task(self):
+        from app.routers.health import stop_detailed_refresh
+
+        health_module._detailed_task = None
+        stop_detailed_refresh()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# TestDetailedRefreshLoop — _detailed_refresh_loop single-iteration paths
+# ---------------------------------------------------------------------------
+
+
+class TestDetailedRefreshLoop:
+    """Run exactly one iteration of the loop by making the end-of-loop sleep raise CancelledError."""
+
+    def _make_fake_sleep(self, cancel_on: int = 2):
+        calls = [0]
+
+        async def fake_sleep(_):
+            calls[0] += 1
+            if calls[0] >= cancel_on:
+                raise asyncio.CancelledError()
+
+        return fake_sleep
+
+    async def test_ok_result_resets_failure_counter_and_updates_cache(self):
+        from app.routers.health import _detailed_refresh_loop
+
+        result = ReadinessResponse(
+            status="ok",
+            services=[ReadinessService(name="PostgreSQL", ok=True, critical=True)],
+        )
+        health_module._consecutive_failures = 5
+        health_module._last_alert_status = None
+
+        with patch("app.routers.health.asyncio.sleep", side_effect=self._make_fake_sleep()):
+            with patch("app.routers.health._run_detailed_probes", new_callable=AsyncMock, return_value=result):
+                with patch("app.routers.health._refresh_superuser_email_cache", new_callable=AsyncMock):
+                    with patch("app.routers.health._record_health_transition", new_callable=AsyncMock):
+                        with pytest.raises(asyncio.CancelledError):
+                            await _detailed_refresh_loop()
+
+        assert health_module._consecutive_failures == 0
+        assert health_module._detailed_cache is result
+        assert health_module._last_alert_status == "ok"
+
+    async def test_first_non_ok_increments_counter_but_does_not_surface(self):
+        from app.routers.health import _detailed_refresh_loop
+
+        result = ReadinessResponse(
+            status="error",
+            services=[ReadinessService(name="PostgreSQL", ok=False, critical=True)],
+        )
+        health_module._consecutive_failures = 0
+
+        # On first non-ok the loop does an extra sleep(_FAILURE_RETRY_GAP_S) then `continue`,
+        # so the end-of-loop sleep is never reached — CancelledError comes from call 2.
+        with patch("app.routers.health.asyncio.sleep", side_effect=self._make_fake_sleep(2)):
+            with patch("app.routers.health._run_detailed_probes", new_callable=AsyncMock, return_value=result):
+                with patch("app.routers.health._refresh_superuser_email_cache", new_callable=AsyncMock):
+                    with patch("app.routers.health._record_health_transition", new_callable=AsyncMock) as mock_record:
+                        with pytest.raises(asyncio.CancelledError):
+                            await _detailed_refresh_loop()
+
+        assert health_module._consecutive_failures == 1
+        mock_record.assert_not_called()  # not surfaced yet
+
+    async def test_confirmed_failure_surfaces_and_updates_cache(self):
+        from app.routers.health import _detailed_refresh_loop
+
+        result = ReadinessResponse(
+            status="error",
+            services=[ReadinessService(name="PostgreSQL", ok=False, critical=True)],
+        )
+        # Already at the threshold — next non-ok gets surfaced
+        health_module._consecutive_failures = 3
+        health_module._last_alert_status = None
+
+        with patch("app.routers.health.asyncio.sleep", side_effect=self._make_fake_sleep()):
+            with patch("app.routers.health._run_detailed_probes", new_callable=AsyncMock, return_value=result):
+                with patch("app.routers.health._refresh_superuser_email_cache", new_callable=AsyncMock):
+                    with patch("app.routers.health._record_health_transition", new_callable=AsyncMock) as mock_record:
+                        with pytest.raises(asyncio.CancelledError):
+                            await _detailed_refresh_loop()
+
+        mock_record.assert_called_once()
+        assert health_module._detailed_cache is result
+
+    async def test_status_change_triggers_alert_task(self):
+        from app.routers.health import _detailed_refresh_loop
+
+        result = ReadinessResponse(
+            status="error",
+            services=[ReadinessService(name="PostgreSQL", ok=False, critical=True)],
+        )
+        health_module._consecutive_failures = 3
+        health_module._last_alert_status = "ok"  # transition from ok → error
+
+        with patch("app.routers.health.asyncio.sleep", side_effect=self._make_fake_sleep()):
+            with patch("app.routers.health._run_detailed_probes", new_callable=AsyncMock, return_value=result):
+                with patch("app.routers.health._refresh_superuser_email_cache", new_callable=AsyncMock):
+                    with patch("app.routers.health._record_health_transition", new_callable=AsyncMock):
+                        with patch("app.routers.health.asyncio.create_task") as mock_create_task:
+                            with pytest.raises(asyncio.CancelledError):
+                                await _detailed_refresh_loop()
+
+        mock_create_task.assert_called_once()
+        assert health_module._last_alert_status == "error"
+
+    async def test_recovery_triggers_alert_task(self):
+        from app.routers.health import _detailed_refresh_loop
+
+        result = ReadinessResponse(status="ok", services=[])
+        health_module._consecutive_failures = 0
+        health_module._last_alert_status = "error"  # transition from error → ok
+
+        with patch("app.routers.health.asyncio.sleep", side_effect=self._make_fake_sleep()):
+            with patch("app.routers.health._run_detailed_probes", new_callable=AsyncMock, return_value=result):
+                with patch("app.routers.health._refresh_superuser_email_cache", new_callable=AsyncMock):
+                    with patch("app.routers.health._record_health_transition", new_callable=AsyncMock):
+                        with patch("app.routers.health.asyncio.create_task") as mock_create_task:
+                            with pytest.raises(asyncio.CancelledError):
+                                await _detailed_refresh_loop()
+
+        mock_create_task.assert_called_once()
+
+    async def test_loop_catches_probe_exception_and_continues(self):
+        from app.routers.health import _detailed_refresh_loop
+
+        # Probe raises → except Exception catches it → end-of-loop sleep raises CancelledError
+        with patch("app.routers.health.asyncio.sleep", side_effect=self._make_fake_sleep()):
+            with patch(
+                "app.routers.health._run_detailed_probes",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("probe failed"),
+            ):
+                with pytest.raises(asyncio.CancelledError):
+                    await _detailed_refresh_loop()

--- a/backend/tests/routers/test_projects.py
+++ b/backend/tests/routers/test_projects.py
@@ -2995,3 +2995,426 @@ class TestSetReed:
         await db_session.commit()
         resp = await auth_client.get(f"/api/projects/{project.id}/drawdown_svg")
         assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# TestShareProject — PATCH/DELETE /{project_id}/share
+# ---------------------------------------------------------------------------
+
+
+class TestShareProject:
+    async def test_share_returns_200(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        resp = await auth_client.patch(f"/api/projects/{project.id}/share", json={"visibility": "link"})
+        assert resp.status_code == 200
+
+    async def test_share_sets_slug(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        body = (await auth_client.patch(f"/api/projects/{project.id}/share", json={"visibility": "link"})).json()
+        assert body["share_slug"] is not None
+        assert body["share_visibility"] == "link"
+
+    async def test_share_sets_expiry(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        body = (
+            await auth_client.patch(
+                f"/api/projects/{project.id}/share",
+                json={"visibility": "link", "expires_at": "2099-01-01T00:00:00Z"},
+            )
+        ).json()
+        assert body["share_expires_at"] is not None
+
+    async def test_second_share_reuses_slug(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        body1 = (await auth_client.patch(f"/api/projects/{project.id}/share", json={"visibility": "link"})).json()
+        body2 = (await auth_client.patch(f"/api/projects/{project.id}/share", json={"visibility": "link"})).json()
+        assert body1["share_slug"] == body2["share_slug"]
+
+    async def test_share_invalid_visibility_returns_400(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        resp = await auth_client.patch(f"/api/projects/{project.id}/share", json={"visibility": "public"})
+        assert resp.status_code == 400
+
+    async def test_share_not_found_returns_404(self, auth_client: AsyncClient):
+        resp = await auth_client.patch(f"/api/projects/{uuid.uuid4()}/share", json={"visibility": "link"})
+        assert resp.status_code == 404
+
+    async def test_share_unauthenticated_returns_401(
+        self, client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        resp = await client.patch(f"/api/projects/{project.id}/share", json={"visibility": "link"})
+        assert resp.status_code == 401
+
+    async def test_revoke_returns_204(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        await auth_client.patch(f"/api/projects/{project.id}/share", json={"visibility": "link"})
+        resp = await auth_client.delete(f"/api/projects/{project.id}/share")
+        assert resp.status_code == 204
+
+    async def test_revoke_clears_slug(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        await auth_client.patch(f"/api/projects/{project.id}/share", json={"visibility": "link"})
+        await auth_client.delete(f"/api/projects/{project.id}/share")
+        await db_session.refresh(project)
+        assert project.share_slug is None
+        assert project.share_visibility == "private"
+
+    async def test_revoke_not_found_returns_404(self, auth_client: AsyncClient):
+        resp = await auth_client.delete(f"/api/projects/{uuid.uuid4()}/share")
+        assert resp.status_code == 404
+
+    async def test_revoke_unauthenticated_returns_401(
+        self, client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        resp = await client.delete(f"/api/projects/{project.id}/share")
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# TestGetSharedProject — GET /api/share/projects/{slug}
+# ---------------------------------------------------------------------------
+
+
+async def _share_project(db_session: AsyncSession, project: "Project", slug: str = "test-slug-abc") -> None:
+    project.share_slug = slug
+    project.share_visibility = "link"
+    await db_session.commit()
+
+
+class TestGetSharedProject:
+    async def test_returns_200_for_valid_slug(self, client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        await _share_project(db_session, project, "my-slug-abc1")
+        resp = await client.get("/api/share/projects/my-slug-abc1")
+        assert resp.status_code == 200
+
+    async def test_returns_project_fields(self, client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        await _share_project(db_session, project, "my-slug-abc2")
+        body = (await client.get("/api/share/projects/my-slug-abc2")).json()
+        assert body["project_name"] == project.name
+        assert body["share_visibility"] == "link"
+        assert "has_drawdown_preview" in body
+
+    async def test_private_slug_returns_404(self, client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        project.share_slug = "private-slug"
+        project.share_visibility = "private"
+        await db_session.commit()
+        resp = await client.get("/api/share/projects/private-slug")
+        assert resp.status_code == 404
+
+    async def test_unknown_slug_returns_404(self, client: AsyncClient):
+        resp = await client.get("/api/share/projects/does-not-exist")
+        assert resp.status_code == 404
+
+    async def test_expired_slug_returns_410(self, client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        project.share_slug = "expired-slug"
+        project.share_visibility = "link"
+        project.share_expires_at = datetime(2000, 1, 1, tzinfo=timezone.utc)
+        await db_session.commit()
+        resp = await client.get("/api/share/projects/expired-slug")
+        assert resp.status_code == 410
+
+    async def test_no_auth_required(self, client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        await _share_project(db_session, project, "my-slug-abc3")
+        resp = await client.get("/api/share/projects/my-slug-abc3")
+        assert resp.status_code == 200
+
+
+class TestGetSharedProjectPreview:
+    async def test_returns_404_when_no_preview(self, client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        await _share_project(db_session, project, "prev-slug1")
+        resp = await client.get("/api/share/projects/prev-slug1/preview")
+        assert resp.status_code == 404
+
+    async def test_returns_404_for_private_project(
+        self, client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        project.share_slug = "prev-priv-slug"
+        project.share_visibility = "private"
+        await db_session.commit()
+        resp = await client.get("/api/share/projects/prev-priv-slug/preview")
+        assert resp.status_code == 404
+
+    async def test_returns_410_for_expired_link(self, client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        project.share_slug = "prev-exp-slug"
+        project.share_visibility = "link"
+        project.share_expires_at = datetime(2000, 1, 1, tzinfo=timezone.utc)
+        await db_session.commit()
+        resp = await client.get("/api/share/projects/prev-exp-slug/preview")
+        assert resp.status_code == 410
+
+    async def test_returns_png_when_preview_exists(
+        self, client: AsyncClient, db_session: AsyncSession, test_user: User, mock_storage: dict
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        preview_path = f"project-previews/{project.id}/preview.png"
+        mock_storage[preview_path] = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+        project.drawdown_preview_path = preview_path
+        await _share_project(db_session, project, "prev-ok-slug")
+        resp = await client.get("/api/share/projects/prev-ok-slug/preview")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "image/png"
+
+
+class TestGetSharedProjectSvg:
+    async def test_returns_404_when_no_svg(self, client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        await _share_project(db_session, project, "svg-slug1")
+        resp = await client.get("/api/share/projects/svg-slug1/svg")
+        assert resp.status_code == 404
+
+    async def test_returns_svg_when_exists(
+        self, client: AsyncClient, db_session: AsyncSession, test_user: User, mock_storage: dict
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        svg_path = f"project-svgs/{project.id}/drawdown.svg"
+        mock_storage[svg_path] = b"<svg></svg>"
+        project.drawdown_svg_path = svg_path
+        await _share_project(db_session, project, "svg-ok-slug")
+        resp = await client.get("/api/share/projects/svg-ok-slug/svg")
+        assert resp.status_code == 200
+        assert "svg" in resp.headers["content-type"]
+
+    async def test_returns_410_for_expired(self, client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        project.share_slug = "svg-exp-slug"
+        project.share_visibility = "link"
+        project.share_expires_at = datetime(2000, 1, 1, tzinfo=timezone.utc)
+        await db_session.commit()
+        resp = await client.get("/api/share/projects/svg-exp-slug/svg")
+        assert resp.status_code == 410
+
+
+# ---------------------------------------------------------------------------
+# TestWarpingPlan — GET /{project_id}/warping-plan
+# ---------------------------------------------------------------------------
+
+
+class TestWarpingPlan:
+    async def test_returns_200(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        resp = await auth_client.get(f"/api/projects/{project.id}/warping-plan")
+        assert resp.status_code == 200
+
+    async def test_returns_required_fields(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        body = (await auth_client.get(f"/api/projects/{project.id}/warping-plan")).json()
+        assert "project_id" in body
+        assert "draft_name" in body
+        assert "project_type" in body
+        assert "warp_color_summary" in body
+        assert "weft_color_summary" in body
+
+    async def test_not_found_returns_404(self, auth_client: AsyncClient):
+        resp = await auth_client.get(f"/api/projects/{uuid.uuid4()}/warping-plan")
+        assert resp.status_code == 404
+
+    async def test_unauthenticated_returns_401(self, client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        resp = await client.get(f"/api/projects/{project.id}/warping-plan")
+        assert resp.status_code == 401
+
+    async def test_has_threading_when_wif_has_it(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        draft.has_threading = True
+        await db_session.commit()
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        body = (await auth_client.get(f"/api/projects/{project.id}/warping-plan")).json()
+        assert body["has_threading"] is True
+
+
+# ---------------------------------------------------------------------------
+# TestDrawdownPreviewEndpoint — GET /{project_id}/drawdown/preview
+# ---------------------------------------------------------------------------
+
+
+class TestDrawdownPreviewEndpoint:
+    async def test_returns_png(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        _, project = await _insert_project_with_wif(db_session, test_user)
+        resp = await auth_client.get(f"/api/projects/{project.id}/drawdown/preview")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "image/png"
+
+    async def test_returns_404_when_wif_missing(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        draft.wif_path = "drafts/nonexistent.wif"
+        await db_session.commit()
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        resp = await auth_client.get(f"/api/projects/{project.id}/drawdown/preview")
+        assert resp.status_code == 404
+
+    async def test_invalid_color_replacements_json_returns_400(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        _, project = await _insert_project_with_wif(db_session, test_user)
+        resp = await auth_client.get(f"/api/projects/{project.id}/drawdown/preview?color_replacements=not-json")
+        assert resp.status_code == 400
+
+    async def test_unauthenticated_returns_401(self, client: AsyncClient, db_session: AsyncSession, test_user: User):
+        _, project = await _insert_project_with_wif(db_session, test_user)
+        resp = await client.get(f"/api/projects/{project.id}/drawdown/preview")
+        assert resp.status_code == 401
+
+    async def test_not_found_returns_404(self, auth_client: AsyncClient):
+        resp = await auth_client.get(f"/api/projects/{uuid.uuid4()}/drawdown/preview")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# TestCachedDrawdownPreviewAndSvg
+# ---------------------------------------------------------------------------
+
+
+class TestCachedDrawdownPreview:
+    async def test_returns_png_when_present(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User, mock_storage: dict
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        preview_path = f"project-previews/{project.id}/preview.png"
+        mock_storage[preview_path] = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+        project.drawdown_preview_path = preview_path
+        await db_session.commit()
+        resp = await auth_client.get(f"/api/projects/{project.id}/drawdown_preview")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "image/png"
+
+    async def test_unauthenticated_returns_401(self, client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        resp = await client.get(f"/api/projects/{project.id}/drawdown_preview")
+        assert resp.status_code == 401
+
+
+class TestCachedDrawdownSvg:
+    async def test_returns_svg_when_present(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User, mock_storage: dict
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        svg_path = f"project-svgs/{project.id}/drawdown.svg"
+        mock_storage[svg_path] = b"<svg><rect/></svg>"
+        project.drawdown_svg_path = svg_path
+        await db_session.commit()
+        resp = await auth_client.get(f"/api/projects/{project.id}/drawdown_svg")
+        assert resp.status_code == 200
+        assert "svg" in resp.headers["content-type"]
+
+    async def test_unauthenticated_returns_401(self, client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        resp = await client.get(f"/api/projects/{project.id}/drawdown_svg")
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# TestSlugifyHelper
+# ---------------------------------------------------------------------------
+
+
+class TestSlugifyHelper:
+    def test_basic_slugify(self):
+        from app.routers.projects import _slugify
+
+        assert _slugify("My Draft Name") == "my-draft-name"
+
+    def test_strips_special_chars(self):
+        from app.routers.projects import _slugify
+
+        assert _slugify("Hello! World?") == "hello-world"
+
+    def test_empty_input_returns_project(self):
+        from app.routers.projects import _slugify
+
+        assert _slugify("   ") == "project"
+
+    def test_truncates_long_name(self):
+        from app.routers.projects import _slugify
+
+        long_name = "a" * 100
+        result = _slugify(long_name)
+        assert len(result) <= 48
+
+
+# ---------------------------------------------------------------------------
+# TestComputeColorRuns
+# ---------------------------------------------------------------------------
+
+
+class TestComputeColorRuns:
+    def test_empty_returns_empty(self):
+        from app.routers.projects import _compute_color_runs
+
+        assert _compute_color_runs([]) == []
+
+    def test_single_entry(self):
+        from app.routers.projects import _compute_color_runs
+
+        entries = [{"color": "#ff0000", "color_name": "Red", "end": 1}]
+        runs = _compute_color_runs(entries)
+        assert len(runs) == 1
+        assert runs[0].color == "#ff0000"
+        assert runs[0].count == 1
+
+    def test_consecutive_same_color_merged(self):
+        from app.routers.projects import _compute_color_runs
+
+        entries = [
+            {"color": "#ff0000", "color_name": "Red", "end": 1},
+            {"color": "#ff0000", "color_name": "Red", "end": 2},
+            {"color": "#ff0000", "color_name": "Red", "end": 3},
+        ]
+        runs = _compute_color_runs(entries)
+        assert len(runs) == 1
+        assert runs[0].count == 3
+
+    def test_color_change_creates_new_run(self):
+        from app.routers.projects import _compute_color_runs
+
+        entries = [
+            {"color": "#ff0000", "color_name": "Red", "end": 1},
+            {"color": "#0000ff", "color_name": "Blue", "end": 2},
+        ]
+        runs = _compute_color_runs(entries)
+        assert len(runs) == 2
+        assert runs[0].color == "#ff0000"
+        assert runs[1].color == "#0000ff"


### PR DESCRIPTION
## Summary
- **Issue #745** — `app/routers/health.py` coverage: 48% → 97%  
  Added `TestRunDetailedProbes`, `TestRecordHealthTransitionDBPaths`, `TestStartStopDetailedRefresh`, and `TestDetailedRefreshLoop` covering startup probes, DB-write event paths, lifecycle helpers, and single-iteration loop paths (ok result, first/confirmed failure, alert dispatch, recovery alert, exception handling)
- **Issue #749** — `app/routers/projects.py` coverage: 84% → 93%  
  Added `TestShareProject`, `TestGetSharedProject`, `TestGetSharedProjectPreview`, `TestGetSharedProjectSvg`, `TestWarpingPlan`, `TestDrawdownPreviewEndpoint`, `TestCachedDrawdownPreview`, `TestCachedDrawdownSvg`, `TestSlugifyHelper`, and `TestComputeColorRuns`
- All 2296 tests pass; ruff clean

## Test plan
- [x] `pytest tests/routers/test_health.py` — 63 passed
- [x] `pytest tests/routers/test_projects.py` — 281 passed
- [x] `pytest tests/` (full suite, excluding pre-existing broken tasks) — 2296 passed, 2 skipped
- [x] Ruff lint + format: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)