### PR TITLE
fix: add security headers to nginx for static file responses (#757)

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -26,6 +26,15 @@ server {
 
     client_max_body_size 25M;
 
+    # Security headers for all responses (static files and proxied API alike).
+    # Location blocks that declare their own add_header directives override
+    # these — see location = /env-config.js below which repeats them.
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), interest-cohort=(), payment=(), usb=()" always;
+
     # Upload endpoints — stricter rate limit
     location ~ ^/(api/projects$|api/projects/[^/]+/photos$) {
         limit_req zone=uploads burst=10 nodelay;
@@ -63,8 +72,15 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
-    # env-config.js is rewritten at every container start — never cache it
+    # env-config.js is rewritten at every container start — never cache it.
+    # add_header in a location block overrides the server-level directives, so
+    # security headers must be repeated here alongside the cache headers.
     location = /env-config.js {
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), interest-cohort=(), payment=(), usb=()" always;
         add_header Cache-Control "no-store, no-cache, must-revalidate";
         add_header Pragma "no-cache";
         expires 0;


### PR DESCRIPTION
## Summary

- Adds `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Strict-Transport-Security`, and `Permissions-Policy` at the `server {}` block level in `nginx.conf`
- Covers all nginx-served responses (SPA shell, JS/CSS bundles) that previously had no security headers — only API responses via `SecurityHeadersMiddleware` were protected
- Repeats the headers explicitly in `location = /env-config.js` because nginx location blocks with their own `add_header` directives silently discard inherited server-level headers (nginx quirk documented in comments)
- CSP intentionally omitted — left to backend middleware as it requires Clerk-specific origins

## Test plan

- [ ] After `rbd`, verify `curl -I http://localhost/` returns `X-Frame-Options: DENY` and `Strict-Transport-Security`
- [ ] Verify `curl -I http://localhost/env-config.js` returns security headers AND `Cache-Control: no-store`
- [ ] Verify API responses (`/api/health`) still work normally (duplicate headers from backend middleware are harmless)

Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)