### PR TITLE
fix: PIL magic-byte image validation and authenticated log relay (#758 #759)

### DIFF
--- a/backend/app/routers/logs.py
+++ b/backend/app/routers/logs.py
@@ -2,15 +2,19 @@
 writes them through the shared JsonFormatter logger so client-side events
 appear in the same JSON log stream as backend events.
 
-Rate limiting is handled at the nginx layer (30 req/s per IP on /api/).
-No authentication required — this endpoint only writes, never reads.
+Rate limiting is handled at the nginx layer (dedicated client_logs zone: 2 req/s).
+Unauthenticated requests are silently dropped (204 with no logging) to prevent
+log injection from external callers while never breaking client-side logging UX.
 """
 
 import logging
 from typing import Annotated, Literal
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel, Field
+
+from app.deps import get_optional_user
+from app.models.user import User
 
 log = logging.getLogger("frontend")
 router = APIRouter(prefix="/api/logs", tags=["logs"])
@@ -28,7 +32,10 @@ class ClientLogEvent(BaseModel):
 async def ingest_client_logs(
     events: Annotated[list[ClientLogEvent], Field(max_length=_MAX_EVENTS_PER_REQUEST)],
     request: Request,
+    current_user: User | None = Depends(get_optional_user),
 ) -> None:
+    if current_user is None:
+        return
     client_ip = request.headers.get("X-Real-IP") or (request.client.host if request.client else "unknown")
     for event in events[:_MAX_EVENTS_PER_REQUEST]:
         level_fn = getattr(log, event.level, log.info)

--- a/backend/app/routers/looms.py
+++ b/backend/app/routers/looms.py
@@ -24,7 +24,7 @@ from app.models.loom import (
 )
 from app.models.user import User
 from app.services import storage
-from app.services.images import resize_to_jpeg
+from app.services.images import resize_to_jpeg, validate_image_format
 from app.services.storage_quota import check_storage_quota
 
 router = APIRouter(prefix="/api/looms", tags=["looms"])
@@ -303,6 +303,13 @@ def _validate_image(file: UploadFile) -> None:
         raise HTTPException(status_code=400, detail=f"Unsupported image type: {ct}. Use JPEG, PNG, WebP, or GIF.")
 
 
+def _validate_image_bytes(data: bytes) -> None:
+    try:
+        validate_image_format(data)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
 def _validate_receipt(file: UploadFile) -> None:
     ct = file.content_type or ""
     if ct not in ALLOWED_RECEIPT_TYPES:
@@ -437,6 +444,7 @@ async def upload_loom_photo(
     data = await file.read()
     if len(data) > MAX_FILE_SIZE:
         raise HTTPException(status_code=400, detail="File too large (max 5 MB)")
+    _validate_image_bytes(data)
     try:
         data = resize_to_jpeg(data)
     except Exception:
@@ -528,6 +536,7 @@ async def upload_version_photo(
     data = await file.read()
     if len(data) > MAX_FILE_SIZE:
         raise HTTPException(status_code=400, detail="File too large (max 5 MB)")
+    _validate_image_bytes(data)
     try:
         data = resize_to_jpeg(data)
     except Exception:

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -19,7 +19,7 @@ from app.models.loom import PROJECT_SUPPORTED_LOOM_TYPES, Loom, LoomVersion
 from app.models.project import Project, ProjectPhoto, ProjectStep, WeaveSession
 from app.models.user import User
 from app.services import storage, wif_parser
-from app.services.images import resize_to_jpeg
+from app.services.images import resize_to_jpeg, validate_image_format
 from app.services.storage_quota import check_storage_quota
 from app.tasks.preview import (
     generate_drawdown_preview,
@@ -28,7 +28,7 @@ from app.tasks.preview import (
 )
 from app.tasks.tiles import prerender_project_tiles
 
-ALLOWED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/webp", "image/heic", "image/heif"}
+ALLOWED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/webp", "image/heic", "image/heif"}  # fast pre-filter only
 MAX_PROJECT_PHOTOS = 10
 MAX_PHOTO_SIZE = 25 * 1024 * 1024  # 25 MB raw (resized output is much smaller)
 _PROJECT_RESIZE_MAX_PX = 2048
@@ -1401,6 +1401,11 @@ async def upload_project_photo(
     data = await file.read()
     if len(data) > MAX_PHOTO_SIZE:
         raise HTTPException(status_code=400, detail=f"File too large (max {MAX_PHOTO_SIZE // (1024 * 1024)} MB)")
+
+    try:
+        validate_image_format(data)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
 
     existing = await db.scalars(select(ProjectPhoto).where(ProjectPhoto.project_id == project.id))
     if len(existing.all()) >= MAX_PROJECT_PHOTOS:

--- a/backend/app/services/images.py
+++ b/backend/app/services/images.py
@@ -3,6 +3,21 @@ import io
 from PIL import Image as PILImage
 
 _JPEG_QUALITY = 85
+_ALLOWED_PIL_FORMATS = {"JPEG", "PNG", "WEBP", "HEIF"}
+
+
+def validate_image_format(data: bytes) -> None:
+    """Verify image bytes decode to an allowed format via PIL magic bytes.
+
+    Raises ValueError for non-image bytes or formats outside the allowlist.
+    Content-Type headers are intentionally ignored — they are client-controlled.
+    """
+    try:
+        img = PILImage.open(io.BytesIO(data))
+    except Exception as exc:
+        raise ValueError("Could not decode image") from exc
+    if img.format not in _ALLOWED_PIL_FORMATS:
+        raise ValueError(f"Unsupported image format: {img.format}. Allowed: JPEG, PNG, WebP, HEIF")
 
 
 def resize_to_jpeg(data: bytes, max_px: int = 1600) -> bytes:

--- a/backend/tests/routers/test_logs.py
+++ b/backend/tests/routers/test_logs.py
@@ -4,22 +4,22 @@ from httpx import AsyncClient
 
 
 class TestClientLogs:
-    async def test_single_info_event(self, client: AsyncClient):
-        resp = await client.post(
+    async def test_single_info_event(self, auth_client: AsyncClient):
+        resp = await auth_client.post(
             "/api/logs",
             json=[{"level": "info", "message": "page loaded"}],
         )
         assert resp.status_code == 204
 
-    async def test_event_with_context(self, client: AsyncClient):
-        resp = await client.post(
+    async def test_event_with_context(self, auth_client: AsyncClient):
+        resp = await auth_client.post(
             "/api/logs",
             json=[{"level": "error", "message": "fetch failed", "context": {"route": "/dashboard", "status": 500}}],
         )
         assert resp.status_code == 204
 
-    async def test_multiple_events(self, client: AsyncClient):
-        resp = await client.post(
+    async def test_multiple_events(self, auth_client: AsyncClient):
+        resp = await auth_client.post(
             "/api/logs",
             json=[
                 {"level": "debug", "message": "component mounted"},
@@ -28,20 +28,21 @@ class TestClientLogs:
         )
         assert resp.status_code == 204
 
-    async def test_empty_list(self, client: AsyncClient):
-        resp = await client.post("/api/logs", json=[])
+    async def test_empty_list(self, auth_client: AsyncClient):
+        resp = await auth_client.post("/api/logs", json=[])
         assert resp.status_code == 204
 
-    async def test_no_auth_required(self, client: AsyncClient):
+    async def test_unauthenticated_request_silently_dropped(self, client: AsyncClient):
+        # Unauthenticated callers get 204 (not 401/403) so client-side logging
+        # never breaks auth UX, but events are not written to the log stream.
         resp = await client.post(
             "/api/logs",
-            json=[{"level": "info", "message": "unauthenticated event"}],
+            json=[{"level": "info", "message": "injected log event"}],
         )
-        assert resp.status_code != 401
-        assert resp.status_code != 403
+        assert resp.status_code == 204
 
-    async def test_x_real_ip_header_accepted(self, client: AsyncClient):
-        resp = await client.post(
+    async def test_x_real_ip_header_accepted(self, auth_client: AsyncClient):
+        resp = await auth_client.post(
             "/api/logs",
             headers={"X-Real-IP": "203.0.113.5"},
             json=[{"level": "info", "message": "event with real ip"}],

--- a/backend/tests/routers/test_looms.py
+++ b/backend/tests/routers/test_looms.py
@@ -527,6 +527,16 @@ class TestLoomPhoto:
         )
         assert resp.status_code == 400
 
+    async def test_spoofed_content_type_rejected(self, auth_client: AsyncClient):
+        # Regression: garbage bytes claiming to be PNG must be rejected via PIL
+        # magic-byte check, not the client-supplied Content-Type header.
+        loom = await _create_loom(auth_client)
+        resp = await auth_client.put(
+            f"/api/looms/{loom['id']}/photo",
+            files={"file": ("evil.png", b"not an image at all", "image/png")},
+        )
+        assert resp.status_code == 400
+
     async def test_get_photo_returns_200_after_upload(self, auth_client: AsyncClient):
         loom = await _create_loom(auth_client)
         await auth_client.put(

--- a/backend/tests/routers/test_projects.py
+++ b/backend/tests/routers/test_projects.py
@@ -733,6 +733,19 @@ class TestProjectPhotos:
         )
         assert resp.status_code == 400
 
+    async def test_spoofed_content_type_rejected(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        # Regression: garbage bytes claiming to be JPEG must be rejected via PIL
+        # magic-byte check, not the client-supplied Content-Type header.
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        resp = await auth_client.post(
+            f"/api/projects/{project.id}/photos",
+            files={"file": ("evil.jpg", b"not an image at all", "image/jpeg")},
+        )
+        assert resp.status_code == 400
+
     async def test_upload_cap_returns_400(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -16,6 +16,9 @@ log_format json_combined escape=json
 limit_req_zone $binary_remote_addr zone=api:10m rate=30r/s;
 # Upload endpoints: 5 req/s per IP, burst 10 (WIF uploads and photo uploads)
 limit_req_zone $binary_remote_addr zone=uploads:10m rate=5r/s;
+# Client log relay: 2 req/s per IP, burst 5 — tighter than the general API zone to
+# limit log-injection volume from unauthenticated callers
+limit_req_zone $binary_remote_addr zone=client_logs:5m rate=2r/s;
 
 server {
     listen 80;
@@ -56,6 +59,17 @@ server {
 
     location /auth/ {
         limit_req zone=api burst=60 nodelay;
+        limit_req_status 429;
+        proxy_pass http://backend:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    # Stricter rate limit for the client log relay — exact match takes priority
+    # over the general /api/ prefix block
+    location = /api/logs {
+        limit_req zone=client_logs burst=5 nodelay;
         limit_req_status 429;
         proxy_pass http://backend:8000;
         proxy_set_header Host $host;


### PR DESCRIPTION
## Summary

### #758 — Photo MIME validation via PIL magic bytes

- Adds `validate_image_format(data: bytes)` to `app/services/images.py` — opens the file with PIL and checks `img.format` against an allowlist (`JPEG`, `PNG`, `WEBP`, `HEIF`)
- Called in `projects.py` and `looms.py` after `file.read()`, so the actual image bytes are inspected regardless of what `Content-Type` the client claims
- The existing `content_type` allowlist is kept as a fast pre-filter for obviously wrong types (e.g. `application/pdf`), but is no longer the only gate
- Regression tests added: garbage bytes claiming `image/jpeg` or `image/png` now return 400

### #759 — Authenticated-only log relay

- `POST /api/logs` now uses `get_optional_user` — unauthenticated requests return 204 and are silently dropped (no log write), preventing log injection from external callers
- Silent 204 (not 401) preserves client-side logging UX — auth errors in the browser will never cascade into broken log calls
- Adds a dedicated nginx rate-limit zone (`client_logs: 2 req/s, burst 5`) as a defence-in-depth layer, tighter than the general API zone (30 req/s)

## Test plan

- [ ] CI pytest passes (new regression tests for spoofed MIME and unauthed log drop)
- [ ] Upload a valid JPEG/PNG via project photo endpoint — still works
- [ ] Upload a text file with `Content-Type: image/jpeg` — returns 400
- [ ] Browser console logs still appear in backend logs when authenticated
- [ ] Curl POST to `/api/logs` without a Bearer token — returns 204, nothing logged

Closes #758
Closes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)