### PR TITLE
ci: add weekly schedule to ci-dev-push for unconditional SBOM refresh (#765)

### DIFF
--- a/.github/workflows/ci-dev-push.yml
+++ b/.github/workflows/ci-dev-push.yml
@@ -13,6 +13,11 @@ name: Dev push
 # Note: do NOT put ci-skip tokens in bot commit messages; they propagate
 # into merge commit bodies and suppress PR workflows on the target branch.
 #
+# On scheduled runs (weekly Monday 03:00 UTC) both SBOMs are regenerated
+# unconditionally regardless of whether package files changed. This ensures
+# the backend SBOM stays current even when requirements.txt is unchanged for
+# extended periods (backend packages change less often than frontend npm deps).
+#
 # Required secrets:
 #   WEFTMARK_BOT_CLIENT_ID   — GitHub App client ID
 #   WEFTMARK_BOT_PRIVATE_KEY — GitHub App private key
@@ -20,6 +25,8 @@ name: Dev push
 on:
   push:
     branches: [dev]
+  schedule:
+    - cron: "0 3 * * 1"  # Mondays 03:00 UTC
 
 concurrency:
   group: dev-push-${{ github.ref }}
@@ -47,7 +54,9 @@ jobs:
       - name: Detect backend package changes
         id: detect
         run: |
-          if git rev-parse HEAD~1 >/dev/null 2>&1; then
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          elif git rev-parse HEAD~1 >/dev/null 2>&1; then
             git diff --name-only HEAD~1 HEAD | grep -q "^backend/requirements" \
               && echo "changed=true" >> $GITHUB_OUTPUT \
               || echo "changed=false" >> $GITHUB_OUTPUT
@@ -109,7 +118,9 @@ jobs:
       - name: Detect frontend package changes
         id: detect
         run: |
-          if git rev-parse HEAD~1 >/dev/null 2>&1; then
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          elif git rev-parse HEAD~1 >/dev/null 2>&1; then
             git diff --name-only HEAD~1 HEAD | grep -qE "^frontend/package(-lock)?\.json" \
               && echo "changed=true" >> $GITHUB_OUTPUT \
               || echo "changed=false" >> $GITHUB_OUTPUT
@@ -154,7 +165,7 @@ jobs:
     name: Bump version
     runs-on: ubuntu-latest
     needs: [sbom-backend, sbom-frontend]
-    if: github.actor != 'weftmark-bot[bot]'
+    if: github.actor != 'weftmark-bot[bot]' && github.event_name != 'schedule'
     steps:
       - name: Generate bot token
         id: app-token


### PR DESCRIPTION
## Summary

- Adds `schedule: cron: "0 3 * * 1"` (Mondays 03:00 UTC) to `ci-dev-push.yml`
- Both `sbom-backend` and `sbom-frontend` detect steps now short-circuit to `changed=true` on scheduled runs, bypassing the git diff gate
- `bump-version` is skipped on scheduled runs (nothing to version-bump)

## Root cause (from #765 investigation)

The asymmetry was by design, not a bug: `requirements.txt` only changes when a new Python package is explicitly added (last change: 2026-05-12), while `package.json`/`package-lock.json` changes on nearly every PR that touches npm (installs, lock file regen from Linux rebuild, version field bumps). The detection logic was correct — the backend SBOM was last generated 2026-05-13 and is accurate for the current `requirements.txt`.

The weekly schedule ensures the backend SBOM doesn't silently drift if a transitive dependency changes its metadata without `requirements.txt` being touched.

## pip freeze status

`requirements.txt` is current as of 2026-05-12 (PyWeaving vendoring). No new Python packages were added in any of the recent security fix PRs (#755–#761). No pip freeze needed.

## Test plan

- [ ] Verify workflow YAML is valid (CI lint)
- [ ] Confirm scheduled runs generate both SBOM files and commit them
- [ ] Confirm `bump-version` step is skipped on scheduled runs (no spurious version bump)

Closes #765

🤖 Generated with [Claude Code](https://claude.com/claude-code)