### PR TITLE
fix: use frontend_url as expected azp in JWT verification (#770)

### DIFF
--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -40,7 +40,8 @@ async def get_current_user(
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Auth not configured")
 
     jwks_url = jwks_url_from_publishable_key(settings.clerk_publishable_key)
-    clerk_user_id = verify_session_token(token, jwks_url, expected_azp=settings.clerk_publishable_key)
+    # Clerk sets azp to the frontend origin URL, not the publishable key
+    clerk_user_id = verify_session_token(token, jwks_url, expected_azp=settings.frontend_url.rstrip("/"))
     if not clerk_user_id:
         log.info("auth_failure reason=invalid_token method=%s path=%s", method, path)
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired token")

--- a/backend/tests/services/test_clerk_auth.py
+++ b/backend/tests/services/test_clerk_auth.py
@@ -74,13 +74,14 @@ class TestVerifySessionToken:
         mock_signing_key.key = "fake-key"
         mock_client.get_signing_key_from_jwt.return_value = mock_signing_key
 
-        payload = {"sub": "user_abc", "azp": "pk_test_other_app"}
+        # Clerk azp is the frontend origin URL; wrong origin must be rejected
+        payload = {"sub": "user_abc", "azp": "https://other.example.com"}
         with patch("app.services.clerk_auth._jwks_client", return_value=mock_client):
             with patch("app.services.clerk_auth.jwt.decode", return_value=payload):
                 result = verify_session_token(
                     "fake.jwt.token",
                     "https://example.com/.well-known/jwks.json",
-                    expected_azp="pk_test_this_app",
+                    expected_azp="https://app.example.com",
                 )
 
         assert result is None
@@ -91,13 +92,14 @@ class TestVerifySessionToken:
         mock_signing_key.key = "fake-key"
         mock_client.get_signing_key_from_jwt.return_value = mock_signing_key
 
-        payload = {"sub": "user_abc", "azp": "pk_test_this_app"}
+        # Clerk azp is the frontend origin URL; correct origin must be accepted
+        payload = {"sub": "user_abc", "azp": "https://app.example.com"}
         with patch("app.services.clerk_auth._jwks_client", return_value=mock_client):
             with patch("app.services.clerk_auth.jwt.decode", return_value=payload):
                 result = verify_session_token(
                     "fake.jwt.token",
                     "https://example.com/.well-known/jwks.json",
-                    expected_azp="pk_test_this_app",
+                    expected_azp="https://app.example.com",
                 )
 
         assert result == "user_abc"


### PR DESCRIPTION
## Summary

- Fixes login breakage on dev introduced by the azp check in #767
- Clerk's JWT `azp` claim is the **frontend origin URL** (`https://dev.weftmark.com`), not the publishable key (`pk_test_...`)
- Changed `expected_azp=settings.clerk_publishable_key` → `expected_azp=settings.frontend_url.rstrip("/")`
- Updated `test_clerk_auth.py` azp test payloads to use URL-shaped strings matching the real production value

Closes #770

## Test plan

- [ ] `pytest backend/tests/services/test_clerk_auth.py` — all azp tests pass
- [ ] After merge + deploy, Google SSO sign-in on dev completes without redirect loop
- [ ] `GET /auth/me` returns 200 with a valid session (no `jwt_azp_mismatch` in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)