### PR TITLE
feat: switch e2e auth to Clerk sign-in tokens, add multi-env support (#773)

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -3,4 +3,8 @@ node_modules/
 test-results/
 playwright-report/
 .env
+.env.local
+.env.dev
+.env.prod
+!.env.example
 credentials/

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -2,7 +2,10 @@ import { defineConfig, devices } from "@playwright/test";
 import dotenv from "dotenv";
 import path from "path";
 
-dotenv.config({ path: path.resolve(__dirname, ".env") });
+// DOTENV_FILE=.env.local  → localhost:3000   (default)
+// DOTENV_FILE=.env.dev    → dev.weftmark.com
+// DOTENV_FILE=.env.prod   → weftmark.com
+dotenv.config({ path: path.resolve(__dirname, process.env.DOTENV_FILE ?? ".env.local") });
 
 export default defineConfig({
   testDir: "./tests",

--- a/e2e/tests/global.setup.ts
+++ b/e2e/tests/global.setup.ts
@@ -4,25 +4,39 @@ import path from "path";
 const userFile = path.join(__dirname, "../.auth/user.json");
 const adminFile = path.join(__dirname, "../.auth/admin.json");
 
-async function signIn(page: Page, email: string, password: string) {
-  await page.goto("/login");
+const BASE_URL = process.env.E2E_BASE_URL || "http://localhost:3000";
+const CLERK_SECRET_KEY = process.env.CLERK_SECRET_KEY!;
 
-  // Wait for Clerk's embedded <SignIn> component to render the email field
-  const emailField = page.getByLabel(/email address/i).first();
-  await emailField.waitFor({ state: "visible", timeout: 15_000 });
-  await emailField.fill(email);
+// Clerk's Backend API returns a sign-in URL that auto-logs in the user.
+// This bypasses the Clerk UI entirely, avoiding Google Workspace domain detection
+// that redirects @weftmark.com addresses to Google OAuth instead of the password step.
+async function getSignInUrl(userId: string): Promise<string> {
+  const resp = await fetch("https://api.clerk.com/v1/sign_in_tokens", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${CLERK_SECRET_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ user_id: userId }),
+  });
+  if (!resp.ok) {
+    const err = await resp.text();
+    throw new Error(`Clerk sign-in token failed (${resp.status}): ${err}`);
+  }
+  const data = await resp.json();
+  // Clerk returns e.g. https://verified-anchovy-95.accounts.dev/sign-in?__clerk_ticket=...
+  // Append redirect_url so Clerk sends us back to the app after sign-in.
+  return `${data.url}&redirect_url=${encodeURIComponent(`${BASE_URL}/home`)}`;
+}
 
-  // Click Continue to advance to password step
-  await page.getByRole("button", { name: /continue/i }).first().click();
-
-  // Wait for password field (two-step flow)
-  const passwordField = page.getByLabel(/^password$/i).first();
-  await passwordField.waitFor({ state: "visible", timeout: 10_000 });
-  await passwordField.fill(password);
-  await page.getByRole("button", { name: /continue|sign in/i }).first().click();
-
-  // Wait for redirect to authenticated area
-  await page.waitForURL(/\/(home|admin|pending)/, { timeout: 20_000 });
+async function signIn(page: Page, userId: string) {
+  const signInUrl = await getSignInUrl(userId);
+  // Extract the ticket and present it on the app's own login page.
+  // Clerk's frontend SDK on the app domain handles __clerk_ticket natively,
+  // avoiding cross-domain session sync issues that arise from navigating to accounts.dev.
+  const ticket = new URL(signInUrl).searchParams.get("__clerk_ticket")!;
+  await page.goto(`${BASE_URL}/login?__clerk_ticket=${ticket}`);
+  await page.waitForURL(/\/(home|admin|pending)/, { timeout: 30_000 });
 
   // Handle EulaGate if shown on first sign-in
   const eulaVisible = await page
@@ -40,11 +54,11 @@ async function signIn(page: Page, email: string, password: string) {
 }
 
 setup("authenticate as regular user", async ({ page }) => {
-  await signIn(page, process.env.E2E_USER_EMAIL!, process.env.E2E_USER_PASSWORD!);
+  await signIn(page, process.env.E2E_USER_ID!);
   await page.context().storageState({ path: userFile });
 });
 
 setup("authenticate as admin user", async ({ page }) => {
-  await signIn(page, process.env.E2E_ADMIN_EMAIL!, process.env.E2E_ADMIN_PASSWORD!);
+  await signIn(page, process.env.E2E_ADMIN_ID!);
   await page.context().storageState({ path: adminFile });
 });


### PR DESCRIPTION
## Summary

- Replaces UI-based Playwright sign-in with Clerk Backend API sign-in tokens — bypasses Google Workspace domain detection that was redirecting `@weftmark.com` accounts to Google OAuth instead of the password step
- Adds `DOTENV_FILE` env var to `playwright.config.ts` for multi-environment targeting: `DOTENV_FILE=.env.dev` → `dev.weftmark.com`, default `.env.local` → `localhost:3000`
- Updates `e2e/.gitignore` to cover all three env file variants (`.env.local`, `.env.dev`, `.env.prod`)

Closes the auth infrastructure blocking issue in #773 (stale selector fixes and new coverage tracked separately in that issue).

## Test plan

- [ ] `DOTENV_FILE=.env.dev npx playwright test` in `e2e/` — setup project passes, authenticated tests run against dev.weftmark.com
- [ ] Unauthenticated tests still pass (no dependency on sign-in tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)