### PR TITLE
feat: loom reference database catalog (#775)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,6 +11,7 @@ RUN pip install --no-cache-dir -r requirements-dev.txt
 
 COPY backend/ .
 COPY VERSION .
+COPY docs/research/looms/loom-data-master.json seeds/
 # Substitute DejaVu Sans for Arial in the vendored weaving engine
 RUN cp /usr/share/fonts/truetype/dejavu/DejaVuSans.ttf /app/app/weaving/data/Arial.ttf
 

--- a/backend/alembic/versions/0029_loom_references.py
+++ b/backend/alembic/versions/0029_loom_references.py
@@ -1,0 +1,133 @@
+"""loom_references table, loom_reference_id FK on looms, extend loom_type enum
+
+Revision ID: 7d8e9f0a1b2c
+Revises: 6c7d8e9f0a1b
+Create Date: 2026-05-18
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+revision: str = "7d8e9f0a1b2c"
+down_revision: str = "6c7d8e9f0a1b"
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------ #
+    # 1. Extend loom_type values on existing looms rows                   #
+    #    (column is VARCHAR — no Postgres enum to alter, just data)       #
+    # ------------------------------------------------------------------ #
+    op.execute("UPDATE looms SET loom_type = 'dobby_floor_loom' WHERE loom_type = 'dobby'")
+
+    # ------------------------------------------------------------------ #
+    # 2. Create loom_references catalog table                             #
+    # ------------------------------------------------------------------ #
+    op.create_table(
+        "loom_references",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        # Core identity
+        sa.Column("brand", sa.String(255), nullable=False),
+        sa.Column("model_name", sa.String(255), nullable=False),
+        sa.Column("model_series", sa.String(255), nullable=True),
+        sa.Column("loom_category", sa.String(50), nullable=False),
+        sa.Column("shedding_mechanism", sa.String(50), nullable=True),
+        # Configuration arrays
+        sa.Column("shaft_count_options", JSONB, nullable=True),
+        sa.Column("treadle_count", JSONB, nullable=True),
+        sa.Column("weaving_width_options_inches", JSONB, nullable=True),
+        sa.Column("weaving_width_options_cm", JSONB, nullable=True),
+        # Physical
+        sa.Column("frame_material", sa.String(50), nullable=True),
+        sa.Column("foldable", sa.Boolean, nullable=True),
+        sa.Column("foldable_while_warped", sa.Boolean, nullable=True),
+        sa.Column("weight_lbs", sa.Numeric(8, 2), nullable=True),
+        sa.Column("unfolded_depth_inches", sa.Numeric(8, 2), nullable=True),
+        sa.Column("folded_depth_inches", sa.Numeric(8, 2), nullable=True),
+        sa.Column("castle_height_inches", sa.Numeric(8, 2), nullable=True),
+        sa.Column("breast_beam_height_inches", sa.Numeric(8, 2), nullable=True),
+        # Reed / heddle
+        sa.Column("reed_included", sa.Boolean, nullable=True),
+        sa.Column("reed_dent_included", JSONB, nullable=True),
+        sa.Column("reed_material", sa.String(50), nullable=True),
+        sa.Column("heddle_type", sa.String(50), nullable=True),
+        sa.Column("heddles_per_shaft_included", sa.Numeric(8, 1), nullable=True),
+        # Beater / brake / tie-up
+        sa.Column("brake_type", sa.String(50), nullable=True),
+        sa.Column("beater_type", sa.String(50), nullable=True),
+        sa.Column("beater_adjustable", sa.Boolean, nullable=True),
+        sa.Column("tie_up_system", sa.String(50), nullable=True),
+        sa.Column("treadle_hinge", sa.String(50), nullable=True),
+        # Upgrades / accessories
+        sa.Column("shaft_upgrade_available", sa.Boolean, nullable=True),
+        sa.Column("max_shafts_with_upgrade", sa.Integer, nullable=True),
+        sa.Column("four_now_four_later", sa.Boolean, nullable=True),
+        sa.Column("height_extender_available", sa.Boolean, nullable=True),
+        sa.Column("height_extender_inches", sa.Numeric(6, 2), nullable=True),
+        sa.Column("sectional_beam_available", sa.Boolean, nullable=True),
+        sa.Column("double_back_beam_available", sa.Boolean, nullable=True),
+        sa.Column("floating_breast_beam", sa.Boolean, nullable=True),
+        sa.Column("fly_shuttle_available", sa.Boolean, nullable=True),
+        sa.Column("mobility_wheels_included", sa.Boolean, nullable=True),
+        sa.Column("stroller_available", sa.Boolean, nullable=True),
+        sa.Column("shaft_switching_device_available", sa.Boolean, nullable=True),
+        # Included accessories
+        sa.Column("lease_sticks_included", sa.Boolean, nullable=True),
+        sa.Column("raddle_included", sa.Boolean, nullable=True),
+        sa.Column("shuttle_included", sa.Boolean, nullable=True),
+        sa.Column("carry_bag_included", sa.Boolean, nullable=True),
+        # Assembly / finish
+        sa.Column("assembly_required", sa.Boolean, nullable=True),
+        sa.Column("finish_required", sa.Boolean, nullable=True),
+        # Origin / warranty
+        sa.Column("origin_country", sa.String(100), nullable=True),
+        sa.Column("warranty_years", sa.Numeric(5, 1), nullable=True),
+        # Dobby-specific
+        sa.Column("dobby_type", sa.String(50), nullable=True),
+        sa.Column("compatible_software", JSONB, nullable=True),
+        # Timestamps
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index("ix_loom_references_brand", "loom_references", ["brand"])
+    op.create_index("ix_loom_references_model_name", "loom_references", ["model_name"])
+    op.create_index("ix_loom_references_loom_category", "loom_references", ["loom_category"])
+    op.create_index(
+        "ix_loom_references_brand_model",
+        "loom_references",
+        ["brand", "model_name"],
+        unique=True,
+    )
+
+    # ------------------------------------------------------------------ #
+    # 3. Add loom_reference_id FK to looms                               #
+    # ------------------------------------------------------------------ #
+    op.add_column(
+        "looms",
+        sa.Column("loom_reference_id", UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_looms_loom_reference_id",
+        "looms",
+        "loom_references",
+        ["loom_reference_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index("ix_looms_loom_reference_id", "looms", ["loom_reference_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_looms_loom_reference_id", "looms")
+    op.drop_constraint("fk_looms_loom_reference_id", "looms", type_="foreignkey")
+    op.drop_column("looms", "loom_reference_id")
+
+    op.drop_index("ix_loom_references_brand_model", "loom_references")
+    op.drop_index("ix_loom_references_loom_category", "loom_references")
+    op.drop_index("ix_loom_references_model_name", "loom_references")
+    op.drop_index("ix_loom_references_brand", "loom_references")
+    op.drop_table("loom_references")
+
+    op.execute("UPDATE looms SET loom_type = 'dobby' WHERE loom_type = 'dobby_floor_loom'")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,6 +26,7 @@ from app.routers import (  # noqa: E402
     feedback,
     health,
     logs,
+    loom_catalog,
     looms,
     projects,
     system,
@@ -232,6 +233,8 @@ app.include_router(webhooks.router)
 app.include_router(users.eula_router)
 app.include_router(users.router)
 app.include_router(drafts.router)
+app.include_router(loom_catalog.public_router)
+app.include_router(loom_catalog.admin_catalog_router)
 app.include_router(looms.router)
 app.include_router(yarn.router)
 app.include_router(projects.router)

--- a/backend/app/models/loom.py
+++ b/backend/app/models/loom.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import date
 from decimal import Decimal
 
-from sqlalchemy import Boolean, Date, Float, ForeignKey, Integer, Numeric, String, Text, UniqueConstraint
+from sqlalchemy import Boolean, Date, Float, ForeignKey, Index, Integer, Numeric, String, Text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -36,7 +36,7 @@ class LoomReference(Base, TimestampMixin):
     """Admin-maintained catalog of commercially available looms seeded from market research."""
 
     __tablename__ = "loom_references"
-    __table_args__ = (UniqueConstraint("brand", "model_name", name="ix_loom_references_brand_model"),)
+    __table_args__ = (Index("ix_loom_references_brand_model", "brand", "model_name", unique=True),)
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
 

--- a/backend/app/models/loom.py
+++ b/backend/app/models/loom.py
@@ -3,15 +3,28 @@ from datetime import date
 from decimal import Decimal
 
 from sqlalchemy import Boolean, Date, Float, ForeignKey, Integer, Numeric, String, Text
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, SoftDeleteMixin, TimestampMixin
 
-LOOM_TYPES = ("floor_loom", "table_loom", "rigid_heddle", "inkle", "dobby", "other")
+LOOM_TYPES = (
+    "floor_loom",
+    "table_loom",
+    "rigid_heddle",
+    "inkle",
+    "dobby_floor_loom",
+    "tapestry_loom",
+    "rug_loom",
+    "frame_loom",
+    "other",
+)
 
 # Only these types support project tracking (treadle or lift).
 PROJECT_SUPPORTED_LOOM_TYPES = frozenset({"floor_loom", "table_loom"})
+
+# These types exist for inventory but do not support project tracking.
+UNSUPPORTED_LOOM_TYPES = frozenset(LOOM_TYPES) - PROJECT_SUPPORTED_LOOM_TYPES
 
 
 def loom_tracking_flags(loom_type: str) -> tuple[bool, bool]:
@@ -19,11 +32,93 @@ def loom_tracking_flags(loom_type: str) -> tuple[bool, bool]:
     return loom_type == "table_loom", loom_type == "floor_loom"
 
 
+class LoomReference(Base, TimestampMixin):
+    """Admin-maintained catalog of commercially available looms seeded from market research."""
+
+    __tablename__ = "loom_references"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    # Core identity
+    brand: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    model_name: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    model_series: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    loom_category: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    shedding_mechanism: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
+    # Configuration arrays (JSONB — parallel arrays; user picks one index)
+    shaft_count_options: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    treadle_count: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    weaving_width_options_inches: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    weaving_width_options_cm: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+
+    # Physical characteristics
+    frame_material: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    foldable: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    foldable_while_warped: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    weight_lbs: Mapped[Decimal | None] = mapped_column(Numeric(8, 2), nullable=True)
+    unfolded_depth_inches: Mapped[Decimal | None] = mapped_column(Numeric(8, 2), nullable=True)
+    folded_depth_inches: Mapped[Decimal | None] = mapped_column(Numeric(8, 2), nullable=True)
+    castle_height_inches: Mapped[Decimal | None] = mapped_column(Numeric(8, 2), nullable=True)
+    breast_beam_height_inches: Mapped[Decimal | None] = mapped_column(Numeric(8, 2), nullable=True)
+
+    # Reed / heddle details
+    reed_included: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    reed_dent_included: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    reed_material: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    heddle_type: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    heddles_per_shaft_included: Mapped[Decimal | None] = mapped_column(Numeric(8, 1), nullable=True)
+
+    # Beater / brake / tie-up
+    brake_type: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    beater_type: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    beater_adjustable: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    tie_up_system: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    treadle_hinge: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
+    # Upgrades / accessories
+    shaft_upgrade_available: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    max_shafts_with_upgrade: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    four_now_four_later: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    height_extender_available: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    height_extender_inches: Mapped[Decimal | None] = mapped_column(Numeric(6, 2), nullable=True)
+    sectional_beam_available: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    double_back_beam_available: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    floating_breast_beam: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    fly_shuttle_available: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    mobility_wheels_included: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    stroller_available: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    shaft_switching_device_available: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+
+    # Included accessories
+    lease_sticks_included: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    raddle_included: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    shuttle_included: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    carry_bag_included: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+
+    # Assembly / finish
+    assembly_required: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    finish_required: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+
+    # Origin / warranty
+    origin_country: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    warranty_years: Mapped[Decimal | None] = mapped_column(Numeric(5, 1), nullable=True)
+
+    # Dobby-specific
+    dobby_type: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    compatible_software: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+
+    looms: Mapped[list["Loom"]] = relationship("Loom", back_populates="loom_reference")
+
+
 class Loom(Base, TimestampMixin, SoftDeleteMixin):
     __tablename__ = "looms"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     owner_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, index=True)
+    loom_reference_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("loom_references.id", ondelete="SET NULL"), nullable=True, index=True
+    )
 
     loom_type: Mapped[str] = mapped_column(String(30), nullable=False, default="floor_loom")
 
@@ -53,6 +148,7 @@ class Loom(Base, TimestampMixin, SoftDeleteMixin):
         "LoomReed", back_populates="loom", order_by="LoomReed.dents_per_inch", cascade="all, delete-orphan"
     )
     owner: Mapped["User"] = relationship("User", foreign_keys=[owner_id])  # type: ignore[name-defined]
+    loom_reference: Mapped["LoomReference | None"] = relationship("LoomReference", back_populates="looms")
 
     @property
     def current_version(self) -> "LoomVersion | None":

--- a/backend/app/models/loom.py
+++ b/backend/app/models/loom.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import date
 from decimal import Decimal
 
-from sqlalchemy import Boolean, Date, Float, ForeignKey, Integer, Numeric, String, Text
+from sqlalchemy import Boolean, Date, Float, ForeignKey, Integer, Numeric, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -36,6 +36,7 @@ class LoomReference(Base, TimestampMixin):
     """Admin-maintained catalog of commercially available looms seeded from market research."""
 
     __tablename__ = "loom_references"
+    __table_args__ = (UniqueConstraint("brand", "model_name", name="ix_loom_references_brand_model"),)
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
 

--- a/backend/app/routers/loom_catalog.py
+++ b/backend/app/routers/loom_catalog.py
@@ -29,8 +29,8 @@ class LoomReferenceSchema(BaseModel):
     model_series: str | None
     loom_category: str
     shedding_mechanism: str | None
-    shaft_count_options: list[int] | None
-    treadle_count: list[int] | None
+    shaft_count_options: list[float] | None
+    treadle_count: list[float] | None
     weaving_width_options_inches: list[float] | None
     weaving_width_options_cm: list[float] | None
     frame_material: str | None
@@ -42,7 +42,7 @@ class LoomReferenceSchema(BaseModel):
     castle_height_inches: Decimal | None
     breast_beam_height_inches: Decimal | None
     reed_included: bool | None
-    reed_dent_included: list[int] | None
+    reed_dent_included: list[float] | None
     reed_material: str | None
     heddle_type: str | None
     heddles_per_shaft_included: Decimal | None
@@ -84,8 +84,8 @@ class LoomReferenceSummary(BaseModel):
     model_series: str | None
     loom_category: str
     shedding_mechanism: str | None
-    shaft_count_options: list[int] | None
-    treadle_count: list[int] | None
+    shaft_count_options: list[float] | None
+    treadle_count: list[float] | None
     weaving_width_options_inches: list[float] | None
     weaving_width_options_cm: list[float] | None
     foldable: bool | None
@@ -100,8 +100,8 @@ class CreateLoomReferenceRequest(BaseModel):
     model_series: str | None = None
     loom_category: str
     shedding_mechanism: str | None = None
-    shaft_count_options: list[int] | None = None
-    treadle_count: list[int] | None = None
+    shaft_count_options: list[float] | None = None
+    treadle_count: list[float] | None = None
     weaving_width_options_inches: list[float] | None = None
     weaving_width_options_cm: list[float] | None = None
     frame_material: str | None = None
@@ -113,7 +113,7 @@ class CreateLoomReferenceRequest(BaseModel):
     castle_height_inches: Decimal | None = None
     breast_beam_height_inches: Decimal | None = None
     reed_included: bool | None = None
-    reed_dent_included: list[int] | None = None
+    reed_dent_included: list[float] | None = None
     reed_material: str | None = None
     heddle_type: str | None = None
     heddles_per_shaft_included: Decimal | None = None
@@ -152,8 +152,8 @@ class UpdateLoomReferenceRequest(BaseModel):
     model_series: str | None = None
     loom_category: str | None = None
     shedding_mechanism: str | None = None
-    shaft_count_options: list[int] | None = None
-    treadle_count: list[int] | None = None
+    shaft_count_options: list[float] | None = None
+    treadle_count: list[float] | None = None
     weaving_width_options_inches: list[float] | None = None
     weaving_width_options_cm: list[float] | None = None
     frame_material: str | None = None
@@ -165,7 +165,7 @@ class UpdateLoomReferenceRequest(BaseModel):
     castle_height_inches: Decimal | None = None
     breast_beam_height_inches: Decimal | None = None
     reed_included: bool | None = None
-    reed_dent_included: list[int] | None = None
+    reed_dent_included: list[float] | None = None
     reed_material: str | None = None
     heddle_type: str | None = None
     heddles_per_shaft_included: Decimal | None = None

--- a/backend/app/routers/loom_catalog.py
+++ b/backend/app/routers/loom_catalog.py
@@ -1,0 +1,355 @@
+"""Public loom catalog and admin CRUD for loom_references."""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.deps import get_db, require_admin
+from app.models.loom import LoomReference
+from app.models.user import User
+
+router = APIRouter(tags=["loom-catalog"])
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class LoomReferenceSchema(BaseModel):
+    id: uuid.UUID
+    brand: str
+    model_name: str
+    model_series: str | None
+    loom_category: str
+    shedding_mechanism: str | None
+    shaft_count_options: list[int] | None
+    treadle_count: list[int] | None
+    weaving_width_options_inches: list[float] | None
+    weaving_width_options_cm: list[float] | None
+    frame_material: str | None
+    foldable: bool | None
+    foldable_while_warped: bool | None
+    weight_lbs: Decimal | None
+    unfolded_depth_inches: Decimal | None
+    folded_depth_inches: Decimal | None
+    castle_height_inches: Decimal | None
+    breast_beam_height_inches: Decimal | None
+    reed_included: bool | None
+    reed_dent_included: list[int] | None
+    reed_material: str | None
+    heddle_type: str | None
+    heddles_per_shaft_included: Decimal | None
+    brake_type: str | None
+    beater_type: str | None
+    beater_adjustable: bool | None
+    tie_up_system: str | None
+    treadle_hinge: str | None
+    shaft_upgrade_available: bool | None
+    max_shafts_with_upgrade: int | None
+    four_now_four_later: bool | None
+    height_extender_available: bool | None
+    height_extender_inches: Decimal | None
+    sectional_beam_available: bool | None
+    double_back_beam_available: bool | None
+    floating_breast_beam: bool | None
+    fly_shuttle_available: bool | None
+    mobility_wheels_included: bool | None
+    stroller_available: bool | None
+    shaft_switching_device_available: bool | None
+    lease_sticks_included: bool | None
+    raddle_included: bool | None
+    shuttle_included: bool | None
+    carry_bag_included: bool | None
+    assembly_required: bool | None
+    finish_required: bool | None
+    origin_country: str | None
+    warranty_years: Decimal | None
+    dobby_type: str | None
+    compatible_software: list[str] | None
+
+    model_config = {"from_attributes": True}
+
+
+class LoomReferenceSummary(BaseModel):
+    id: uuid.UUID
+    brand: str
+    model_name: str
+    model_series: str | None
+    loom_category: str
+    shedding_mechanism: str | None
+    shaft_count_options: list[int] | None
+    treadle_count: list[int] | None
+    weaving_width_options_inches: list[float] | None
+    weaving_width_options_cm: list[float] | None
+    foldable: bool | None
+    origin_country: str | None
+
+    model_config = {"from_attributes": True}
+
+
+class CreateLoomReferenceRequest(BaseModel):
+    brand: str
+    model_name: str
+    model_series: str | None = None
+    loom_category: str
+    shedding_mechanism: str | None = None
+    shaft_count_options: list[int] | None = None
+    treadle_count: list[int] | None = None
+    weaving_width_options_inches: list[float] | None = None
+    weaving_width_options_cm: list[float] | None = None
+    frame_material: str | None = None
+    foldable: bool | None = None
+    foldable_while_warped: bool | None = None
+    weight_lbs: Decimal | None = None
+    unfolded_depth_inches: Decimal | None = None
+    folded_depth_inches: Decimal | None = None
+    castle_height_inches: Decimal | None = None
+    breast_beam_height_inches: Decimal | None = None
+    reed_included: bool | None = None
+    reed_dent_included: list[int] | None = None
+    reed_material: str | None = None
+    heddle_type: str | None = None
+    heddles_per_shaft_included: Decimal | None = None
+    brake_type: str | None = None
+    beater_type: str | None = None
+    beater_adjustable: bool | None = None
+    tie_up_system: str | None = None
+    treadle_hinge: str | None = None
+    shaft_upgrade_available: bool | None = None
+    max_shafts_with_upgrade: int | None = None
+    four_now_four_later: bool | None = None
+    height_extender_available: bool | None = None
+    height_extender_inches: Decimal | None = None
+    sectional_beam_available: bool | None = None
+    double_back_beam_available: bool | None = None
+    floating_breast_beam: bool | None = None
+    fly_shuttle_available: bool | None = None
+    mobility_wheels_included: bool | None = None
+    stroller_available: bool | None = None
+    shaft_switching_device_available: bool | None = None
+    lease_sticks_included: bool | None = None
+    raddle_included: bool | None = None
+    shuttle_included: bool | None = None
+    carry_bag_included: bool | None = None
+    assembly_required: bool | None = None
+    finish_required: bool | None = None
+    origin_country: str | None = None
+    warranty_years: Decimal | None = None
+    dobby_type: str | None = None
+    compatible_software: list[str] | None = None
+
+
+class UpdateLoomReferenceRequest(BaseModel):
+    brand: str | None = None
+    model_name: str | None = None
+    model_series: str | None = None
+    loom_category: str | None = None
+    shedding_mechanism: str | None = None
+    shaft_count_options: list[int] | None = None
+    treadle_count: list[int] | None = None
+    weaving_width_options_inches: list[float] | None = None
+    weaving_width_options_cm: list[float] | None = None
+    frame_material: str | None = None
+    foldable: bool | None = None
+    foldable_while_warped: bool | None = None
+    weight_lbs: Decimal | None = None
+    unfolded_depth_inches: Decimal | None = None
+    folded_depth_inches: Decimal | None = None
+    castle_height_inches: Decimal | None = None
+    breast_beam_height_inches: Decimal | None = None
+    reed_included: bool | None = None
+    reed_dent_included: list[int] | None = None
+    reed_material: str | None = None
+    heddle_type: str | None = None
+    heddles_per_shaft_included: Decimal | None = None
+    brake_type: str | None = None
+    beater_type: str | None = None
+    beater_adjustable: bool | None = None
+    tie_up_system: str | None = None
+    treadle_hinge: str | None = None
+    shaft_upgrade_available: bool | None = None
+    max_shafts_with_upgrade: int | None = None
+    four_now_four_later: bool | None = None
+    height_extender_available: bool | None = None
+    height_extender_inches: Decimal | None = None
+    sectional_beam_available: bool | None = None
+    double_back_beam_available: bool | None = None
+    floating_breast_beam: bool | None = None
+    fly_shuttle_available: bool | None = None
+    mobility_wheels_included: bool | None = None
+    stroller_available: bool | None = None
+    shaft_switching_device_available: bool | None = None
+    lease_sticks_included: bool | None = None
+    raddle_included: bool | None = None
+    shuttle_included: bool | None = None
+    carry_bag_included: bool | None = None
+    assembly_required: bool | None = None
+    finish_required: bool | None = None
+    origin_country: str | None = None
+    warranty_years: Decimal | None = None
+    dobby_type: str | None = None
+    compatible_software: list[str] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Public endpoints (no auth required)
+# ---------------------------------------------------------------------------
+
+public_router = APIRouter(prefix="/api/loom-catalog", tags=["loom-catalog"])
+
+
+@public_router.get("", response_model=list[LoomReferenceSummary])
+async def list_loom_catalog(
+    q: str | None = Query(None, description="Search brand, model, or series"),
+    category: str | None = Query(None),
+    min_shafts: int | None = Query(None),
+    foldable: bool | None = Query(None),
+    origin_country: str | None = Query(None),
+    db: AsyncSession = Depends(get_db),
+) -> list[LoomReferenceSummary]:
+    stmt = select(LoomReference).order_by(LoomReference.brand, LoomReference.model_name)
+
+    if q:
+        stmt = stmt.where(
+            or_(
+                func.lower(LoomReference.brand).contains(q.lower()),
+                func.lower(LoomReference.model_name).contains(q.lower()),
+                func.lower(func.coalesce(LoomReference.model_series, "")).contains(q.lower()),
+            )
+        )
+    if category:
+        stmt = stmt.where(LoomReference.loom_category == category)
+    if foldable is not None:
+        stmt = stmt.where(LoomReference.foldable == foldable)
+    if origin_country:
+        stmt = stmt.where(func.lower(LoomReference.origin_country) == origin_country.lower())
+
+    rows = await db.scalars(stmt)
+    results = list(rows.all())
+
+    # Filter by min_shafts in Python (JSONB array containment)
+    if min_shafts is not None:
+        results = [r for r in results if r.shaft_count_options and any(s >= min_shafts for s in r.shaft_count_options)]
+
+    return [LoomReferenceSummary.model_validate(r) for r in results]
+
+
+@public_router.get("/search", response_model=list[LoomReferenceSummary])
+async def search_loom_catalog(
+    q: str = Query(..., min_length=1),
+    limit: int = Query(20, le=50),
+    db: AsyncSession = Depends(get_db),
+) -> list[LoomReferenceSummary]:
+    """Typeahead search — returns summaries matching brand or model name."""
+    ql = q.lower()
+    stmt = (
+        select(LoomReference)
+        .where(
+            or_(
+                func.lower(LoomReference.brand).contains(ql),
+                func.lower(LoomReference.model_name).contains(ql),
+                func.lower(func.coalesce(LoomReference.model_series, "")).contains(ql),
+            )
+        )
+        .order_by(LoomReference.brand, LoomReference.model_name)
+        .limit(limit)
+    )
+    rows = await db.scalars(stmt)
+    return [LoomReferenceSummary.model_validate(r) for r in rows.all()]
+
+
+@public_router.get("/{ref_id}", response_model=LoomReferenceSchema)
+async def get_loom_reference(
+    ref_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+) -> LoomReferenceSchema:
+    ref = await db.get(LoomReference, ref_id)
+    if ref is None:
+        raise HTTPException(status_code=404, detail="Loom reference not found")
+    return LoomReferenceSchema.model_validate(ref)
+
+
+# ---------------------------------------------------------------------------
+# Admin endpoints
+# ---------------------------------------------------------------------------
+
+admin_catalog_router = APIRouter(prefix="/api/admin/loom-catalog", tags=["admin"])
+
+
+@admin_catalog_router.get("", response_model=list[LoomReferenceSchema])
+async def admin_list_loom_catalog(
+    q: str | None = Query(None),
+    db: AsyncSession = Depends(get_db),
+    _admin: User = Depends(require_admin),
+) -> list[LoomReferenceSchema]:
+    stmt = select(LoomReference).order_by(LoomReference.brand, LoomReference.model_name)
+    if q:
+        ql = q.lower()
+        stmt = stmt.where(
+            or_(
+                func.lower(LoomReference.brand).contains(ql),
+                func.lower(LoomReference.model_name).contains(ql),
+            )
+        )
+    rows = await db.scalars(stmt)
+    return [LoomReferenceSchema.model_validate(r) for r in rows.all()]
+
+
+@admin_catalog_router.post("", response_model=LoomReferenceSchema, status_code=201)
+async def admin_create_loom_reference(
+    body: CreateLoomReferenceRequest,
+    db: AsyncSession = Depends(get_db),
+    _admin: User = Depends(require_admin),
+) -> LoomReferenceSchema:
+    existing = await db.scalar(
+        select(LoomReference).where(
+            func.lower(LoomReference.brand) == body.brand.lower(),
+            func.lower(LoomReference.model_name) == body.model_name.lower(),
+        )
+    )
+    if existing:
+        raise HTTPException(status_code=409, detail="A loom reference with this brand and model already exists")
+    ref = LoomReference(**body.model_dump())
+    db.add(ref)
+    await db.commit()
+    await db.refresh(ref)
+    return LoomReferenceSchema.model_validate(ref)
+
+
+@admin_catalog_router.patch("/{ref_id}", response_model=LoomReferenceSchema)
+async def admin_update_loom_reference(
+    ref_id: uuid.UUID,
+    body: UpdateLoomReferenceRequest,
+    db: AsyncSession = Depends(get_db),
+    _admin: User = Depends(require_admin),
+) -> LoomReferenceSchema:
+    ref = await db.get(LoomReference, ref_id)
+    if ref is None:
+        raise HTTPException(status_code=404, detail="Loom reference not found")
+    for field, value in body.model_dump(exclude_unset=True).items():
+        setattr(ref, field, value)
+    await db.commit()
+    await db.refresh(ref)
+    return LoomReferenceSchema.model_validate(ref)
+
+
+@admin_catalog_router.delete("/{ref_id}", status_code=204)
+async def admin_delete_loom_reference(
+    ref_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    _admin: User = Depends(require_admin),
+) -> None:
+    ref = await db.get(LoomReference, ref_id)
+    if ref is None:
+        raise HTTPException(status_code=404, detail="Loom reference not found")
+    # Nullify FK on any linked user looms (cascade SET NULL handles DB side,
+    # but explicit check lets us warn callers if needed)
+    await db.delete(ref)
+    await db.commit()

--- a/backend/app/routers/looms.py
+++ b/backend/app/routers/looms.py
@@ -252,6 +252,10 @@ class AddVersionRequest(BaseModel):
 class UpdateVersionRequest(BaseModel):
     name: str | None = None
     description: str | None = None
+    num_shafts: int | None = None
+    num_treadles: int | None = None
+    weaving_width: Decimal | None = None
+    weaving_width_unit: str | None = None
     warp_waste_allowance: Decimal | None = None
     warp_waste_unit: str | None = None
 

--- a/backend/app/routers/looms.py
+++ b/backend/app/routers/looms.py
@@ -16,6 +16,7 @@ from app.deps import get_current_user, get_db
 from app.models.loom import (
     Loom,
     LoomReed,
+    LoomReference,
     LoomVersion,
     LoomVersionAccessory,
     LoomVersionPhoto,
@@ -37,7 +38,17 @@ def _content_disposition(disposition: str, filename: str) -> str:
     return f"{disposition}; filename=\"{ascii_fallback}\"; filename*=UTF-8''{encoded}"
 
 
-LoomType = Literal["floor_loom", "table_loom", "rigid_heddle", "inkle", "dobby", "other"]
+LoomType = Literal[
+    "floor_loom",
+    "table_loom",
+    "rigid_heddle",
+    "inkle",
+    "dobby_floor_loom",
+    "tapestry_loom",
+    "rug_loom",
+    "frame_loom",
+    "other",
+]
 
 ALLOWED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/webp", "image/gif"}
 ALLOWED_RECEIPT_TYPES = {"image/jpeg", "image/png", "image/webp", "application/pdf"}
@@ -114,6 +125,7 @@ class LoomSummary(BaseModel):
     manufacturer: str
     model_name: str
     serial_number: str | None
+    loom_reference_id: uuid.UUID | None
     supports_lift_tracking: bool
     supports_treadle_tracking: bool
     notes: str | None
@@ -132,6 +144,7 @@ class LoomSummary(BaseModel):
             "manufacturer": loom.manufacturer,
             "model_name": loom.model_name,
             "serial_number": loom.serial_number,
+            "loom_reference_id": loom.loom_reference_id,
             "supports_lift_tracking": loom.supports_lift_tracking,
             "supports_treadle_tracking": loom.supports_treadle_tracking,
             "notes": loom.notes,
@@ -150,6 +163,7 @@ class LoomDetail(BaseModel):
     manufacturer: str
     model_name: str
     serial_number: str | None
+    loom_reference_id: uuid.UUID | None
     purchase_date: date | None
     purchase_price: Decimal | None
     vendor: str | None
@@ -173,6 +187,7 @@ class LoomDetail(BaseModel):
             "manufacturer": loom.manufacturer,
             "model_name": loom.model_name,
             "serial_number": loom.serial_number,
+            "loom_reference_id": loom.loom_reference_id,
             "purchase_date": loom.purchase_date,
             "purchase_price": loom.purchase_price,
             "vendor": loom.vendor,
@@ -193,6 +208,7 @@ class CreateLoomRequest(BaseModel):
     manufacturer: str
     model_name: str
     serial_number: str | None = None
+    loom_reference_id: uuid.UUID | None = None
     purchase_date: date | None = None
     purchase_price: Decimal | None = None
     vendor: str | None = None
@@ -338,6 +354,7 @@ async def create_loom(
         manufacturer=body.manufacturer,
         model_name=body.model_name,
         serial_number=body.serial_number,
+        loom_reference_id=body.loom_reference_id,
         purchase_date=body.purchase_date,
         purchase_price=body.purchase_price,
         vendor=body.vendor,
@@ -813,3 +830,33 @@ async def delete_reed(
         raise HTTPException(status_code=404, detail="Reed not found")
     await db.delete(reed)
     await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Catalog linking
+# ---------------------------------------------------------------------------
+
+
+class LinkReferenceRequest(BaseModel):
+    loom_reference_id: uuid.UUID | None
+
+
+@router.post("/{loom_id}/link-reference", response_model=LoomDetail)
+async def link_loom_reference(
+    loom_id: uuid.UUID,
+    body: LinkReferenceRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> LoomDetail:
+    """Link (or unlink) an existing user loom to a catalog entry."""
+    loom = await _get_owned_loom(loom_id, current_user, db)
+
+    if body.loom_reference_id is not None:
+        ref = await db.get(LoomReference, body.loom_reference_id)
+        if ref is None:
+            raise HTTPException(status_code=404, detail="Loom reference not found")
+
+    loom.loom_reference_id = body.loom_reference_id
+    await db.commit()
+    loom = await _get_owned_loom(loom_id, current_user, db)
+    return LoomDetail.from_loom(loom)

--- a/backend/seeds/loom_references.py
+++ b/backend/seeds/loom_references.py
@@ -92,8 +92,10 @@ _DB_COLUMNS = {
 def _locate_json() -> Path:
     """Find loom-data-master.json regardless of where the script is invoked from."""
     candidates = [
+        # Bundled alongside the seed script inside the Docker image (primary)
+        Path(__file__).parent / "loom-data-master.json",
+        # Repo root — local dev running outside the container
         Path(__file__).parent.parent.parent / "docs" / "research" / "looms" / "loom-data-master.json",
-        Path("/app/docs/research/looms/loom-data-master.json"),
         Path("docs/research/looms/loom-data-master.json"),
     ]
     for p in candidates:

--- a/backend/seeds/loom_references.py
+++ b/backend/seeds/loom_references.py
@@ -1,0 +1,221 @@
+"""Seed loom_references from docs/research/looms/loom-data-master.json.
+
+Usage (from repo root):
+    docker exec weaving_site_backend python seeds/loom_references.py
+    docker exec weftmark-dev_backend python seeds/loom_references.py
+
+Idempotent — upserts on (brand, model_name). Safe to re-run after the JSON
+is updated to add new entries or correct existing ones.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+import uuid
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+# Fields that exist in the JSON data but are NOT stored in the DB (metadata only).
+_SKIP_FIELDS = {"_brand", "_model", "_confidence", "_flags", "_verified_by", "_source_notes"}
+
+# Mapping from research JSON field names to DB column names where they differ.
+_FIELD_MAP: dict[str, str] = {}  # currently identical; kept for future divergence
+
+# JSON fields whose values are lists (stored as JSONB arrays).
+_ARRAY_FIELDS = {
+    "shaft_count_options",
+    "treadle_count",
+    "weaving_width_options_inches",
+    "weaving_width_options_cm",
+    "reed_dent_included",
+    "compatible_software",
+}
+
+# All DB columns on loom_references (excluding id / timestamps).
+_DB_COLUMNS = {
+    "brand",
+    "model_name",
+    "model_series",
+    "loom_category",
+    "shedding_mechanism",
+    "shaft_count_options",
+    "treadle_count",
+    "weaving_width_options_inches",
+    "weaving_width_options_cm",
+    "frame_material",
+    "foldable",
+    "foldable_while_warped",
+    "weight_lbs",
+    "unfolded_depth_inches",
+    "folded_depth_inches",
+    "castle_height_inches",
+    "breast_beam_height_inches",
+    "reed_included",
+    "reed_dent_included",
+    "reed_material",
+    "heddle_type",
+    "heddles_per_shaft_included",
+    "brake_type",
+    "beater_type",
+    "beater_adjustable",
+    "tie_up_system",
+    "treadle_hinge",
+    "shaft_upgrade_available",
+    "max_shafts_with_upgrade",
+    "four_now_four_later",
+    "height_extender_available",
+    "height_extender_inches",
+    "sectional_beam_available",
+    "double_back_beam_available",
+    "floating_breast_beam",
+    "fly_shuttle_available",
+    "mobility_wheels_included",
+    "stroller_available",
+    "shaft_switching_device_available",
+    "lease_sticks_included",
+    "raddle_included",
+    "shuttle_included",
+    "carry_bag_included",
+    "assembly_required",
+    "finish_required",
+    "origin_country",
+    "warranty_years",
+    "dobby_type",
+    "compatible_software",
+}
+
+
+def _locate_json() -> Path:
+    """Find loom-data-master.json regardless of where the script is invoked from."""
+    candidates = [
+        Path(__file__).parent.parent.parent / "docs" / "research" / "looms" / "loom-data-master.json",
+        Path("/app/docs/research/looms/loom-data-master.json"),
+        Path("docs/research/looms/loom-data-master.json"),
+    ]
+    for p in candidates:
+        if p.exists():
+            return p
+    raise FileNotFoundError("Could not find loom-data-master.json. Run from the repo root or inside the container.")
+
+
+def _coerce_entry(raw: dict) -> dict:
+    """Convert a raw JSON entry to a dict of DB column values."""
+    row: dict = {}
+    for json_key, value in raw.items():
+        if json_key in _SKIP_FIELDS:
+            continue
+        col = _FIELD_MAP.get(json_key, json_key)
+        if col not in _DB_COLUMNS:
+            continue
+        # Array fields: must be a list of numbers; filter out strings and empty lists
+        if col in _ARRAY_FIELDS:
+            if not isinstance(value, list):
+                value = None
+            else:
+                value = [v for v in value if isinstance(v, (int, float))]
+                if not value:
+                    value = None
+        elif isinstance(value, (dict, list)):
+            # Scalar column received a non-scalar — skip it
+            value = None
+        row[col] = value
+    return row
+
+
+async def seed() -> None:
+    # Import here so this script can be run stand-alone in the container
+    import os
+
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+    from sqlalchemy.orm import sessionmaker
+
+    raw_dsn = os.environ.get("POSTGRES_DSN", "")
+    if not raw_dsn:
+        # Fall back to individual vars (local dev)
+        host = os.environ.get("POSTGRES_HOST", "localhost")
+        port = os.environ.get("POSTGRES_PORT", "5433")
+        db_name = os.environ.get("POSTGRES_DB", "weaving_site")
+        user = os.environ.get("POSTGRES_USER", "postgres")
+        pw = os.environ.get("POSTGRES_PASSWORD", "")
+        raw_dsn = f"postgresql://{user}:{pw}@{host}:{port}/{db_name}"
+
+    dsn = raw_dsn.replace("postgresql://", "postgresql+asyncpg://").replace(
+        "postgresql+psycopg2://", "postgresql+asyncpg://"
+    )
+
+    engine = create_async_engine(dsn, echo=False)
+    Session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    json_path = _locate_json()
+    with json_path.open() as f:
+        data = json.load(f)
+
+    if isinstance(data, dict) and "looms" in data:
+        entries = data["looms"]
+    elif isinstance(data, list):
+        entries = data
+    else:
+        raise ValueError("Unexpected JSON structure — expected a list or {looms: [...]}")
+
+    inserted = updated = skipped = 0
+
+    async with Session() as session:
+        async with session.begin():
+            for raw in entries:
+                row = _coerce_entry(raw)
+                brand = row.get("brand", "").strip()
+                model = row.get("model_name", "").strip()
+                if not brand or not model:
+                    log.warning("Skipping entry with missing brand/model: %s", raw.get("_model"))
+                    skipped += 1
+                    continue
+
+                existing = await session.scalar(
+                    text(
+                        "SELECT id FROM loom_references "
+                        "WHERE lower(brand) = lower(:brand) AND lower(model_name) = lower(:model)"
+                    ).bindparams(brand=brand, model=model)
+                )
+
+                # Serialize params (lists → JSON strings for JSONB columns)
+                params = {k: json.dumps(v) if isinstance(v, list) else v for k, v in row.items()}
+
+                if existing:
+                    # Use CAST syntax so SQLAlchemy's text() parser sees clean :name tokens
+                    set_clauses = ", ".join(
+                        f"{col} = cast(:{col} as jsonb)" if col in _ARRAY_FIELDS else f"{col} = :{col}"
+                        for col in row
+                        if col not in ("brand", "model_name")
+                    )
+                    if set_clauses:
+                        await session.execute(
+                            text(
+                                f"UPDATE loom_references SET {set_clauses}, updated_at = now() "
+                                f"WHERE lower(brand) = lower(:brand) AND lower(model_name) = lower(:model)"
+                            ),
+                            {**params, "brand": brand, "model": model},
+                        )
+                    updated += 1
+                else:
+                    row["id"] = str(uuid.uuid4())
+                    params["id"] = row["id"]
+                    cols = ", ".join(row.keys())
+                    vals = ", ".join(f"cast(:{k} as jsonb)" if k in _ARRAY_FIELDS else f":{k}" for k in row.keys())
+                    await session.execute(
+                        text(f"INSERT INTO loom_references ({cols}) VALUES ({vals})"),
+                        params,
+                    )
+                    inserted += 1
+
+    await engine.dispose()
+    print(f"Seed complete: {inserted} inserted, {updated} updated, {skipped} skipped")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+    asyncio.run(seed())

--- a/backend/tests/routers/test_loom_catalog.py
+++ b/backend/tests/routers/test_loom_catalog.py
@@ -1,0 +1,265 @@
+"""Tests for the loom catalog (loom_references) endpoints."""
+
+from datetime import date
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.loom import Loom, LoomReference, LoomVersion
+from app.models.user import User
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_ref(db: AsyncSession, brand: str = "Schacht", model: str = "Baby Wolf") -> LoomReference:
+    ref = LoomReference(
+        brand=brand,
+        model_name=model,
+        model_series="Wolf Family",
+        loom_category="floor_loom",
+        shedding_mechanism="jack_rising",
+        shaft_count_options=[4, 8],
+        treadle_count=[6, 10],
+        weaving_width_options_inches=[26.0],
+        foldable=True,
+        origin_country="USA",
+    )
+    db.add(ref)
+    await db.flush()
+    await db.commit()
+    return ref
+
+
+# ---------------------------------------------------------------------------
+# Public catalog — list / search / detail
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_public_catalog_list_empty(client: AsyncClient, db_session: AsyncSession):
+    resp = await client.get("/api/loom-catalog")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.anyio
+async def test_public_catalog_list_returns_entries(client: AsyncClient, db_session: AsyncSession):
+    await _make_ref(db_session)
+    resp = await client.get("/api/loom-catalog")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["brand"] == "Schacht"
+    assert data[0]["model_name"] == "Baby Wolf"
+
+
+@pytest.mark.anyio
+async def test_public_catalog_search_by_brand(client: AsyncClient, db_session: AsyncSession):
+    await _make_ref(db_session, brand="Ashford", model="Jack Loom")
+    await _make_ref(db_session, brand="Louet", model="Spring II")
+    resp = await client.get("/api/loom-catalog/search?q=ashford")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["brand"] == "Ashford"
+
+
+@pytest.mark.anyio
+async def test_public_catalog_search_by_model(client: AsyncClient, db_session: AsyncSession):
+    await _make_ref(db_session, brand="Schacht", model="Baby Wolf")
+    await _make_ref(db_session, brand="Schacht", model="Mighty Wolf")
+    # Search "mighty" — unique enough to match only Mighty Wolf regardless of other test data
+    resp = await client.get("/api/loom-catalog/search?q=mighty")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["model_name"] == "Mighty Wolf"
+
+
+@pytest.mark.anyio
+async def test_public_catalog_filter_by_category(client: AsyncClient, db_session: AsyncSession):
+    ref1 = LoomReference(brand="TestCatalog", model_name="Rigid Heddle 24", loom_category="rigid_heddle")
+    ref2 = LoomReference(brand="TestCatalog", model_name="Floor Loom 4S", loom_category="floor_loom")
+    db_session.add_all([ref1, ref2])
+    await db_session.commit()
+
+    resp = await client.get("/api/loom-catalog?category=floor_loom")
+    assert resp.status_code == 200
+    data = resp.json()
+    # All returned entries must be floor_loom; at minimum our entry is present
+    assert all(d["loom_category"] == "floor_loom" for d in data)
+    assert any(d["brand"] == "TestCatalog" and d["model_name"] == "Floor Loom 4S" for d in data)
+
+
+@pytest.mark.anyio
+async def test_public_catalog_detail(client: AsyncClient, db_session: AsyncSession):
+    ref = await _make_ref(db_session)
+    resp = await client.get(f"/api/loom-catalog/{ref.id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == str(ref.id)
+    assert data["shaft_count_options"] == [4, 8]
+    assert data["treadle_count"] == [6, 10]
+    assert data["foldable"] is True
+
+
+@pytest.mark.anyio
+async def test_public_catalog_detail_404(client: AsyncClient, db_session: AsyncSession):
+    import uuid
+
+    resp = await client.get(f"/api/loom-catalog/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Admin CRUD
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_admin_create_loom_reference(admin_client: AsyncClient, db_session: AsyncSession):
+    payload = {
+        "brand": "Harrisville Designs",
+        "model_name": "Traditional Floor Loom",
+        "loom_category": "floor_loom",
+        "shedding_mechanism": "jack_rising",
+        "shaft_count_options": [4, 8],
+        "treadle_count": [6, 10],
+        "weaving_width_options_inches": [22.0, 36.0, 45.0],
+        "foldable": True,
+        "mobility_wheels_included": True,
+        "origin_country": "USA",
+    }
+    resp = await admin_client.post("/api/admin/loom-catalog", json=payload)
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["brand"] == "Harrisville Designs"
+    assert data["shaft_count_options"] == [4, 8]
+    assert data["mobility_wheels_included"] is True
+
+
+@pytest.mark.anyio
+async def test_admin_create_duplicate_rejected(admin_client: AsyncClient, db_session: AsyncSession):
+    await _make_ref(db_session)
+    payload = {"brand": "Schacht", "model_name": "Baby Wolf", "loom_category": "floor_loom"}
+    resp = await admin_client.post("/api/admin/loom-catalog", json=payload)
+    assert resp.status_code == 409
+
+
+@pytest.mark.anyio
+async def test_admin_update_loom_reference(admin_client: AsyncClient, db_session: AsyncSession):
+    ref = await _make_ref(db_session)
+    resp = await admin_client.patch(
+        f"/api/admin/loom-catalog/{ref.id}",
+        json={"origin_country": "Canada", "foldable": False},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["origin_country"] == "Canada"
+    assert data["foldable"] is False
+
+
+@pytest.mark.anyio
+async def test_admin_delete_loom_reference(admin_client: AsyncClient, db_session: AsyncSession):
+    ref = await _make_ref(db_session)
+    resp = await admin_client.delete(f"/api/admin/loom-catalog/{ref.id}")
+    assert resp.status_code == 204
+
+    resp2 = await admin_client.get(f"/api/loom-catalog/{ref.id}")
+    assert resp2.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_non_admin_cannot_create(auth_client: AsyncClient, db_session: AsyncSession):
+    payload = {"brand": "Ashford", "model_name": "Test", "loom_category": "floor_loom"}
+    resp = await auth_client.post("/api/admin/loom-catalog", json=payload)
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Link-reference endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_link_loom_to_reference(auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+    ref = await _make_ref(db_session)
+
+    loom = Loom(
+        owner_id=test_user.id,
+        loom_type="floor_loom",
+        manufacturer="Schacht",
+        model_name="Baby Wolf",
+        supports_lift_tracking=False,
+        supports_treadle_tracking=True,
+    )
+    db_session.add(loom)
+    await db_session.flush()
+    version = LoomVersion(
+        loom_id=loom.id,
+        version_number=1,
+        effective_date=date(2024, 1, 1),
+    )
+    db_session.add(version)
+    await db_session.commit()
+
+    resp = await auth_client.post(
+        f"/api/looms/{loom.id}/link-reference",
+        json={"loom_reference_id": str(ref.id)},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["loom_reference_id"] == str(ref.id)
+
+
+@pytest.mark.anyio
+async def test_unlink_loom_from_reference(auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+    ref = await _make_ref(db_session)
+
+    loom = Loom(
+        owner_id=test_user.id,
+        loom_type="floor_loom",
+        manufacturer="Schacht",
+        model_name="Baby Wolf",
+        loom_reference_id=ref.id,
+        supports_lift_tracking=False,
+        supports_treadle_tracking=True,
+    )
+    db_session.add(loom)
+    await db_session.flush()
+    db_session.add(LoomVersion(loom_id=loom.id, version_number=1, effective_date=date(2024, 1, 1)))
+    await db_session.commit()
+
+    resp = await auth_client.post(
+        f"/api/looms/{loom.id}/link-reference",
+        json={"loom_reference_id": None},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["loom_reference_id"] is None
+
+
+@pytest.mark.anyio
+async def test_link_nonexistent_reference_404(auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+    import uuid
+
+    loom = Loom(
+        owner_id=test_user.id,
+        loom_type="floor_loom",
+        manufacturer="Unknown",
+        model_name="Mystery",
+        supports_lift_tracking=False,
+        supports_treadle_tracking=True,
+    )
+    db_session.add(loom)
+    await db_session.flush()
+    db_session.add(LoomVersion(loom_id=loom.id, version_number=1, effective_date=date(2024, 1, 1)))
+    await db_session.commit()
+
+    resp = await auth_client.post(
+        f"/api/looms/{loom.id}/link-reference",
+        json={"loom_reference_id": str(uuid.uuid4())},
+    )
+    assert resp.status_code == 404

--- a/backend/tests/routers/test_looms.py
+++ b/backend/tests/routers/test_looms.py
@@ -473,18 +473,18 @@ class TestLoomTrackingFlags:
         assert body["supports_treadle_tracking"] is False
 
     async def test_unsupported_type_clears_both_flags(self, auth_client: AsyncClient):
-        for loom_type in ("rigid_heddle", "inkle", "dobby", "other"):
+        for loom_type in ("rigid_heddle", "inkle", "dobby_floor_loom", "tapestry_loom", "other"):
             payload = {**_LOOM_PAYLOAD, "loom_type": loom_type}
             resp = await auth_client.post("/api/looms", json=payload)
             body = resp.json()
             assert body["supports_treadle_tracking"] is False, f"{loom_type} should not set treadle"
             assert body["supports_lift_tracking"] is False, f"{loom_type} should not set lift"
 
-    async def test_dobby_can_be_created(self, auth_client: AsyncClient):
-        payload = {**_LOOM_PAYLOAD, "loom_type": "dobby"}
+    async def test_dobby_floor_loom_can_be_created(self, auth_client: AsyncClient):
+        payload = {**_LOOM_PAYLOAD, "loom_type": "dobby_floor_loom"}
         resp = await auth_client.post("/api/looms", json=payload)
         assert resp.status_code == 201
-        assert resp.json()["loom_type"] == "dobby"
+        assert resp.json()["loom_type"] == "dobby_floor_loom"
 
     async def test_changing_type_updates_tracking_flags(self, auth_client: AsyncClient):
         loom = await _create_loom(auth_client)
@@ -499,7 +499,7 @@ class TestLoomTrackingFlags:
 
     async def test_changing_to_unsupported_type_clears_flags(self, auth_client: AsyncClient):
         loom = await _create_loom(auth_client)
-        resp = await auth_client.patch(f"/api/looms/{loom['id']}", json={"loom_type": "dobby"})
+        resp = await auth_client.patch(f"/api/looms/{loom['id']}", json={"loom_type": "tapestry_loom"})
         body = resp.json()
         assert body["supports_treadle_tracking"] is False
         assert body["supports_lift_tracking"] is False

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -113,7 +113,7 @@ services:
       - internal
     environment:
       APP_ENV: ${APP_ENV}
-          DEBUG: ${DEBUG}
+      DEBUG: ${DEBUG}
       LOG_LEVEL: ${LOG_LEVEL}
       SEED_ENABLED: ${SEED_ENABLED}
       CORS_ORIGINS: ${CORS_ORIGINS}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import { ProjectDetailPage } from "@/pages/ProjectDetailPage";
 import { ProjectLandingPage } from "@/pages/ProjectLandingPage";
 import { WarpingPlanPage } from "@/pages/WarpingPlanPage";
 import { SharedProjectPage } from "@/pages/SharedProjectPage";
+import { LoomCatalogPage } from "@/pages/LoomCatalogPage";
 import { AdminPage } from "@/pages/AdminPage";
 import { SettingsPage } from "@/pages/SettingsPage";
 import { SignOutPage } from "@/pages/SignOutPage";
@@ -98,6 +99,7 @@ export default function App() {
                   <Route path="/privacy" element={<PrivacyPage />} />
                   <Route path="/terms" element={<TermsPage />} />
                   <Route path="/costs" element={<CostsPage />} />
+                  <Route path="/catalog/looms" element={<LoomCatalogPage />} />
                   <Route path="/" element={<RootRoute />} />
                   <Route path="/home" element={<AuthRoute><DashboardPage /></AuthRoute>} />
                   <Route path="/drafts" element={<AuthRoute><DraftsPage /></AuthRoute>} />

--- a/frontend/src/api/looms.ts
+++ b/frontend/src/api/looms.ts
@@ -1,11 +1,23 @@
-export type LoomType = "floor_loom" | "table_loom" | "rigid_heddle" | "inkle" | "dobby" | "other";
+export type LoomType =
+  | "floor_loom"
+  | "table_loom"
+  | "rigid_heddle"
+  | "inkle"
+  | "dobby_floor_loom"
+  | "tapestry_loom"
+  | "rug_loom"
+  | "frame_loom"
+  | "other";
 
 export const LOOM_TYPE_LABELS: Record<LoomType, string> = {
   floor_loom: "Floor Loom — treadle tracking",
   table_loom: "Table Loom — lift tracking",
   rigid_heddle: "Rigid Heddle",
   inkle: "Inkle",
-  dobby: "Dobby Loom",
+  dobby_floor_loom: "Dobby Floor Loom",
+  tapestry_loom: "Tapestry Loom — project tracking not currently supported",
+  rug_loom: "Rug Loom — project tracking not currently supported",
+  frame_loom: "Frame Loom — project tracking not currently supported",
   other: "Other",
 };
 
@@ -67,6 +79,7 @@ export interface Loom {
   manufacturer: string;
   model_name: string;
   serial_number: string | null;
+  loom_reference_id: string | null;
   supports_lift_tracking: boolean;
   supports_treadle_tracking: boolean;
   notes: string | null;
@@ -88,6 +101,7 @@ export interface CreateLoomPayload {
   manufacturer: string;
   model_name: string;
   serial_number?: string;
+  loom_reference_id?: string;
   purchase_date?: string;
   purchase_price?: number;
   vendor?: string;
@@ -330,4 +344,122 @@ export function addReed(loomId: string, payload: AddReedPayload): Promise<LoomRe
 
 export function deleteReed(loomId: string, reedId: string): Promise<void> {
   return req(`/api/looms/${loomId}/reeds/${reedId}`, { method: "DELETE" });
+}
+
+// ---------------------------------------------------------------------------
+// Loom catalog (loom_references)
+// ---------------------------------------------------------------------------
+
+export interface LoomReferenceSummary {
+  id: string;
+  brand: string;
+  model_name: string;
+  model_series: string | null;
+  loom_category: string;
+  shedding_mechanism: string | null;
+  shaft_count_options: number[] | null;
+  treadle_count: number[] | null;
+  weaving_width_options_inches: number[] | null;
+  weaving_width_options_cm: number[] | null;
+  foldable: boolean | null;
+  origin_country: string | null;
+}
+
+export interface LoomReferenceDetail extends LoomReferenceSummary {
+  frame_material: string | null;
+  foldable_while_warped: boolean | null;
+  weight_lbs: string | null;
+  unfolded_depth_inches: string | null;
+  folded_depth_inches: string | null;
+  castle_height_inches: string | null;
+  breast_beam_height_inches: string | null;
+  reed_included: boolean | null;
+  reed_dent_included: number[] | null;
+  reed_material: string | null;
+  heddle_type: string | null;
+  heddles_per_shaft_included: string | null;
+  brake_type: string | null;
+  beater_type: string | null;
+  beater_adjustable: boolean | null;
+  tie_up_system: string | null;
+  treadle_hinge: string | null;
+  shaft_upgrade_available: boolean | null;
+  max_shafts_with_upgrade: number | null;
+  four_now_four_later: boolean | null;
+  height_extender_available: boolean | null;
+  height_extender_inches: string | null;
+  sectional_beam_available: boolean | null;
+  double_back_beam_available: boolean | null;
+  floating_breast_beam: boolean | null;
+  fly_shuttle_available: boolean | null;
+  mobility_wheels_included: boolean | null;
+  stroller_available: boolean | null;
+  shaft_switching_device_available: boolean | null;
+  lease_sticks_included: boolean | null;
+  raddle_included: boolean | null;
+  shuttle_included: boolean | null;
+  carry_bag_included: boolean | null;
+  assembly_required: boolean | null;
+  finish_required: boolean | null;
+  origin_country: string | null;
+  warranty_years: string | null;
+  dobby_type: string | null;
+  compatible_software: string[] | null;
+}
+
+/** Search the public catalog (no auth required). Used for typeahead. */
+export function searchLoomCatalog(q: string): Promise<LoomReferenceSummary[]> {
+  return fetch(`/api/loom-catalog/search?q=${encodeURIComponent(q)}&limit=20`)
+    .then((r) => r.json());
+}
+
+/** Full catalog list with optional filters. */
+export function listLoomCatalog(params?: {
+  q?: string;
+  category?: string;
+  foldable?: boolean;
+}): Promise<LoomReferenceSummary[]> {
+  const sp = new URLSearchParams();
+  if (params?.q) sp.set("q", params.q);
+  if (params?.category) sp.set("category", params.category);
+  if (params?.foldable !== undefined) sp.set("foldable", String(params.foldable));
+  return fetch(`/api/loom-catalog?${sp}`).then((r) => r.json());
+}
+
+export function getLoomCatalogEntry(id: string): Promise<LoomReferenceDetail> {
+  return fetch(`/api/loom-catalog/${id}`).then((r) => r.json());
+}
+
+export function linkLoomReference(loomId: string, referenceId: string | null): Promise<LoomDetail> {
+  return req(`/api/looms/${loomId}/link-reference`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ loom_reference_id: referenceId }),
+  });
+}
+
+// Admin catalog CRUD
+export function adminListLoomCatalog(q?: string): Promise<LoomReferenceDetail[]> {
+  const url = q ? `/api/admin/loom-catalog?q=${encodeURIComponent(q)}` : "/api/admin/loom-catalog";
+  return req(url);
+}
+
+export function adminCreateLoomReference(payload: Partial<LoomReferenceDetail>): Promise<LoomReferenceDetail> {
+  return req("/api/admin/loom-catalog", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}
+
+export function adminUpdateLoomReference(id: string, payload: Partial<LoomReferenceDetail>): Promise<LoomReferenceDetail> {
+  return req(`/api/admin/loom-catalog/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}
+
+export function adminDeleteLoomReference(id: string): Promise<void> {
+  return req(`/api/admin/loom-catalog/${id}`, { method: "DELETE" });
 }

--- a/frontend/src/api/looms.ts
+++ b/frontend/src/api/looms.ts
@@ -144,6 +144,10 @@ export interface AddVersionPayload {
 export interface UpdateVersionPayload {
   name?: string;
   description?: string;
+  num_shafts?: number;
+  num_treadles?: number;
+  weaving_width?: number;
+  weaving_width_unit?: string;
   warp_waste_allowance?: number | null;
   warp_waste_unit?: string;
 }

--- a/frontend/src/components/PublicFooter.tsx
+++ b/frontend/src/components/PublicFooter.tsx
@@ -5,6 +5,7 @@ export function PublicFooter() {
     <footer className="border-t border-border bg-muted py-4 px-6">
       <div className="mx-auto flex max-w-4xl flex-col items-center gap-2 sm:flex-row sm:justify-between">
         <nav className="flex flex-wrap gap-4 text-sm text-subdued">
+          <Link to="/catalog/looms" className="hover:text-foreground transition-colors">Loom catalog</Link>
           <Link to="/about" className="hover:text-foreground transition-colors">About</Link>
           <Link to="/privacy" className="hover:text-foreground transition-colors">Privacy</Link>
           <Link to="/terms" className="hover:text-foreground transition-colors">Terms</Link>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -41,6 +41,7 @@ const ADMIN_SECTIONS = [
   { id: "feedback", label: "Feedback" },
   { id: "credentials", label: "Credentials" },
   { id: "slugs", label: "Share links" },
+  { id: "looms", label: "Loom database" },
   { id: "superuser", label: "Superuser", superuserOnly: true },
 ];
 

--- a/frontend/src/components/looms/CatalogRequestButton.tsx
+++ b/frontend/src/components/looms/CatalogRequestButton.tsx
@@ -1,0 +1,284 @@
+import { useState, useEffect } from "react";
+import { type LoomDetail, LOOM_TYPE_LABELS } from "@/api/looms";
+
+// ---------- types ----------
+
+interface GithubIssue {
+  number: number;
+  title: string;
+  url: string;
+}
+
+interface CheckCache {
+  token: string;
+  issues: GithubIssue[];
+  checkedAt: number;
+}
+
+type CheckState = "checking" | "no_dupes" | "dupes_found" | "failed" | "submitted";
+
+// ---------- constants ----------
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const CACHE_PREFIX = "wm:catalog_check:";
+const SUBMITTED_KEY = "wm:catalog_submitted";
+
+// ---------- dedup token ----------
+// djb2 hash of "manufacturer:model" (lowercased). Deterministic, collision-
+// resistant enough for dedup. Louet Spring and Louet Spring II produce
+// completely different tokens so there are no prefix-match false positives.
+
+function requestToken(manufacturer: string, model: string): string {
+  const str = `${manufacturer.toLowerCase()}:${model.toLowerCase()}`;
+  let h = 5381;
+  for (let i = 0; i < str.length; i++) {
+    h = ((h << 5) + h) ^ str.charCodeAt(i);
+  }
+  return `wmloom${(h >>> 0).toString(36)}`;
+}
+
+// ---------- localStorage helpers ----------
+
+function getCached(loomId: string, token: string): CheckCache | null {
+  try {
+    const raw = localStorage.getItem(CACHE_PREFIX + loomId);
+    if (!raw) return null;
+    const c: CheckCache = JSON.parse(raw);
+    if (c.token !== token) return null; // loom renamed — invalidate
+    if (Date.now() - c.checkedAt > CACHE_TTL_MS) return null;
+    return c;
+  } catch {
+    return null;
+  }
+}
+
+function setCached(loomId: string, cache: CheckCache): void {
+  try {
+    localStorage.setItem(CACHE_PREFIX + loomId, JSON.stringify(cache));
+  } catch {
+    // ignore storage errors
+  }
+}
+
+function isSubmitted(loomId: string): boolean {
+  try {
+    const raw = localStorage.getItem(SUBMITTED_KEY);
+    return raw ? (JSON.parse(raw) as string[]).includes(loomId) : false;
+  } catch {
+    return false;
+  }
+}
+
+function markSubmitted(loomId: string): void {
+  try {
+    const raw = localStorage.getItem(SUBMITTED_KEY);
+    const arr: string[] = raw ? JSON.parse(raw) : [];
+    if (!arr.includes(loomId)) {
+      arr.push(loomId);
+      localStorage.setItem(SUBMITTED_KEY, JSON.stringify(arr));
+    }
+  } catch {
+    // ignore storage errors
+  }
+}
+
+// ---------- GitHub API ----------
+
+async function fetchGithubIssues(token: string): Promise<GithubIssue[]> {
+  // Search for the exact token in issue bodies.
+  // "wm-req:abc123" is a unique string per manufacturer:model hash so there
+  // are no partial-match false positives (Spring ≠ Spring II).
+  const q = encodeURIComponent(
+    `repo:weftmark/weftmark "wm-req:${token}" is:issue is:open`,
+  );
+  const res = await fetch(
+    `https://api.github.com/search/issues?q=${q}&per_page=5`,
+    { headers: { Accept: "application/vnd.github+json" } },
+  );
+  if (!res.ok) throw new Error(`GitHub ${res.status}`);
+  const data = await res.json();
+  return (data.items ?? []).map(
+    (item: { number: number; title: string; html_url: string }) => ({
+      number: item.number,
+      title: item.title,
+      url: item.html_url,
+    }),
+  );
+}
+
+// ---------- URL builder ----------
+
+function buildIssueUrl(
+  loom: LoomDetail,
+  token: string,
+  existingIssues: GithubIssue[],
+): string {
+  const title = encodeURIComponent(
+    `Loom catalog request: ${loom.manufacturer} ${loom.model_name}`,
+  );
+
+  const relatedSection =
+    existingIssues.length > 0
+      ? `\n**Related existing requests:**\n${existingIssues
+          .map((i) => `- #${i.number} — ${i.url}`)
+          .join("\n")}\n`
+      : "";
+
+  const body = encodeURIComponent(
+    `## Loom catalog request\n\n` +
+      `**Brand:** ${loom.manufacturer}\n` +
+      `**Model:** ${loom.model_name}\n` +
+      `**Type:** ${LOOM_TYPE_LABELS[loom.loom_type] ?? loom.loom_type}\n` +
+      `**Loom ID (admin):** ${loom.id}\n` +
+      `${relatedSection}\n` +
+      `Please add this loom to the weftmark catalog so other users can find and link it.\n\n` +
+      `---\n` +
+      `wm-req:${token}`,
+  );
+
+  return `https://github.com/weftmark/weftmark/issues/new?title=${title}&body=${body}`;
+}
+
+// ---------- component ----------
+
+interface Props {
+  loom: LoomDetail;
+}
+
+export function CatalogRequestButton({ loom }: Props) {
+  const token = requestToken(loom.manufacturer, loom.model_name);
+
+  // Initialise synchronously from localStorage to avoid a "checking" flash
+  // when we already have a cached result or a prior submission.
+  const [state, setState] = useState<CheckState>(() => {
+    if (isSubmitted(loom.id)) return "submitted";
+    const cached = getCached(loom.id, token);
+    if (cached) return cached.issues.length > 0 ? "dupes_found" : "no_dupes";
+    return "checking";
+  });
+
+  const [issues, setIssues] = useState<GithubIssue[]>(() => {
+    const cached = getCached(loom.id, token);
+    return cached?.issues ?? [];
+  });
+
+  const [showSubmitAnyway, setShowSubmitAnyway] = useState(false);
+
+  // Fetch from GitHub only when there's no cached result.
+  // `state` is intentionally excluded from deps — we only want one fetch per
+  // mount and the initial value is already correctly derived above.
+  useEffect(() => {
+    if (state !== "checking") return;
+    let cancelled = false;
+
+    fetchGithubIssues(token)
+      .then((found) => {
+        if (cancelled) return;
+        setIssues(found);
+        setCached(loom.id, { token, issues: found, checkedAt: Date.now() });
+        setState(found.length > 0 ? "dupes_found" : "no_dupes");
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setState("failed");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loom.id, token]);
+
+  function handleSubmit(withExisting: GithubIssue[]) {
+    window.open(buildIssueUrl(loom, token, withExisting), "_blank", "noopener");
+    markSubmitted(loom.id);
+    setState("submitted");
+  }
+
+  // ── submitted ──
+  if (state === "submitted") {
+    return (
+      <span className="text-xs text-muted-foreground italic">Request submitted</span>
+    );
+  }
+
+  // ── checking ──
+  if (state === "checking") {
+    return (
+      <span className="text-xs text-muted-foreground italic">
+        Checking for existing requests…
+      </span>
+    );
+  }
+
+  // ── no dupes / failed (treat API failure as no dupes — don't block submission) ──
+  if (state === "no_dupes" || state === "failed") {
+    return (
+      <a
+        href={buildIssueUrl(loom, token, [])}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={() => handleSubmit([])}
+        className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2 transition-colors"
+      >
+        Submit request to add to catalog
+      </a>
+    );
+  }
+
+  // ── dupes found ──
+  return (
+    <div className="space-y-1.5">
+      <p className="text-xs font-medium text-muted-foreground">
+        Similar requests already open:
+      </p>
+      <ul className="space-y-0.5 pl-1">
+        {issues.map((issue) => (
+          <li key={issue.number}>
+            <a
+              href={issue.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2"
+            >
+              #{issue.number} — {issue.title}
+            </a>
+          </li>
+        ))}
+      </ul>
+      {!showSubmitAnyway ? (
+        <button
+          type="button"
+          onClick={() => setShowSubmitAnyway(true)}
+          className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2 transition-colors"
+        >
+          Submit a new request anyway
+        </button>
+      ) : (
+        <div className="rounded-md border border-border bg-muted/20 px-3 py-2 space-y-1.5">
+          <p className="text-xs text-muted-foreground">
+            Links to the existing requests above will be included in your submission.
+          </p>
+          <div className="flex items-center gap-3">
+            <a
+              href={buildIssueUrl(loom, token, issues)}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => handleSubmit(issues)}
+              className="text-xs font-medium text-foreground hover:underline"
+            >
+              Submit with references →
+            </a>
+            <button
+              type="button"
+              onClick={() => setShowSubmitAnyway(false)}
+              className="text-xs text-muted-foreground hover:text-foreground"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/looms/EditLoomModal.tsx
+++ b/frontend/src/components/looms/EditLoomModal.tsx
@@ -10,7 +10,7 @@ interface Props {
   onClose: () => void;
 }
 
-const LOOM_TYPES: LoomType[] = ["floor_loom", "table_loom", "rigid_heddle", "inkle", "dobby", "other"];
+const LOOM_TYPES: LoomType[] = ["floor_loom", "table_loom", "rigid_heddle", "inkle", "dobby_floor_loom", "tapestry_loom", "rug_loom", "frame_loom", "other"];
 
 export function EditLoomModal({ loom, onSuccess, onClose }: Props) {
   const [loomType, setLoomType] = useState<LoomType>(loom.loom_type);

--- a/frontend/src/components/looms/LinkToCatalogModal.tsx
+++ b/frontend/src/components/looms/LinkToCatalogModal.tsx
@@ -1,0 +1,584 @@
+import { useState, useRef, useEffect } from "react";
+import {
+  searchLoomCatalog,
+  updateLoom,
+  linkLoomReference,
+  updateVersion,
+  type LoomDetail,
+  type LoomReferenceSummary,
+  type LoomType,
+  type UpdateVersionPayload,
+  LOOM_TYPE_LABELS,
+} from "@/api/looms";
+import { Button } from "@/components/ui/button";
+
+type Step = "search" | "configure" | "confirm";
+
+// ---------- helpers ----------
+
+function categoryToLoomType(cat: string): LoomType {
+  const map: Record<string, LoomType> = {
+    floor_loom: "floor_loom",
+    table_loom: "table_loom",
+    rigid_heddle: "rigid_heddle",
+    inkle_loom: "inkle",
+    dobby_floor_loom: "dobby_floor_loom",
+    tapestry_loom: "tapestry_loom",
+    rug_loom: "rug_loom",
+    frame_loom: "frame_loom",
+  };
+  return map[cat] ?? "other";
+}
+
+function showsShafts(t: LoomType) {
+  return ["floor_loom", "table_loom", "dobby_floor_loom", "other"].includes(t);
+}
+
+function showsTreadles(t: LoomType) {
+  return t === "floor_loom" || t === "dobby_floor_loom";
+}
+
+interface WidthOption {
+  label: string;
+  value: string;
+  unit: "cm" | "in";
+}
+
+function buildWidthOptions(ref: LoomReferenceSummary): WidthOption[] {
+  const cm = ref.weaving_width_options_cm;
+  const inches = ref.weaving_width_options_inches;
+  if (!cm?.length && !inches?.length) return [];
+  if (cm?.length) {
+    const inArr =
+      inches?.length === cm.length
+        ? inches
+        : cm.map((c) => Math.round((c / 2.54) * 10) / 10);
+    return cm.map((c, i) => ({
+      label: `${c} cm (${inArr[i]} in)`,
+      value: String(c),
+      unit: "cm",
+    }));
+  }
+  const cmArr = inches!.map((i) => Math.round(i * 2.54 * 10) / 10);
+  return inches!.map((inch, i) => ({
+    label: `${inch} in (${cmArr[i]} cm)`,
+    value: String(inch),
+    unit: "in",
+  }));
+}
+
+function closestIdx(options: number[], target: number | null | undefined): number {
+  if (!options.length || target == null) return 0;
+  let best = 0;
+  let bestDiff = Math.abs(options[0] - target);
+  for (let i = 1; i < options.length; i++) {
+    const diff = Math.abs(options[i] - target);
+    if (diff < bestDiff) {
+      best = i;
+      bestDiff = diff;
+    }
+  }
+  return best;
+}
+
+function deriveTreadles(
+  shaftVal: number | null,
+  shaftOptions: number[],
+  treadleOptions: number[],
+  loomType: LoomType,
+): number | null {
+  if (!showsTreadles(loomType) || shaftVal == null) return null;
+  if (treadleOptions.length > 0 && shaftOptions.length > 0) {
+    const idx = shaftOptions.indexOf(shaftVal);
+    if (idx !== -1 && treadleOptions[idx] != null) return treadleOptions[idx];
+  }
+  return shaftVal + 2;
+}
+
+// ---------- component ----------
+
+interface Props {
+  loom: LoomDetail;
+  onSuccess: () => void;
+  onClose: () => void;
+}
+
+export function LinkToCatalogModal({ loom, onSuccess, onClose }: Props) {
+  const [step, setStep] = useState<Step>("search");
+
+  // Search state — displayQuery shown in input, searchQuery triggers API
+  const [displayQuery, setDisplayQuery] = useState("");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [results, setResults] = useState<LoomReferenceSummary[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [showResults, setShowResults] = useState(false);
+
+  const [selectedRef, setSelectedRef] = useState<LoomReferenceSummary | null>(null);
+  const [selectedShaftIdx, setSelectedShaftIdx] = useState(0);
+  const [selectedWidthIdx, setSelectedWidthIdx] = useState(0);
+
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const searchContainerRef = useRef<HTMLDivElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Derived values from selection
+  const newLoomType: LoomType = selectedRef
+    ? categoryToLoomType(selectedRef.loom_category)
+    : loom.loom_type;
+  const shaftOptions: number[] = selectedRef?.shaft_count_options ?? [];
+  const treadleOptions: number[] = selectedRef?.treadle_count ?? [];
+  const widthOptions: WidthOption[] = selectedRef ? buildWidthOptions(selectedRef) : [];
+  const selectedShafts: number | null = shaftOptions[selectedShaftIdx] ?? null;
+  const derivedTreadles = deriveTreadles(
+    selectedShafts,
+    shaftOptions,
+    treadleOptions,
+    newLoomType,
+  );
+  const selectedWidthOpt: WidthOption | null = widthOptions[selectedWidthIdx] ?? null;
+
+  // Debounced search — only fires when searchQuery changes (not displayQuery).
+  // Clearing results when the query is short is handled in handleInputChange.
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!searchQuery.trim() || searchQuery.length < 2) return;
+    debounceRef.current = setTimeout(async () => {
+      setSearching(true);
+      try {
+        const data = await searchLoomCatalog(searchQuery);
+        setResults(data);
+        setShowResults(true);
+      } catch {
+        setResults([]);
+      } finally {
+        setSearching(false);
+      }
+    }, 250);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [searchQuery]);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    function handler(e: MouseEvent) {
+      if (
+        searchContainerRef.current &&
+        !searchContainerRef.current.contains(e.target as Node)
+      ) {
+        setShowResults(false);
+      }
+    }
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  function handleInputChange(val: string) {
+    setDisplayQuery(val);
+    setSearchQuery(val); // triggers search effect
+    if (selectedRef) setSelectedRef(null);
+    if (!val.trim() || val.length < 2) {
+      setResults([]);
+      setShowResults(false);
+    }
+  }
+
+  function handleSelectRef(ref: LoomReferenceSummary) {
+    setSelectedRef(ref);
+    // Update display only — do NOT set searchQuery so the useEffect doesn't re-fire
+    setDisplayQuery(`${ref.brand} ${ref.model_name}`);
+    setShowResults(false);
+
+    const lt = categoryToLoomType(ref.loom_category);
+    const sOpts = ref.shaft_count_options ?? [];
+    const wOpts = buildWidthOptions(ref);
+
+    // Auto-match shaft to current version
+    setSelectedShaftIdx(closestIdx(sOpts, loom.current_version?.num_shafts));
+
+    // Auto-match width to current version (convert units if needed)
+    if (wOpts.length > 0 && loom.current_version?.weaving_width) {
+      const curVal = parseFloat(loom.current_version.weaving_width);
+      const curUnit = loom.current_version.weaving_width_unit as "cm" | "in";
+      const targetUnit = wOpts[0].unit;
+      const converted =
+        curUnit === targetUnit
+          ? curVal
+          : curUnit === "cm"
+            ? curVal / 2.54
+            : curVal * 2.54;
+      setSelectedWidthIdx(closestIdx(wOpts.map((o) => parseFloat(o.value)), converted));
+    } else {
+      setSelectedWidthIdx(0);
+    }
+
+    // Skip configure step if nothing to configure
+    const hasDropdowns =
+      (showsShafts(lt) && sOpts.length > 1) || wOpts.length > 1;
+    setStep(hasDropdowns ? "configure" : "confirm");
+  }
+
+  // Diff rows for confirm step
+  const cv = loom.current_version;
+
+  interface DiffRow {
+    label: string;
+    oldVal: string;
+    newVal: string;
+    changed: boolean;
+  }
+
+  const diffRows: DiffRow[] = selectedRef
+    ? [
+        {
+          label: "Manufacturer",
+          oldVal: loom.manufacturer,
+          newVal: selectedRef.brand,
+          changed: loom.manufacturer !== selectedRef.brand,
+        },
+        {
+          label: "Model",
+          oldVal: loom.model_name,
+          newVal: selectedRef.model_name,
+          changed: loom.model_name !== selectedRef.model_name,
+        },
+        {
+          label: "Loom type",
+          oldVal: LOOM_TYPE_LABELS[loom.loom_type] ?? loom.loom_type,
+          newVal: LOOM_TYPE_LABELS[newLoomType] ?? newLoomType,
+          changed: loom.loom_type !== newLoomType,
+        },
+        ...(cv && showsShafts(newLoomType) && selectedShafts != null
+          ? [
+              {
+                label: "Shafts",
+                oldVal: cv.num_shafts != null ? String(cv.num_shafts) : "—",
+                newVal: String(selectedShafts),
+                changed: cv.num_shafts !== selectedShafts,
+              },
+            ]
+          : []),
+        ...(cv && showsTreadles(newLoomType) && derivedTreadles != null
+          ? [
+              {
+                label: "Treadles",
+                oldVal: cv.num_treadles != null ? String(cv.num_treadles) : "—",
+                newVal: String(derivedTreadles),
+                changed: cv.num_treadles !== derivedTreadles,
+              },
+            ]
+          : []),
+        ...(cv && selectedWidthOpt != null
+          ? [
+              {
+                label: "Weaving width",
+                oldVal: cv.weaving_width
+                  ? `${parseFloat(cv.weaving_width)} ${cv.weaving_width_unit}`
+                  : "—",
+                newVal: selectedWidthOpt.label,
+                changed:
+                  !cv.weaving_width ||
+                  parseFloat(cv.weaving_width) !== parseFloat(selectedWidthOpt.value) ||
+                  cv.weaving_width_unit !== selectedWidthOpt.unit,
+              },
+            ]
+          : []),
+      ]
+    : [];
+
+  const hasChanges = diffRows.some((r) => r.changed);
+
+  async function handleSave() {
+    if (!selectedRef) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await updateLoom(loom.id, {
+        manufacturer: selectedRef.brand,
+        model_name: selectedRef.model_name,
+        loom_type: newLoomType,
+      });
+      await linkLoomReference(loom.id, selectedRef.id);
+
+      if (cv) {
+        const versionPayload: UpdateVersionPayload = {};
+        if (showsShafts(newLoomType) && selectedShafts != null) {
+          versionPayload.num_shafts = selectedShafts;
+        }
+        if (showsTreadles(newLoomType) && derivedTreadles != null) {
+          versionPayload.num_treadles = derivedTreadles;
+        }
+        if (selectedWidthOpt != null) {
+          versionPayload.weaving_width = parseFloat(selectedWidthOpt.value);
+          versionPayload.weaving_width_unit = selectedWidthOpt.unit;
+        }
+        if (Object.keys(versionPayload).length > 0) {
+          await updateVersion(loom.id, cv.id, versionPayload);
+        }
+      }
+
+      onSuccess();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save changes");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="w-full max-w-lg rounded-lg border bg-background p-6 shadow-lg overflow-y-auto max-h-[90vh]">
+        <div className="flex items-start justify-between mb-5">
+          <div>
+            <h2 className="text-lg font-semibold">Update from catalog</h2>
+            <p className="text-sm text-muted-foreground">
+              {loom.manufacturer} {loom.model_name}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground transition-colors ml-4"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* ── Step: search ── */}
+        {step === "search" && (
+          <div ref={searchContainerRef} className="relative">
+            <label className="mb-1 block text-sm font-medium">Search loom catalog</label>
+            <input
+              type="search"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+              value={displayQuery}
+              onChange={(e) => handleInputChange(e.target.value)}
+              placeholder="Schacht Baby Wolf, Louet Spring…"
+              autoFocus
+              autoComplete="off"
+            />
+            {searching && (
+              <p className="mt-1 text-xs text-muted-foreground">Searching…</p>
+            )}
+            {showResults && results.length > 0 && (
+              <div className="absolute z-10 mt-1 w-full rounded-md border bg-popover shadow-md max-h-60 overflow-y-auto">
+                {results.map((r) => (
+                  <button
+                    key={r.id}
+                    type="button"
+                    className="w-full px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground flex flex-col"
+                    onMouseDown={() => handleSelectRef(r)}
+                  >
+                    <span className="font-medium">
+                      {r.brand} {r.model_name}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {LOOM_TYPE_LABELS[categoryToLoomType(r.loom_category)]}
+                      {r.shaft_count_options?.length
+                        ? ` · ${r.shaft_count_options.join("/")} shafts`
+                        : ""}
+                      {r.origin_country ? ` · ${r.origin_country}` : ""}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            )}
+            {showResults &&
+              results.length === 0 &&
+              !searching &&
+              displayQuery.length >= 2 && (
+                <div className="absolute z-10 mt-1 w-full rounded-md border bg-popover px-3 py-2 text-sm text-muted-foreground shadow-md">
+                  No results found.
+                </div>
+              )}
+            <div className="mt-4 flex justify-end">
+              <Button type="button" variant="outline" onClick={onClose}>
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* ── Step: configure ── */}
+        {step === "configure" && selectedRef && (
+          <div className="space-y-4">
+            <div className="rounded-md border bg-muted/30 px-3 py-3">
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <p className="text-sm font-semibold">
+                    {selectedRef.brand} {selectedRef.model_name}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {LOOM_TYPE_LABELS[newLoomType]}
+                    {selectedRef.origin_country ? ` · ${selectedRef.origin_country}` : ""}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  className="shrink-0 text-xs text-muted-foreground hover:text-foreground"
+                  onClick={() => {
+                    setSelectedRef(null);
+                    setStep("search");
+                  }}
+                >
+                  Change
+                </button>
+              </div>
+            </div>
+
+            {showsShafts(newLoomType) && shaftOptions.length > 0 && (
+              <div>
+                <label className="mb-1 block text-sm font-medium">Shafts</label>
+                {shaftOptions.length > 1 ? (
+                  <select
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                    value={selectedShaftIdx}
+                    onChange={(e) => setSelectedShaftIdx(Number(e.target.value))}
+                  >
+                    {shaftOptions.map((s, i) => (
+                      <option key={s} value={i}>
+                        {s}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <p className="rounded-md border bg-muted/40 px-3 py-2 text-sm">
+                    {shaftOptions[0]}
+                  </p>
+                )}
+              </div>
+            )}
+
+            {showsTreadles(newLoomType) && derivedTreadles != null && (
+              <div>
+                <label className="mb-1 block text-sm font-medium">Treadles</label>
+                <p className="rounded-md border bg-muted/40 px-3 py-2 text-sm">
+                  {derivedTreadles}
+                </p>
+              </div>
+            )}
+
+            {widthOptions.length > 0 && (
+              <div>
+                <label className="mb-1 block text-sm font-medium">Weaving width</label>
+                {widthOptions.length > 1 ? (
+                  <select
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                    value={selectedWidthIdx}
+                    onChange={(e) => setSelectedWidthIdx(Number(e.target.value))}
+                  >
+                    {widthOptions.map((o, i) => (
+                      <option key={o.value} value={i}>
+                        {o.label}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <p className="rounded-md border bg-muted/40 px-3 py-2 text-sm">
+                    {widthOptions[0].label}
+                  </p>
+                )}
+              </div>
+            )}
+
+            <div className="flex justify-end gap-2 pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setSelectedRef(null);
+                  setStep("search");
+                }}
+              >
+                Back
+              </Button>
+              <Button type="button" onClick={() => setStep("confirm")}>
+                Review changes
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* ── Step: confirm ── */}
+        {step === "confirm" && selectedRef && (
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Review the changes below. The loom identity and current configuration will be
+              updated to match the catalog entry.
+            </p>
+
+            <div className="rounded-md border overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b bg-muted/30">
+                    <th className="px-3 py-2 text-left text-xs font-medium text-muted-foreground w-28">
+                      Field
+                    </th>
+                    <th className="px-3 py-2 text-left text-xs font-medium text-muted-foreground">
+                      Current
+                    </th>
+                    <th className="px-3 py-2 text-center text-xs text-muted-foreground w-6">→</th>
+                    <th className="px-3 py-2 text-left text-xs font-medium text-muted-foreground">
+                      New
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {diffRows.map((row) => (
+                    <tr
+                      key={row.label}
+                      className={`border-b last:border-0 ${row.changed ? "" : "opacity-40"}`}
+                    >
+                      <td className="px-3 py-2 text-xs text-muted-foreground">{row.label}</td>
+                      <td className="px-3 py-2">{row.oldVal}</td>
+                      <td className="px-3 py-2 text-center text-muted-foreground">→</td>
+                      <td
+                        className={`px-3 py-2 ${row.changed ? "font-medium text-foreground" : ""}`}
+                      >
+                        {row.newVal}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {!hasChanges && (
+              <p className="text-sm text-muted-foreground italic">
+                No fields will change — only the catalog link will be set.
+              </p>
+            )}
+
+            {error && (
+              <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                {error}
+              </p>
+            )}
+
+            <div className="flex justify-end gap-2 pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() =>
+                  setStep(
+                    shaftOptions.length > 1 || widthOptions.length > 1
+                      ? "configure"
+                      : "search",
+                  )
+                }
+                disabled={saving}
+              >
+                Back
+              </Button>
+              <Button type="button" onClick={handleSave} disabled={saving}>
+                {saving ? "Saving…" : "Confirm & save"}
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/looms/NewLoomModal.tsx
+++ b/frontend/src/components/looms/NewLoomModal.tsx
@@ -1,5 +1,13 @@
-import { useState } from "react";
-import { createLoom, type CreateLoomPayload, type LoomType, LOOM_TYPE_LABELS, SUPPORTED_LOOM_TYPES } from "@/api/looms";
+import { useState, useEffect, useRef } from "react";
+import {
+  createLoom,
+  searchLoomCatalog,
+  type CreateLoomPayload,
+  type LoomType,
+  type LoomReferenceSummary,
+  LOOM_TYPE_LABELS,
+  SUPPORTED_LOOM_TYPES,
+} from "@/api/looms";
 import { Button } from "@/components/ui/button";
 import { useAuthContext } from "@/context/AuthContext";
 import { measurementSystemToUnit } from "@/lib/units";
@@ -11,21 +19,52 @@ interface Props {
 
 const today = () => new Date(Date.now() - new Date().getTimezoneOffset() * 60000).toISOString().slice(0, 10);
 
-const LOOM_TYPES: LoomType[] = ["floor_loom", "table_loom", "rigid_heddle", "inkle", "dobby", "other"];
+const ALL_LOOM_TYPES: LoomType[] = [
+  "floor_loom", "table_loom", "rigid_heddle", "inkle",
+  "dobby_floor_loom", "tapestry_loom", "rug_loom", "frame_loom", "other",
+];
 
-function showsShafts(t: LoomType) { return t === "floor_loom" || t === "table_loom" || t === "dobby" || t === "other"; }
-function showsTreadles(t: LoomType) { return t === "floor_loom"; }
+function showsShafts(t: LoomType) {
+  return ["floor_loom", "table_loom", "dobby_floor_loom", "other"].includes(t);
+}
+function showsTreadles(t: LoomType) { return t === "floor_loom" || t === "dobby_floor_loom"; }
 function showsHeddles(t: LoomType) { return t === "rigid_heddle" || t === "other"; }
+
+function categoryToLoomType(cat: string): LoomType {
+  const map: Record<string, LoomType> = {
+    floor_loom: "floor_loom",
+    table_loom: "table_loom",
+    rigid_heddle: "rigid_heddle",
+    inkle_loom: "inkle",
+    dobby_floor_loom: "dobby_floor_loom",
+    tapestry_loom: "tapestry_loom",
+    rug_loom: "rug_loom",
+    frame_loom: "frame_loom",
+  };
+  return map[cat] ?? "other";
+}
 
 export function NewLoomModal({ onSuccess, onClose }: Props) {
   const { user } = useAuthContext();
   const defaultUnit = measurementSystemToUnit(user?.measurement_system ?? "metric");
+  const useInches = defaultUnit === "in";
+
+  // Catalog search state
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<LoomReferenceSummary[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [showResults, setShowResults] = useState(false);
+  const [selectedRef, setSelectedRef] = useState<LoomReferenceSummary | null>(null);
+  const searchRef = useRef<HTMLDivElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Form state
   const [loomType, setLoomType] = useState<LoomType>("floor_loom");
   const [manufacturer, setManufacturer] = useState("");
   const [modelName, setModelName] = useState("");
   const [serialNumber, setSerialNumber] = useState("");
   const [numShafts, setNumShafts] = useState("4");
-  const [numTreadles, setNumTreadles] = useState("6"); // default: 4 shafts + 2
+  const [numTreadles, setNumTreadles] = useState("6");
   const [treadlesManuallySet, setTreadlesManuallySet] = useState(false);
   const [numHeddles, setNumHeddles] = useState("");
   const [weavingWidth, setWeavingWidth] = useState("");
@@ -38,7 +77,114 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  const isUnsupported = !SUPPORTED_LOOM_TYPES.has(loomType);
+  // When a ref is selected: available shaft/width options for pickers
+  const shaftOptions = selectedRef?.shaft_count_options ?? null;
+  const widthOptionsIn = selectedRef?.weaving_width_options_inches ?? null;
+  const widthOptionsCm = selectedRef?.weaving_width_options_cm ?? null;
+  const activeWidthOptions = useInches ? widthOptionsIn : (widthOptionsCm ?? widthOptionsIn);
+  const treadleOptions = selectedRef?.treadle_count ?? null;
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    function handler(e: MouseEvent) {
+      if (searchRef.current && !searchRef.current.contains(e.target as Node)) {
+        setShowResults(false);
+      }
+    }
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  // Debounced catalog search
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!searchQuery.trim() || searchQuery.length < 2) return;
+    debounceRef.current = setTimeout(async () => {
+      setSearching(true);
+      try {
+        const results = await searchLoomCatalog(searchQuery);
+        setSearchResults(results);
+        setShowResults(true);
+      } catch {
+        setSearchResults([]);
+      } finally {
+        setSearching(false);
+      }
+    }, 250);
+    return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
+  }, [searchQuery]);
+
+  const applyReference = (ref: LoomReferenceSummary) => {
+    setSelectedRef(ref);
+    setSearchQuery(`${ref.brand} ${ref.model_name}`);
+    setShowResults(false);
+    setManufacturer(ref.brand);
+    setModelName(ref.model_name);
+    const lt = categoryToLoomType(ref.loom_category);
+    setLoomType(lt);
+    setAcknowledged(false);
+    setTreadlesManuallySet(false);
+
+    // Pre-fill shaft/treadle: pick first option from arrays
+    if (ref.shaft_count_options?.length) {
+      const first = String(ref.shaft_count_options[0]);
+      setNumShafts(first);
+      if (ref.treadle_count?.length) {
+        setNumTreadles(String(ref.treadle_count[0]));
+      } else if (showsTreadles(lt)) {
+        const s = parseInt(first, 10);
+        setNumTreadles(String(s + 2));
+      }
+    }
+
+    // Pre-fill width: pick first option
+    if (useInches && ref.weaving_width_options_inches?.length) {
+      setWeavingWidth(String(ref.weaving_width_options_inches[0]));
+      setWeavingWidthUnit("in");
+    } else if (!useInches && ref.weaving_width_options_cm?.length) {
+      setWeavingWidth(String(ref.weaving_width_options_cm[0]));
+      setWeavingWidthUnit("cm");
+    } else if (ref.weaving_width_options_inches?.length) {
+      setWeavingWidth(String(ref.weaving_width_options_inches[0]));
+      setWeavingWidthUnit("in");
+    }
+  };
+
+  const clearReference = () => {
+    setSelectedRef(null);
+    setSearchQuery("");
+    setManufacturer("");
+    setModelName("");
+    setLoomType("floor_loom");
+    setNumShafts("4");
+    setNumTreadles("6");
+    setWeavingWidth("");
+    setAcknowledged(false);
+    setTreadlesManuallySet(false);
+  };
+
+  const handleShaftOptionChange = (val: string) => {
+    setNumShafts(val);
+    if (!treadlesManuallySet && treadleOptions && shaftOptions) {
+      const idx = shaftOptions.indexOf(parseInt(val, 10));
+      if (idx !== -1 && treadleOptions[idx] != null) {
+        setNumTreadles(String(treadleOptions[idx]));
+        return;
+      }
+    }
+    if (!treadlesManuallySet && showsTreadles(loomType)) {
+      const s = parseInt(val, 10);
+      if (!isNaN(s)) setNumTreadles(String(s + 2));
+    }
+  };
+
+  const handleShaftsManual = (val: string) => {
+    setNumShafts(val);
+    if (loomType === "floor_loom" && !treadlesManuallySet) {
+      const s = parseInt(val, 10);
+      if (!isNaN(s)) setNumTreadles(String(s + 2));
+    }
+  };
 
   const handleTypeChange = (newType: LoomType) => {
     setLoomType(newType);
@@ -50,13 +196,7 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
     }
   };
 
-  const handleShaftsChange = (val: string) => {
-    setNumShafts(val);
-    if (loomType === "floor_loom" && !treadlesManuallySet) {
-      const s = parseInt(val, 10);
-      if (!isNaN(s)) setNumTreadles(String(s + 2));
-    }
-  };
+  const isUnsupported = !SUPPORTED_LOOM_TYPES.has(loomType);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -68,6 +208,7 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
         manufacturer,
         model_name: modelName,
         serial_number: serialNumber || undefined,
+        loom_reference_id: selectedRef?.id,
         notes: notes || undefined,
         effective_date: effectiveDate,
         num_shafts: showsShafts(loomType) && numShafts ? parseInt(numShafts, 10) : undefined,
@@ -93,6 +234,60 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
         <h2 className="mb-4 text-lg font-semibold">New Loom</h2>
 
         <form onSubmit={handleSubmit} className="space-y-4">
+
+          {/* Catalog typeahead */}
+          <div ref={searchRef} className="relative">
+            <label className="mb-1 block text-sm font-medium">
+              Find your loom{" "}
+              <span className="font-normal text-muted-foreground">(optional — start typing brand or model)</span>
+            </label>
+            <input
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+              value={searchQuery}
+              onChange={(e) => { const v = e.target.value; setSearchQuery(v); if (selectedRef) setSelectedRef(null); if (!v.trim() || v.length < 2) { setSearchResults([]); setShowResults(false); } }}
+              placeholder="Schacht Baby Wolf, Ashford Jack Loom…"
+              autoComplete="off"
+            />
+            {searching && (
+              <p className="mt-1 text-xs text-muted-foreground">Searching…</p>
+            )}
+            {showResults && searchResults.length > 0 && (
+              <div className="absolute z-10 mt-1 w-full rounded-md border bg-popover shadow-md max-h-56 overflow-y-auto">
+                {searchResults.map((r) => (
+                  <button
+                    key={r.id}
+                    type="button"
+                    className="w-full px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground flex flex-col"
+                    onMouseDown={() => applyReference(r)}
+                  >
+                    <span className="font-medium">{r.brand} {r.model_name}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {r.loom_category.replace(/_/g, " ")}
+                      {r.shaft_count_options?.length ? ` · ${r.shaft_count_options.join("/")} shafts` : ""}
+                      {r.origin_country ? ` · ${r.origin_country}` : ""}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            )}
+            {showResults && searchResults.length === 0 && !searching && searchQuery.length >= 2 && (
+              <div className="absolute z-10 mt-1 w-full rounded-md border bg-popover shadow-md px-3 py-2">
+                <p className="text-sm text-muted-foreground">No results — enter details manually below.</p>
+              </div>
+            )}
+          </div>
+
+          {selectedRef && (
+            <div className="flex items-center justify-between rounded-md bg-muted px-3 py-2 text-sm">
+              <span className="text-muted-foreground">
+                Linked to catalog: <span className="font-medium text-foreground">{selectedRef.brand} {selectedRef.model_name}</span>
+              </span>
+              <button type="button" className="text-xs text-muted-foreground hover:text-foreground ml-2" onClick={clearReference}>
+                Clear
+              </button>
+            </div>
+          )}
+
           {/* Loom type */}
           <div>
             <label className="mb-1 block text-sm font-medium">Loom type</label>
@@ -101,7 +296,7 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
               value={loomType}
               onChange={(e) => handleTypeChange(e.target.value as LoomType)}
             >
-              {LOOM_TYPES.map((t) => (
+              {ALL_LOOM_TYPES.map((t) => (
                 <option key={t} value={t}>{LOOM_TYPE_LABELS[t]}</option>
               ))}
             </select>
@@ -113,7 +308,7 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
               <p className="font-medium text-copper-on-subtle">Project tracking not supported</p>
               <p className="text-xs text-copper-on-subtle">
                 This loom type is not currently supported for project tracking. You can save it for documentation
-                and it will be available if support is added later, but projects cannot be created using it.
+                and it will be available if support is added later.
               </p>
               <label className="flex items-center gap-2 text-xs text-copper-on-subtle cursor-pointer">
                 <input
@@ -178,14 +373,26 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
               {showsShafts(loomType) && (
                 <div>
                   <label className="mb-1 block text-sm font-medium">Shafts</label>
-                  <input
-                    type="number"
-                    min={1}
-                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-                    value={numShafts}
-                    onChange={(e) => handleShaftsChange(e.target.value)}
-                    required={loomType !== "other" && loomType !== "dobby"}
-                  />
+                  {shaftOptions && shaftOptions.length > 1 ? (
+                    <select
+                      className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                      value={numShafts}
+                      onChange={(e) => handleShaftOptionChange(e.target.value)}
+                    >
+                      {shaftOptions.map((s) => (
+                        <option key={s} value={String(s)}>{s}</option>
+                      ))}
+                    </select>
+                  ) : (
+                    <input
+                      type="number"
+                      min={1}
+                      className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                      value={numShafts}
+                      onChange={(e) => handleShaftsManual(e.target.value)}
+                      required={loomType !== "other" && loomType !== "dobby_floor_loom"}
+                    />
+                  )}
                 </div>
               )}
               {showsTreadles(loomType) && (
@@ -216,30 +423,48 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
             </div>
           )}
 
-          {/* Dimensions — available for all types except inkle */}
+          {/* Weaving width */}
           {loomType !== "inkle" && (
             <div className="space-y-3">
               <div>
                 <label className="mb-1 block text-sm font-medium">Weaving width (optional)</label>
-                <div className="flex gap-2">
-                  <input
-                    type="number"
-                    min={0}
-                    step="0.1"
-                    className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-                    value={weavingWidth}
-                    onChange={(e) => setWeavingWidth(e.target.value)}
-                    placeholder="60"
-                  />
-                  <select
-                    className="rounded-md border border-input bg-background px-2 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-                    value={weavingWidthUnit}
-                    onChange={(e) => setWeavingWidthUnit(e.target.value)}
-                  >
-                    <option value="cm">cm</option>
-                    <option value="in">in</option>
-                  </select>
-                </div>
+                {activeWidthOptions && activeWidthOptions.length > 1 ? (
+                  <div className="flex gap-2">
+                    <select
+                      className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                      value={weavingWidth}
+                      onChange={(e) => setWeavingWidth(e.target.value)}
+                    >
+                      <option value="">— select —</option>
+                      {activeWidthOptions.map((w) => (
+                        <option key={w} value={String(w)}>{w}</option>
+                      ))}
+                    </select>
+                    <span className="flex items-center px-2 text-sm text-muted-foreground">
+                      {useInches ? "in" : "cm"}
+                    </span>
+                  </div>
+                ) : (
+                  <div className="flex gap-2">
+                    <input
+                      type="number"
+                      min={0}
+                      step="0.1"
+                      className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                      value={weavingWidth}
+                      onChange={(e) => setWeavingWidth(e.target.value)}
+                      placeholder="60"
+                    />
+                    <select
+                      className="rounded-md border border-input bg-background px-2 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                      value={weavingWidthUnit}
+                      onChange={(e) => setWeavingWidthUnit(e.target.value)}
+                    >
+                      <option value="cm">cm</option>
+                      <option value="in">in</option>
+                    </select>
+                  </div>
+                )}
               </div>
               <div>
                 <label className="mb-1 block text-sm font-medium">Warp waste (optional)</label>

--- a/frontend/src/components/looms/NewLoomModal.tsx
+++ b/frontend/src/components/looms/NewLoomModal.tsx
@@ -440,26 +440,9 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
                   {showsTreadles(loomType) && (
                     <div>
                       <label className="mb-1 block text-sm font-medium">Treadles</label>
-                      {treadleOptions && treadleOptions.length > 1 ? (
-                        <select
-                          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-                          value={numTreadles}
-                          onChange={(e) => {
-                            setNumTreadles(e.target.value);
-                            setTreadlesManuallySet(true);
-                          }}
-                        >
-                          {treadleOptions.map((t) => (
-                            <option key={t} value={String(t)}>
-                              {t}
-                            </option>
-                          ))}
-                        </select>
-                      ) : (
-                        <p className="rounded-md border bg-muted/40 px-3 py-2 text-sm text-foreground">
-                          {numTreadles}
-                        </p>
-                      )}
+                      <p className="rounded-md border bg-muted/40 px-3 py-2 text-sm text-foreground">
+                        {numTreadles}
+                      </p>
                     </div>
                   )}
                 </div>

--- a/frontend/src/components/looms/NewLoomModal.tsx
+++ b/frontend/src/components/looms/NewLoomModal.tsx
@@ -17,18 +17,32 @@ interface Props {
   onClose: () => void;
 }
 
-const today = () => new Date(Date.now() - new Date().getTimezoneOffset() * 60000).toISOString().slice(0, 10);
+const today = () =>
+  new Date(Date.now() - new Date().getTimezoneOffset() * 60000)
+    .toISOString()
+    .slice(0, 10);
 
 const ALL_LOOM_TYPES: LoomType[] = [
-  "floor_loom", "table_loom", "rigid_heddle", "inkle",
-  "dobby_floor_loom", "tapestry_loom", "rug_loom", "frame_loom", "other",
+  "floor_loom",
+  "table_loom",
+  "rigid_heddle",
+  "inkle",
+  "dobby_floor_loom",
+  "tapestry_loom",
+  "rug_loom",
+  "frame_loom",
+  "other",
 ];
 
 function showsShafts(t: LoomType) {
   return ["floor_loom", "table_loom", "dobby_floor_loom", "other"].includes(t);
 }
-function showsTreadles(t: LoomType) { return t === "floor_loom" || t === "dobby_floor_loom"; }
-function showsHeddles(t: LoomType) { return t === "rigid_heddle" || t === "other"; }
+function showsTreadles(t: LoomType) {
+  return t === "floor_loom" || t === "dobby_floor_loom";
+}
+function showsHeddles(t: LoomType) {
+  return t === "rigid_heddle" || t === "other";
+}
 
 function categoryToLoomType(cat: string): LoomType {
   const map: Record<string, LoomType> = {
@@ -44,17 +58,48 @@ function categoryToLoomType(cat: string): LoomType {
   return map[cat] ?? "other";
 }
 
+interface WidthOption {
+  label: string;
+  value: string;
+  unit: "cm" | "in";
+}
+
+function buildWidthOptions(ref: LoomReferenceSummary): WidthOption[] {
+  const cm = ref.weaving_width_options_cm;
+  const inches = ref.weaving_width_options_inches;
+  if (!cm?.length && !inches?.length) return [];
+
+  if (cm?.length) {
+    const inArr =
+      inches?.length === cm.length
+        ? inches
+        : cm.map((c) => Math.round((c / 2.54) * 10) / 10);
+    return cm.map((c, i) => ({
+      label: `${c} cm (${inArr[i]} in)`,
+      value: String(c),
+      unit: "cm",
+    }));
+  }
+  // Only inches available — convert to cm for display
+  const cmArr = inches!.map((i) => Math.round(i * 2.54 * 10) / 10);
+  return inches!.map((inch, i) => ({
+    label: `${inch} in (${cmArr[i]} cm)`,
+    value: String(inch),
+    unit: "in",
+  }));
+}
+
 export function NewLoomModal({ onSuccess, onClose }: Props) {
   const { user } = useAuthContext();
   const defaultUnit = measurementSystemToUnit(user?.measurement_system ?? "metric");
-  const useInches = defaultUnit === "in";
 
-  // Catalog search state
+  // Search state
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<LoomReferenceSummary[]>([]);
   const [searching, setSearching] = useState(false);
   const [showResults, setShowResults] = useState(false);
   const [selectedRef, setSelectedRef] = useState<LoomReferenceSummary | null>(null);
+  const [manualMode, setManualMode] = useState(false);
   const searchRef = useRef<HTMLDivElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -77,12 +122,14 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  // When a ref is selected: available shaft/width options for pickers
+  // Derived catalog option lists
   const shaftOptions = selectedRef?.shaft_count_options ?? null;
-  const widthOptionsIn = selectedRef?.weaving_width_options_inches ?? null;
-  const widthOptionsCm = selectedRef?.weaving_width_options_cm ?? null;
-  const activeWidthOptions = useInches ? widthOptionsIn : (widthOptionsCm ?? widthOptionsIn);
   const treadleOptions = selectedRef?.treadle_count ?? null;
+  const widthOptions = selectedRef ? buildWidthOptions(selectedRef) : [];
+
+  const mode = selectedRef ? "catalog" : manualMode ? "manual" : "searching";
+  const showForm = mode === "catalog" || mode === "manual";
+  const isUnsupported = !SUPPORTED_LOOM_TYPES.has(loomType);
 
   // Close dropdown on outside click
   useEffect(() => {
@@ -111,12 +158,13 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
         setSearching(false);
       }
     }, 250);
-    return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
   }, [searchQuery]);
 
   const applyReference = (ref: LoomReferenceSummary) => {
     setSelectedRef(ref);
-    setSearchQuery(`${ref.brand} ${ref.model_name}`);
     setShowResults(false);
     setManufacturer(ref.brand);
     setModelName(ref.model_name);
@@ -125,7 +173,6 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
     setAcknowledged(false);
     setTreadlesManuallySet(false);
 
-    // Pre-fill shaft/treadle: pick first option from arrays
     if (ref.shaft_count_options?.length) {
       const first = String(ref.shaft_count_options[0]);
       setNumShafts(first);
@@ -137,16 +184,13 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
       }
     }
 
-    // Pre-fill width: pick first option
-    if (useInches && ref.weaving_width_options_inches?.length) {
-      setWeavingWidth(String(ref.weaving_width_options_inches[0]));
-      setWeavingWidthUnit("in");
-    } else if (!useInches && ref.weaving_width_options_cm?.length) {
-      setWeavingWidth(String(ref.weaving_width_options_cm[0]));
-      setWeavingWidthUnit("cm");
-    } else if (ref.weaving_width_options_inches?.length) {
-      setWeavingWidth(String(ref.weaving_width_options_inches[0]));
-      setWeavingWidthUnit("in");
+    const opts = buildWidthOptions(ref);
+    if (opts.length) {
+      setWeavingWidth(opts[0].value);
+      setWeavingWidthUnit(opts[0].unit);
+    } else {
+      setWeavingWidth("");
+      setWeavingWidthUnit(defaultUnit);
     }
   };
 
@@ -159,6 +203,7 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
     setNumShafts("4");
     setNumTreadles("6");
     setWeavingWidth("");
+    setWeavingWidthUnit(defaultUnit);
     setAcknowledged(false);
     setTreadlesManuallySet(false);
   };
@@ -196,8 +241,6 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
     }
   };
 
-  const isUnsupported = !SUPPORTED_LOOM_TYPES.has(loomType);
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
@@ -211,9 +254,14 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
         loom_reference_id: selectedRef?.id,
         notes: notes || undefined,
         effective_date: effectiveDate,
-        num_shafts: showsShafts(loomType) && numShafts ? parseInt(numShafts, 10) : undefined,
-        num_treadles: showsTreadles(loomType) && numTreadles !== "" ? parseInt(numTreadles, 10) : undefined,
-        num_heddles: showsHeddles(loomType) && numHeddles ? parseInt(numHeddles, 10) : undefined,
+        num_shafts:
+          showsShafts(loomType) && numShafts ? parseInt(numShafts, 10) : undefined,
+        num_treadles:
+          showsTreadles(loomType) && numTreadles !== ""
+            ? parseInt(numTreadles, 10)
+            : undefined,
+        num_heddles:
+          showsHeddles(loomType) && numHeddles ? parseInt(numHeddles, 10) : undefined,
         weaving_width: weavingWidth ? parseFloat(weavingWidth) : undefined,
         weaving_width_unit: weavingWidthUnit,
         warp_waste_allowance: warpWaste ? parseFloat(warpWaste) : undefined,
@@ -235,182 +283,194 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
 
         <form onSubmit={handleSubmit} className="space-y-4">
 
-          {/* Catalog typeahead */}
-          <div ref={searchRef} className="relative">
-            <label className="mb-1 block text-sm font-medium">
-              Find your loom{" "}
-              <span className="font-normal text-muted-foreground">(optional — start typing brand or model)</span>
-            </label>
-            <input
-              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-              value={searchQuery}
-              onChange={(e) => { const v = e.target.value; setSearchQuery(v); if (selectedRef) setSelectedRef(null); if (!v.trim() || v.length < 2) { setSearchResults([]); setShowResults(false); } }}
-              placeholder="Schacht Baby Wolf, Ashford Jack Loom…"
-              autoComplete="off"
-            />
-            {searching && (
-              <p className="mt-1 text-xs text-muted-foreground">Searching…</p>
-            )}
-            {showResults && searchResults.length > 0 && (
-              <div className="absolute z-10 mt-1 w-full rounded-md border bg-popover shadow-md max-h-56 overflow-y-auto">
-                {searchResults.map((r) => (
+          {/* ── Search (visible in search and catalog modes) ── */}
+          {mode !== "manual" && (
+            <div ref={searchRef} className="relative">
+              <label className="mb-1 block text-sm font-medium">Find your loom</label>
+              <input
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                value={searchQuery}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  setSearchQuery(v);
+                  if (selectedRef) clearReference();
+                  if (!v.trim() || v.length < 2) {
+                    setSearchResults([]);
+                    setShowResults(false);
+                  }
+                }}
+                placeholder="Schacht Baby Wolf, Louet Spring…"
+                autoComplete="off"
+              />
+              {searching && (
+                <p className="mt-1 text-xs text-muted-foreground">Searching…</p>
+              )}
+              {showResults && searchResults.length > 0 && (
+                <div className="absolute z-10 mt-1 w-full rounded-md border bg-popover shadow-md max-h-56 overflow-y-auto">
+                  {searchResults.map((r) => (
+                    <button
+                      key={r.id}
+                      type="button"
+                      className="w-full px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground flex flex-col"
+                      onMouseDown={() => applyReference(r)}
+                    >
+                      <span className="font-medium">
+                        {r.brand} {r.model_name}
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        {LOOM_TYPE_LABELS[categoryToLoomType(r.loom_category)]}
+                        {r.shaft_count_options?.length
+                          ? ` · ${r.shaft_count_options.join("/")} shafts`
+                          : ""}
+                        {r.origin_country ? ` · ${r.origin_country}` : ""}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              )}
+              {showResults &&
+                searchResults.length === 0 &&
+                !searching &&
+                searchQuery.length >= 2 && (
+                  <div className="absolute z-10 mt-1 w-full rounded-md border bg-popover shadow-md px-3 py-2">
+                    <p className="text-sm text-muted-foreground">No results.</p>
+                  </div>
+                )}
+              {mode === "searching" && (
+                <p className="mt-1.5 text-xs text-muted-foreground">
+                  Not in the catalog?{" "}
                   <button
-                    key={r.id}
                     type="button"
-                    className="w-full px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground flex flex-col"
-                    onMouseDown={() => applyReference(r)}
+                    className="underline hover:text-foreground"
+                    onClick={() => setManualMode(true)}
                   >
-                    <span className="font-medium">{r.brand} {r.model_name}</span>
-                    <span className="text-xs text-muted-foreground">
-                      {r.loom_category.replace(/_/g, " ")}
-                      {r.shaft_count_options?.length ? ` · ${r.shaft_count_options.join("/")} shafts` : ""}
-                      {r.origin_country ? ` · ${r.origin_country}` : ""}
-                    </span>
+                    Enter details manually
                   </button>
-                ))}
-              </div>
-            )}
-            {showResults && searchResults.length === 0 && !searching && searchQuery.length >= 2 && (
-              <div className="absolute z-10 mt-1 w-full rounded-md border bg-popover shadow-md px-3 py-2">
-                <p className="text-sm text-muted-foreground">No results — enter details manually below.</p>
-              </div>
-            )}
-          </div>
+                </p>
+              )}
+            </div>
+          )}
 
-          {selectedRef && (
-            <div className="flex items-center justify-between rounded-md bg-muted px-3 py-2 text-sm">
-              <span className="text-muted-foreground">
-                Linked to catalog: <span className="font-medium text-foreground">{selectedRef.brand} {selectedRef.model_name}</span>
-              </span>
-              <button type="button" className="text-xs text-muted-foreground hover:text-foreground ml-2" onClick={clearReference}>
-                Clear
+          {/* ── Manual mode banner ── */}
+          {mode === "manual" && (
+            <div className="flex items-center justify-between rounded-md border bg-muted/30 px-3 py-2 text-sm">
+              <span className="text-muted-foreground">Entering details manually</span>
+              <button
+                type="button"
+                className="text-xs underline text-muted-foreground hover:text-foreground"
+                onClick={() => setManualMode(false)}
+              >
+                Search catalog
               </button>
             </div>
           )}
 
-          {/* Loom type */}
-          <div>
-            <label className="mb-1 block text-sm font-medium">Loom type</label>
-            <select
-              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-              value={loomType}
-              onChange={(e) => handleTypeChange(e.target.value as LoomType)}
-            >
-              {ALL_LOOM_TYPES.map((t) => (
-                <option key={t} value={t}>{LOOM_TYPE_LABELS[t]}</option>
-              ))}
-            </select>
-          </div>
+          {/* ── CATALOG MODE: fixed identity + pickers ── */}
+          {mode === "catalog" && (
+            <>
+              <div className="rounded-md border bg-muted/30 px-3 py-3">
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <p className="text-sm font-semibold">
+                      {selectedRef!.brand} {selectedRef!.model_name}
+                    </p>
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      {LOOM_TYPE_LABELS[loomType]}
+                      {selectedRef!.origin_country
+                        ? ` · ${selectedRef!.origin_country}`
+                        : ""}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={clearReference}
+                    className="shrink-0 text-xs text-muted-foreground hover:text-foreground"
+                  >
+                    Change
+                  </button>
+                </div>
+              </div>
 
-          {/* Unsupported type warning + acknowledgement */}
-          {isUnsupported && (
-            <div className="rounded-md border border-copper-subtle bg-copper-subtle px-3 py-3 text-sm space-y-2">
-              <p className="font-medium text-copper-on-subtle">Project tracking not supported</p>
-              <p className="text-xs text-copper-on-subtle">
-                This loom type is not currently supported for project tracking. You can save it for documentation
-                and it will be available if support is added later.
-              </p>
-              <label className="flex items-center gap-2 text-xs text-copper-on-subtle cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={acknowledged}
-                  onChange={(e) => setAcknowledged(e.target.checked)}
-                />
-                I understand this loom cannot be used for project tracking
-              </label>
-            </div>
-          )}
-
-          {/* Identity */}
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="mb-1 block text-sm font-medium">Manufacturer</label>
-              <input
-                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-                value={manufacturer}
-                onChange={(e) => setManufacturer(e.target.value)}
-                placeholder="Ashford"
-                required
-              />
-            </div>
-            <div>
-              <label className="mb-1 block text-sm font-medium">Model</label>
-              <input
-                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-                value={modelName}
-                onChange={(e) => setModelName(e.target.value)}
-                placeholder="Table Loom 8"
-                required
-              />
-            </div>
-          </div>
-
-          <div>
-            <label className="mb-1 block text-sm font-medium">Serial number (optional)</label>
-            <input
-              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-              value={serialNumber}
-              onChange={(e) => setSerialNumber(e.target.value)}
-              placeholder="SN-12345"
-            />
-          </div>
-
-          {/* Initial configuration */}
-          <div>
-            <label className="mb-1 block text-sm font-medium">Configuration as of</label>
-            <input
-              type="date"
-              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-              value={effectiveDate}
-              onChange={(e) => setEffectiveDate(e.target.value)}
-              required
-            />
-          </div>
-
-          {/* Type-specific spec fields */}
-          {(showsShafts(loomType) || showsTreadles(loomType) || showsHeddles(loomType)) && (
-            <div className="grid grid-cols-2 gap-3">
-              {showsShafts(loomType) && (
-                <div>
-                  <label className="mb-1 block text-sm font-medium">Shafts</label>
-                  {shaftOptions && shaftOptions.length > 1 ? (
-                    <select
-                      className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-                      value={numShafts}
-                      onChange={(e) => handleShaftOptionChange(e.target.value)}
-                    >
-                      {shaftOptions.map((s) => (
-                        <option key={s} value={String(s)}>{s}</option>
-                      ))}
-                    </select>
-                  ) : (
+              {isUnsupported && (
+                <div className="rounded-md border border-copper-subtle bg-copper-subtle px-3 py-3 text-sm space-y-2">
+                  <p className="font-medium text-copper-on-subtle">
+                    Project tracking not supported
+                  </p>
+                  <p className="text-xs text-copper-on-subtle">
+                    This loom type is not currently supported for project tracking. You
+                    can save it for documentation and it will be available if support is
+                    added later.
+                  </p>
+                  <label className="flex items-center gap-2 text-xs text-copper-on-subtle cursor-pointer">
                     <input
-                      type="number"
-                      min={1}
-                      className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-                      value={numShafts}
-                      onChange={(e) => handleShaftsManual(e.target.value)}
-                      required={loomType !== "other" && loomType !== "dobby_floor_loom"}
+                      type="checkbox"
+                      checked={acknowledged}
+                      onChange={(e) => setAcknowledged(e.target.checked)}
                     />
+                    I understand this loom cannot be used for project tracking
+                  </label>
+                </div>
+              )}
+
+              {/* Shafts + Treadles */}
+              {(showsShafts(loomType) || showsTreadles(loomType)) && (
+                <div className="grid grid-cols-2 gap-3">
+                  {showsShafts(loomType) && (
+                    <div>
+                      <label className="mb-1 block text-sm font-medium">Shafts</label>
+                      {shaftOptions && shaftOptions.length > 1 ? (
+                        <select
+                          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                          value={numShafts}
+                          onChange={(e) => handleShaftOptionChange(e.target.value)}
+                        >
+                          {shaftOptions.map((s) => (
+                            <option key={s} value={String(s)}>
+                              {s}
+                            </option>
+                          ))}
+                        </select>
+                      ) : (
+                        <p className="rounded-md border bg-muted/40 px-3 py-2 text-sm text-foreground">
+                          {shaftOptions?.[0] ?? numShafts}
+                        </p>
+                      )}
+                    </div>
+                  )}
+                  {showsTreadles(loomType) && (
+                    <div>
+                      <label className="mb-1 block text-sm font-medium">Treadles</label>
+                      {treadleOptions && treadleOptions.length > 1 ? (
+                        <select
+                          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                          value={numTreadles}
+                          onChange={(e) => {
+                            setNumTreadles(e.target.value);
+                            setTreadlesManuallySet(true);
+                          }}
+                        >
+                          {treadleOptions.map((t) => (
+                            <option key={t} value={String(t)}>
+                              {t}
+                            </option>
+                          ))}
+                        </select>
+                      ) : (
+                        <p className="rounded-md border bg-muted/40 px-3 py-2 text-sm text-foreground">
+                          {numTreadles}
+                        </p>
+                      )}
+                    </div>
                   )}
                 </div>
               )}
-              {showsTreadles(loomType) && (
-                <div>
-                  <label className="mb-1 block text-sm font-medium">Treadles</label>
-                  <input
-                    type="number"
-                    min={0}
-                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-                    value={numTreadles}
-                    onChange={(e) => { setNumTreadles(e.target.value); setTreadlesManuallySet(true); }}
-                    required
-                  />
-                </div>
-              )}
+
+              {/* Heddles (rigid heddle / other) */}
               {showsHeddles(loomType) && (
                 <div>
-                  <label className="mb-1 block text-sm font-medium">Heddles (optional)</label>
+                  <label className="mb-1 block text-sm font-medium">
+                    Heddles (optional)
+                  </label>
                   <input
                     type="number"
                     min={1}
@@ -420,31 +480,173 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
                   />
                 </div>
               )}
-            </div>
-          )}
 
-          {/* Weaving width */}
-          {loomType !== "inkle" && (
-            <div className="space-y-3">
-              <div>
-                <label className="mb-1 block text-sm font-medium">Weaving width (optional)</label>
-                {activeWidthOptions && activeWidthOptions.length > 1 ? (
-                  <div className="flex gap-2">
+              {/* Weaving width — paired cm/in dropdown */}
+              {loomType !== "inkle" && (
+                <div>
+                  <label className="mb-1 block text-sm font-medium">
+                    Weaving width
+                  </label>
+                  {widthOptions.length > 0 ? (
                     <select
-                      className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                      className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                       value={weavingWidth}
-                      onChange={(e) => setWeavingWidth(e.target.value)}
+                      onChange={(e) => {
+                        setWeavingWidth(e.target.value);
+                        const opt = widthOptions.find(
+                          (o) => o.value === e.target.value
+                        );
+                        if (opt) setWeavingWidthUnit(opt.unit);
+                      }}
                     >
                       <option value="">— select —</option>
-                      {activeWidthOptions.map((w) => (
-                        <option key={w} value={String(w)}>{w}</option>
+                      {widthOptions.map((o) => (
+                        <option key={o.value} value={o.value}>
+                          {o.label}
+                        </option>
                       ))}
                     </select>
-                    <span className="flex items-center px-2 text-sm text-muted-foreground">
-                      {useInches ? "in" : "cm"}
-                    </span>
-                  </div>
-                ) : (
+                  ) : (
+                    <div className="flex gap-2">
+                      <input
+                        type="number"
+                        min={0}
+                        step="0.1"
+                        className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                        value={weavingWidth}
+                        onChange={(e) => setWeavingWidth(e.target.value)}
+                        placeholder="60"
+                      />
+                      <select
+                        className="rounded-md border border-input bg-background px-2 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                        value={weavingWidthUnit}
+                        onChange={(e) => setWeavingWidthUnit(e.target.value)}
+                      >
+                        <option value="cm">cm</option>
+                        <option value="in">in</option>
+                      </select>
+                    </div>
+                  )}
+                </div>
+              )}
+            </>
+          )}
+
+          {/* ── MANUAL MODE: all free-text inputs ── */}
+          {mode === "manual" && (
+            <>
+              <div>
+                <label className="mb-1 block text-sm font-medium">Loom type</label>
+                <select
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                  value={loomType}
+                  onChange={(e) => handleTypeChange(e.target.value as LoomType)}
+                >
+                  {ALL_LOOM_TYPES.map((t) => (
+                    <option key={t} value={t}>
+                      {LOOM_TYPE_LABELS[t]}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {isUnsupported && (
+                <div className="rounded-md border border-copper-subtle bg-copper-subtle px-3 py-3 text-sm space-y-2">
+                  <p className="font-medium text-copper-on-subtle">
+                    Project tracking not supported
+                  </p>
+                  <p className="text-xs text-copper-on-subtle">
+                    This loom type is not currently supported for project tracking. You
+                    can save it for documentation and it will be available if support is
+                    added later.
+                  </p>
+                  <label className="flex items-center gap-2 text-xs text-copper-on-subtle cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={acknowledged}
+                      onChange={(e) => setAcknowledged(e.target.checked)}
+                    />
+                    I understand this loom cannot be used for project tracking
+                  </label>
+                </div>
+              )}
+
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="mb-1 block text-sm font-medium">Manufacturer</label>
+                  <input
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                    value={manufacturer}
+                    onChange={(e) => setManufacturer(e.target.value)}
+                    placeholder="Ashford"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-sm font-medium">Model</label>
+                  <input
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                    value={modelName}
+                    onChange={(e) => setModelName(e.target.value)}
+                    placeholder="Table Loom 8"
+                    required
+                  />
+                </div>
+              </div>
+
+              {(showsShafts(loomType) || showsTreadles(loomType) || showsHeddles(loomType)) && (
+                <div className="grid grid-cols-2 gap-3">
+                  {showsShafts(loomType) && (
+                    <div>
+                      <label className="mb-1 block text-sm font-medium">Shafts</label>
+                      <input
+                        type="number"
+                        min={1}
+                        className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                        value={numShafts}
+                        onChange={(e) => handleShaftsManual(e.target.value)}
+                        required={loomType !== "other" && loomType !== "dobby_floor_loom"}
+                      />
+                    </div>
+                  )}
+                  {showsTreadles(loomType) && (
+                    <div>
+                      <label className="mb-1 block text-sm font-medium">Treadles</label>
+                      <input
+                        type="number"
+                        min={0}
+                        className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                        value={numTreadles}
+                        onChange={(e) => {
+                          setNumTreadles(e.target.value);
+                          setTreadlesManuallySet(true);
+                        }}
+                        required
+                      />
+                    </div>
+                  )}
+                  {showsHeddles(loomType) && (
+                    <div>
+                      <label className="mb-1 block text-sm font-medium">
+                        Heddles (optional)
+                      </label>
+                      <input
+                        type="number"
+                        min={1}
+                        className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                        value={numHeddles}
+                        onChange={(e) => setNumHeddles(e.target.value)}
+                      />
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {loomType !== "inkle" && (
+                <div>
+                  <label className="mb-1 block text-sm font-medium">
+                    Weaving width (optional)
+                  </label>
                   <div className="flex gap-2">
                     <input
                       type="number"
@@ -464,10 +666,43 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
                       <option value="in">in</option>
                     </select>
                   </div>
-                )}
-              </div>
+                </div>
+              )}
+            </>
+          )}
+
+          {/* ── Shared fields (visible once a mode is active) ── */}
+          {showForm && (
+            <>
               <div>
-                <label className="mb-1 block text-sm font-medium">Warp waste (optional)</label>
+                <label className="mb-1 block text-sm font-medium">
+                  Serial number (optional)
+                </label>
+                <input
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                  value={serialNumber}
+                  onChange={(e) => setSerialNumber(e.target.value)}
+                  placeholder="SN-12345"
+                />
+              </div>
+
+              <div>
+                <label className="mb-1 block text-sm font-medium">
+                  Configuration as of
+                </label>
+                <input
+                  type="date"
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                  value={effectiveDate}
+                  onChange={(e) => setEffectiveDate(e.target.value)}
+                  required
+                />
+              </div>
+
+              <div>
+                <label className="mb-1 block text-sm font-medium">
+                  Warp waste (optional)
+                </label>
                 <div className="flex gap-2">
                   <input
                     type="number"
@@ -488,31 +723,40 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
                   </select>
                 </div>
               </div>
-            </div>
+
+              <div>
+                <label className="mb-1 block text-sm font-medium">
+                  Notes (optional)
+                </label>
+                <textarea
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                  rows={2}
+                  placeholder="Any additional notes…"
+                />
+              </div>
+            </>
           )}
 
-          <div>
-            <label className="mb-1 block text-sm font-medium">Notes (optional)</label>
-            <textarea
-              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-              value={notes}
-              onChange={(e) => setNotes(e.target.value)}
-              rows={2}
-              placeholder="Any additional notes…"
-            />
-          </div>
-
           {error && (
-            <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</p>
+            <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </p>
           )}
 
           <div className="flex justify-end gap-2 pt-2">
             <Button type="button" variant="outline" onClick={onClose} disabled={loading}>
               Cancel
             </Button>
-            <Button type="submit" disabled={loading || (isUnsupported && !acknowledged)}>
-              {loading ? "Creating…" : "Create loom"}
-            </Button>
+            {showForm && (
+              <Button
+                type="submit"
+                disabled={loading || (isUnsupported && !acknowledged)}
+              >
+                {loading ? "Creating…" : "Create loom"}
+              </Button>
+            )}
           </div>
         </form>
       </div>

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -82,8 +82,15 @@ import { getHealthDetailed, type ReadinessResponse, type ReadinessService } from
 import { EulaContent } from "@/components/EulaContent";
 import { CopyEmail } from "@/components/admin/CopyEmail";
 import { formatBytes } from "@/lib/image-utils";
+import {
+  adminListLoomCatalog,
+  adminCreateLoomReference,
+  adminUpdateLoomReference,
+  adminDeleteLoomReference,
+  type LoomReferenceDetail,
+} from "@/api/looms";
 
-type Tab = "users" | "invites" | "stats" | "health" | "services" | "deps" | "audit" | "credentials" | "superuser" | "slugs" | "feedback";
+type Tab = "users" | "invites" | "stats" | "health" | "services" | "deps" | "audit" | "credentials" | "superuser" | "slugs" | "feedback" | "looms";
 
 function formatLastActive(iso: string | null): string {
   if (!iso) return "Never";
@@ -174,6 +181,7 @@ export function AdminPage() {
       {tab === "credentials" && <CredentialsTab />}
       {tab === "slugs" && <SlugsTab />}
       {tab === "superuser" && <SuperuserTab />}
+      {tab === "looms" && <LoomDatabaseTab />}
     </div>
   );
 }
@@ -3412,6 +3420,385 @@ function ScheduledTasksTab() {
           onSaved={() => qc.invalidateQueries({ queryKey: ["admin", "scheduled-tasks"] })}
         />
       ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Loom Database tab
+// ---------------------------------------------------------------------------
+
+const LOOM_CATEGORY_OPTIONS = [
+  { value: "floor_loom", label: "Floor Loom" },
+  { value: "table_loom", label: "Table Loom" },
+  { value: "rigid_heddle", label: "Rigid Heddle" },
+  { value: "inkle", label: "Inkle" },
+  { value: "dobby_floor_loom", label: "Dobby Floor Loom" },
+  { value: "tapestry_loom", label: "Tapestry Loom" },
+  { value: "rug_loom", label: "Rug Loom" },
+  { value: "frame_loom", label: "Frame Loom" },
+  { value: "other", label: "Other" },
+];
+
+const SHEDDING_OPTIONS = [
+  "jack_rising", "counterbalance", "countermarch", "dobby_mechanical",
+  "dobby_electronic", "tapestry", "other",
+];
+
+function parseIntArray(s: string): number[] | undefined {
+  const parts = s.split(",").map((p) => p.trim()).filter(Boolean).map(Number).filter((n) => !isNaN(n));
+  return parts.length > 0 ? parts : undefined;
+}
+
+function parseFloatArray(s: string): number[] | undefined {
+  const parts = s.split(",").map((p) => p.trim()).filter(Boolean).map(Number).filter((n) => !isNaN(n));
+  return parts.length > 0 ? parts : undefined;
+}
+
+function formatArray(arr: number[] | null | undefined): string {
+  return arr ? arr.join(", ") : "";
+}
+
+interface LoomRefForm {
+  brand: string;
+  model_name: string;
+  model_series: string;
+  loom_category: string;
+  shedding_mechanism: string;
+  shaft_count_options: string;
+  treadle_count: string;
+  weaving_width_options_inches: string;
+  weaving_width_options_cm: string;
+  foldable: "" | "true" | "false";
+  origin_country: string;
+}
+
+function emptyForm(): LoomRefForm {
+  return {
+    brand: "", model_name: "", model_series: "", loom_category: "floor_loom",
+    shedding_mechanism: "", shaft_count_options: "", treadle_count: "",
+    weaving_width_options_inches: "", weaving_width_options_cm: "",
+    foldable: "", origin_country: "",
+  };
+}
+
+function formFromRef(ref: LoomReferenceDetail): LoomRefForm {
+  return {
+    brand: ref.brand,
+    model_name: ref.model_name,
+    model_series: ref.model_series ?? "",
+    loom_category: ref.loom_category,
+    shedding_mechanism: ref.shedding_mechanism ?? "",
+    shaft_count_options: formatArray(ref.shaft_count_options),
+    treadle_count: formatArray(ref.treadle_count),
+    weaving_width_options_inches: formatArray(ref.weaving_width_options_inches),
+    weaving_width_options_cm: formatArray(ref.weaving_width_options_cm),
+    foldable: ref.foldable === null ? "" : ref.foldable ? "true" : "false",
+    origin_country: ref.origin_country ?? "",
+  };
+}
+
+function buildPayload(form: LoomRefForm): Partial<LoomReferenceDetail> {
+  return {
+    brand: form.brand.trim(),
+    model_name: form.model_name.trim(),
+    model_series: form.model_series.trim() || undefined,
+    loom_category: form.loom_category,
+    shedding_mechanism: form.shedding_mechanism || undefined,
+    shaft_count_options: parseIntArray(form.shaft_count_options) ?? null,
+    treadle_count: parseIntArray(form.treadle_count) ?? null,
+    weaving_width_options_inches: parseFloatArray(form.weaving_width_options_inches) ?? null,
+    weaving_width_options_cm: parseFloatArray(form.weaving_width_options_cm) ?? null,
+    foldable: form.foldable === "" ? null : form.foldable === "true",
+    origin_country: form.origin_country.trim() || undefined,
+  };
+}
+
+function LoomRefFormModal({
+  title,
+  form,
+  onChange,
+  onSave,
+  onCancel,
+  saving,
+  error,
+}: {
+  title: string;
+  form: LoomRefForm;
+  onChange: (f: LoomRefForm) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  saving: boolean;
+  error: string | null;
+}) {
+  const inputCls = "w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
+  const labelCls = "mb-1 block text-sm font-medium";
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 p-4 overflow-y-auto">
+      <div className="w-full max-w-lg rounded-lg border bg-background shadow-lg p-6 space-y-4 my-8">
+        <h3 className="font-semibold">{title}</h3>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className={labelCls}>Brand <span className="text-destructive">*</span></label>
+            <input className={inputCls} value={form.brand} onChange={(e) => onChange({ ...form, brand: e.target.value })} placeholder="Schacht" />
+          </div>
+          <div>
+            <label className={labelCls}>Model name <span className="text-destructive">*</span></label>
+            <input className={inputCls} value={form.model_name} onChange={(e) => onChange({ ...form, model_name: e.target.value })} placeholder="Baby Wolf" />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className={labelCls}>Series <span className="text-muted-foreground font-normal text-xs">(optional)</span></label>
+            <input className={inputCls} value={form.model_series} onChange={(e) => onChange({ ...form, model_series: e.target.value })} placeholder="Wolf Family" />
+          </div>
+          <div>
+            <label className={labelCls}>Category</label>
+            <select className={inputCls} value={form.loom_category} onChange={(e) => onChange({ ...form, loom_category: e.target.value })}>
+              {LOOM_CATEGORY_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+            </select>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className={labelCls}>Shedding mechanism</label>
+            <select className={inputCls} value={form.shedding_mechanism} onChange={(e) => onChange({ ...form, shedding_mechanism: e.target.value })}>
+              <option value="">—</option>
+              {SHEDDING_OPTIONS.map((o) => <option key={o} value={o}>{o.replace(/_/g, " ")}</option>)}
+            </select>
+          </div>
+          <div>
+            <label className={labelCls}>Origin country</label>
+            <input className={inputCls} value={form.origin_country} onChange={(e) => onChange({ ...form, origin_country: e.target.value })} placeholder="USA" />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className={labelCls}>Shaft count options <span className="text-muted-foreground font-normal text-xs">comma-separated</span></label>
+            <input className={inputCls} value={form.shaft_count_options} onChange={(e) => onChange({ ...form, shaft_count_options: e.target.value })} placeholder="4, 8" />
+          </div>
+          <div>
+            <label className={labelCls}>Treadle count options <span className="text-muted-foreground font-normal text-xs">parallel to shafts</span></label>
+            <input className={inputCls} value={form.treadle_count} onChange={(e) => onChange({ ...form, treadle_count: e.target.value })} placeholder="6, 10" />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className={labelCls}>Weaving width (inches) <span className="text-muted-foreground font-normal text-xs">comma-separated</span></label>
+            <input className={inputCls} value={form.weaving_width_options_inches} onChange={(e) => onChange({ ...form, weaving_width_options_inches: e.target.value })} placeholder="26" />
+          </div>
+          <div>
+            <label className={labelCls}>Weaving width (cm) <span className="text-muted-foreground font-normal text-xs">comma-separated</span></label>
+            <input className={inputCls} value={form.weaving_width_options_cm} onChange={(e) => onChange({ ...form, weaving_width_options_cm: e.target.value })} placeholder="66" />
+          </div>
+        </div>
+
+        <div>
+          <label className={labelCls}>Foldable</label>
+          <select className={inputCls} value={form.foldable} onChange={(e) => onChange({ ...form, foldable: e.target.value as LoomRefForm["foldable"] })}>
+            <option value="">Unknown</option>
+            <option value="true">Yes</option>
+            <option value="false">No</option>
+          </select>
+        </div>
+
+        {error && <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</p>}
+
+        <div className="flex justify-end gap-2 pt-1">
+          <Button type="button" variant="outline" onClick={onCancel} disabled={saving}>Cancel</Button>
+          <Button onClick={onSave} disabled={saving}>{saving ? "Saving…" : "Save"}</Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function LoomDatabaseTab() {
+  const queryClient = useQueryClient();
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [adding, setAdding] = useState(false);
+  const [editing, setEditing] = useState<LoomReferenceDetail | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<LoomReferenceDetail | null>(null);
+  const [form, setForm] = useState<LoomRefForm>(emptyForm());
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+  }, [search]);
+
+  const { data: refs = [], isLoading } = useQuery({
+    queryKey: ["admin", "loom-catalog", debouncedSearch],
+    queryFn: () => adminListLoomCatalog(debouncedSearch || undefined),
+  });
+
+  function openAdd() {
+    setForm(emptyForm());
+    setFormError(null);
+    setAdding(true);
+  }
+
+  function openEdit(ref: LoomReferenceDetail) {
+    setForm(formFromRef(ref));
+    setFormError(null);
+    setEditing(ref);
+  }
+
+  function closeForm() { setAdding(false); setEditing(null); setFormError(null); }
+
+  async function handleSave() {
+    if (!form.brand.trim()) { setFormError("Brand is required"); return; }
+    if (!form.model_name.trim()) { setFormError("Model name is required"); return; }
+    setSaving(true); setFormError(null);
+    try {
+      const payload = buildPayload(form);
+      if (adding) {
+        await adminCreateLoomReference(payload);
+      } else if (editing) {
+        await adminUpdateLoomReference(editing.id, payload);
+      }
+      queryClient.invalidateQueries({ queryKey: ["admin", "loom-catalog"] });
+      closeForm();
+    } catch (e) {
+      setFormError(e instanceof Error ? e.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      await adminDeleteLoomReference(deleteTarget.id);
+      queryClient.invalidateQueries({ queryKey: ["admin", "loom-catalog"] });
+      setDeleteTarget(null);
+    } catch (e) {
+      setFormError(e instanceof Error ? e.message : "Failed to delete");
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-base font-semibold">Loom database</h2>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Admin-maintained catalog of commercially available looms. Used for typeahead in loom creation.
+          </p>
+        </div>
+        <Button size="sm" onClick={openAdd}>Add loom</Button>
+      </div>
+
+      <input
+        type="search"
+        placeholder="Search brand or model…"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className="w-full max-w-xs rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+      />
+
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : refs.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-4 text-center">
+          {debouncedSearch ? "No looms match that search." : "No looms in the catalog yet."}
+        </p>
+      ) : (
+        <div className="rounded-md border border-border overflow-x-auto">
+          <table className="w-full text-sm min-w-[700px]">
+            <thead className="bg-muted/50">
+              <tr>
+                {["Brand", "Model", "Category", "Shafts", "Widths (in)", "Foldable", "Origin", ""].map((h) => (
+                  <th key={h} className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground whitespace-nowrap">
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {refs.map((ref) => (
+                <tr key={ref.id} className="hover:bg-muted/30">
+                  <td className="px-3 py-2.5 font-medium whitespace-nowrap">{ref.brand}</td>
+                  <td className="px-3 py-2.5">
+                    <span>{ref.model_name}</span>
+                    {ref.model_series && (
+                      <span className="ml-1.5 text-xs text-muted-foreground">{ref.model_series}</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2.5 text-xs text-muted-foreground whitespace-nowrap">
+                    {LOOM_CATEGORY_OPTIONS.find((o) => o.value === ref.loom_category)?.label ?? ref.loom_category}
+                  </td>
+                  <td className="px-3 py-2.5 text-xs text-muted-foreground whitespace-nowrap">
+                    {ref.shaft_count_options ? ref.shaft_count_options.join(", ") : "—"}
+                  </td>
+                  <td className="px-3 py-2.5 text-xs text-muted-foreground whitespace-nowrap">
+                    {ref.weaving_width_options_inches ? ref.weaving_width_options_inches.join(", ") : "—"}
+                  </td>
+                  <td className="px-3 py-2.5 text-xs text-muted-foreground">
+                    {ref.foldable === null ? "—" : ref.foldable ? "Yes" : "No"}
+                  </td>
+                  <td className="px-3 py-2.5 text-xs text-muted-foreground">{ref.origin_country ?? "—"}</td>
+                  <td className="px-3 py-2.5 text-right whitespace-nowrap">
+                    <button className="text-xs text-muted-foreground hover:text-foreground mr-3" onClick={() => openEdit(ref)}>
+                      Edit
+                    </button>
+                    <button className="text-xs text-destructive hover:text-destructive/80" onClick={() => setDeleteTarget(ref)}>
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {refs.length > 0 && (
+        <p className="text-xs text-muted-foreground">{refs.length} {refs.length === 1 ? "entry" : "entries"}</p>
+      )}
+
+      {(adding || editing) && (
+        <LoomRefFormModal
+          title={adding ? "Add loom" : `Edit — ${editing?.brand} ${editing?.model_name}`}
+          form={form}
+          onChange={setForm}
+          onSave={handleSave}
+          onCancel={closeForm}
+          saving={saving}
+          error={formError}
+        />
+      )}
+
+      {deleteTarget && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-sm rounded-lg border bg-background shadow-lg p-6 space-y-4">
+            <h3 className="font-semibold">Delete loom?</h3>
+            <p className="text-sm text-muted-foreground">
+              Permanently remove <strong>{deleteTarget.brand} {deleteTarget.model_name}</strong> from the catalog.
+              Existing user looms linked to this entry will be unlinked automatically.
+            </p>
+            {formError && <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">{formError}</p>}
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setDeleteTarget(null)} disabled={deleting}>Cancel</Button>
+              <Button variant="destructive" onClick={handleDelete} disabled={deleting}>{deleting ? "Deleting…" : "Delete"}</Button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -42,12 +42,20 @@ export function LandingPage() {
             <WeftmarkLogo className="h-7 w-auto text-zinc-800" />
             <span className="text-base font-semibold tracking-tight" style={{ fontFamily: '"Segoe UI", system-ui, sans-serif' }}>weftmark</span>
           </div>
-          <Link
-            to="/login"
-            className="text-sm font-medium text-stone-600 transition-colors hover:text-stone-900"
-          >
-            Sign in
-          </Link>
+          <div className="flex items-center gap-5">
+            <Link
+              to="/catalog/looms"
+              className="text-sm font-medium text-stone-600 transition-colors hover:text-stone-900"
+            >
+              Loom catalog
+            </Link>
+            <Link
+              to="/login"
+              className="text-sm font-medium text-stone-600 transition-colors hover:text-stone-900"
+            >
+              Sign in
+            </Link>
+          </div>
         </div>
       </header>
 

--- a/frontend/src/pages/LoomCatalogPage.tsx
+++ b/frontend/src/pages/LoomCatalogPage.tsx
@@ -1,0 +1,206 @@
+import { useState, useEffect, useRef } from "react";
+import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { WeftmarkLogo } from "@/components/WeftmarkLogo";
+import { PublicFooter } from "@/components/PublicFooter";
+import { listLoomCatalog, type LoomReferenceSummary } from "@/api/looms";
+
+const CATEGORY_LABELS: Record<string, string> = {
+  floor_loom: "Floor Loom",
+  table_loom: "Table Loom",
+  rigid_heddle: "Rigid Heddle",
+  inkle: "Inkle",
+  dobby_floor_loom: "Dobby Floor Loom",
+  tapestry_loom: "Tapestry Loom",
+  rug_loom: "Rug Loom",
+  frame_loom: "Frame Loom",
+  other: "Other",
+};
+
+const ALL_CATEGORIES = Object.entries(CATEGORY_LABELS).map(([value, label]) => ({ value, label }));
+
+function ShaftBadge({ options }: { options: number[] | null }) {
+  if (!options || options.length === 0) return <span className="text-stone-400">—</span>;
+  return <span>{options.map((n) => `${n}`).join(" / ")}</span>;
+}
+
+function WidthBadge({ options }: { options: number[] | null }) {
+  if (!options || options.length === 0) return <span className="text-stone-400">—</span>;
+  return <span>{options.map((n) => `${n}"`).join(" / ")}</span>;
+}
+
+function LoomCard({ loom }: { loom: LoomReferenceSummary }) {
+  return (
+    <div className="rounded-xl border border-stone-200 bg-white p-5 space-y-3 hover:border-amber-300 transition-colors">
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <p className="text-xs font-medium text-amber-700 uppercase tracking-wide">{loom.brand}</p>
+          <h3 className="font-semibold text-stone-900 leading-snug">{loom.model_name}</h3>
+          {loom.model_series && (
+            <p className="text-xs text-stone-500">{loom.model_series}</p>
+          )}
+        </div>
+        <span className="shrink-0 text-xs rounded-full bg-stone-100 text-stone-600 px-2.5 py-1 font-medium">
+          {CATEGORY_LABELS[loom.loom_category] ?? loom.loom_category}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1.5 text-sm text-stone-700">
+        {loom.shaft_count_options && loom.shaft_count_options.length > 0 && (
+          <>
+            <span className="text-stone-500">Shafts</span>
+            <ShaftBadge options={loom.shaft_count_options} />
+          </>
+        )}
+        {loom.weaving_width_options_inches && loom.weaving_width_options_inches.length > 0 && (
+          <>
+            <span className="text-stone-500">Width</span>
+            <WidthBadge options={loom.weaving_width_options_inches} />
+          </>
+        )}
+        {loom.shedding_mechanism && (
+          <>
+            <span className="text-stone-500">Shedding</span>
+            <span>{loom.shedding_mechanism.replace(/_/g, " ")}</span>
+          </>
+        )}
+        {loom.foldable !== null && (
+          <>
+            <span className="text-stone-500">Foldable</span>
+            <span>{loom.foldable ? "Yes" : "No"}</span>
+          </>
+        )}
+        {loom.origin_country && (
+          <>
+            <span className="text-stone-500">Origin</span>
+            <span>{loom.origin_country}</span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function LoomCatalogPage() {
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [category, setCategory] = useState("");
+  const [foldable, setFoldable] = useState<"" | "true" | "false">("");
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+  }, [search]);
+
+  const { data: looms = [], isLoading } = useQuery({
+    queryKey: ["loom-catalog-public", debouncedSearch, category, foldable],
+    queryFn: () =>
+      listLoomCatalog({
+        q: debouncedSearch || undefined,
+        category: category || undefined,
+        foldable: foldable === "" ? undefined : foldable === "true",
+      }),
+  });
+
+  const brands = [...new Set(looms.map((l) => l.brand))].sort();
+
+  const grouped = brands.reduce<Record<string, LoomReferenceSummary[]>>((acc, brand) => {
+    acc[brand] = looms.filter((l) => l.brand === brand);
+    return acc;
+  }, {});
+
+  return (
+    <div className="flex min-h-screen flex-col bg-stone-50 text-stone-900">
+      <header className="border-b border-stone-200 bg-stone-50 px-6 py-4">
+        <div className="mx-auto flex max-w-5xl items-center justify-between gap-3">
+          <Link to="/" className="flex items-center gap-3 hover:opacity-80 transition-opacity">
+            <WeftmarkLogo className="h-8 w-auto text-amber-800" />
+            <span className="text-lg font-semibold tracking-tight" style={{ fontFamily: '"Segoe UI", system-ui, sans-serif' }}>weftmark</span>
+          </Link>
+          <Link to="/login" className="text-sm text-stone-600 hover:text-stone-900 transition-colors">
+            Sign in
+          </Link>
+        </div>
+      </header>
+
+      <main className="flex-1 px-4 py-12">
+        <div className="mx-auto max-w-5xl space-y-8">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight mb-2">Supported looms</h1>
+            <p className="text-stone-600">
+              Looms in our catalog can be selected during loom setup for automatic spec pre-fill.
+              {looms.length > 0 && (
+                <span className="ml-1 text-stone-500">{looms.length} {looms.length === 1 ? "loom" : "looms"} in the catalog.</span>
+              )}
+            </p>
+          </div>
+
+          {/* Filters */}
+          <div className="flex flex-wrap gap-3">
+            <input
+              type="search"
+              placeholder="Search brand or model…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 w-64"
+            />
+            <select
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              className="rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+            >
+              <option value="">All categories</option>
+              {ALL_CATEGORIES.map((c) => (
+                <option key={c.value} value={c.value}>{c.label}</option>
+              ))}
+            </select>
+            <select
+              value={foldable}
+              onChange={(e) => setFoldable(e.target.value as "" | "true" | "false")}
+              className="rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+            >
+              <option value="">Foldable: any</option>
+              <option value="true">Foldable only</option>
+              <option value="false">Non-foldable only</option>
+            </select>
+            {(search || category || foldable) && (
+              <button
+                onClick={() => { setSearch(""); setCategory(""); setFoldable(""); }}
+                className="text-sm text-stone-500 hover:text-stone-700 transition-colors"
+              >
+                Clear filters
+              </button>
+            )}
+          </div>
+
+          {isLoading ? (
+            <div className="text-center py-16 text-stone-400">Loading catalog…</div>
+          ) : looms.length === 0 ? (
+            <div className="text-center py-16 text-stone-400">
+              {debouncedSearch || category || foldable
+                ? "No looms match these filters."
+                : "The catalog is empty."}
+            </div>
+          ) : (
+            <div className="space-y-8">
+              {Object.entries(grouped).map(([brand, entries]) => (
+                <section key={brand}>
+                  <h2 className="text-lg font-semibold text-stone-700 mb-3">{brand}</h2>
+                  <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                    {entries.map((loom) => (
+                      <LoomCard key={loom.id} loom={loom} />
+                    ))}
+                  </div>
+                </section>
+              ))}
+            </div>
+          )}
+        </div>
+      </main>
+
+      <PublicFooter />
+    </div>
+  );
+}

--- a/frontend/src/pages/LoomDetailPage.tsx
+++ b/frontend/src/pages/LoomDetailPage.tsx
@@ -20,6 +20,7 @@ import { AddVersionModal } from "@/components/looms/AddVersionModal";
 import { EditLoomModal } from "@/components/looms/EditLoomModal";
 import { CloneVersionModal } from "@/components/looms/CloneVersionModal";
 import { LinkToCatalogModal } from "@/components/looms/LinkToCatalogModal";
+import { CatalogRequestButton } from "@/components/looms/CatalogRequestButton";
 import { Button } from "@/components/ui/button";
 import { AuthedImage } from "@/components/ui/AuthedImage";
 import { downloadAuthed } from "@/api/client";
@@ -28,43 +29,6 @@ import { SuperuserInspectionBanner } from "@/components/ui/SuperuserInspectionBa
 
 const PHOTO_MAX_BYTES = 5 * 1024 * 1024; // 5 MB — must match backend MAX_FILE_SIZE
 const MAX_VERSION_PHOTOS = 5;            // must match backend MAX_VERSION_PHOTOS
-const CATALOG_REQUESTS_KEY = "weftmark:catalog_requests_submitted";
-
-function hasSubmittedCatalogRequest(loomId: string): boolean {
-  try {
-    const stored = localStorage.getItem(CATALOG_REQUESTS_KEY);
-    return stored ? (JSON.parse(stored) as string[]).includes(loomId) : false;
-  } catch {
-    return false;
-  }
-}
-
-function markCatalogRequestSubmitted(loomId: string): void {
-  try {
-    const stored = localStorage.getItem(CATALOG_REQUESTS_KEY);
-    const arr: string[] = stored ? JSON.parse(stored) : [];
-    if (!arr.includes(loomId)) {
-      arr.push(loomId);
-      localStorage.setItem(CATALOG_REQUESTS_KEY, JSON.stringify(arr));
-    }
-  } catch {
-    // ignore storage errors
-  }
-}
-
-function catalogRequestUrl(loom: LoomDetail): string {
-  const title = encodeURIComponent(
-    `Loom catalog request: ${loom.manufacturer} ${loom.model_name}`,
-  );
-  const body = encodeURIComponent(
-    `## Loom catalog request\n\n` +
-      `**Brand:** ${loom.manufacturer}\n` +
-      `**Model:** ${loom.model_name}\n` +
-      `**Type:** ${LOOM_TYPE_LABELS[loom.loom_type] ?? loom.loom_type}\n\n` +
-      `Please add this loom to the weftmark catalog so other users can find and link it.\n`,
-  );
-  return `https://github.com/weftmark/weftmark/discussions/new?title=${title}&body=${body}`;
-}
 
 // ---------------------------------------------------------------------------
 // Reusable inline confirm
@@ -861,9 +825,6 @@ export function LoomDetailPage() {
   const [deleting, setDeleting] = useState(false);
   const [dangerZoneOpen, setDangerZoneOpen] = useState(false);
   const [unlinking, setUnlinking] = useState(false);
-  const [requestSubmitted, setRequestSubmitted] = useState(() =>
-    hasSubmittedCatalogRequest(id ?? ""),
-  );
 
   const { data: loom, isLoading, error } = useQuery({
     queryKey: ["loom", id],
@@ -985,22 +946,7 @@ export function LoomDetailPage() {
                   <span className="text-xs rounded-full bg-muted text-muted-foreground px-2 py-0.5 font-medium">
                     Not in catalog
                   </span>
-                  {requestSubmitted ? (
-                    <span className="text-xs text-muted-foreground italic">Request submitted</span>
-                  ) : (
-                    <a
-                      href={catalogRequestUrl(loom)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      onClick={() => {
-                        markCatalogRequestSubmitted(loom.id);
-                        setRequestSubmitted(true);
-                      }}
-                      className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2 transition-colors"
-                    >
-                      Submit request to add to catalog
-                    </a>
-                  )}
+                  <CatalogRequestButton loom={loom} />
                 </>
               )}
             </div>

--- a/frontend/src/pages/LoomDetailPage.tsx
+++ b/frontend/src/pages/LoomDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect } from "react";
+import { useRef, useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { AppIcons } from "@/lib/icons";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -11,15 +11,15 @@ import {
   uploadVersionPhoto, deleteVersionPhoto, versionPhotoUrl,
   uploadVersionReceipt, deleteVersionReceipt, versionReceiptUrl,
   addAccessory, deleteAccessory, updateVersion,
-  addReed, deleteReed, searchLoomCatalog, linkLoomReference,
+  addReed, deleteReed, linkLoomReference,
   type LoomDetail, type LoomVersion, type LoomVersionPhoto,
   type LoomVersionReceipt, type LoomVersionAccessory, type LoomReed,
-  type LoomReferenceSummary,
   LOOM_TYPE_LABELS, SUPPORTED_LOOM_TYPES,
 } from "@/api/looms";
 import { AddVersionModal } from "@/components/looms/AddVersionModal";
 import { EditLoomModal } from "@/components/looms/EditLoomModal";
 import { CloneVersionModal } from "@/components/looms/CloneVersionModal";
+import { LinkToCatalogModal } from "@/components/looms/LinkToCatalogModal";
 import { Button } from "@/components/ui/button";
 import { AuthedImage } from "@/components/ui/AuthedImage";
 import { downloadAuthed } from "@/api/client";
@@ -28,6 +28,43 @@ import { SuperuserInspectionBanner } from "@/components/ui/SuperuserInspectionBa
 
 const PHOTO_MAX_BYTES = 5 * 1024 * 1024; // 5 MB — must match backend MAX_FILE_SIZE
 const MAX_VERSION_PHOTOS = 5;            // must match backend MAX_VERSION_PHOTOS
+const CATALOG_REQUESTS_KEY = "weftmark:catalog_requests_submitted";
+
+function hasSubmittedCatalogRequest(loomId: string): boolean {
+  try {
+    const stored = localStorage.getItem(CATALOG_REQUESTS_KEY);
+    return stored ? (JSON.parse(stored) as string[]).includes(loomId) : false;
+  } catch {
+    return false;
+  }
+}
+
+function markCatalogRequestSubmitted(loomId: string): void {
+  try {
+    const stored = localStorage.getItem(CATALOG_REQUESTS_KEY);
+    const arr: string[] = stored ? JSON.parse(stored) : [];
+    if (!arr.includes(loomId)) {
+      arr.push(loomId);
+      localStorage.setItem(CATALOG_REQUESTS_KEY, JSON.stringify(arr));
+    }
+  } catch {
+    // ignore storage errors
+  }
+}
+
+function catalogRequestUrl(loom: LoomDetail): string {
+  const title = encodeURIComponent(
+    `Loom catalog request: ${loom.manufacturer} ${loom.model_name}`,
+  );
+  const body = encodeURIComponent(
+    `## Loom catalog request\n\n` +
+      `**Brand:** ${loom.manufacturer}\n` +
+      `**Model:** ${loom.model_name}\n` +
+      `**Type:** ${LOOM_TYPE_LABELS[loom.loom_type] ?? loom.loom_type}\n\n` +
+      `Please add this loom to the weftmark catalog so other users can find and link it.\n`,
+  );
+  return `https://github.com/weftmark/weftmark/discussions/new?title=${title}&body=${body}`;
+}
 
 // ---------------------------------------------------------------------------
 // Reusable inline confirm
@@ -811,148 +848,6 @@ function VersionCard({
 // Page
 // ---------------------------------------------------------------------------
 
-// ---------------------------------------------------------------------------
-// Catalog link section
-// ---------------------------------------------------------------------------
-
-function CatalogLinkSection({ loom, onChanged }: { loom: LoomDetail; onChanged: () => void }) {
-  const [expanded, setExpanded] = useState(false);
-  const [search, setSearch] = useState("");
-  const [results, setResults] = useState<LoomReferenceSummary[]>([]);
-  const [searching, setSearching] = useState(false);
-  const [selected, setSelected] = useState<LoomReferenceSummary | null>(null);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [showResults, setShowResults] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    if (!search.trim()) return;
-    if (timerRef.current) clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(async () => {
-      setSearching(true);
-      try {
-        const data = await searchLoomCatalog(search);
-        setResults(data);
-        setShowResults(true);
-      } finally {
-        setSearching(false);
-      }
-    }, 250);
-    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
-  }, [search]);
-
-  async function handleLink() {
-    if (!selected) return;
-    setSaving(true); setError(null);
-    try {
-      await linkLoomReference(loom.id, selected.id);
-      onChanged();
-      setExpanded(false);
-      setSelected(null);
-      setSearch("");
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to link");
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  async function handleUnlink() {
-    setSaving(true); setError(null);
-    try {
-      await linkLoomReference(loom.id, null);
-      onChanged();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to unlink");
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  if (loom.loom_reference_id) {
-    return (
-      <div className="flex items-center gap-2 text-sm text-muted-foreground">
-        <span className="text-xs rounded-full bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 px-2 py-0.5 font-medium">
-          Linked to catalog
-        </span>
-        <button
-          onClick={handleUnlink}
-          disabled={saving}
-          className="text-xs text-muted-foreground hover:text-destructive transition-colors"
-        >
-          {saving ? "Unlinking…" : "Unlink"}
-        </button>
-        {error && <span className="text-xs text-destructive">{error}</span>}
-      </div>
-    );
-  }
-
-  if (!expanded) {
-    return (
-      <button
-        onClick={() => setExpanded(true)}
-        className="text-xs text-muted-foreground hover:text-foreground transition-colors underline underline-offset-2"
-      >
-        Link to loom catalog
-      </button>
-    );
-  }
-
-  return (
-    <div className="rounded-md border border-border p-3 space-y-2 bg-muted/20">
-      <p className="text-xs text-muted-foreground font-medium">Search the loom catalog to link this loom</p>
-      <div className="relative">
-        <input
-          type="search"
-          placeholder="Search brand or model…"
-          value={search}
-          onChange={(e) => { const v = e.target.value; setSearch(v); setSelected(null); if (!v.trim()) { setResults([]); setShowResults(false); } }}
-          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-          autoFocus
-        />
-        {searching && (
-          <span className="absolute right-3 top-2.5 text-xs text-muted-foreground">Searching…</span>
-        )}
-        {showResults && results.length > 0 && !selected && (
-          <ul className="absolute z-10 mt-1 w-full rounded-md border border-border bg-popover shadow-lg overflow-hidden">
-            {results.map((r) => (
-              <li key={r.id}>
-                <button
-                  className="w-full text-left px-3 py-2 hover:bg-accent/50 text-sm"
-                  onClick={() => { setSelected(r); setSearch(`${r.brand} ${r.model_name}`); setShowResults(false); }}
-                >
-                  <span className="font-medium">{r.brand} {r.model_name}</span>
-                  {r.model_series && <span className="ml-1.5 text-xs text-muted-foreground">{r.model_series}</span>}
-                  {r.shaft_count_options && r.shaft_count_options.length > 0 && (
-                    <span className="ml-2 text-xs text-muted-foreground">{r.shaft_count_options.join("/")} shaft</span>
-                  )}
-                </button>
-              </li>
-            ))}
-          </ul>
-        )}
-        {showResults && results.length === 0 && search.trim() && !searching && (
-          <div className="absolute z-10 mt-1 w-full rounded-md border border-border bg-popover px-3 py-2 text-sm text-muted-foreground shadow-lg">
-            No matches found.
-          </div>
-        )}
-      </div>
-
-      {error && <p className="text-xs text-destructive">{error}</p>}
-
-      <div className="flex gap-2 pt-1">
-        <Button size="sm" onClick={handleLink} disabled={!selected || saving}>
-          {saving ? "Linking…" : "Link to catalog"}
-        </Button>
-        <Button size="sm" variant="outline" onClick={() => { setExpanded(false); setSelected(null); setSearch(""); setError(null); }}>
-          Cancel
-        </Button>
-      </div>
-    </div>
-  );
-}
-
 export function LoomDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -960,10 +855,15 @@ export function LoomDetailPage() {
   const { user } = useAuthContext();
   const [showAddVersion, setShowAddVersion] = useState(false);
   const [showEdit, setShowEdit] = useState(false);
+  const [showLinkCatalog, setShowLinkCatalog] = useState(false);
   const [cloneSource, setCloneSource] = useState<LoomVersion | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [dangerZoneOpen, setDangerZoneOpen] = useState(false);
+  const [unlinking, setUnlinking] = useState(false);
+  const [requestSubmitted, setRequestSubmitted] = useState(() =>
+    hasSubmittedCatalogRequest(id ?? ""),
+  );
 
   const { data: loom, isLoading, error } = useQuery({
     queryKey: ["loom", id],
@@ -1004,6 +904,17 @@ export function LoomDetailPage() {
     }
   };
 
+  const handleUnlink = async () => {
+    if (!loom) return;
+    setUnlinking(true);
+    try {
+      await linkLoomReference(loom.id, null);
+      invalidate();
+    } finally {
+      setUnlinking(false);
+    }
+  };
+
   if (isLoading) return <div className="flex min-h-screen items-center justify-center"><p className="text-muted-foreground text-sm">Loading…</p></div>;
   if (error || !loom) return <div className="flex min-h-screen items-center justify-center"><p className="text-destructive text-sm">Loom not found.</p></div>;
 
@@ -1023,6 +934,11 @@ export function LoomDetailPage() {
           <span className="text-xs text-muted-foreground">{LOOM_TYPE_LABELS[loom.loom_type]}</span>
         </div>
         <div className="flex gap-2">
+          {!isReadOnly && (
+            <Button size="sm" variant="outline" onClick={() => setShowLinkCatalog(true)}>
+              Update from catalog
+            </Button>
+          )}
           {!isReadOnly && <Button size="sm" variant="outline" onClick={() => setShowEdit(true)}>Edit</Button>}
           {!isReadOnly && <Button size="sm" onClick={() => setShowAddVersion(true)}>Add version</Button>}
         </div>
@@ -1049,7 +965,46 @@ export function LoomDetailPage() {
             </div>
           )}
           {loom.notes && <p className="text-sm text-muted-foreground whitespace-pre-wrap">{loom.notes}</p>}
-          {!isReadOnly && <CatalogLinkSection loom={loom} onChanged={invalidate} />}
+          {!isReadOnly && (
+            <div className="flex items-center gap-2 flex-wrap">
+              {loom.loom_reference_id ? (
+                <>
+                  <span className="text-xs rounded-full bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 px-2 py-0.5 font-medium">
+                    Linked to catalog
+                  </span>
+                  <button
+                    onClick={handleUnlink}
+                    disabled={unlinking}
+                    className="text-xs text-muted-foreground hover:text-destructive transition-colors"
+                  >
+                    {unlinking ? "Unlinking…" : "Unlink"}
+                  </button>
+                </>
+              ) : (
+                <>
+                  <span className="text-xs rounded-full bg-muted text-muted-foreground px-2 py-0.5 font-medium">
+                    Not in catalog
+                  </span>
+                  {requestSubmitted ? (
+                    <span className="text-xs text-muted-foreground italic">Request submitted</span>
+                  ) : (
+                    <a
+                      href={catalogRequestUrl(loom)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={() => {
+                        markCatalogRequestSubmitted(loom.id);
+                        setRequestSubmitted(true);
+                      }}
+                      className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2 transition-colors"
+                    >
+                      Submit request to add to catalog
+                    </a>
+                  )}
+                </>
+              )}
+            </div>
+          )}
           {activeProject && (
             <div className="rounded-md border border-green-300 bg-green-50 dark:bg-green-950/30 dark:border-green-700 px-3 py-2.5 text-sm flex items-center justify-between gap-4">
               <div>
@@ -1134,6 +1089,9 @@ export function LoomDetailPage() {
       )}
       {showEdit && (
         <EditLoomModal loom={loom} onSuccess={handleEditSaved} onClose={() => setShowEdit(false)} />
+      )}
+      {showLinkCatalog && (
+        <LinkToCatalogModal loom={loom} onSuccess={() => { setShowLinkCatalog(false); invalidate(); }} onClose={() => setShowLinkCatalog(false)} />
       )}
       {cloneSource && (
         <CloneVersionModal loomId={loom.id} source={cloneSource} onSuccess={handleCloned} onClose={() => setCloneSource(null)} />

--- a/frontend/src/pages/LoomDetailPage.tsx
+++ b/frontend/src/pages/LoomDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { AppIcons } from "@/lib/icons";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -11,9 +11,10 @@ import {
   uploadVersionPhoto, deleteVersionPhoto, versionPhotoUrl,
   uploadVersionReceipt, deleteVersionReceipt, versionReceiptUrl,
   addAccessory, deleteAccessory, updateVersion,
-  addReed, deleteReed,
+  addReed, deleteReed, searchLoomCatalog, linkLoomReference,
   type LoomDetail, type LoomVersion, type LoomVersionPhoto,
   type LoomVersionReceipt, type LoomVersionAccessory, type LoomReed,
+  type LoomReferenceSummary,
   LOOM_TYPE_LABELS, SUPPORTED_LOOM_TYPES,
 } from "@/api/looms";
 import { AddVersionModal } from "@/components/looms/AddVersionModal";
@@ -810,6 +811,148 @@ function VersionCard({
 // Page
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Catalog link section
+// ---------------------------------------------------------------------------
+
+function CatalogLinkSection({ loom, onChanged }: { loom: LoomDetail; onChanged: () => void }) {
+  const [expanded, setExpanded] = useState(false);
+  const [search, setSearch] = useState("");
+  const [results, setResults] = useState<LoomReferenceSummary[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [selected, setSelected] = useState<LoomReferenceSummary | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showResults, setShowResults] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!search.trim()) return;
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(async () => {
+      setSearching(true);
+      try {
+        const data = await searchLoomCatalog(search);
+        setResults(data);
+        setShowResults(true);
+      } finally {
+        setSearching(false);
+      }
+    }, 250);
+    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+  }, [search]);
+
+  async function handleLink() {
+    if (!selected) return;
+    setSaving(true); setError(null);
+    try {
+      await linkLoomReference(loom.id, selected.id);
+      onChanged();
+      setExpanded(false);
+      setSelected(null);
+      setSearch("");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to link");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleUnlink() {
+    setSaving(true); setError(null);
+    try {
+      await linkLoomReference(loom.id, null);
+      onChanged();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to unlink");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loom.loom_reference_id) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <span className="text-xs rounded-full bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 px-2 py-0.5 font-medium">
+          Linked to catalog
+        </span>
+        <button
+          onClick={handleUnlink}
+          disabled={saving}
+          className="text-xs text-muted-foreground hover:text-destructive transition-colors"
+        >
+          {saving ? "Unlinking…" : "Unlink"}
+        </button>
+        {error && <span className="text-xs text-destructive">{error}</span>}
+      </div>
+    );
+  }
+
+  if (!expanded) {
+    return (
+      <button
+        onClick={() => setExpanded(true)}
+        className="text-xs text-muted-foreground hover:text-foreground transition-colors underline underline-offset-2"
+      >
+        Link to loom catalog
+      </button>
+    );
+  }
+
+  return (
+    <div className="rounded-md border border-border p-3 space-y-2 bg-muted/20">
+      <p className="text-xs text-muted-foreground font-medium">Search the loom catalog to link this loom</p>
+      <div className="relative">
+        <input
+          type="search"
+          placeholder="Search brand or model…"
+          value={search}
+          onChange={(e) => { const v = e.target.value; setSearch(v); setSelected(null); if (!v.trim()) { setResults([]); setShowResults(false); } }}
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          autoFocus
+        />
+        {searching && (
+          <span className="absolute right-3 top-2.5 text-xs text-muted-foreground">Searching…</span>
+        )}
+        {showResults && results.length > 0 && !selected && (
+          <ul className="absolute z-10 mt-1 w-full rounded-md border border-border bg-popover shadow-lg overflow-hidden">
+            {results.map((r) => (
+              <li key={r.id}>
+                <button
+                  className="w-full text-left px-3 py-2 hover:bg-accent/50 text-sm"
+                  onClick={() => { setSelected(r); setSearch(`${r.brand} ${r.model_name}`); setShowResults(false); }}
+                >
+                  <span className="font-medium">{r.brand} {r.model_name}</span>
+                  {r.model_series && <span className="ml-1.5 text-xs text-muted-foreground">{r.model_series}</span>}
+                  {r.shaft_count_options && r.shaft_count_options.length > 0 && (
+                    <span className="ml-2 text-xs text-muted-foreground">{r.shaft_count_options.join("/")} shaft</span>
+                  )}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+        {showResults && results.length === 0 && search.trim() && !searching && (
+          <div className="absolute z-10 mt-1 w-full rounded-md border border-border bg-popover px-3 py-2 text-sm text-muted-foreground shadow-lg">
+            No matches found.
+          </div>
+        )}
+      </div>
+
+      {error && <p className="text-xs text-destructive">{error}</p>}
+
+      <div className="flex gap-2 pt-1">
+        <Button size="sm" onClick={handleLink} disabled={!selected || saving}>
+          {saving ? "Linking…" : "Link to catalog"}
+        </Button>
+        <Button size="sm" variant="outline" onClick={() => { setExpanded(false); setSelected(null); setSearch(""); setError(null); }}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 export function LoomDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -906,6 +1049,7 @@ export function LoomDetailPage() {
             </div>
           )}
           {loom.notes && <p className="text-sm text-muted-foreground whitespace-pre-wrap">{loom.notes}</p>}
+          {!isReadOnly && <CatalogLinkSection loom={loom} onChanged={invalidate} />}
           {activeProject && (
             <div className="rounded-md border border-green-300 bg-green-50 dark:bg-green-950/30 dark:border-green-700 px-3 py-2.5 text-sm flex items-center justify-between gap-4">
               <div>

--- a/frontend/src/pages/LoomsPage.tsx
+++ b/frontend/src/pages/LoomsPage.tsx
@@ -129,7 +129,12 @@ export function LoomsPage() {
     <div className="p-6 max-w-4xl mx-auto w-full">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-xl font-semibold">Equipment</h1>
-        <Button size="sm" onClick={() => setShowNew(true)}>New loom</Button>
+        <div className="flex items-center gap-3">
+          <Link to="/catalog/looms" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+            Browse loom catalog
+          </Link>
+          <Button size="sm" onClick={() => setShowNew(true)}>New loom</Button>
+        </div>
       </div>
 
       {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}


### PR DESCRIPTION
## Summary

- Adds `loom_references` table (Alembic migration 0029) seeded from 68 real-world looms from market research data
- New `loom_catalog` router with public list/search/detail + admin CRUD endpoints
- Extended `loom_type` enum: `dobby_floor_loom`, `tapestry_loom`, `rug_loom`, `frame_loom` (replaces the old `dobby` type)
- Frontend typeahead in **New Loom Modal** — users can search the catalog when adding a loom
- Admin **Loom Database** tab in AdminPage for managing catalog entries
- Public **`/catalog/looms`** page (no auth required) with search, brand grouping, and category/foldable filters
- **Link to catalog** UI on LoomDetailPage — retroactively link existing looms to a catalog entry

## Test plan

- [ ] Admin: navigate to Admin > Loom database tab — confirm 68 entries load, search filters work, add/edit/delete functions
- [ ] New Loom Modal: type "schacht" in the "Search loom catalog" field — confirm results appear, clicking a result pre-fills manufacturer + model and shows spec badges
- [ ] Public catalog: visit `/catalog/looms` (while logged out or in a fresh tab) — confirm looms display grouped by brand
- [ ] Loom detail: open an existing loom, click "Link to loom catalog", search and select a match, confirm the "Linked to catalog" badge appears; test Unlink too
- [ ] `pytest backend/tests/routers/test_loom_catalog.py` — 12 tests pass
- [ ] `tsc --noEmit` — clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)