### PR TITLE
feat: archive/retire/deletion-guard for drafts and looms (#777)

### DIFF
--- a/backend/alembic/versions/0030_retired_at.py
+++ b/backend/alembic/versions/0030_retired_at.py
@@ -1,7 +1,7 @@
 """Add retired_at to drafts and looms.
 
 Revision ID: 0030_retired_at
-Revises: 0029_loom_references
+Revises: 7d8e9f0a1b2c
 Create Date: 2026-05-19
 """
 
@@ -9,7 +9,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision = "0030_retired_at"
-down_revision = "0029_loom_references"
+down_revision = "7d8e9f0a1b2c"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/0030_retired_at.py
+++ b/backend/alembic/versions/0030_retired_at.py
@@ -1,0 +1,24 @@
+"""Add retired_at to drafts and looms.
+
+Revision ID: 0030_retired_at
+Revises: 0029_loom_references
+Create Date: 2026-05-19
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0030_retired_at"
+down_revision = "0029_loom_references"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("drafts", sa.Column("retired_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("looms", sa.Column("retired_at", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("drafts", "retired_at")
+    op.drop_column("looms", "retired_at")

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -24,3 +24,17 @@ class SoftDeleteMixin:
 
     def soft_delete(self) -> None:
         self.deleted_at = datetime.now(timezone.utc)
+
+
+class RetireMixin:
+    retired_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, default=None)
+
+    @property
+    def is_retired(self) -> bool:
+        return self.retired_at is not None
+
+    def retire(self) -> None:
+        self.retired_at = datetime.now(timezone.utc)
+
+    def unretire(self) -> None:
+        self.retired_at = None

--- a/backend/app/models/draft.py
+++ b/backend/app/models/draft.py
@@ -4,10 +4,10 @@ from sqlalchemy import Boolean, Float, ForeignKey, Integer, String, Text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from app.models.base import Base, SoftDeleteMixin, TimestampMixin
+from app.models.base import Base, RetireMixin, SoftDeleteMixin, TimestampMixin
 
 
-class Draft(Base, TimestampMixin, SoftDeleteMixin):
+class Draft(Base, TimestampMixin, SoftDeleteMixin, RetireMixin):
     __tablename__ = "drafts"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)

--- a/backend/app/models/loom.py
+++ b/backend/app/models/loom.py
@@ -6,7 +6,7 @@ from sqlalchemy import Boolean, Date, Float, ForeignKey, Index, Integer, Numeric
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from app.models.base import Base, SoftDeleteMixin, TimestampMixin
+from app.models.base import Base, RetireMixin, SoftDeleteMixin, TimestampMixin
 
 LOOM_TYPES = (
     "floor_loom",
@@ -112,7 +112,7 @@ class LoomReference(Base, TimestampMixin):
     looms: Mapped[list["Loom"]] = relationship("Loom", back_populates="loom_reference")
 
 
-class Loom(Base, TimestampMixin, SoftDeleteMixin):
+class Loom(Base, TimestampMixin, SoftDeleteMixin, RetireMixin):
     __tablename__ = "looms"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)

--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -727,6 +727,7 @@ def _draft_detail_data(draft: Draft) -> dict:
     data["has_preview"] = storage.preview_exists(draft.preview_path)
     data["has_drawdown_preview"] = storage.drawdown_preview_exists(draft.drawdown_preview_path)
     data["has_modified_file"] = bool(draft.wif_modified_path and storage.file_exists(draft.wif_modified_path))
+    data["archived_at"] = data.pop("retired_at", None)
     overrides = draft.metadata_overrides or {}
     warnings = list(data.get("lint_warnings") or [])
     if "num_treadles" in overrides:

--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -85,6 +85,7 @@ class DraftSummary(BaseModel):
     weaving_width_override_cm: float | None
     epi_override: float | None
     is_shared: bool
+    archived_at: datetime | None
     created_at: datetime
     updated_at: datetime
 
@@ -96,6 +97,7 @@ class DraftSummary(BaseModel):
         data["has_preview"] = storage.preview_exists(d.preview_path)
         data["has_drawdown_preview"] = storage.drawdown_preview_exists(d.drawdown_preview_path)
         data["has_modified_file"] = bool(d.wif_modified_path and storage.file_exists(d.wif_modified_path))
+        data["archived_at"] = data.pop("retired_at", None)
         return cls(**data)
 
 
@@ -190,14 +192,15 @@ async def create_draft(
 
 @router.get("", response_model=list[DraftSummary])
 async def list_drafts(
+    include_archived: bool = Query(False),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> list[DraftSummary]:
-    result = await db.scalars(
-        select(Draft)
-        .where(Draft.owner_id == current_user.id, Draft.deleted_at.is_(None))
-        .order_by(Draft.created_at.desc())
-    )
+    q = select(Draft).where(Draft.owner_id == current_user.id, Draft.deleted_at.is_(None))
+    if not include_archived:
+        q = q.where(Draft.retired_at.is_(None))
+    q = q.order_by(Draft.created_at.desc())
+    result = await db.scalars(q)
     return [DraftSummary.from_draft(d) for d in result.all()]
 
 
@@ -488,18 +491,64 @@ async def download_wif_modified(
 
 
 # ---------------------------------------------------------------------------
-# Delete (soft)
+# Delete (soft) — with deletion guard and optional force
 # ---------------------------------------------------------------------------
 
 
 @router.delete("/{draft_id}", status_code=204)
 async def delete_draft(
     draft_id: uuid.UUID,
+    force: bool = Query(False),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    from app.models.project import Project
+
+    draft = await _get_owned_draft(draft_id, current_user, db)
+    active_projects = (
+        await db.scalars(select(Project).where(Project.draft_id == draft.id, Project.deleted_at.is_(None)))
+    ).all()
+
+    if active_projects and not force:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "draft_in_use",
+                "projects": [{"id": str(p.id), "name": p.name} for p in active_projects],
+            },
+        )
+
+    for p in active_projects:
+        p.soft_delete()
+
+    draft.soft_delete()
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Archive / Unarchive
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{draft_id}/archive", status_code=204)
+async def archive_draft(
+    draft_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> None:
     draft = await _get_owned_draft(draft_id, current_user, db)
-    draft.soft_delete()
+    draft.retire()
+    await db.commit()
+
+
+@router.post("/{draft_id}/unarchive", status_code=204)
+async def unarchive_draft(
+    draft_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    draft = await _get_owned_draft(draft_id, current_user, db)
+    draft.unretire()
     await db.commit()
 
 

--- a/backend/app/routers/looms.py
+++ b/backend/app/routers/looms.py
@@ -5,7 +5,7 @@ from datetime import date, datetime
 from decimal import Decimal
 from typing import Literal
 
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from fastapi.responses import Response
 from pydantic import BaseModel
 from sqlalchemy import select
@@ -132,6 +132,7 @@ class LoomSummary(BaseModel):
     has_photo: bool
     current_version: LoomVersionSchema | None
     reeds: list[LoomReedSchema]
+    retired_at: datetime | None
     created_at: datetime
 
     model_config = {"from_attributes": True}
@@ -151,6 +152,7 @@ class LoomSummary(BaseModel):
             "has_photo": loom.photo_path is not None,
             "current_version": loom.current_version,
             "reeds": loom.reeds,
+            "retired_at": loom.retired_at,
             "created_at": loom.created_at,
         }
         return cls.model_validate(data)
@@ -174,6 +176,7 @@ class LoomDetail(BaseModel):
     current_version: LoomVersionSchema | None
     versions: list[LoomVersionSchema]
     reeds: list[LoomReedSchema]
+    retired_at: datetime | None
     created_at: datetime
 
     model_config = {"from_attributes": True}
@@ -198,6 +201,7 @@ class LoomDetail(BaseModel):
             "current_version": loom.current_version,
             "versions": loom.versions,
             "reeds": loom.reeds,
+            "retired_at": loom.retired_at,
             "created_at": loom.created_at,
         }
         return cls.model_validate(data)
@@ -391,10 +395,11 @@ async def create_loom(
 
 @router.get("", response_model=list[LoomSummary])
 async def list_looms(
+    include_retired: bool = Query(False),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> list[LoomSummary]:
-    result = await db.scalars(
+    q = (
         select(Loom)
         .where(Loom.owner_id == current_user.id, Loom.deleted_at.is_(None))
         .options(
@@ -405,6 +410,9 @@ async def list_looms(
         )
         .order_by(Loom.created_at.desc())
     )
+    if not include_retired:
+        q = q.where(Loom.retired_at.is_(None))
+    result = await db.scalars(q)
     return [LoomSummary.from_loom(loom) for loom in result.all()]
 
 
@@ -440,11 +448,58 @@ async def update_loom(
 @router.delete("/{loom_id}", status_code=204)
 async def delete_loom(
     loom_id: uuid.UUID,
+    force: bool = Query(False),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    from app.models.project import Project
+
+    loom = await _get_owned_loom(loom_id, current_user, db)
+    active_projects = (
+        await db.scalars(select(Project).where(Project.loom_id == loom.id, Project.deleted_at.is_(None)))
+    ).all()
+
+    if active_projects and not force:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "loom_in_use",
+                "projects": [{"id": str(p.id), "name": p.name} for p in active_projects],
+            },
+        )
+
+    for p in active_projects:
+        p.loom_id = None
+        p.loom_version_id = None
+
+    loom.soft_delete()
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Retire / Unretire
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{loom_id}/retire", status_code=204)
+async def retire_loom(
+    loom_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> None:
     loom = await _get_owned_loom(loom_id, current_user, db)
-    loom.soft_delete()
+    loom.retire()
+    await db.commit()
+
+
+@router.post("/{loom_id}/unretire", status_code=204)
+async def unretire_loom(
+    loom_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    loom = await _get_owned_loom(loom_id, current_user, db)
+    loom.unretire()
     await db.commit()
 
 

--- a/backend/tests/routers/test_drafts.py
+++ b/backend/tests/routers/test_drafts.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.audit_log import AuditLog
 from app.models.draft import Draft
+from app.models.project import Project
 from app.models.user import User
 from app.services import rendering
 
@@ -1177,3 +1178,173 @@ class TestUploadRateLimit:
             assert "retry-after" in resp.headers
         finally:
             app.dependency_overrides[_upload_rate_limit] = lambda: None
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/drafts/{draft_id} — deletion guard (409) and force-delete
+# ---------------------------------------------------------------------------
+
+
+async def _insert_project_for_draft(
+    db_session: AsyncSession,
+    owner: User,
+    draft: Draft,
+    *,
+    status: str = "active",
+) -> Project:
+    project = Project(
+        owner_id=owner.id,
+        draft_id=draft.id,
+        name="Test Project",
+        project_type="treadle",
+        total_picks=10,
+        status=status,
+    )
+    db_session.add(project)
+    await db_session.commit()
+    return project
+
+
+class TestDeleteDraftGuard:
+    async def test_returns_409_when_draft_has_active_project(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user, wif_path="d/x.wif")
+        await _insert_project_for_draft(db_session, test_user, draft)
+        resp = await auth_client.delete(f"/api/drafts/{draft.id}")
+        assert resp.status_code == 409
+
+    async def test_409_detail_has_code_and_projects(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user, wif_path="d/x.wif")
+        project = await _insert_project_for_draft(db_session, test_user, draft)
+        body = (await auth_client.delete(f"/api/drafts/{draft.id}")).json()
+        assert body["detail"]["code"] == "draft_in_use"
+        assert any(p["id"] == str(project.id) for p in body["detail"]["projects"])
+
+    async def test_blocks_on_completed_project(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user, wif_path="d/x.wif")
+        await _insert_project_for_draft(db_session, test_user, draft, status="completed")
+        resp = await auth_client.delete(f"/api/drafts/{draft.id}")
+        assert resp.status_code == 409
+
+    async def test_no_guard_when_project_is_soft_deleted(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user, wif_path="d/x.wif")
+        project = await _insert_project_for_draft(db_session, test_user, draft)
+        project.soft_delete()
+        await db_session.commit()
+        resp = await auth_client.delete(f"/api/drafts/{draft.id}")
+        assert resp.status_code == 204
+
+    async def test_force_delete_returns_204(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user, wif_path="d/x.wif")
+        await _insert_project_for_draft(db_session, test_user, draft)
+        resp = await auth_client.delete(f"/api/drafts/{draft.id}?force=true")
+        assert resp.status_code == 204
+
+    async def test_force_delete_soft_deletes_draft(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user, wif_path="d/x.wif")
+        await _insert_project_for_draft(db_session, test_user, draft)
+        await auth_client.delete(f"/api/drafts/{draft.id}?force=true")
+        await db_session.refresh(draft)
+        assert draft.deleted_at is not None
+
+    async def test_force_delete_soft_deletes_associated_projects(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user, wif_path="d/x.wif")
+        project = await _insert_project_for_draft(db_session, test_user, draft)
+        await auth_client.delete(f"/api/drafts/{draft.id}?force=true")
+        await db_session.refresh(project)
+        assert project.deleted_at is not None
+
+
+# ---------------------------------------------------------------------------
+# POST /api/drafts/{draft_id}/archive  and  POST /api/drafts/{draft_id}/unarchive
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveDraft:
+    async def test_archive_returns_204(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user, wif_path="d/x.wif")
+        resp = await auth_client.post(f"/api/drafts/{draft.id}/archive")
+        assert resp.status_code == 204
+
+    async def test_archive_sets_retired_at(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user, wif_path="d/x.wif")
+        await auth_client.post(f"/api/drafts/{draft.id}/archive")
+        await db_session.refresh(draft)
+        assert draft.retired_at is not None
+
+    async def test_archived_draft_excluded_from_list_by_default(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user, wif_path="d/x.wif")
+        draft.retire()
+        await db_session.commit()
+        resp = await auth_client.get("/api/drafts")
+        assert resp.json() == []
+
+    async def test_archived_draft_included_with_param(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user, wif_path="d/x.wif")
+        draft.retire()
+        await db_session.commit()
+        data = (await auth_client.get("/api/drafts?include_archived=true")).json()
+        assert any(d["id"] == str(draft.id) for d in data)
+
+    async def test_archived_draft_has_archived_at_in_response(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user, wif_path="d/x.wif")
+        draft.retire()
+        await db_session.commit()
+        data = (await auth_client.get("/api/drafts?include_archived=true")).json()
+        match = next(d for d in data if d["id"] == str(draft.id))
+        assert match["archived_at"] is not None
+
+    async def test_unarchive_returns_204(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user, wif_path="d/x.wif")
+        draft.retire()
+        await db_session.commit()
+        resp = await auth_client.post(f"/api/drafts/{draft.id}/unarchive")
+        assert resp.status_code == 204
+
+    async def test_unarchive_clears_retired_at(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user, wif_path="d/x.wif")
+        draft.retire()
+        await db_session.commit()
+        await auth_client.post(f"/api/drafts/{draft.id}/unarchive")
+        await db_session.refresh(draft)
+        assert draft.retired_at is None
+
+    async def test_unarchived_draft_appears_in_default_list(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user, wif_path="d/x.wif")
+        draft.retire()
+        await db_session.commit()
+        await auth_client.post(f"/api/drafts/{draft.id}/unarchive")
+        data = (await auth_client.get("/api/drafts")).json()
+        assert any(d["id"] == str(draft.id) for d in data)
+
+    async def test_archive_nonexistent_returns_404(self, auth_client: AsyncClient):
+        resp = await auth_client.post(f"/api/drafts/{uuid.uuid4()}/archive")
+        assert resp.status_code == 404
+
+    async def test_archive_other_users_draft_returns_404(
+        self, auth_client: AsyncClient, db_session: AsyncSession, admin_user: User
+    ):
+        draft = await _insert_draft(db_session, admin_user, wif_path="d/other.wif")
+        resp = await auth_client.post(f"/api/drafts/{draft.id}/archive")
+        assert resp.status_code == 404

--- a/backend/tests/routers/test_looms.py
+++ b/backend/tests/routers/test_looms.py
@@ -7,7 +7,9 @@ from PIL import Image
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.draft import Draft
 from app.models.loom import Loom, LoomVersion, LoomVersionAccessory
+from app.models.project import Project
 from app.models.user import User
 
 
@@ -790,3 +792,190 @@ class TestReedInventory:
     async def test_unauthenticated_returns_401(self, client: AsyncClient):
         resp = await client.post(f"/api/looms/{uuid.uuid4()}/reeds", json={"dents_per_inch": 10})
         assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/looms/{loom_id} — deletion guard (409) and force-delete
+# ---------------------------------------------------------------------------
+
+
+async def _insert_draft_for_user(db_session: AsyncSession, owner: User) -> Draft:
+    draft = Draft(
+        owner_id=owner.id,
+        name="Test Draft",
+        wif_filename="test.wif",
+        wif_path="d/x.wif",
+        has_treadling=True,
+        num_shafts=4,
+        num_treadles=4,
+        weft_threads=4,
+    )
+    db_session.add(draft)
+    await db_session.commit()
+    return draft
+
+
+async def _insert_project_for_loom(
+    db_session: AsyncSession,
+    owner: User,
+    draft: Draft,
+    loom: Loom,
+    *,
+    status: str = "active",
+) -> Project:
+    project = Project(
+        owner_id=owner.id,
+        draft_id=draft.id,
+        loom_id=loom.id,
+        name="Test Project",
+        project_type="treadle",
+        total_picks=10,
+        status=status,
+    )
+    db_session.add(project)
+    await db_session.commit()
+    return project
+
+
+class TestDeleteLoomGuard:
+    async def test_returns_409_when_loom_has_active_project(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        loom = await _insert_loom_for_user(db_session, test_user)
+        draft = await _insert_draft_for_user(db_session, test_user)
+        await _insert_project_for_loom(db_session, test_user, draft, loom)
+        resp = await auth_client.delete(f"/api/looms/{loom.id}")
+        assert resp.status_code == 409
+
+    async def test_409_detail_has_code_and_projects(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        loom = await _insert_loom_for_user(db_session, test_user)
+        draft = await _insert_draft_for_user(db_session, test_user)
+        project = await _insert_project_for_loom(db_session, test_user, draft, loom)
+        body = (await auth_client.delete(f"/api/looms/{loom.id}")).json()
+        assert body["detail"]["code"] == "loom_in_use"
+        assert any(p["id"] == str(project.id) for p in body["detail"]["projects"])
+
+    async def test_no_guard_when_project_is_soft_deleted(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        loom = await _insert_loom_for_user(db_session, test_user)
+        draft = await _insert_draft_for_user(db_session, test_user)
+        project = await _insert_project_for_loom(db_session, test_user, draft, loom)
+        project.soft_delete()
+        await db_session.commit()
+        resp = await auth_client.delete(f"/api/looms/{loom.id}")
+        assert resp.status_code == 204
+
+    async def test_force_delete_returns_204(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        loom = await _insert_loom_for_user(db_session, test_user)
+        draft = await _insert_draft_for_user(db_session, test_user)
+        await _insert_project_for_loom(db_session, test_user, draft, loom)
+        resp = await auth_client.delete(f"/api/looms/{loom.id}?force=true")
+        assert resp.status_code == 204
+
+    async def test_force_delete_soft_deletes_loom(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        loom = await _insert_loom_for_user(db_session, test_user)
+        draft = await _insert_draft_for_user(db_session, test_user)
+        await _insert_project_for_loom(db_session, test_user, draft, loom)
+        await auth_client.delete(f"/api/looms/{loom.id}?force=true")
+        await db_session.refresh(loom)
+        assert loom.deleted_at is not None
+
+    async def test_force_delete_nullifies_loom_on_project(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        loom = await _insert_loom_for_user(db_session, test_user)
+        draft = await _insert_draft_for_user(db_session, test_user)
+        project = await _insert_project_for_loom(db_session, test_user, draft, loom)
+        await auth_client.delete(f"/api/looms/{loom.id}?force=true")
+        await db_session.refresh(project)
+        assert project.loom_id is None
+        assert project.deleted_at is None
+
+
+# ---------------------------------------------------------------------------
+# POST /api/looms/{loom_id}/retire  and  POST /api/looms/{loom_id}/unretire
+# ---------------------------------------------------------------------------
+
+
+class TestRetireLoom:
+    async def test_retire_returns_204(self, auth_client: AsyncClient):
+        loom = await _create_loom(auth_client)
+        resp = await auth_client.post(f"/api/looms/{loom['id']}/retire")
+        assert resp.status_code == 204
+
+    async def test_retire_sets_retired_at(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        loom = await _insert_loom_for_user(db_session, test_user)
+        await auth_client.post(f"/api/looms/{loom.id}/retire")
+        await db_session.refresh(loom)
+        assert loom.retired_at is not None
+
+    async def test_retired_loom_excluded_from_list_by_default(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        loom = await _insert_loom_for_user(db_session, test_user)
+        loom.retire()
+        await db_session.commit()
+        resp = await auth_client.get("/api/looms")
+        assert resp.json() == []
+
+    async def test_retired_loom_included_with_param(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        loom = await _insert_loom_for_user(db_session, test_user)
+        loom.retire()
+        await db_session.commit()
+        data = (await auth_client.get("/api/looms?include_retired=true")).json()
+        assert any(entry["id"] == str(loom.id) for entry in data)
+
+    async def test_retired_loom_has_retired_at_in_response(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        loom = await _insert_loom_for_user(db_session, test_user)
+        loom.retire()
+        await db_session.commit()
+        data = (await auth_client.get("/api/looms?include_retired=true")).json()
+        match = next(entry for entry in data if entry["id"] == str(loom.id))
+        assert match["retired_at"] is not None
+
+    async def test_unretire_returns_204(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        loom = await _insert_loom_for_user(db_session, test_user)
+        loom.retire()
+        await db_session.commit()
+        resp = await auth_client.post(f"/api/looms/{loom.id}/unretire")
+        assert resp.status_code == 204
+
+    async def test_unretire_clears_retired_at(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        loom = await _insert_loom_for_user(db_session, test_user)
+        loom.retire()
+        await db_session.commit()
+        await auth_client.post(f"/api/looms/{loom.id}/unretire")
+        await db_session.refresh(loom)
+        assert loom.retired_at is None
+
+    async def test_unretired_loom_appears_in_default_list(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        loom = await _insert_loom_for_user(db_session, test_user)
+        loom.retire()
+        await db_session.commit()
+        await auth_client.post(f"/api/looms/{loom.id}/unretire")
+        data = (await auth_client.get("/api/looms")).json()
+        assert any(entry["id"] == str(loom.id) for entry in data)
+
+    async def test_retire_nonexistent_returns_404(self, auth_client: AsyncClient):
+        resp = await auth_client.post(f"/api/looms/{uuid.uuid4()}/retire")
+        assert resp.status_code == 404
+
+    async def test_retire_other_users_loom_returns_404(
+        self, auth_client: AsyncClient, db_session: AsyncSession, admin_user: User
+    ):
+        loom = await _insert_loom_for_user(db_session, admin_user)
+        resp = await auth_client.post(f"/api/looms/{loom.id}/retire")
+        assert resp.status_code == 404

--- a/frontend/src/api/drafts.ts
+++ b/frontend/src/api/drafts.ts
@@ -63,6 +63,7 @@ export interface Draft {
   weaving_width_override_cm: number | null;
   epi_override: number | null;
   is_shared: boolean;
+  archived_at: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -89,8 +90,13 @@ async function req<T>(url: string, init?: RequestInit): Promise<T> {
   return res.json();
 }
 
-export async function listDrafts(): Promise<Draft[]> {
-  return req("/api/drafts");
+export interface DeleteConflict {
+  code: string;
+  projects: { id: string; name: string }[];
+}
+
+export async function listDrafts(includeArchived = false): Promise<Draft[]> {
+  return req(`/api/drafts${includeArchived ? "?include_archived=true" : ""}`);
 }
 
 export async function getDraft(id: string): Promise<DraftDetail> {
@@ -109,8 +115,30 @@ export async function uploadDraft(
   return req("/api/drafts", { method: "POST", body: form });
 }
 
-export async function deleteDraft(id: string): Promise<void> {
-  return req(`/api/drafts/${id}`, { method: "DELETE" });
+export async function deleteDraft(id: string, force = false): Promise<DeleteConflict | void> {
+  const token = await getAuthToken();
+  const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
+  const res = await fetch(`/api/drafts/${id}${force ? "?force=true" : ""}`, {
+    method: "DELETE",
+    credentials: "include",
+    headers,
+  });
+  if (res.status === 409) {
+    const body = await res.json();
+    return body.detail as DeleteConflict;
+  }
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: "Request failed" }));
+    throw new Error(err.detail ?? "Request failed");
+  }
+}
+
+export async function archiveDraft(id: string): Promise<void> {
+  return req(`/api/drafts/${id}/archive`, { method: "POST" });
+}
+
+export async function unarchiveDraft(id: string): Promise<void> {
+  return req(`/api/drafts/${id}/unarchive`, { method: "POST" });
 }
 
 export function previewUrl(id: string): string {

--- a/frontend/src/api/looms.ts
+++ b/frontend/src/api/looms.ts
@@ -86,6 +86,7 @@ export interface Loom {
   has_photo: boolean;
   current_version: LoomVersion | null;
   reeds: LoomReed[];
+  retired_at: string | null;
   created_at: string;
 }
 
@@ -176,8 +177,8 @@ async function req<T>(url: string, init?: RequestInit): Promise<T> {
   return res.json();
 }
 
-export function listLooms(): Promise<Loom[]> {
-  return req("/api/looms");
+export function listLooms(includeRetired = false): Promise<Loom[]> {
+  return req(`/api/looms${includeRetired ? "?include_retired=true" : ""}`);
 }
 
 export function getLoom(id: string): Promise<LoomDetail> {
@@ -216,8 +217,30 @@ export function addLoomVersion(id: string, payload: AddVersionPayload): Promise<
   });
 }
 
-export function deleteLoom(id: string): Promise<void> {
-  return req(`/api/looms/${id}`, { method: "DELETE" });
+export async function deleteLoom(id: string, force = false): Promise<import("@/api/drafts").DeleteConflict | void> {
+  const token = await getAuthToken();
+  const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
+  const res = await fetch(`/api/looms/${id}${force ? "?force=true" : ""}`, {
+    method: "DELETE",
+    credentials: "include",
+    headers,
+  });
+  if (res.status === 409) {
+    const body = await res.json();
+    return body.detail as import("@/api/drafts").DeleteConflict;
+  }
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: "Request failed" }));
+    throw new Error(err.detail ?? "Request failed");
+  }
+}
+
+export function retireLoom(id: string): Promise<void> {
+  return req(`/api/looms/${id}/retire`, { method: "POST" });
+}
+
+export function unretireLoom(id: string): Promise<void> {
+  return req(`/api/looms/${id}/unretire`, { method: "POST" });
 }
 
 export function loomPhotoUrl(id: string): string {

--- a/frontend/src/components/drafts/DraftCard.tsx
+++ b/frontend/src/components/drafts/DraftCard.tsx
@@ -14,9 +14,10 @@ interface ProjectCounts {
 interface Props {
   draft: Draft;
   projectCounts?: ProjectCounts;
+  archived?: boolean;
 }
 
-export function DraftCard({ draft, projectCounts }: Props) {
+export function DraftCard({ draft, projectCounts, archived }: Props) {
   const navigate = useNavigate();
 
   const featureBadges = [
@@ -46,6 +47,9 @@ export function DraftCard({ draft, projectCounts }: Props) {
           <p className="text-xs text-muted-foreground mt-0.5 truncate">{draft.wif_filename}</p>
         </div>
         <div className="flex items-center gap-2 shrink-0">
+          {archived && (
+            <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">Archived</span>
+          )}
           {draft.has_liftplan && (
             <AppIcons.lift className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
           )}

--- a/frontend/src/components/looms/CatalogRequestButton.tsx
+++ b/frontend/src/components/looms/CatalogRequestButton.tsx
@@ -1,64 +1,13 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { AppIcons } from "@/lib/icons";
 import { type LoomDetail, LOOM_TYPE_LABELS } from "@/api/looms";
+import { submitFeedback } from "@/api/feedback";
 
-// ---------- types ----------
+// ---------- localStorage dedup ----------
 
-interface GithubIssue {
-  number: number;
-  title: string;
-  url: string;
-}
-
-interface CheckCache {
-  token: string;
-  issues: GithubIssue[];
-  checkedAt: number;
-}
-
-type CheckState = "checking" | "no_dupes" | "dupes_found" | "failed" | "submitted";
-
-// ---------- constants ----------
-
-const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
-const CACHE_PREFIX = "wm:catalog_check:";
 const SUBMITTED_KEY = "wm:catalog_submitted";
-
-// ---------- dedup token ----------
-// djb2 hash of "manufacturer:model" (lowercased). Deterministic, collision-
-// resistant enough for dedup. Louet Spring and Louet Spring II produce
-// completely different tokens so there are no prefix-match false positives.
-
-function requestToken(manufacturer: string, model: string): string {
-  const str = `${manufacturer.toLowerCase()}:${model.toLowerCase()}`;
-  let h = 5381;
-  for (let i = 0; i < str.length; i++) {
-    h = ((h << 5) + h) ^ str.charCodeAt(i);
-  }
-  return `wmloom${(h >>> 0).toString(36)}`;
-}
-
-// ---------- localStorage helpers ----------
-
-function getCached(loomId: string, token: string): CheckCache | null {
-  try {
-    const raw = localStorage.getItem(CACHE_PREFIX + loomId);
-    if (!raw) return null;
-    const c: CheckCache = JSON.parse(raw);
-    if (c.token !== token) return null; // loom renamed — invalidate
-    if (Date.now() - c.checkedAt > CACHE_TTL_MS) return null;
-    return c;
-  } catch {
-    return null;
-  }
-}
-
-function setCached(loomId: string, cache: CheckCache): void {
-  try {
-    localStorage.setItem(CACHE_PREFIX + loomId, JSON.stringify(cache));
-  } catch {
-    // ignore storage errors
-  }
-}
 
 function isSubmitted(loomId: string): boolean {
   try {
@@ -82,63 +31,6 @@ function markSubmitted(loomId: string): void {
   }
 }
 
-// ---------- GitHub API ----------
-
-async function fetchGithubIssues(token: string): Promise<GithubIssue[]> {
-  // Search for the exact token in issue bodies.
-  // "wm-req:abc123" is a unique string per manufacturer:model hash so there
-  // are no partial-match false positives (Spring ≠ Spring II).
-  const q = encodeURIComponent(
-    `repo:weftmark/weftmark "wm-req:${token}" is:issue is:open`,
-  );
-  const res = await fetch(
-    `https://api.github.com/search/issues?q=${q}&per_page=5`,
-    { headers: { Accept: "application/vnd.github+json" } },
-  );
-  if (!res.ok) throw new Error(`GitHub ${res.status}`);
-  const data = await res.json();
-  return (data.items ?? []).map(
-    (item: { number: number; title: string; html_url: string }) => ({
-      number: item.number,
-      title: item.title,
-      url: item.html_url,
-    }),
-  );
-}
-
-// ---------- URL builder ----------
-
-function buildIssueUrl(
-  loom: LoomDetail,
-  token: string,
-  existingIssues: GithubIssue[],
-): string {
-  const title = encodeURIComponent(
-    `Loom catalog request: ${loom.manufacturer} ${loom.model_name}`,
-  );
-
-  const relatedSection =
-    existingIssues.length > 0
-      ? `\n**Related existing requests:**\n${existingIssues
-          .map((i) => `- #${i.number} — ${i.url}`)
-          .join("\n")}\n`
-      : "";
-
-  const body = encodeURIComponent(
-    `## Loom catalog request\n\n` +
-      `**Brand:** ${loom.manufacturer}\n` +
-      `**Model:** ${loom.model_name}\n` +
-      `**Type:** ${LOOM_TYPE_LABELS[loom.loom_type] ?? loom.loom_type}\n` +
-      `**Loom ID (admin):** ${loom.id}\n` +
-      `${relatedSection}\n` +
-      `Please add this loom to the weftmark catalog so other users can find and link it.\n\n` +
-      `---\n` +
-      `wm-req:${token}`,
-  );
-
-  return `https://github.com/weftmark/weftmark/issues/new?title=${title}&body=${body}`;
-}
-
 // ---------- component ----------
 
 interface Props {
@@ -146,139 +38,134 @@ interface Props {
 }
 
 export function CatalogRequestButton({ loom }: Props) {
-  const token = requestToken(loom.manufacturer, loom.model_name);
+  const [showModal, setShowModal] = useState(false);
+  const [done, setDone] = useState(() => isSubmitted(loom.id));
 
-  // Initialise synchronously from localStorage to avoid a "checking" flash
-  // when we already have a cached result or a prior submission.
-  const [state, setState] = useState<CheckState>(() => {
-    if (isSubmitted(loom.id)) return "submitted";
-    const cached = getCached(loom.id, token);
-    if (cached) return cached.issues.length > 0 ? "dupes_found" : "no_dupes";
-    return "checking";
+  const mutation = useMutation({
+    mutationFn: submitFeedback,
+    onSuccess: () => {
+      markSubmitted(loom.id);
+      setDone(true);
+      setShowModal(false);
+    },
   });
 
-  const [issues, setIssues] = useState<GithubIssue[]>(() => {
-    const cached = getCached(loom.id, token);
-    return cached?.issues ?? [];
-  });
-
-  const [showSubmitAnyway, setShowSubmitAnyway] = useState(false);
-
-  // Fetch from GitHub only when there's no cached result.
-  // `state` is intentionally excluded from deps — we only want one fetch per
-  // mount and the initial value is already correctly derived above.
-  useEffect(() => {
-    if (state !== "checking") return;
-    let cancelled = false;
-
-    fetchGithubIssues(token)
-      .then((found) => {
-        if (cancelled) return;
-        setIssues(found);
-        setCached(loom.id, { token, issues: found, checkedAt: Date.now() });
-        setState(found.length > 0 ? "dupes_found" : "no_dupes");
-      })
-      .catch(() => {
-        if (cancelled) return;
-        setState("failed");
-      });
-
-    return () => {
-      cancelled = true;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loom.id, token]);
-
-  function handleSubmit(withExisting: GithubIssue[]) {
-    window.open(buildIssueUrl(loom, token, withExisting), "_blank", "noopener");
-    markSubmitted(loom.id);
-    setState("submitted");
+  function handleSubmit() {
+    const typeLabel = LOOM_TYPE_LABELS[loom.loom_type] ?? loom.loom_type;
+    mutation.mutate({
+      submission_type: "feature_request",
+      subject: `Loom catalog request: ${loom.manufacturer} ${loom.model_name}`,
+      body: [
+        "## Loom catalog request",
+        "",
+        `**Brand:** ${loom.manufacturer}`,
+        `**Model:** ${loom.model_name}`,
+        `**Type:** ${typeLabel}`,
+        `**Loom ID (admin):** ${loom.id}`,
+        "",
+        "Please add this loom to the weftmark catalog so other users can find and link it.",
+      ].join("\n"),
+      is_anonymous: false,
+      diagnostics: {
+        environment:
+          window.location.hostname === "weftmark.com" ||
+          window.location.hostname.endsWith(".weftmark.com")
+            ? `https://${window.location.hostname}`
+            : "local instance",
+        page_url: window.location.pathname,
+        user_agent: navigator.userAgent,
+        app_version: null,
+      },
+    });
   }
 
-  // ── submitted ──
-  if (state === "submitted") {
+  if (done) {
     return (
       <span className="text-xs text-muted-foreground italic">Request submitted</span>
     );
   }
 
-  // ── checking ──
-  if (state === "checking") {
-    return (
-      <span className="text-xs text-muted-foreground italic">
-        Checking for existing requests…
-      </span>
-    );
-  }
-
-  // ── no dupes / failed (treat API failure as no dupes — don't block submission) ──
-  if (state === "no_dupes" || state === "failed") {
-    return (
-      <a
-        href={buildIssueUrl(loom, token, [])}
-        target="_blank"
-        rel="noopener noreferrer"
-        onClick={() => handleSubmit([])}
-        className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2 transition-colors"
-      >
-        Submit request to add to catalog
-      </a>
-    );
-  }
-
-  // ── dupes found ──
   return (
-    <div className="space-y-1.5">
-      <p className="text-xs font-medium text-muted-foreground">
-        Similar requests already open:
-      </p>
-      <ul className="space-y-0.5 pl-1">
-        {issues.map((issue) => (
-          <li key={issue.number}>
-            <a
-              href={issue.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2"
-            >
-              #{issue.number} — {issue.title}
-            </a>
-          </li>
-        ))}
-      </ul>
-      {!showSubmitAnyway ? (
-        <button
-          type="button"
-          onClick={() => setShowSubmitAnyway(true)}
-          className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2 transition-colors"
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        className="text-xs h-7"
+        onClick={() => setShowModal(true)}
+      >
+        Request catalog addition
+      </Button>
+
+      {showModal && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          onClick={() => { if (!mutation.isPending) setShowModal(false); }}
         >
-          Submit a new request anyway
-        </button>
-      ) : (
-        <div className="rounded-md border border-border bg-muted/20 px-3 py-2 space-y-1.5">
-          <p className="text-xs text-muted-foreground">
-            Links to the existing requests above will be included in your submission.
-          </p>
-          <div className="flex items-center gap-3">
-            <a
-              href={buildIssueUrl(loom, token, issues)}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => handleSubmit(issues)}
-              className="text-xs font-medium text-foreground hover:underline"
-            >
-              Submit with references →
-            </a>
-            <button
-              type="button"
-              onClick={() => setShowSubmitAnyway(false)}
-              className="text-xs text-muted-foreground hover:text-foreground"
-            >
-              Cancel
-            </button>
+          <div
+            className="w-full max-w-md rounded-lg border border-border bg-background shadow-xl p-6 space-y-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between">
+              <h2 className="text-base font-semibold">Request catalog addition</h2>
+              <button
+                type="button"
+                onClick={() => setShowModal(false)}
+                disabled={mutation.isPending}
+                className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
+                aria-label="Close"
+              >
+                <AppIcons.close className="h-4 w-4" />
+              </button>
+            </div>
+
+            <p className="text-sm text-muted-foreground">
+              Submit a request to add this loom to the weftmark catalog. Once added, all
+              users can link their loom to it and see manufacturer specs.
+            </p>
+
+            <div className="rounded-md border border-border bg-muted/30 px-4 py-3 space-y-1.5 text-sm">
+              <div className="flex gap-3">
+                <span className="text-muted-foreground w-14 shrink-0">Brand</span>
+                <span className="font-medium">{loom.manufacturer}</span>
+              </div>
+              <div className="flex gap-3">
+                <span className="text-muted-foreground w-14 shrink-0">Model</span>
+                <span className="font-medium">{loom.model_name}</span>
+              </div>
+              <div className="flex gap-3">
+                <span className="text-muted-foreground w-14 shrink-0">Type</span>
+                <span className="font-medium">
+                  {LOOM_TYPE_LABELS[loom.loom_type] ?? loom.loom_type}
+                </span>
+              </div>
+            </div>
+
+            {mutation.isError && (
+              <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                Failed to submit. Please try again.
+              </p>
+            )}
+
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setShowModal(false)}
+                disabled={mutation.isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                onClick={handleSubmit}
+                disabled={mutation.isPending}
+              >
+                {mutation.isPending ? "Submitting…" : "Submit Request"}
+              </Button>
+            </div>
           </div>
         </div>
       )}
-    </div>
+    </>
   );
 }

--- a/frontend/src/components/projects/AssignLoomModal.tsx
+++ b/frontend/src/components/projects/AssignLoomModal.tsx
@@ -25,7 +25,7 @@ export function AssignLoomModal({ projectId, activeProjects, projectType, draftN
   const [error, setError] = useState<string | null>(null);
   const [conflictProject, setConflictProject] = useState<ProjectSummary | null>(null);
 
-  const { data: looms = [] } = useQuery({ queryKey: ["looms"], queryFn: listLooms });
+  const { data: looms = [] } = useQuery({ queryKey: ["looms"], queryFn: () => listLooms() });
   const { data: loomDetail } = useQuery({
     queryKey: ["loom", loomId],
     queryFn: () => getLoom(loomId),

--- a/frontend/src/components/projects/CreateProjectModal.tsx
+++ b/frontend/src/components/projects/CreateProjectModal.tsx
@@ -51,8 +51,8 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
   const [error, setError] = useState<string | null>(null);
   const [conflictProject, setConflictProject] = useState<ProjectSummary | null>(null);
 
-  const { data: drafts = [] } = useQuery({ queryKey: ["drafts"], queryFn: listDrafts });
-  const { data: looms = [] } = useQuery({ queryKey: ["looms"], queryFn: listLooms });
+  const { data: drafts = [] } = useQuery({ queryKey: ["drafts"], queryFn: () => listDrafts() });
+  const { data: looms = [] } = useQuery({ queryKey: ["looms"], queryFn: () => listLooms() });
   const { data: loomDetail } = useQuery({
     queryKey: ["loom", loomId],
     queryFn: () => getLoom(loomId),

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -296,12 +296,12 @@ export function DashboardPage() {
 
   const { data: drafts = [] } = useQuery({
     queryKey: ["drafts"],
-    queryFn: listDrafts,
+    queryFn: () => listDrafts(),
   });
 
   const { data: looms = [] } = useQuery({
     queryKey: ["looms"],
-    queryFn: listLooms,
+    queryFn: () => listLooms(),
   });
 
   const activeProjects = projects.filter((a) => (a.status === "active" || a.status === "created") && !!a.loom_id);

--- a/frontend/src/pages/DraftDetailPage.tsx
+++ b/frontend/src/pages/DraftDetailPage.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { AppIcons } from "@/lib/icons";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getDraft, deleteDraft, generateLiftplan, overrideDraftMetadata, setDraftWarpLength, setDraftWeavingWidth, setDraftEpi, previewUrl, previewSvgUrl, downloadWif, downloadWifModified, type ColorStat } from "@/api/drafts";
+import { getDraft, deleteDraft, archiveDraft, unarchiveDraft, generateLiftplan, overrideDraftMetadata, setDraftWarpLength, setDraftWeavingWidth, setDraftEpi, previewUrl, previewSvgUrl, downloadWif, downloadWifModified, type ColorStat, type DeleteConflict } from "@/api/drafts";
 import { listProjects } from "@/api/projects";
 import { ProjectSummaryList } from "@/components/projects/ProjectSummaryList";
 import { CreateProjectModal } from "@/components/projects/CreateProjectModal";
@@ -22,6 +22,8 @@ export function DraftDetailPage() {
   const { user } = useAuthContext();
   const displayUnit = measurementSystemToUnit(user?.measurement_system ?? "metric");
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [deleteConflict, setDeleteConflict] = useState<DeleteConflict | null>(null);
+  const [confirmForceDelete, setConfirmForceDelete] = useState(false);
   const [showDangerZone, setShowDangerZone] = useState(false);
   const [showCreateProject, setShowCreateProject] = useState(false);
   const [downloading, setDownloading] = useState(false);
@@ -49,11 +51,26 @@ export function DraftDetailPage() {
   });
 
   const deleteMutation = useMutation({
-    mutationFn: () => deleteDraft(id!),
-    onSuccess: () => {
+    mutationFn: (force: boolean) => deleteDraft(id!, force),
+    onSuccess: (result) => {
+      if (result && "code" in result) {
+        setDeleteConflict(result as DeleteConflict);
+        setConfirmDelete(false);
+        return;
+      }
       queryClient.invalidateQueries({ queryKey: ["drafts"] });
       navigate("/drafts", { replace: true });
     },
+  });
+
+  const archiveMutation = useMutation({
+    mutationFn: () => archiveDraft(id!),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["draft", id] }),
+  });
+
+  const unarchiveMutation = useMutation({
+    mutationFn: () => unarchiveDraft(id!),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["draft", id] }),
   });
 
   const generateMutation = useMutation({
@@ -156,6 +173,12 @@ export function DraftDetailPage() {
   return (
     <div className="max-w-5xl mx-auto w-full">
       {isReadOnly && <SuperuserInspectionBanner />}
+      {draft.archived_at && (
+        <div className="px-6 py-2 bg-muted/50 border-b border-border text-sm text-muted-foreground flex items-center gap-2">
+          <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium">Archived</span>
+          This draft is archived and hidden from your active list.
+        </div>
+      )}
       <div className="p-6 space-y-6">
       <div className="flex items-center gap-2 text-sm">
         <Link to="/drafts" className="text-muted-foreground hover:text-foreground">Drafts</Link>
@@ -772,42 +795,106 @@ export function DraftDetailPage() {
         {!isReadOnly && <div className="border-t pt-4">
           <button
             type="button"
-            onClick={() => setShowDangerZone((v) => !v)}
+            onClick={() => { setShowDangerZone((v) => !v); setConfirmDelete(false); setDeleteConflict(null); setConfirmForceDelete(false); }}
             className="flex items-center gap-2 text-xs font-medium text-muted-foreground uppercase tracking-wide hover:text-destructive transition-colors"
           >
             <span>Danger zone</span>
             <span>{showDangerZone ? "▲" : "▼"}</span>
           </button>
           {showDangerZone && (
-            <div className="mt-3 rounded-md border border-destructive/30 p-4 flex items-center justify-between gap-4">
-              <div>
-                <p className="text-sm font-medium">Delete draft</p>
-                <p className="text-xs text-muted-foreground mt-0.5">Permanently removes this draft and its WIF file. Projects are not deleted.</p>
+            <div className="mt-3 space-y-3">
+              {/* Archive / Unarchive */}
+              <div className="rounded-md border border-border p-4 flex items-center justify-between gap-4">
+                <div>
+                  <p className="text-sm font-medium">{draft.archived_at ? "Unarchive draft" : "Archive draft"}</p>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    {draft.archived_at
+                      ? "Restore this draft to your active list."
+                      : "Hide this draft from active lists without deleting it. Existing projects are unaffected."}
+                  </p>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => draft.archived_at ? unarchiveMutation.mutate() : archiveMutation.mutate()}
+                  disabled={archiveMutation.isPending || unarchiveMutation.isPending}
+                >
+                  {draft.archived_at ? "Unarchive" : "Archive"}
+                </Button>
               </div>
-              <div className="flex gap-2 shrink-0">
-                {!confirmDelete ? (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="text-destructive hover:text-destructive"
-                    onClick={() => setConfirmDelete(true)}
-                  >
-                    Delete draft
-                  </Button>
-                ) : (
-                  <>
-                    <Button
-                      variant="destructive"
-                      size="sm"
-                      onClick={() => deleteMutation.mutate()}
-                      disabled={deleteMutation.isPending}
-                    >
-                      Confirm delete
-                    </Button>
-                    <Button variant="outline" size="sm" onClick={() => setConfirmDelete(false)}>
-                      Cancel
-                    </Button>
-                  </>
+
+              {/* Delete */}
+              <div className="rounded-md border border-destructive/30 p-4 space-y-3">
+                <div className="flex items-center justify-between gap-4">
+                  <div>
+                    <p className="text-sm font-medium">Delete draft</p>
+                    <p className="text-xs text-muted-foreground mt-0.5">Permanently removes this draft and its WIF file.</p>
+                  </div>
+                  <div className="flex gap-2 shrink-0">
+                    {!confirmDelete && !deleteConflict ? (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="text-destructive hover:text-destructive"
+                        onClick={() => setConfirmDelete(true)}
+                      >
+                        Delete draft
+                      </Button>
+                    ) : confirmDelete ? (
+                      <>
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          onClick={() => deleteMutation.mutate(false)}
+                          disabled={deleteMutation.isPending}
+                        >
+                          Confirm delete
+                        </Button>
+                        <Button variant="outline" size="sm" onClick={() => setConfirmDelete(false)}>
+                          Cancel
+                        </Button>
+                      </>
+                    ) : null}
+                  </div>
+                </div>
+
+                {/* 409 conflict */}
+                {deleteConflict && (
+                  <div className="space-y-2">
+                    <p className="text-sm text-destructive font-medium">
+                      This draft is used by {deleteConflict.projects.length} active project{deleteConflict.projects.length !== 1 ? "s" : ""}:
+                    </p>
+                    <ul className="text-xs text-muted-foreground space-y-0.5 pl-3">
+                      {deleteConflict.projects.map((p) => <li key={p.id}>· {p.name}</li>)}
+                    </ul>
+                    <p className="text-xs text-muted-foreground">
+                      Remove this draft from those projects first, or force-delete — which will also delete all listed projects.
+                    </p>
+                    {!confirmForceDelete ? (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="text-destructive hover:text-destructive"
+                        onClick={() => setConfirmForceDelete(true)}
+                      >
+                        Force delete ({deleteConflict.projects.length} project{deleteConflict.projects.length !== 1 ? "s" : ""} will be deleted)
+                      </Button>
+                    ) : (
+                      <div className="flex gap-2">
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          onClick={() => deleteMutation.mutate(true)}
+                          disabled={deleteMutation.isPending}
+                        >
+                          Confirm force delete
+                        </Button>
+                        <Button variant="outline" size="sm" onClick={() => { setDeleteConflict(null); setConfirmForceDelete(false); }}>
+                          Cancel
+                        </Button>
+                      </div>
+                    )}
+                  </div>
                 )}
               </div>
             </div>

--- a/frontend/src/pages/DraftDetailPage.tsx
+++ b/frontend/src/pages/DraftDetailPage.tsx
@@ -24,6 +24,7 @@ export function DraftDetailPage() {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleteConflict, setDeleteConflict] = useState<DeleteConflict | null>(null);
   const [confirmForceDelete, setConfirmForceDelete] = useState(false);
+  const [confirmArchive, setConfirmArchive] = useState(false);
   const [showDangerZone, setShowDangerZone] = useState(false);
   const [showCreateProject, setShowCreateProject] = useState(false);
   const [downloading, setDownloading] = useState(false);
@@ -804,7 +805,7 @@ export function DraftDetailPage() {
           {showDangerZone && (
             <div className="mt-3 space-y-3">
               {/* Archive / Unarchive */}
-              <div className="rounded-md border border-border p-4 flex items-center justify-between gap-4">
+              <div className="rounded-md border border-border p-4 flex items-start justify-between gap-4">
                 <div>
                   <p className="text-sm font-medium">{draft.archived_at ? "Unarchive draft" : "Archive draft"}</p>
                   <p className="text-xs text-muted-foreground mt-0.5">
@@ -813,14 +814,34 @@ export function DraftDetailPage() {
                       : "Hide this draft from active lists without deleting it. Existing projects are unaffected."}
                   </p>
                 </div>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => draft.archived_at ? unarchiveMutation.mutate() : archiveMutation.mutate()}
-                  disabled={archiveMutation.isPending || unarchiveMutation.isPending}
-                >
-                  {draft.archived_at ? "Unarchive" : "Archive"}
-                </Button>
+                <div className="flex gap-2 shrink-0">
+                  {!confirmArchive ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setConfirmArchive(true)}
+                    >
+                      {draft.archived_at ? "Unarchive" : "Archive"}
+                    </Button>
+                  ) : (
+                    <>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => {
+                          setConfirmArchive(false);
+                          if (draft.archived_at) unarchiveMutation.mutate(); else archiveMutation.mutate();
+                        }}
+                        disabled={archiveMutation.isPending || unarchiveMutation.isPending}
+                      >
+                        Confirm
+                      </Button>
+                      <Button variant="ghost" size="sm" onClick={() => setConfirmArchive(false)}>
+                        Cancel
+                      </Button>
+                    </>
+                  )}
+                </div>
               </div>
 
               {/* Delete */}

--- a/frontend/src/pages/DraftsPage.tsx
+++ b/frontend/src/pages/DraftsPage.tsx
@@ -9,10 +9,11 @@ import { Button } from "@/components/ui/button";
 export function DraftsPage() {
   const queryClient = useQueryClient();
   const [showUpload, setShowUpload] = useState(false);
+  const [showArchived, setShowArchived] = useState(false);
 
   const { data: drafts = [], isLoading, error } = useQuery({
-    queryKey: ["drafts"],
-    queryFn: listDrafts,
+    queryKey: ["drafts", { includeArchived: showArchived }],
+    queryFn: () => listDrafts(showArchived),
   });
 
   const { data: projects = [] } = useQuery({
@@ -38,11 +39,23 @@ export function DraftsPage() {
     queryClient.invalidateQueries({ queryKey: ["drafts"] });
   };
 
+  const activeDrafts = drafts.filter((d) => !d.archived_at);
+  const archivedDrafts = drafts.filter((d) => d.archived_at);
+
   return (
     <div className="p-6 max-w-4xl mx-auto w-full">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-xl font-semibold">Drafts</h1>
-        <Button onClick={() => setShowUpload(true)}>New Draft</Button>
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => setShowArchived((v) => !v)}
+            className={`text-sm transition-colors ${showArchived ? "text-foreground font-medium" : "text-muted-foreground hover:text-foreground"}`}
+          >
+            {showArchived ? "Hide archived" : "Show archived"}
+          </button>
+          <Button onClick={() => setShowUpload(true)}>New Draft</Button>
+        </div>
       </div>
 
       {isLoading && <p className="text-sm text-muted-foreground">Loading drafts…</p>}
@@ -51,19 +64,34 @@ export function DraftsPage() {
       {!isLoading && drafts.length === 0 && (
         <div className="rounded-lg border border-dashed p-12 text-center">
           <p className="text-sm text-muted-foreground">
-            No drafts yet. Upload a WIF file to get started.
+            {showArchived ? "No archived drafts." : "No drafts yet. Upload a WIF file to get started."}
           </p>
-          <Button className="mt-4" onClick={() => setShowUpload(true)}>
-            New Draft
-          </Button>
+          {!showArchived && (
+            <Button className="mt-4" onClick={() => setShowUpload(true)}>
+              New Draft
+            </Button>
+          )}
         </div>
       )}
 
-      <div className="grid gap-4 sm:grid-cols-2">
-        {drafts.map((d) => (
-          <DraftCard key={d.id} draft={d} projectCounts={projectCountsByDraft[d.id]} />
-        ))}
-      </div>
+      {activeDrafts.length > 0 && (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {activeDrafts.map((d) => (
+            <DraftCard key={d.id} draft={d} projectCounts={projectCountsByDraft[d.id]} />
+          ))}
+        </div>
+      )}
+
+      {showArchived && archivedDrafts.length > 0 && (
+        <div className="mt-8">
+          <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide mb-3">Archived</h2>
+          <div className="grid gap-4 sm:grid-cols-2 opacity-60">
+            {archivedDrafts.map((d) => (
+              <DraftCard key={d.id} draft={d} projectCounts={projectCountsByDraft[d.id]} archived />
+            ))}
+          </div>
+        </div>
+      )}
 
       {showUpload && (
         <UploadWifModal

--- a/frontend/src/pages/DraftsPage.tsx
+++ b/frontend/src/pages/DraftsPage.tsx
@@ -5,15 +5,16 @@ import { listProjects } from "@/api/projects";
 import { DraftCard } from "@/components/drafts/DraftCard";
 import { UploadWifModal } from "@/components/drafts/UploadWifModal";
 import { Button } from "@/components/ui/button";
+import { AppIcons } from "@/lib/icons";
 
 export function DraftsPage() {
   const queryClient = useQueryClient();
   const [showUpload, setShowUpload] = useState(false);
-  const [showArchived, setShowArchived] = useState(false);
+  const [archivedOpen, setArchivedOpen] = useState(false);
 
   const { data: drafts = [], isLoading, error } = useQuery({
-    queryKey: ["drafts", { includeArchived: showArchived }],
-    queryFn: () => listDrafts(showArchived),
+    queryKey: ["drafts", { includeArchived: true }],
+    queryFn: () => listDrafts(true),
   });
 
   const { data: projects = [] } = useQuery({
@@ -46,31 +47,18 @@ export function DraftsPage() {
     <div className="p-6 max-w-4xl mx-auto w-full">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-xl font-semibold">Drafts</h1>
-        <div className="flex items-center gap-3">
-          <button
-            type="button"
-            onClick={() => setShowArchived((v) => !v)}
-            className={`text-sm transition-colors ${showArchived ? "text-foreground font-medium" : "text-muted-foreground hover:text-foreground"}`}
-          >
-            {showArchived ? "Hide archived" : "Show archived"}
-          </button>
-          <Button onClick={() => setShowUpload(true)}>New Draft</Button>
-        </div>
+        <Button onClick={() => setShowUpload(true)}>New Draft</Button>
       </div>
 
       {isLoading && <p className="text-sm text-muted-foreground">Loading drafts…</p>}
       {error && <p className="text-sm text-destructive">Failed to load drafts.</p>}
 
-      {!isLoading && drafts.length === 0 && (
+      {!isLoading && activeDrafts.length === 0 && archivedDrafts.length === 0 && (
         <div className="rounded-lg border border-dashed p-12 text-center">
-          <p className="text-sm text-muted-foreground">
-            {showArchived ? "No archived drafts." : "No drafts yet. Upload a WIF file to get started."}
-          </p>
-          {!showArchived && (
-            <Button className="mt-4" onClick={() => setShowUpload(true)}>
-              New Draft
-            </Button>
-          )}
+          <p className="text-sm text-muted-foreground">No drafts yet. Upload a WIF file to get started.</p>
+          <Button className="mt-4" onClick={() => setShowUpload(true)}>
+            New Draft
+          </Button>
         </div>
       )}
 
@@ -82,14 +70,25 @@ export function DraftsPage() {
         </div>
       )}
 
-      {showArchived && archivedDrafts.length > 0 && (
+      {archivedDrafts.length > 0 && (
         <div className="mt-8">
-          <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide mb-3">Archived</h2>
-          <div className="grid gap-4 sm:grid-cols-2 opacity-60">
-            {archivedDrafts.map((d) => (
-              <DraftCard key={d.id} draft={d} projectCounts={projectCountsByDraft[d.id]} archived />
-            ))}
-          </div>
+          <button
+            type="button"
+            onClick={() => setArchivedOpen((v) => !v)}
+            className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors w-full text-left"
+          >
+            <AppIcons.chevronDown
+              className={`h-4 w-4 transition-transform duration-200 ${archivedOpen ? "rotate-180" : ""}`}
+            />
+            Archived ({archivedDrafts.length})
+          </button>
+          {archivedOpen && (
+            <div className="mt-3 grid gap-4 sm:grid-cols-2 opacity-60">
+              {archivedDrafts.map((d) => (
+                <DraftCard key={d.id} draft={d} projectCounts={projectCountsByDraft[d.id]} archived />
+              ))}
+            </div>
+          )}
         </div>
       )}
 

--- a/frontend/src/pages/LoomCatalogPage.tsx
+++ b/frontend/src/pages/LoomCatalogPage.tsx
@@ -1,11 +1,11 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { WeftmarkLogo } from "@/components/WeftmarkLogo";
 import { PublicFooter } from "@/components/PublicFooter";
 import { listLoomCatalog, type LoomReferenceSummary } from "@/api/looms";
 
-const CATEGORY_LABELS: Record<string, string> = {
+const LOOM_TYPE_LABELS: Record<string, string> = {
   floor_loom: "Floor Loom",
   table_loom: "Table Loom",
   rigid_heddle: "Rigid Heddle",
@@ -17,16 +17,25 @@ const CATEGORY_LABELS: Record<string, string> = {
   other: "Other",
 };
 
-const ALL_CATEGORIES = Object.entries(CATEGORY_LABELS).map(([value, label]) => ({ value, label }));
-
 function ShaftBadge({ options }: { options: number[] | null }) {
   if (!options || options.length === 0) return <span className="text-stone-400">—</span>;
-  return <span>{options.map((n) => `${n}`).join(" / ")}</span>;
+  return <span>{options.map((n) => Math.round(n)).join(" / ")}</span>;
 }
 
-function WidthBadge({ options }: { options: number[] | null }) {
-  if (!options || options.length === 0) return <span className="text-stone-400">—</span>;
-  return <span>{options.map((n) => `${n}"`).join(" / ")}</span>;
+function WidthBadge({ loom }: { loom: LoomReferenceSummary }) {
+  const cm = loom.weaving_width_options_cm ?? [];
+  const inches = loom.weaving_width_options_inches ?? [];
+  if (inches.length === 0 && cm.length === 0) {
+    return <span className="text-stone-400">—</span>;
+  }
+  const count = Math.max(inches.length, cm.length);
+  const parts = Array.from({ length: count }, (_, i) => {
+    const inPart = inches[i] != null ? `${Math.round(inches[i])}"` : null;
+    const cmPart = cm[i] != null ? `${Math.round(cm[i])} cm` : null;
+    if (inPart && cmPart) return `${inPart} (${cmPart})`;
+    return inPart ?? cmPart ?? "";
+  });
+  return <span>{parts.join(" / ")}</span>;
 }
 
 function LoomCard({ loom }: { loom: LoomReferenceSummary }) {
@@ -41,7 +50,7 @@ function LoomCard({ loom }: { loom: LoomReferenceSummary }) {
           )}
         </div>
         <span className="shrink-0 text-xs rounded-full bg-stone-100 text-stone-600 px-2.5 py-1 font-medium">
-          {CATEGORY_LABELS[loom.loom_category] ?? loom.loom_category}
+          {LOOM_TYPE_LABELS[loom.loom_category] ?? loom.loom_category}
         </span>
       </div>
 
@@ -52,12 +61,12 @@ function LoomCard({ loom }: { loom: LoomReferenceSummary }) {
             <ShaftBadge options={loom.shaft_count_options} />
           </>
         )}
-        {loom.weaving_width_options_inches && loom.weaving_width_options_inches.length > 0 && (
+        {(loom.weaving_width_options_cm?.length || loom.weaving_width_options_inches?.length) ? (
           <>
             <span className="text-stone-500">Width</span>
-            <WidthBadge options={loom.weaving_width_options_inches} />
+            <WidthBadge loom={loom} />
           </>
-        )}
+        ) : null}
         {loom.shedding_mechanism && (
           <>
             <span className="text-stone-500">Shedding</span>
@@ -84,8 +93,9 @@ function LoomCard({ loom }: { loom: LoomReferenceSummary }) {
 export function LoomCatalogPage() {
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
-  const [category, setCategory] = useState("");
-  const [foldable, setFoldable] = useState<"" | "true" | "false">("");
+  const [loomType, setLoomType] = useState("");
+  const [manufacturer, setManufacturer] = useState("");
+  const [shaftCount, setShaftCount] = useState("");
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -94,22 +104,49 @@ export function LoomCatalogPage() {
     return () => { if (timerRef.current) clearTimeout(timerRef.current); };
   }, [search]);
 
-  const { data: looms = [], isLoading } = useQuery({
-    queryKey: ["loom-catalog-public", debouncedSearch, category, foldable],
-    queryFn: () =>
-      listLoomCatalog({
-        q: debouncedSearch || undefined,
-        category: category || undefined,
-        foldable: foldable === "" ? undefined : foldable === "true",
-      }),
+  // Load all looms; only text search is server-side. Other filters are client-side
+  // so dropdown options stay stable as you filter.
+  const { data: allLooms = [], isLoading } = useQuery({
+    queryKey: ["loom-catalog-public", debouncedSearch],
+    queryFn: () => listLoomCatalog({ q: debouncedSearch || undefined }),
   });
 
-  const brands = [...new Set(looms.map((l) => l.brand))].sort();
+  // Derive dropdown options from the full server result (stable across client filters)
+  const manufacturerOptions = useMemo(
+    () => [...new Set(allLooms.map((l) => l.brand))].sort(),
+    [allLooms],
+  );
 
-  const grouped = brands.reduce<Record<string, LoomReferenceSummary[]>>((acc, brand) => {
-    acc[brand] = looms.filter((l) => l.brand === brand);
-    return acc;
-  }, {});
+  const shaftCountOptions = useMemo(() => {
+    const counts = new Set<number>();
+    for (const l of allLooms) {
+      for (const n of l.shaft_count_options ?? []) counts.add(Math.round(n));
+    }
+    return [...counts].sort((a, b) => a - b);
+  }, [allLooms]);
+
+  // Apply client-side filters
+  const looms = useMemo(() => {
+    return allLooms.filter((l) => {
+      if (loomType && l.loom_category !== loomType) return false;
+      if (manufacturer && l.brand !== manufacturer) return false;
+      if (shaftCount) {
+        const n = Number(shaftCount);
+        if (!(l.shaft_count_options ?? []).some((s) => Math.round(s) === n)) return false;
+      }
+      return true;
+    });
+  }, [allLooms, loomType, manufacturer, shaftCount]);
+
+  const brands = [...new Set(looms.map((l) => l.brand))].sort();
+  const grouped = Object.fromEntries(
+    brands.map((brand) => [brand, looms.filter((l) => l.brand === brand)]),
+  );
+
+  const hasFilters = search || loomType || manufacturer || shaftCount;
+
+  const selectClass =
+    "rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400";
 
   return (
     <div className="flex min-h-screen flex-col bg-stone-50 text-stone-900">
@@ -117,7 +154,12 @@ export function LoomCatalogPage() {
         <div className="mx-auto flex max-w-5xl items-center justify-between gap-3">
           <Link to="/" className="flex items-center gap-3 hover:opacity-80 transition-opacity">
             <WeftmarkLogo className="h-8 w-auto text-amber-800" />
-            <span className="text-lg font-semibold tracking-tight" style={{ fontFamily: '"Segoe UI", system-ui, sans-serif' }}>weftmark</span>
+            <span
+              className="text-lg font-semibold tracking-tight"
+              style={{ fontFamily: '"Segoe UI", system-ui, sans-serif' }}
+            >
+              weftmark
+            </span>
           </Link>
           <Link to="/login" className="text-sm text-stone-600 hover:text-stone-900 transition-colors">
             Sign in
@@ -131,8 +173,10 @@ export function LoomCatalogPage() {
             <h1 className="text-3xl font-bold tracking-tight mb-2">Supported looms</h1>
             <p className="text-stone-600">
               Looms in our catalog can be selected during loom setup for automatic spec pre-fill.
-              {looms.length > 0 && (
-                <span className="ml-1 text-stone-500">{looms.length} {looms.length === 1 ? "loom" : "looms"} in the catalog.</span>
+              {allLooms.length > 0 && (
+                <span className="ml-1 text-stone-500">
+                  {allLooms.length} {allLooms.length === 1 ? "loom" : "looms"} in the catalog.
+                </span>
               )}
             </p>
           </div>
@@ -144,30 +188,52 @@ export function LoomCatalogPage() {
               placeholder="Search brand or model…"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 w-64"
+              className="rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 w-56"
             />
+
             <select
-              value={category}
-              onChange={(e) => setCategory(e.target.value)}
-              className="rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+              value={loomType}
+              onChange={(e) => setLoomType(e.target.value)}
+              className={selectClass}
             >
-              <option value="">All categories</option>
-              {ALL_CATEGORIES.map((c) => (
-                <option key={c.value} value={c.value}>{c.label}</option>
+              <option value="">All loom types</option>
+              {Object.entries(LOOM_TYPE_LABELS).map(([value, label]) => (
+                <option key={value} value={value}>{label}</option>
               ))}
             </select>
+
             <select
-              value={foldable}
-              onChange={(e) => setFoldable(e.target.value as "" | "true" | "false")}
-              className="rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+              value={manufacturer}
+              onChange={(e) => setManufacturer(e.target.value)}
+              className={selectClass}
+              disabled={manufacturerOptions.length === 0}
             >
-              <option value="">Foldable: any</option>
-              <option value="true">Foldable only</option>
-              <option value="false">Non-foldable only</option>
+              <option value="">All manufacturers</option>
+              {manufacturerOptions.map((b) => (
+                <option key={b} value={b}>{b}</option>
+              ))}
             </select>
-            {(search || category || foldable) && (
+
+            <select
+              value={shaftCount}
+              onChange={(e) => setShaftCount(e.target.value)}
+              className={selectClass}
+              disabled={shaftCountOptions.length === 0}
+            >
+              <option value="">Any shaft count</option>
+              {shaftCountOptions.map((n) => (
+                <option key={n} value={n}>{n} shafts</option>
+              ))}
+            </select>
+
+            {hasFilters && (
               <button
-                onClick={() => { setSearch(""); setCategory(""); setFoldable(""); }}
+                onClick={() => {
+                  setSearch("");
+                  setLoomType("");
+                  setManufacturer("");
+                  setShaftCount("");
+                }}
                 className="text-sm text-stone-500 hover:text-stone-700 transition-colors"
               >
                 Clear filters
@@ -179,9 +245,7 @@ export function LoomCatalogPage() {
             <div className="text-center py-16 text-stone-400">Loading catalog…</div>
           ) : looms.length === 0 ? (
             <div className="text-center py-16 text-stone-400">
-              {debouncedSearch || category || foldable
-                ? "No looms match these filters."
-                : "The catalog is empty."}
+              {hasFilters ? "No looms match these filters." : "The catalog is empty."}
             </div>
           ) : (
             <div className="space-y-8">

--- a/frontend/src/pages/LoomDetailPage.tsx
+++ b/frontend/src/pages/LoomDetailPage.tsx
@@ -827,6 +827,7 @@ export function LoomDetailPage() {
   const [confirmForceDelete, setConfirmForceDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [retiring, setRetiring] = useState(false);
+  const [confirmRetire, setConfirmRetire] = useState(false);
   const [dangerZoneOpen, setDangerZoneOpen] = useState(false);
   const [unlinking, setUnlinking] = useState(false);
 
@@ -1042,9 +1043,20 @@ export function LoomDetailPage() {
                         : "Hide this loom from active lists without deleting it. Existing projects are unaffected."}
                     </p>
                   </div>
-                  <Button variant="outline" size="sm" className="shrink-0" onClick={handleRetire} disabled={retiring}>
-                    {loom.retired_at ? "Unretire" : "Retire"}
-                  </Button>
+                  {!confirmRetire ? (
+                    <Button variant="outline" size="sm" className="shrink-0" onClick={() => setConfirmRetire(true)}>
+                      {loom.retired_at ? "Unretire" : "Retire"}
+                    </Button>
+                  ) : (
+                    <div className="flex gap-2 shrink-0">
+                      <Button variant="outline" size="sm"
+                        onClick={() => { setConfirmRetire(false); handleRetire(); }}
+                        disabled={retiring}>
+                        Confirm
+                      </Button>
+                      <Button variant="ghost" size="sm" onClick={() => setConfirmRetire(false)}>Cancel</Button>
+                    </div>
+                  )}
                 </div>
 
                 {/* Delete */}

--- a/frontend/src/pages/LoomDetailPage.tsx
+++ b/frontend/src/pages/LoomDetailPage.tsx
@@ -7,7 +7,7 @@ import { measurementSystemToUnit, displayLength, convertLength, type LengthUnit 
 import { listProjects } from "@/api/projects";
 import { ProjectSummaryList } from "@/components/projects/ProjectSummaryList";
 import {
-  getLoom, deleteLoom, uploadLoomPhoto, deleteLoomPhoto, loomPhotoUrl,
+  getLoom, deleteLoom, retireLoom, unretireLoom, uploadLoomPhoto, deleteLoomPhoto, loomPhotoUrl,
   uploadVersionPhoto, deleteVersionPhoto, versionPhotoUrl,
   uploadVersionReceipt, deleteVersionReceipt, versionReceiptUrl,
   addAccessory, deleteAccessory, updateVersion,
@@ -16,6 +16,7 @@ import {
   type LoomVersionReceipt, type LoomVersionAccessory, type LoomReed,
   LOOM_TYPE_LABELS, SUPPORTED_LOOM_TYPES,
 } from "@/api/looms";
+import { type DeleteConflict } from "@/api/drafts";
 import { AddVersionModal } from "@/components/looms/AddVersionModal";
 import { EditLoomModal } from "@/components/looms/EditLoomModal";
 import { CloneVersionModal } from "@/components/looms/CloneVersionModal";
@@ -822,7 +823,10 @@ export function LoomDetailPage() {
   const [showLinkCatalog, setShowLinkCatalog] = useState(false);
   const [cloneSource, setCloneSource] = useState<LoomVersion | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [deleteConflict, setDeleteConflict] = useState<DeleteConflict | null>(null);
+  const [confirmForceDelete, setConfirmForceDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [retiring, setRetiring] = useState(false);
   const [dangerZoneOpen, setDangerZoneOpen] = useState(false);
   const [unlinking, setUnlinking] = useState(false);
 
@@ -852,16 +856,37 @@ export function LoomDetailPage() {
     setShowEdit(false);
   };
 
-  const handleDelete = async () => {
+  const handleDelete = async (force = false) => {
     if (!id) return;
     setDeleting(true);
     try {
-      await deleteLoom(id);
+      const result = await deleteLoom(id, force);
+      if (result && "code" in result) {
+        setDeleteConflict(result as DeleteConflict);
+        setConfirmDelete(false);
+        setDeleting(false);
+        return;
+      }
       queryClient.invalidateQueries({ queryKey: ["looms"] });
       navigate("/looms", { replace: true });
     } catch {
       setDeleting(false);
       setConfirmDelete(false);
+    }
+  };
+
+  const handleRetire = async () => {
+    if (!id || !loom) return;
+    setRetiring(true);
+    try {
+      if (loom.retired_at) {
+        await unretireLoom(id);
+      } else {
+        await retireLoom(id);
+      }
+      invalidate();
+    } finally {
+      setRetiring(false);
     }
   };
 
@@ -1000,28 +1025,78 @@ export function LoomDetailPage() {
             <button
               type="button"
               className="flex w-full items-center justify-between text-sm font-medium text-destructive hover:text-destructive/80"
-              onClick={() => { setDangerZoneOpen((o) => !o); setConfirmDelete(false); }}
+              onClick={() => { setDangerZoneOpen((o) => !o); setConfirmDelete(false); setDeleteConflict(null); setConfirmForceDelete(false); }}
             >
               <span>Danger zone</span>
               <span className="text-xs text-muted-foreground">{dangerZoneOpen ? "▲ collapse" : "▼ expand"}</span>
             </button>
             {dangerZoneOpen && (
-              <div className="mt-4 rounded-md border border-destructive/30 px-4 py-4">
-                <div className="flex items-start justify-between gap-4">
+              <div className="mt-4 space-y-3">
+                {/* Retire / Unretire */}
+                <div className="rounded-md border border-border px-4 py-4 flex items-start justify-between gap-4">
                   <div>
-                    <p className="text-sm font-medium">Delete this loom</p>
-                    <p className="mt-0.5 text-xs text-muted-foreground">Permanently removes the loom and all its configurations. This cannot be undone.</p>
+                    <p className="text-sm font-medium">{loom.retired_at ? "Unretire loom" : "Retire loom"}</p>
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      {loom.retired_at
+                        ? "Restore this loom to your active equipment list."
+                        : "Hide this loom from active lists without deleting it. Existing projects are unaffected."}
+                    </p>
                   </div>
-                  {!confirmDelete ? (
-                    <Button variant="outline" size="sm" className="shrink-0 border-destructive/50 text-destructive hover:bg-destructive/10" onClick={() => setConfirmDelete(true)}>
-                      Delete loom
-                    </Button>
-                  ) : (
-                    <div className="flex shrink-0 items-center gap-2">
-                      <Button variant="outline" size="sm" onClick={() => setConfirmDelete(false)} disabled={deleting}>Cancel</Button>
-                      <Button size="sm" onClick={handleDelete} disabled={deleting} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
-                        {deleting ? "Deleting…" : "Confirm delete"}
+                  <Button variant="outline" size="sm" className="shrink-0" onClick={handleRetire} disabled={retiring}>
+                    {loom.retired_at ? "Unretire" : "Retire"}
+                  </Button>
+                </div>
+
+                {/* Delete */}
+                <div className="rounded-md border border-destructive/30 px-4 py-4 space-y-3">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <p className="text-sm font-medium">Delete this loom</p>
+                      <p className="mt-0.5 text-xs text-muted-foreground">Permanently removes the loom and all its configurations. This cannot be undone.</p>
+                    </div>
+                    {!confirmDelete && !deleteConflict ? (
+                      <Button variant="outline" size="sm" className="shrink-0 border-destructive/50 text-destructive hover:bg-destructive/10" onClick={() => setConfirmDelete(true)}>
+                        Delete loom
                       </Button>
+                    ) : confirmDelete ? (
+                      <div className="flex shrink-0 items-center gap-2">
+                        <Button variant="outline" size="sm" onClick={() => setConfirmDelete(false)} disabled={deleting}>Cancel</Button>
+                        <Button size="sm" onClick={() => handleDelete(false)} disabled={deleting} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
+                          {deleting ? "Deleting…" : "Confirm delete"}
+                        </Button>
+                      </div>
+                    ) : null}
+                  </div>
+
+                  {/* 409 conflict */}
+                  {deleteConflict && (
+                    <div className="space-y-2">
+                      <p className="text-sm text-destructive font-medium">
+                        This loom is used by {deleteConflict.projects.length} active project{deleteConflict.projects.length !== 1 ? "s" : ""}:
+                      </p>
+                      <ul className="text-xs text-muted-foreground space-y-0.5 pl-3">
+                        {deleteConflict.projects.map((p) => <li key={p.id}>· {p.name}</li>)}
+                      </ul>
+                      <p className="text-xs text-muted-foreground">
+                        The loom will be unlinked from those projects. Projects themselves will not be deleted.
+                      </p>
+                      {!confirmForceDelete ? (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="border-destructive/50 text-destructive hover:bg-destructive/10"
+                          onClick={() => setConfirmForceDelete(true)}
+                        >
+                          Force delete (unlinks {deleteConflict.projects.length} project{deleteConflict.projects.length !== 1 ? "s" : ""})
+                        </Button>
+                      ) : (
+                        <div className="flex gap-2">
+                          <Button size="sm" onClick={() => handleDelete(true)} disabled={deleting} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
+                            {deleting ? "Deleting…" : "Confirm force delete"}
+                          </Button>
+                          <Button variant="outline" size="sm" onClick={() => { setDeleteConflict(null); setConfirmForceDelete(false); }}>Cancel</Button>
+                        </div>
+                      )}
                     </div>
                   )}
                 </div>

--- a/frontend/src/pages/LoomsPage.tsx
+++ b/frontend/src/pages/LoomsPage.tsx
@@ -14,7 +14,7 @@ interface LoomProjectCounts {
   abandoned: number;
 }
 
-function LoomCard({ loom, projectCounts }: { loom: Loom; projectCounts?: LoomProjectCounts }) {
+function LoomCard({ loom, projectCounts, retired }: { loom: Loom; projectCounts?: LoomProjectCounts; retired?: boolean }) {
   const v = loom.current_version;
   return (
     <Link
@@ -47,7 +47,10 @@ function LoomCard({ loom, projectCounts }: { loom: Loom; projectCounts?: LoomPro
             )}
           </div>
         </div>
-        <div className="text-right text-xs text-muted-foreground shrink-0">
+        <div className="flex items-center gap-2 shrink-0 text-right text-xs text-muted-foreground">
+          {retired && (
+            <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">Retired</span>
+          )}
           {v && (
             <span>
               {v.num_shafts != null ? `${v.num_shafts}S` : null}
@@ -96,11 +99,12 @@ function LoomCard({ loom, projectCounts }: { loom: Loom; projectCounts?: LoomPro
 
 export function LoomsPage() {
   const [showNew, setShowNew] = useState(false);
+  const [showRetired, setShowRetired] = useState(false);
   const queryClient = useQueryClient();
 
   const { data: looms, isLoading, error } = useQuery({
-    queryKey: ["looms"],
-    queryFn: listLooms,
+    queryKey: ["looms", { includeRetired: showRetired }],
+    queryFn: () => listLooms(showRetired),
   });
 
   const { data: projects = [] } = useQuery({
@@ -133,6 +137,13 @@ export function LoomsPage() {
           <Link to="/catalog/looms" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
             Browse loom catalog
           </Link>
+          <button
+            type="button"
+            onClick={() => setShowRetired((v) => !v)}
+            className={`text-sm transition-colors ${showRetired ? "text-foreground font-medium" : "text-muted-foreground hover:text-foreground"}`}
+          >
+            {showRetired ? "Hide retired" : "Show retired"}
+          </button>
           <Button size="sm" onClick={() => setShowNew(true)}>New loom</Button>
         </div>
       </div>
@@ -143,21 +154,42 @@ export function LoomsPage() {
           Failed to load looms
         </p>
       )}
-      {looms && looms.length === 0 && (
-        <div className="flex flex-col items-center justify-center py-20 text-center">
-          <p className="text-muted-foreground">No looms yet.</p>
-          <Button className="mt-4" onClick={() => setShowNew(true)}>
-            Add your first loom
-          </Button>
-        </div>
-      )}
-      {looms && looms.length > 0 && (
-        <div className="grid gap-4 sm:grid-cols-2">
-          {looms.map((l) => (
-            <LoomCard key={l.id} loom={l} projectCounts={projectCountsByLoom[l.id]} />
-          ))}
-        </div>
-      )}
+
+      {(() => {
+        const activeLooms = (looms ?? []).filter((l) => !l.retired_at);
+        const retiredLooms = (looms ?? []).filter((l) => l.retired_at);
+        return (
+          <>
+            {looms && activeLooms.length === 0 && retiredLooms.length === 0 && (
+              <div className="flex flex-col items-center justify-center py-20 text-center">
+                <p className="text-muted-foreground">{showRetired ? "No retired looms." : "No looms yet."}</p>
+                {!showRetired && (
+                  <Button className="mt-4" onClick={() => setShowNew(true)}>
+                    Add your first loom
+                  </Button>
+                )}
+              </div>
+            )}
+            {activeLooms.length > 0 && (
+              <div className="grid gap-4 sm:grid-cols-2">
+                {activeLooms.map((l) => (
+                  <LoomCard key={l.id} loom={l} projectCounts={projectCountsByLoom[l.id]} />
+                ))}
+              </div>
+            )}
+            {showRetired && retiredLooms.length > 0 && (
+              <div className="mt-8">
+                <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide mb-3">Retired</h2>
+                <div className="grid gap-4 sm:grid-cols-2 opacity-60">
+                  {retiredLooms.map((l) => (
+                    <LoomCard key={l.id} loom={l} projectCounts={projectCountsByLoom[l.id]} retired />
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
+        );
+      })()}
 
       {showNew && (
         <NewLoomModal onSuccess={handleSuccess} onClose={() => setShowNew(false)} />

--- a/frontend/src/pages/LoomsPage.tsx
+++ b/frontend/src/pages/LoomsPage.tsx
@@ -99,12 +99,12 @@ function LoomCard({ loom, projectCounts, retired }: { loom: Loom; projectCounts?
 
 export function LoomsPage() {
   const [showNew, setShowNew] = useState(false);
-  const [showRetired, setShowRetired] = useState(false);
+  const [retiredOpen, setRetiredOpen] = useState(false);
   const queryClient = useQueryClient();
 
   const { data: looms, isLoading, error } = useQuery({
-    queryKey: ["looms", { includeRetired: showRetired }],
-    queryFn: () => listLooms(showRetired),
+    queryKey: ["looms", { includeRetired: true }],
+    queryFn: () => listLooms(true),
   });
 
   const { data: projects = [] } = useQuery({
@@ -129,23 +129,19 @@ export function LoomsPage() {
     queryClient.invalidateQueries({ queryKey: ["looms"] });
   };
 
+  const activeLooms = (looms ?? []).filter((l) => !l.retired_at);
+  const retiredLooms = (looms ?? []).filter((l) => l.retired_at);
+
   return (
     <div className="p-6 max-w-4xl mx-auto w-full">
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex items-center justify-between mb-1">
         <h1 className="text-xl font-semibold">Equipment</h1>
-        <div className="flex items-center gap-3">
-          <Link to="/catalog/looms" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
-            Browse loom catalog
-          </Link>
-          <button
-            type="button"
-            onClick={() => setShowRetired((v) => !v)}
-            className={`text-sm transition-colors ${showRetired ? "text-foreground font-medium" : "text-muted-foreground hover:text-foreground"}`}
-          >
-            {showRetired ? "Hide retired" : "Show retired"}
-          </button>
-          <Button size="sm" onClick={() => setShowNew(true)}>New loom</Button>
-        </div>
+        <Button size="sm" onClick={() => setShowNew(true)}>New loom</Button>
+      </div>
+      <div className="mb-6">
+        <Link to="/catalog/looms" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+          Browse loom catalog
+        </Link>
       </div>
 
       {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
@@ -155,41 +151,44 @@ export function LoomsPage() {
         </p>
       )}
 
-      {(() => {
-        const activeLooms = (looms ?? []).filter((l) => !l.retired_at);
-        const retiredLooms = (looms ?? []).filter((l) => l.retired_at);
-        return (
-          <>
-            {looms && activeLooms.length === 0 && retiredLooms.length === 0 && (
-              <div className="flex flex-col items-center justify-center py-20 text-center">
-                <p className="text-muted-foreground">{showRetired ? "No retired looms." : "No looms yet."}</p>
-                {!showRetired && (
-                  <Button className="mt-4" onClick={() => setShowNew(true)}>
-                    Add your first loom
-                  </Button>
-                )}
-              </div>
-            )}
-            {activeLooms.length > 0 && (
-              <div className="grid gap-4 sm:grid-cols-2">
-                {activeLooms.map((l) => (
-                  <LoomCard key={l.id} loom={l} projectCounts={projectCountsByLoom[l.id]} />
-                ))}
-              </div>
-            )}
-            {showRetired && retiredLooms.length > 0 && (
-              <div className="mt-8">
-                <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide mb-3">Retired</h2>
-                <div className="grid gap-4 sm:grid-cols-2 opacity-60">
-                  {retiredLooms.map((l) => (
-                    <LoomCard key={l.id} loom={l} projectCounts={projectCountsByLoom[l.id]} retired />
-                  ))}
-                </div>
-              </div>
-            )}
-          </>
-        );
-      })()}
+      {looms && activeLooms.length === 0 && retiredLooms.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-20 text-center">
+          <p className="text-muted-foreground">No looms yet.</p>
+          <Button className="mt-4" onClick={() => setShowNew(true)}>
+            Add your first loom
+          </Button>
+        </div>
+      )}
+
+      {activeLooms.length > 0 && (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {activeLooms.map((l) => (
+            <LoomCard key={l.id} loom={l} projectCounts={projectCountsByLoom[l.id]} />
+          ))}
+        </div>
+      )}
+
+      {retiredLooms.length > 0 && (
+        <div className="mt-8">
+          <button
+            type="button"
+            onClick={() => setRetiredOpen((v) => !v)}
+            className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors w-full text-left"
+          >
+            <AppIcons.chevronDown
+              className={`h-4 w-4 transition-transform duration-200 ${retiredOpen ? "rotate-180" : ""}`}
+            />
+            Retired ({retiredLooms.length})
+          </button>
+          {retiredOpen && (
+            <div className="mt-3 grid gap-4 sm:grid-cols-2 opacity-60">
+              {retiredLooms.map((l) => (
+                <LoomCard key={l.id} loom={l} projectCounts={projectCountsByLoom[l.id]} retired />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
 
       {showNew && (
         <NewLoomModal onSuccess={handleSuccess} onClose={() => setShowNew(false)} />

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -19,7 +19,7 @@ export function SettingsPage() {
 
   const { data: drafts = [] } = useQuery({
     queryKey: ["drafts"],
-    queryFn: listDrafts,
+    queryFn: () => listDrafts(),
   });
   const sharedDraftCount = drafts.filter((d) => d.is_shared).length;
 


### PR DESCRIPTION
## Summary

- **Archive for drafts, Retire for looms** — reversible soft-deactivation using shared `RetireMixin`; column is `retired_at` internally, exposed as `archived_at` in draft API responses
- **Deletion guard** — `DELETE /api/drafts/{id}` and `DELETE /api/looms/{id}` return 409 with project list when item is referenced by non-deleted projects; `?force=true` bypasses (drafts cascade-delete projects; looms nullify `loom_id` on projects without deleting them)
- **List filtering** — `GET /api/drafts?include_archived=true` and `GET /api/looms?include_retired=true` include hidden items
- **Migration 0030** — adds `retired_at` column to both `drafts` and `looms` tables
- **Catalog request button** rewritten to use internal feedback workflow (no GitHub account needed for users)
- **Loom catalog filters** — loom type, manufacturer, shaft count dropdowns; dual-unit width display (`39" (100 cm)`)
- **Backend tests** — deletion guard (409, force-delete cascade), archive/retire endpoints, include_archived/include_retired list param

## Test plan

- [ ] Archive a draft → disappears from `/drafts` list, appears with "Archived" badge under "Show archived"
- [ ] Unarchive → returns to active list
- [ ] Delete a draft used by an active project → 409 shown with project list; force-delete → draft and project both gone
- [ ] Retire a loom → disappears from `/looms` list; "Show retired" reveals it in collapsed section
- [ ] Unretire → returns to active list
- [ ] Delete a loom used by an active project → 409; force-delete → loom gone, project remains with loom unassigned
- [ ] Loom catalog: loom type / manufacturer / shaft count dropdowns filter correctly; width shows both units
- [ ] "Request catalog addition" button opens modal → submits without needing GitHub account

🤖 Generated with [Claude Code](https://claude.com/claude-code)