### PR TITLE
feat: user-defined tags on drafts and projects (#781)

### DIFF
--- a/backend/alembic/versions/0032_tags.py
+++ b/backend/alembic/versions/0032_tags.py
@@ -1,0 +1,25 @@
+"""add tags to drafts and projects
+
+Revision ID: 0032_tags
+Revises: 0031_collections
+Create Date: 2026-05-19
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "0032_tags"
+down_revision = "0031_collections"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("drafts", sa.Column("tags", JSONB, nullable=False, server_default="[]"))
+    op.add_column("projects", sa.Column("tags", JSONB, nullable=False, server_default="[]"))
+
+
+def downgrade() -> None:
+    op.drop_column("drafts", "tags")
+    op.drop_column("projects", "tags")

--- a/backend/app/models/draft.py
+++ b/backend/app/models/draft.py
@@ -88,6 +88,9 @@ class Draft(Base, TimestampMixin, SoftDeleteMixin, RetireMixin):
     # User-entered EPI override (ends per inch; null = derive from WIF warp_spacing or width ÷ thread count).
     epi_override: Mapped[float | None] = mapped_column(Float, nullable=True)
 
+    # User-defined tags for categorisation (e.g. "twill", "cotton", "gift")
+    tags: Mapped[list] = mapped_column(JSONB, default=list, nullable=False)
+
     # Sharing
     is_shared: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     share_slug: Mapped[str | None] = mapped_column(String(64), unique=True, nullable=True)

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -66,6 +66,7 @@ class Project(Base, TimestampMixin, SoftDeleteMixin):
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
     hide_unused_shafts_treadles: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     color_replacements: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    tags: Mapped[list] = mapped_column(JSONB, default=list, nullable=False)
     reed_dents_per_inch: Mapped[float | None] = mapped_column(Float, nullable=True)
     drawdown_preview_path: Mapped[str | None] = mapped_column(String(500), nullable=True)
     drawdown_svg_path: Mapped[str | None] = mapped_column(String(500), nullable=True)

--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -86,6 +86,7 @@ class DraftSummary(BaseModel):
     epi_override: float | None
     is_shared: bool
     archived_at: datetime | None
+    tags: list[str]
     created_at: datetime
     updated_at: datetime
 
@@ -98,12 +99,19 @@ class DraftSummary(BaseModel):
         data["has_drawdown_preview"] = storage.drawdown_preview_exists(d.drawdown_preview_path)
         data["has_modified_file"] = bool(d.wif_modified_path and storage.file_exists(d.wif_modified_path))
         data["archived_at"] = data.pop("retired_at", None)
+        data.setdefault("tags", [])
         return cls(**data)
 
 
 class DraftDetail(DraftSummary):
     wif_source_software: str | None
     wif_source_version: str | None
+
+
+class UpdateDraftRequest(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    tags: list[str] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -116,6 +124,7 @@ async def create_draft(
     name: Annotated[str, Form()],
     wif_file: Annotated[UploadFile, File()],
     description: Annotated[str | None, Form()] = None,
+    tags: Annotated[str | None, Form()] = None,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
     _rl: None = Depends(_upload_rate_limit),
@@ -140,10 +149,20 @@ async def create_draft(
     lint = wif_linter.lint(wif_bytes)
     measurements = wif_parser.extract_measurements(wif_bytes)
 
+    import json as _json
+
+    parsed_tags: list[str] = []
+    if tags:
+        try:
+            parsed_tags = [str(t).strip().lower() for t in _json.loads(tags) if str(t).strip()]
+        except (ValueError, TypeError):
+            parsed_tags = [t.strip().lower() for t in tags.split(",") if t.strip()]
+
     draft = Draft(
         owner_id=current_user.id,
         name=name,
         description=description,
+        tags=parsed_tags,
         wif_filename=wif_file.filename,
         wif_path="",  # set after we have the draft id
         num_shafts=lint.num_shafts,
@@ -193,6 +212,7 @@ async def create_draft(
 @router.get("", response_model=list[DraftSummary])
 async def list_drafts(
     include_archived: bool = Query(False),
+    tags: list[str] | None = Query(None),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> list[DraftSummary]:
@@ -201,7 +221,10 @@ async def list_drafts(
         q = q.where(Draft.retired_at.is_(None))
     q = q.order_by(Draft.created_at.desc())
     result = await db.scalars(q)
-    return [DraftSummary.from_draft(d) for d in result.all()]
+    drafts = result.all()
+    if tags:
+        drafts = [d for d in drafts if any(t in (d.tags or []) for t in tags)]
+    return [DraftSummary.from_draft(d) for d in drafts]
 
 
 # ---------------------------------------------------------------------------
@@ -216,6 +239,30 @@ async def get_draft(
     db: AsyncSession = Depends(get_db),
 ) -> DraftDetail:
     draft = await _get_owned_draft(draft_id, current_user, db, allow_superuser=True)
+    return DraftDetail(**_draft_detail_data(draft))
+
+
+@router.patch("/{draft_id}", response_model=DraftDetail)
+async def update_draft(
+    draft_id: uuid.UUID,
+    body: UpdateDraftRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> DraftDetail:
+    if body.name is None and body.description is None and body.tags is None:
+        raise HTTPException(status_code=400, detail="At least one field must be provided")
+    draft = await _get_owned_draft(draft_id, current_user, db)
+    if body.name is not None:
+        name = body.name.strip()
+        if not name:
+            raise HTTPException(status_code=400, detail="Name cannot be empty")
+        draft.name = name
+    if body.description is not None:
+        draft.description = body.description or None
+    if body.tags is not None:
+        draft.tags = [t.strip().lower() for t in body.tags if t.strip()]
+    await db.commit()
+    await db.refresh(draft)
     return DraftDetail(**_draft_detail_data(draft))
 
 

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -74,6 +74,7 @@ class ProjectSummary(BaseModel):
     share_slug: str | None = None
     share_visibility: str = "private"
     share_expires_at: datetime | None = None
+    tags: list[str] = []
 
     model_config = {"from_attributes": True}
 
@@ -122,12 +123,14 @@ class CreateProjectRequest(BaseModel):
     waste_between_items: Decimal | None = None
     warp_waste_allowance: Decimal | None = None
     length_unit: str = "cm"
+    tags: list[str] = []
 
 
 class RenameProjectRequest(BaseModel):
     name: str | None = None
     notes: str | None = None
     hide_unused_shafts_treadles: bool | None = None
+    tags: list[str] | None = None
 
 
 class WarpSetupRequest(BaseModel):
@@ -429,6 +432,7 @@ def _to_detail(
         share_visibility=project.share_visibility,
         share_expires_at=project.share_expires_at,
         reed_dents_per_inch=project.reed_dents_per_inch,
+        tags=project.tags or [],
         loom_reeds=loom_reeds or [],
         photos=[ProjectPhotoSchema.model_validate(p) for p in (photos or [])],
     )
@@ -520,6 +524,7 @@ async def create_project(
         warp_waste_allowance=body.warp_waste_allowance,
         length_unit=body.length_unit,
         hide_unused_shafts_treadles=current_user.hide_unused_shafts_treadles,
+        tags=[t.strip().lower() for t in body.tags if t.strip()],
     )
     db.add(project)
     await db.commit()
@@ -540,6 +545,7 @@ async def create_project(
 async def list_projects(
     draft_id: uuid.UUID | None = Query(None),
     loom_id: uuid.UUID | None = Query(None),
+    tags: list[str] | None = Query(None),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> list[ProjectSummary]:
@@ -549,7 +555,10 @@ async def list_projects(
     if loom_id is not None:
         q = q.where(Project.loom_id == loom_id)
     result = await db.scalars(q.order_by(Project.created_at.desc()))
-    return [ProjectSummary.model_validate(p) for p in result.all()]
+    projects = result.all()
+    if tags:
+        projects = [p for p in projects if any(t in (p.tags or []) for t in tags)]
+    return [ProjectSummary.model_validate(p) for p in projects]
 
 
 @router.get("/{project_id}/drawdown")
@@ -896,7 +905,7 @@ async def rename_project(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> ProjectDetail:
-    if body.name is None and body.notes is None and body.hide_unused_shafts_treadles is None:
+    if body.name is None and body.notes is None and body.hide_unused_shafts_treadles is None and body.tags is None:
         raise HTTPException(status_code=400, detail="At least one field must be provided")
     project = await _get_owned_project(project_id, current_user, db)
     if body.name is not None:
@@ -908,6 +917,8 @@ async def rename_project(
         project.notes = body.notes
     if body.hide_unused_shafts_treadles is not None:
         project.hide_unused_shafts_treadles = body.hide_unused_shafts_treadles
+    if body.tags is not None:
+        project.tags = [t.strip().lower() for t in body.tags if t.strip()]
     await db.commit()
     await db.refresh(project)
     draft = await db.get(Draft, project.draft_id)

--- a/backend/tests/routers/test_tags.py
+++ b/backend/tests/routers/test_tags.py
@@ -1,0 +1,302 @@
+"""Tests for tags on drafts and projects (#781)."""
+
+import io
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.draft import Draft
+from app.models.project import Project
+from app.models.user import User
+
+
+@pytest.fixture(autouse=True)
+def _mock_draft_tasks(monkeypatch):
+    monkeypatch.setattr("app.routers.drafts.generate_drawdown_preview", MagicMock())
+    monkeypatch.setattr("app.routers.drafts.prerender_drawdown_tiles", MagicMock())
+
+
+@pytest.fixture(autouse=True)
+def _mock_project_tasks(monkeypatch):
+    monkeypatch.setattr("app.routers.projects.generate_drawdown_preview", MagicMock())
+    monkeypatch.setattr("app.routers.projects.prerender_project_tiles", MagicMock())
+    monkeypatch.setattr("app.routers.projects.generate_project_drawdown_preview", MagicMock())
+    monkeypatch.setattr("app.routers.projects.generate_project_drawdown_svg", MagicMock())
+
+
+_WIF = b"""[WIF]
+Version=1.1
+[CONTENTS]
+THREADING=true
+TIEUP=true
+TREADLING=true
+[WEAVING]
+Shafts=4
+Treadles=4
+Rising Shed=true
+[WARP]
+Threads=4
+[WEFT]
+Threads=4
+[THREADING]
+1=1
+2=2
+3=3
+4=4
+[TIEUP]
+1=1
+2=2
+3=3
+4=4
+[TREADLING]
+1=1
+2=2
+3=3
+4=4
+"""
+
+
+async def _insert_draft(db: AsyncSession, owner: User, *, tags: list[str] | None = None) -> Draft:
+    import app.services.storage as storage
+
+    draft_id = uuid.uuid4()
+    wif_key = storage.save_wif(draft_id, "test.wif", _WIF)
+    d = Draft(
+        id=draft_id,
+        owner_id=owner.id,
+        name="Test Draft",
+        wif_filename="test.wif",
+        wif_path=wif_key,
+        has_treadling=True,
+        num_shafts=4,
+        num_treadles=4,
+        weft_threads=4,
+        tags=tags or [],
+    )
+    db.add(d)
+    await db.commit()
+    return d
+
+
+async def _insert_project(db: AsyncSession, owner: User, draft: Draft, *, tags: list[str] | None = None) -> Project:
+    p = Project(
+        owner_id=owner.id,
+        draft_id=draft.id,
+        name="Test Project",
+        project_type="treadle",
+        status="created",
+        total_picks=100,
+        tags=tags or [],
+    )
+    db.add(p)
+    await db.commit()
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Draft tags — upload
+# ---------------------------------------------------------------------------
+
+
+class TestDraftUploadTags:
+    async def test_upload_with_tags_stores_them(self, auth_client: AsyncClient):
+        resp = await auth_client.post(
+            "/api/drafts",
+            data={"name": "Tagged Draft", "tags": '["twill", "cotton"]'},
+            files={"wif_file": ("test.wif", io.BytesIO(_WIF), "text/plain")},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["tags"] == ["twill", "cotton"]
+
+    async def test_upload_without_tags_defaults_empty(self, auth_client: AsyncClient):
+        resp = await auth_client.post(
+            "/api/drafts",
+            data={"name": "Plain Draft"},
+            files={"wif_file": ("test.wif", io.BytesIO(_WIF), "text/plain")},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["tags"] == []
+
+    async def test_tags_appear_in_list(self, auth_client: AsyncClient):
+        await auth_client.post(
+            "/api/drafts",
+            data={"name": "Tagged", "tags": '["twill"]'},
+            files={"wif_file": ("test.wif", io.BytesIO(_WIF), "text/plain")},
+        )
+        data = (await auth_client.get("/api/drafts")).json()
+        assert data[0]["tags"] == ["twill"]
+
+
+# ---------------------------------------------------------------------------
+# Draft tags — PATCH
+# ---------------------------------------------------------------------------
+
+
+class TestPatchDraftTags:
+    async def test_update_tags(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        d = await _insert_draft(db_session, test_user)
+        resp = await auth_client.patch(f"/api/drafts/{d.id}", json={"tags": ["lace", "silk"]})
+        assert resp.status_code == 200
+        assert resp.json()["tags"] == ["lace", "silk"]
+
+    async def test_clear_tags(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        d = await _insert_draft(db_session, test_user, tags=["twill"])
+        resp = await auth_client.patch(f"/api/drafts/{d.id}", json={"tags": []})
+        assert resp.status_code == 200
+        assert resp.json()["tags"] == []
+
+    async def test_update_name_and_tags_together(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        d = await _insert_draft(db_session, test_user)
+        resp = await auth_client.patch(f"/api/drafts/{d.id}", json={"name": "Renamed", "tags": ["gift"]})
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Renamed"
+        assert resp.json()["tags"] == ["gift"]
+
+    async def test_other_users_draft_returns_404(
+        self, auth_client: AsyncClient, db_session: AsyncSession, admin_user: User
+    ):
+        d = await _insert_draft(db_session, admin_user)
+        resp = await auth_client.patch(f"/api/drafts/{d.id}", json={"tags": ["x"]})
+        assert resp.status_code == 404
+
+    async def test_nonexistent_draft_returns_404(self, auth_client: AsyncClient):
+        resp = await auth_client.patch(f"/api/drafts/{uuid.uuid4()}", json={"tags": ["x"]})
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Draft tags — filter
+# ---------------------------------------------------------------------------
+
+
+class TestFilterDraftsByTag:
+    async def test_filter_returns_matching_draft(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        await _insert_draft(db_session, test_user, tags=["twill"])
+        await _insert_draft(db_session, test_user, tags=["plain"])
+        resp = await auth_client.get("/api/drafts?tags=twill")
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["tags"] == ["twill"]
+
+    async def test_filter_multiple_tags_returns_any_match(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        await _insert_draft(db_session, test_user, tags=["twill"])
+        await _insert_draft(db_session, test_user, tags=["plain"])
+        await _insert_draft(db_session, test_user, tags=["lace"])
+        resp = await auth_client.get("/api/drafts?tags=twill&tags=lace")
+        data = resp.json()
+        assert len(data) == 2
+
+    async def test_no_filter_returns_all(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        await _insert_draft(db_session, test_user, tags=["twill"])
+        await _insert_draft(db_session, test_user, tags=["plain"])
+        data = (await auth_client.get("/api/drafts")).json()
+        assert len(data) == 2
+
+    async def test_filter_no_match_returns_empty(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        await _insert_draft(db_session, test_user, tags=["twill"])
+        data = (await auth_client.get("/api/drafts?tags=lace")).json()
+        assert data == []
+
+
+# ---------------------------------------------------------------------------
+# Project tags — create
+# ---------------------------------------------------------------------------
+
+
+class TestCreateProjectTags:
+    async def test_create_with_tags(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        d = await _insert_draft(db_session, test_user)
+        resp = await auth_client.post(
+            "/api/projects",
+            json={
+                "name": "Tagged Project",
+                "draft_id": str(d.id),
+                "project_type": "treadle",
+                "tags": ["wip", "cotton"],
+            },
+        )
+        assert resp.status_code == 201
+        assert resp.json()["tags"] == ["wip", "cotton"]
+
+    async def test_create_without_tags_defaults_empty(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        d = await _insert_draft(db_session, test_user)
+        resp = await auth_client.post(
+            "/api/projects",
+            json={"name": "Plain Project", "draft_id": str(d.id), "project_type": "treadle"},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["tags"] == []
+
+
+# ---------------------------------------------------------------------------
+# Project tags — PATCH
+# ---------------------------------------------------------------------------
+
+
+class TestPatchProjectTags:
+    async def test_update_tags(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        d = await _insert_draft(db_session, test_user)
+        p = await _insert_project(db_session, test_user, d)
+        resp = await auth_client.patch(f"/api/projects/{p.id}", json={"tags": ["gift", "wool"]})
+        assert resp.status_code == 200
+        assert resp.json()["tags"] == ["gift", "wool"]
+
+    async def test_clear_tags(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        d = await _insert_draft(db_session, test_user)
+        p = await _insert_project(db_session, test_user, d, tags=["wip"])
+        resp = await auth_client.patch(f"/api/projects/{p.id}", json={"tags": []})
+        assert resp.status_code == 200
+        assert resp.json()["tags"] == []
+
+    async def test_tags_in_list_response(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        d = await _insert_draft(db_session, test_user)
+        await _insert_project(db_session, test_user, d, tags=["gift"])
+        data = (await auth_client.get("/api/projects")).json()
+        assert data[0]["tags"] == ["gift"]
+
+
+# ---------------------------------------------------------------------------
+# Project tags — filter
+# ---------------------------------------------------------------------------
+
+
+class TestFilterProjectsByTag:
+    async def test_filter_returns_matching(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        d = await _insert_draft(db_session, test_user)
+        await _insert_project(db_session, test_user, d, tags=["wip"])
+        await _insert_project(db_session, test_user, d, tags=["done"])
+        resp = await auth_client.get("/api/projects?tags=wip")
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["tags"] == ["wip"]
+
+    async def test_filter_multiple_tags_any_match(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        d = await _insert_draft(db_session, test_user)
+        await _insert_project(db_session, test_user, d, tags=["wip"])
+        await _insert_project(db_session, test_user, d, tags=["done"])
+        await _insert_project(db_session, test_user, d, tags=["gift"])
+        resp = await auth_client.get("/api/projects?tags=wip&tags=gift")
+        data = resp.json()
+        assert len(data) == 2
+
+    async def test_no_filter_returns_all(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        d = await _insert_draft(db_session, test_user)
+        await _insert_project(db_session, test_user, d, tags=["wip"])
+        await _insert_project(db_session, test_user, d, tags=["done"])
+        data = (await auth_client.get("/api/projects")).json()
+        assert len(data) == 2

--- a/backend/tests/tasks/test_post_migrate.py
+++ b/backend/tests/tasks/test_post_migrate.py
@@ -84,12 +84,12 @@ async def _seed_draft(db_session, owner_id, *, wif_colors=None, deleted=False):
     if wif_colors is None:
         # Omit wif_colors → SQL NULL default; include deleted_at when needed
         _bool_defaults = "FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE"
-        _jsonb_defaults = "'[]'::jsonb, '[]'::jsonb"
+        _jsonb_defaults = "'[]'::jsonb, '[]'::jsonb, '[]'::jsonb"
         _bool_cols = (
             "has_threading, has_tieup, has_treadling, has_liftplan, has_color_palette, "
             "liftplan_generated, warp_length_overridden, is_shared"
         )
-        _jsonb_cols = "lint_warnings, lint_errors"
+        _jsonb_cols = "lint_warnings, lint_errors, tags"
         if deleted:
             sql = text(
                 "INSERT INTO drafts "

--- a/frontend/src/api/drafts.ts
+++ b/frontend/src/api/drafts.ts
@@ -64,6 +64,7 @@ export interface Draft {
   epi_override: number | null;
   is_shared: boolean;
   archived_at: string | null;
+  tags: string[];
   created_at: string;
   updated_at: string;
 }
@@ -95,8 +96,12 @@ export interface DeleteConflict {
   projects: { id: string; name: string }[];
 }
 
-export async function listDrafts(includeArchived = false): Promise<Draft[]> {
-  return req(`/api/drafts${includeArchived ? "?include_archived=true" : ""}`);
+export async function listDrafts(includeArchived = false, tags?: string[]): Promise<Draft[]> {
+  const qs = new URLSearchParams();
+  if (includeArchived) qs.set("include_archived", "true");
+  if (tags?.length) tags.forEach((t) => qs.append("tags", t));
+  const query = qs.size ? `?${qs}` : "";
+  return req(`/api/drafts${query}`);
 }
 
 export async function getDraft(id: string): Promise<DraftDetail> {
@@ -107,12 +112,25 @@ export async function uploadDraft(
   name: string,
   file: File,
   description?: string,
+  tags?: string[],
 ): Promise<Draft> {
   const form = new FormData();
   form.append("name", name);
   form.append("wif_file", file);
   if (description) form.append("description", description);
+  if (tags?.length) form.append("tags", JSON.stringify(tags));
   return req("/api/drafts", { method: "POST", body: form });
+}
+
+export async function updateDraft(
+  id: string,
+  data: { name?: string; description?: string; tags?: string[] },
+): Promise<DraftDetail> {
+  return req(`/api/drafts/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
 }
 
 export async function deleteDraft(id: string, force = false): Promise<DeleteConflict | void> {

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -38,6 +38,7 @@ export interface ProjectSummary {
   share_slug: string | null;
   share_visibility: ShareVisibility;
   share_expires_at: string | null;
+  tags: string[];
 }
 
 export interface WifColor {
@@ -157,6 +158,7 @@ export interface CreateProjectPayload {
   waste_between_items?: number;
   warp_waste_allowance?: number;
   length_unit?: string;
+  tags?: string[];
 }
 
 export interface StepResponse {
@@ -293,10 +295,11 @@ export function projectDrawdownSvgUrl(projectId: string): string {
   return `/api/projects/${projectId}/drawdown_svg`;
 }
 
-export function listProjects(params?: { draftId?: string; loomId?: string }): Promise<ProjectSummary[]> {
+export function listProjects(params?: { draftId?: string; loomId?: string; tags?: string[] }): Promise<ProjectSummary[]> {
   const qs = new URLSearchParams();
   if (params?.draftId) qs.set("draft_id", params.draftId);
   if (params?.loomId) qs.set("loom_id", params.loomId);
+  if (params?.tags?.length) params.tags.forEach((t) => qs.append("tags", t));
   const query = qs.size ? `?${qs}` : "";
   return req(`/api/projects${query}`);
 }
@@ -338,6 +341,14 @@ export function renameProject(id: string, name: string): Promise<ProjectDetail> 
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ name }),
+  });
+}
+
+export function updateProjectTags(id: string, tags: string[]): Promise<ProjectDetail> {
+  return req(`/api/projects/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ tags }),
   });
 }
 

--- a/frontend/src/components/drafts/DraftCard.tsx
+++ b/frontend/src/components/drafts/DraftCard.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router-dom";
 import type { Draft } from "@/api/drafts";
 import { drawdownPreviewUrl } from "@/api/drafts";
 import { AuthedImage } from "@/components/ui/AuthedImage";
+import { TagChips } from "@/components/ui/TagChips";
 import { AppIcons } from "@/lib/icons";
 
 interface ProjectCounts {
@@ -99,6 +100,10 @@ export function DraftCard({ draft, projectCounts, archived }: Props) {
         <p className="mt-2 text-xs text-muted-foreground">
           {draft.lint_warnings.length} warning{draft.lint_warnings.length > 1 ? "s" : ""}
         </p>
+      )}
+
+      {draft.tags && draft.tags.length > 0 && (
+        <TagChips tags={draft.tags} className="mt-2" />
       )}
 
       {projectCounts && (projectCounts.active + projectCounts.planning + projectCounts.completed + projectCounts.abandoned) > 0 && (

--- a/frontend/src/components/drafts/UploadWifModal.tsx
+++ b/frontend/src/components/drafts/UploadWifModal.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 import { uploadDraft } from "@/api/drafts";
 import { Button } from "@/components/ui/button";
+import { TagInput } from "@/components/ui/TagInput";
 
 interface Props {
   onSuccess: () => void;
@@ -10,6 +11,7 @@ interface Props {
 export function UploadWifModal({ onSuccess, onClose }: Props) {
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
+  const [tags, setTags] = useState<string[]>([]);
   const [file, setFile] = useState<File | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -21,7 +23,7 @@ export function UploadWifModal({ onSuccess, onClose }: Props) {
     setError(null);
     setLoading(true);
     try {
-      await uploadDraft(name, file, description || undefined);
+      await uploadDraft(name, file, description || undefined, tags.length ? tags : undefined);
       onSuccess();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Upload failed");
@@ -56,6 +58,11 @@ export function UploadWifModal({ onSuccess, onClose }: Props) {
               rows={2}
               placeholder="Notes about this design…"
             />
+          </div>
+
+          <div>
+            <label className="mb-1 block text-sm font-medium">Tags <span className="text-muted-foreground font-normal">(optional)</span></label>
+            <TagInput tags={tags} onChange={setTags} placeholder="twill, cotton…" />
           </div>
 
           <div>

--- a/frontend/src/components/projects/CreateProjectModal.tsx
+++ b/frontend/src/components/projects/CreateProjectModal.tsx
@@ -4,6 +4,7 @@ import { createProject, completeProject, abandonProject, listProjects, ApiError,
 import { listDrafts } from "@/api/drafts";
 import { listLooms, getLoom, SUPPORTED_LOOM_TYPES } from "@/api/looms";
 import { Button } from "@/components/ui/button";
+import { TagInput } from "@/components/ui/TagInput";
 import { useAuthContext } from "@/context/AuthContext";
 import { measurementSystemToUnit, convertLength, formatLength } from "@/lib/units";
 
@@ -47,6 +48,7 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
     setWarpWaste((v) => convertLen(v, newUnit));
     setLengthUnit(newUnit);
   };
+  const [tags, setTags] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [conflictProject, setConflictProject] = useState<ProjectSummary | null>(null);
@@ -169,6 +171,7 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
     waste_between_items: wasteBetween ? parseFloat(wasteBetween) : undefined,
     warp_waste_allowance: warpWaste ? parseFloat(warpWaste) : undefined,
     length_unit: lengthUnit,
+    tags: tags.length ? tags : undefined,
   });
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -226,6 +229,11 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
           <div>
             <label className="mb-1 block text-sm font-medium">Project name <span className="text-destructive">*</span></label>
             <input className={f} value={name} onChange={(e) => setName(e.target.value)} placeholder="Spring towels — warp 1" required />
+          </div>
+
+          <div>
+            <label className="mb-1 block text-sm font-medium">Tags <span className="text-muted-foreground font-normal">(optional)</span></label>
+            <TagInput tags={tags} onChange={setTags} placeholder="cotton, twill…" />
           </div>
 
           <div>

--- a/frontend/src/components/ui/TagChips.tsx
+++ b/frontend/src/components/ui/TagChips.tsx
@@ -1,0 +1,25 @@
+interface Props {
+  tags: string[];
+  max?: number;
+  className?: string;
+}
+
+export function TagChips({ tags, max = 3, className = "" }: Props) {
+  if (!tags.length) return null;
+  const visible = tags.slice(0, max);
+  const overflow = tags.length - max;
+  return (
+    <div className={`flex flex-wrap gap-1 ${className}`}>
+      {visible.map((t) => (
+        <span key={t} className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+          {t}
+        </span>
+      ))}
+      {overflow > 0 && (
+        <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+          +{overflow}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/TagInput.tsx
+++ b/frontend/src/components/ui/TagInput.tsx
@@ -1,0 +1,72 @@
+import { useState, useRef } from "react";
+import { AppIcons } from "@/lib/icons";
+
+interface Props {
+  tags: string[];
+  onChange: (tags: string[]) => void;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+export function TagInput({ tags, onChange, placeholder = "Add a tag…", disabled = false }: Props) {
+  const [input, setInput] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function addTag(raw: string) {
+    const trimmed = raw.trim().toLowerCase();
+    if (trimmed && !tags.includes(trimmed)) {
+      onChange([...tags, trimmed]);
+    }
+    setInput("");
+  }
+
+  function removeTag(tag: string) {
+    onChange(tags.filter((t) => t !== tag));
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      addTag(input);
+    } else if (e.key === "Backspace" && input === "" && tags.length > 0) {
+      onChange(tags.slice(0, -1));
+    }
+  }
+
+  return (
+    <div
+      className="flex flex-wrap gap-1.5 rounded-md border border-input bg-background px-2 py-1.5 cursor-text min-h-[36px]"
+      onClick={() => inputRef.current?.focus()}
+    >
+      {tags.map((tag) => (
+        <span
+          key={tag}
+          className="flex items-center gap-1 rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+        >
+          {tag}
+          {!disabled && (
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); removeTag(tag); }}
+              className="hover:text-foreground leading-none"
+              aria-label={`Remove tag ${tag}`}
+            >
+              <AppIcons.close className="h-2.5 w-2.5" />
+            </button>
+          )}
+        </span>
+      ))}
+      {!disabled && (
+        <input
+          ref={inputRef}
+          value={input}
+          onChange={(e) => setInput(e.target.value.replace(",", ""))}
+          onKeyDown={handleKeyDown}
+          onBlur={() => { if (input.trim()) addTag(input); }}
+          placeholder={tags.length === 0 ? placeholder : ""}
+          className="flex-1 min-w-[80px] bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/DraftDetailPage.tsx
+++ b/frontend/src/pages/DraftDetailPage.tsx
@@ -2,7 +2,9 @@ import { useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { AppIcons } from "@/lib/icons";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getDraft, deleteDraft, archiveDraft, unarchiveDraft, generateLiftplan, overrideDraftMetadata, setDraftWarpLength, setDraftWeavingWidth, setDraftEpi, previewUrl, previewSvgUrl, downloadWif, downloadWifModified, type ColorStat, type DeleteConflict } from "@/api/drafts";
+import { getDraft, deleteDraft, archiveDraft, unarchiveDraft, generateLiftplan, overrideDraftMetadata, setDraftWarpLength, setDraftWeavingWidth, setDraftEpi, updateDraft, previewUrl, previewSvgUrl, downloadWif, downloadWifModified, type ColorStat, type DeleteConflict } from "@/api/drafts";
+import { TagInput } from "@/components/ui/TagInput";
+import { TagChips } from "@/components/ui/TagChips";
 import { addDraftToCollection, removeDraftFromCollection } from "@/api/collections";
 import { AddToCollectionModal } from "@/components/collections/AddToCollectionModal";
 import { listProjects } from "@/api/projects";
@@ -41,6 +43,8 @@ export function DraftDetailPage() {
   const [weavingWidthUnit, setWeavingWidthUnit] = useState<"cm" | "in">(displayUnit);
   const [editingEpi, setEditingEpi] = useState(false);
   const [epiInput, setEpiInput] = useState("");
+  const [editingTags, setEditingTags] = useState(false);
+  const [pendingTags, setPendingTags] = useState<string[]>([]);
 
   const { data: draft, isLoading, error } = useQuery({
     queryKey: ["draft", id],
@@ -127,6 +131,15 @@ export function DraftDetailPage() {
     },
   });
 
+  const tagsMutation = useMutation({
+    mutationFn: (tags: string[]) => updateDraft(id!, { tags }),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(["draft", id], updated);
+      queryClient.invalidateQueries({ queryKey: ["drafts"] });
+      setEditingTags(false);
+    },
+  });
+
   if (isLoading) {
     return (
       <div className="flex h-screen items-center justify-center">
@@ -186,10 +199,45 @@ export function DraftDetailPage() {
       )}
       <div className="p-6 space-y-6">
       <div className="flex items-start justify-between gap-4">
-        <div className="flex items-center gap-2 text-sm">
-          <Link to="/drafts" className="text-muted-foreground hover:text-foreground">Drafts</Link>
-          <AppIcons.chevronRight className="h-3.5 w-3.5 text-muted-foreground" />
-          <span className="font-medium text-foreground">{draft.name}</span>
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 text-sm">
+            <Link to="/drafts" className="text-muted-foreground hover:text-foreground">Drafts</Link>
+            <AppIcons.chevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+            <span className="font-medium text-foreground">{draft.name}</span>
+          </div>
+          {!editingTags && (
+            <div className="flex items-center gap-2 flex-wrap">
+              {draft.tags && draft.tags.length > 0 && (
+                <TagChips tags={draft.tags} max={10} />
+              )}
+              {!isReadOnly && (
+                <button
+                  type="button"
+                  onClick={() => { setPendingTags(draft.tags ?? []); setEditingTags(true); }}
+                  className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {draft.tags && draft.tags.length > 0 ? "Edit tags" : "+ Add tags"}
+                </button>
+              )}
+            </div>
+          )}
+          {editingTags && (
+            <div className="flex items-center gap-2">
+              <div className="w-64">
+                <TagInput tags={pendingTags} onChange={setPendingTags} />
+              </div>
+              <Button
+                size="sm"
+                onClick={() => tagsMutation.mutate(pendingTags)}
+                disabled={tagsMutation.isPending}
+              >
+                {tagsMutation.isPending ? "Saving…" : "Save"}
+              </Button>
+              <Button size="sm" variant="outline" onClick={() => setEditingTags(false)}>
+                Cancel
+              </Button>
+            </div>
+          )}
         </div>
         {!isReadOnly && (
           <Button size="sm" variant="outline" onClick={() => setShowAddToCollection(true)}>

--- a/frontend/src/pages/DraftsPage.tsx
+++ b/frontend/src/pages/DraftsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { listDrafts } from "@/api/drafts";
 import { listProjects } from "@/api/projects";
@@ -11,6 +11,7 @@ export function DraftsPage() {
   const queryClient = useQueryClient();
   const [showUpload, setShowUpload] = useState(false);
   const [archivedOpen, setArchivedOpen] = useState(false);
+  const [activeTagFilter, setActiveTagFilter] = useState<string | null>(null);
 
   const { data: drafts = [], isLoading, error } = useQuery({
     queryKey: ["drafts", { includeArchived: true }],
@@ -35,31 +36,71 @@ export function DraftsPage() {
     {},
   );
 
+  const allTags = useMemo(() => {
+    const set = new Set<string>();
+    drafts.forEach((d) => d.tags?.forEach((t) => set.add(t)));
+    return [...set].sort();
+  }, [drafts]);
+
   const handleUploadSuccess = () => {
     setShowUpload(false);
     queryClient.invalidateQueries({ queryKey: ["drafts"] });
   };
 
-  const activeDrafts = drafts.filter((d) => !d.archived_at);
-  const archivedDrafts = drafts.filter((d) => d.archived_at);
+  const filteredDrafts = activeTagFilter
+    ? drafts.filter((d) => d.tags?.includes(activeTagFilter))
+    : drafts;
+
+  const activeDrafts = filteredDrafts.filter((d) => !d.archived_at);
+  const archivedDrafts = filteredDrafts.filter((d) => d.archived_at);
 
   return (
     <div className="p-6 max-w-4xl mx-auto w-full">
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex items-center justify-between mb-4">
         <h1 className="text-xl font-semibold">Drafts</h1>
         <Button onClick={() => setShowUpload(true)}>New Draft</Button>
       </div>
 
+      {allTags.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mb-5">
+          {allTags.map((tag) => (
+            <button
+              key={tag}
+              onClick={() => setActiveTagFilter(activeTagFilter === tag ? null : tag)}
+              className={`rounded-full px-2.5 py-0.5 text-xs transition-colors ${
+                activeTagFilter === tag
+                  ? "bg-accent text-accent-foreground"
+                  : "bg-muted text-muted-foreground hover:bg-accent/20"
+              }`}
+            >
+              {tag}
+            </button>
+          ))}
+          {activeTagFilter && (
+            <button
+              onClick={() => setActiveTagFilter(null)}
+              className="rounded-full px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
+            >
+              <AppIcons.close className="h-3 w-3" /> Clear
+            </button>
+          )}
+        </div>
+      )}
+
       {isLoading && <p className="text-sm text-muted-foreground">Loading drafts…</p>}
       {error && <p className="text-sm text-destructive">Failed to load drafts.</p>}
 
-      {!isLoading && activeDrafts.length === 0 && archivedDrafts.length === 0 && (
+      {!isLoading && activeDrafts.length === 0 && archivedDrafts.length === 0 && !activeTagFilter && (
         <div className="rounded-lg border border-dashed p-12 text-center">
           <p className="text-sm text-muted-foreground">No drafts yet. Upload a WIF file to get started.</p>
           <Button className="mt-4" onClick={() => setShowUpload(true)}>
             New Draft
           </Button>
         </div>
+      )}
+
+      {!isLoading && activeDrafts.length === 0 && archivedDrafts.length === 0 && activeTagFilter && (
+        <p className="text-sm text-muted-foreground">No drafts tagged "{activeTagFilter}".</p>
       )}
 
       {activeDrafts.length > 0 && (

--- a/frontend/src/pages/ProjectLandingPage.tsx
+++ b/frontend/src/pages/ProjectLandingPage.tsx
@@ -7,10 +7,12 @@ import { measurementSystemToUnit, displayLength, formatApproxLength, convertLeng
 import {
   getProject, setProjectColorReplacements, deleteProject, updateProjectNotes,
   updateProjectWarpSetup, drawdownSvgUrl, drawdownPreviewUrl, projectDrawdownSvgUrl,
-  getWarpingPlan, completeProject, abandonProject, setProjectReed,
+  getWarpingPlan, completeProject, abandonProject, setProjectReed, updateProjectTags,
   PROJECT_TYPE_LABELS, PROJECT_STATUS_LABELS,
   type ProjectDetail,
 } from "@/api/projects";
+import { TagInput } from "@/components/ui/TagInput";
+import { TagChips } from "@/components/ui/TagChips";
 import { getReedRecommendation, buildDentPattern, nearestCleanDent } from "@/lib/reedRecommendation";
 import { TieUpDiagram } from "@/components/TieUpDiagram";
 import { previewUrl } from "@/api/drafts";
@@ -1172,6 +1174,8 @@ export function ProjectLandingPage() {
   const [tieupOpen, setTieupOpen] = useState(false);
   const [shareModalOpen, setShareModalOpen] = useState(false);
   const [showAddToCollection, setShowAddToCollection] = useState(false);
+  const [editingTags, setEditingTags] = useState(false);
+  const [pendingTags, setPendingTags] = useState<string[]>([]);
 
   const { data: project, isLoading, error } = useQuery({
     queryKey: ["project", id],
@@ -1183,6 +1187,15 @@ export function ProjectLandingPage() {
     mutationFn: (replacements: Record<string, string>) =>
       setProjectColorReplacements(id!, replacements),
     onSuccess: (updated) => qc.setQueryData(["project", id], updated),
+  });
+
+  const tagsMutation = useMutation({
+    mutationFn: (tags: string[]) => updateProjectTags(id!, tags),
+    onSuccess: (updated) => {
+      qc.setQueryData(["project", id], updated);
+      qc.invalidateQueries({ queryKey: ["projects"] });
+      setEditingTags(false);
+    },
   });
 
   const deleteMutation = useMutation({
@@ -1294,6 +1307,37 @@ export function ProjectLandingPage() {
             </Link>
             {project.loom_name && <span> · {project.loom_name}</span>}
           </p>
+          {!editingTags && (
+            <div className="flex items-center gap-2 flex-wrap mt-1.5">
+              {project.tags && project.tags.length > 0 && (
+                <TagChips tags={project.tags} max={10} />
+              )}
+              <button
+                type="button"
+                onClick={() => { setPendingTags(project.tags ?? []); setEditingTags(true); }}
+                className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {project.tags && project.tags.length > 0 ? "Edit tags" : "+ Add tags"}
+              </button>
+            </div>
+          )}
+          {editingTags && (
+            <div className="flex items-center gap-2 mt-1.5">
+              <div className="w-64">
+                <TagInput tags={pendingTags} onChange={setPendingTags} />
+              </div>
+              <Button
+                size="sm"
+                onClick={() => tagsMutation.mutate(pendingTags)}
+                disabled={tagsMutation.isPending}
+              >
+                {tagsMutation.isPending ? "Saving…" : "Save"}
+              </Button>
+              <Button size="sm" variant="outline" onClick={() => setEditingTags(false)}>
+                Cancel
+              </Button>
+            </div>
+          )}
         </div>
         <Button
           variant="ghost"

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { listProjects, projectDrawdownPreviewUrl, PROJECT_TYPE_LABELS, PROJECT_STATUS_LABELS, type ProjectSummary } from "@/api/projects";
@@ -8,6 +8,7 @@ import { AuthedImage } from "@/components/ui/AuthedImage";
 import { CreateProjectModal } from "@/components/projects/CreateProjectModal";
 import { AssignLoomModal } from "@/components/projects/AssignLoomModal";
 import { Button } from "@/components/ui/button";
+import { TagChips } from "@/components/ui/TagChips";
 import { Link } from "react-router-dom";
 
 const STATUS_COLORS: Record<string, string> = {
@@ -104,6 +105,9 @@ function ProjectCard({ project, onAssign }: {
             <p className="mt-0.5 text-sm text-muted-foreground">{PROJECT_TYPE_LABELS[project.project_type]}</p>
             {endDate && (
               <p className="mt-0.5 text-xs text-muted-foreground">{fmtDate(endDate)}</p>
+            )}
+            {project.tags && project.tags.length > 0 && (
+              <TagChips tags={project.tags} className="mt-1.5" />
             )}
             {!isPlanning && project.status === "active" && (
               <div className="mt-3">
@@ -203,23 +207,34 @@ export function ProjectsPage() {
   const queryClient = useQueryClient();
   const [showCreate, setShowCreate] = useState(false);
   const [assigningProjectId, setAssigningProjectId] = useState<string | null>(null);
+  const [activeTagFilter, setActiveTagFilter] = useState<string | null>(null);
 
   const { data: projects = [], isLoading, error } = useQuery({
     queryKey: ["projects"],
     queryFn: () => listProjects(),
   });
 
+  const allTags = useMemo(() => {
+    const set = new Set<string>();
+    projects.forEach((p) => p.tags?.forEach((t) => set.add(t)));
+    return [...set].sort();
+  }, [projects]);
+
+  const filteredProjects = activeTagFilter
+    ? projects.filter((p) => p.tags?.includes(activeTagFilter))
+    : projects;
+
   const currentYear = new Date().getFullYear();
 
-  const planning = projects.filter((p) => (p.status === "active" || p.status === "created") && !p.loom_id);
-  const notStarted = projects.filter((p) => p.status === "created" && !!p.loom_id);
-  const active = projects.filter((p) => p.status === "active" && !!p.loom_id);
+  const planning = filteredProjects.filter((p) => (p.status === "active" || p.status === "created") && !p.loom_id);
+  const notStarted = filteredProjects.filter((p) => p.status === "created" && !!p.loom_id);
+  const active = filteredProjects.filter((p) => p.status === "active" && !!p.loom_id);
 
-  const completed = projects
+  const completed = filteredProjects
     .filter((p) => p.status === "completed")
     .sort((a, b) => (b.completed_at ?? "").localeCompare(a.completed_at ?? ""));
 
-  const abandoned = projects
+  const abandoned = filteredProjects
     .filter((p) => p.status === "abandoned")
     .sort((a, b) => (b.abandoned_at ?? "").localeCompare(a.abandoned_at ?? ""));
 
@@ -232,6 +247,32 @@ export function ProjectsPage() {
         <h1 className="text-xl font-semibold">Projects</h1>
         <Button size="sm" onClick={() => setShowCreate(true)}>New project</Button>
       </div>
+
+      {allTags.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {allTags.map((tag) => (
+            <button
+              key={tag}
+              onClick={() => setActiveTagFilter(activeTagFilter === tag ? null : tag)}
+              className={`rounded-full px-2.5 py-0.5 text-xs transition-colors ${
+                activeTagFilter === tag
+                  ? "bg-accent text-accent-foreground"
+                  : "bg-muted text-muted-foreground hover:bg-accent/20"
+              }`}
+            >
+              {tag}
+            </button>
+          ))}
+          {activeTagFilter && (
+            <button
+              onClick={() => setActiveTagFilter(null)}
+              className="rounded-full px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
+            >
+              <AppIcons.close className="h-3 w-3" /> Clear
+            </button>
+          )}
+        </div>
+      )}
 
       {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
       {error && <p className="text-sm text-destructive">Failed to load projects.</p>}


### PR DESCRIPTION
## Summary

- **Backend**: JSONB `tags` column on `Draft` and `Project` (migration `0032_tags`); new `PATCH /api/drafts/{id}` endpoint; `?tags=` filter on both list endpoints; `tags` field on create/update payloads for projects
- **Frontend components**: `TagInput` (chip-style, enter/comma to add, backspace to remove, lowercase-normalized) and `TagChips` (read-only display with configurable max + "+N" overflow)
- **UI integration**: tags in `UploadWifModal`, `CreateProjectModal`, `DraftCard`, `ProjectCard`; tag filter pill bars on `DraftsPage` and `ProjectsPage`; inline edit on `DraftDetailPage` and `ProjectLandingPage` headers
- **Tests**: 20 backend tests covering draft and project tag CRUD (create, filter, update, empty)

## Test plan

- [ ] Upload a draft with tags in the modal — tags appear on the card in DraftsPage
- [ ] Click a tag pill on DraftsPage to filter; click again or Clear to reset
- [ ] Open a draft detail page — click "+ Add tags", type a tag, press Enter, Save
- [ ] Create a project with tags in CreateProjectModal — tags appear on ProjectCard
- [ ] Click a tag pill on ProjectsPage to filter across sections
- [ ] Open a project landing page — click "Edit tags", modify, Save
- [ ] `pytest backend/tests/routers/test_tags.py` — all 20 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)