### PR TITLE
feat: expose catalog brand/model on loom and enable relinking (#783)

### DIFF
--- a/backend/app/routers/looms.py
+++ b/backend/app/routers/looms.py
@@ -126,6 +126,8 @@ class LoomSummary(BaseModel):
     model_name: str
     serial_number: str | None
     loom_reference_id: uuid.UUID | None
+    loom_reference_brand: str | None
+    loom_reference_model_name: str | None
     supports_lift_tracking: bool
     supports_treadle_tracking: bool
     notes: str | None
@@ -139,6 +141,7 @@ class LoomSummary(BaseModel):
 
     @classmethod
     def from_loom(cls, loom: Loom) -> "LoomSummary":
+        ref = loom.loom_reference
         data = {
             "id": loom.id,
             "loom_type": loom.loom_type,
@@ -146,6 +149,8 @@ class LoomSummary(BaseModel):
             "model_name": loom.model_name,
             "serial_number": loom.serial_number,
             "loom_reference_id": loom.loom_reference_id,
+            "loom_reference_brand": ref.brand if ref else None,
+            "loom_reference_model_name": ref.model_name if ref else None,
             "supports_lift_tracking": loom.supports_lift_tracking,
             "supports_treadle_tracking": loom.supports_treadle_tracking,
             "notes": loom.notes,
@@ -166,6 +171,8 @@ class LoomDetail(BaseModel):
     model_name: str
     serial_number: str | None
     loom_reference_id: uuid.UUID | None
+    loom_reference_brand: str | None
+    loom_reference_model_name: str | None
     purchase_date: date | None
     purchase_price: Decimal | None
     vendor: str | None
@@ -183,6 +190,7 @@ class LoomDetail(BaseModel):
 
     @classmethod
     def from_loom(cls, loom: Loom) -> "LoomDetail":
+        ref = loom.loom_reference
         data = {
             "id": loom.id,
             "owner_id": loom.owner_id,
@@ -191,6 +199,8 @@ class LoomDetail(BaseModel):
             "model_name": loom.model_name,
             "serial_number": loom.serial_number,
             "loom_reference_id": loom.loom_reference_id,
+            "loom_reference_brand": ref.brand if ref else None,
+            "loom_reference_model_name": ref.model_name if ref else None,
             "purchase_date": loom.purchase_date,
             "purchase_price": loom.purchase_price,
             "vendor": loom.vendor,
@@ -287,7 +297,14 @@ class AddReedRequest(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-async def _get_owned_loom(loom_id: uuid.UUID, user: User, db: AsyncSession, *, allow_superuser: bool = False) -> Loom:
+async def _get_owned_loom(
+    loom_id: uuid.UUID,
+    user: User,
+    db: AsyncSession,
+    *,
+    allow_superuser: bool = False,
+    populate_existing: bool = False,
+) -> Loom:
     stmt = (
         select(Loom)
         .where(Loom.id == loom_id, Loom.deleted_at.is_(None))
@@ -296,10 +313,13 @@ async def _get_owned_loom(loom_id: uuid.UUID, user: User, db: AsyncSession, *, a
             selectinload(Loom.versions).selectinload(LoomVersion.receipts),
             selectinload(Loom.versions).selectinload(LoomVersion.accessories),
             selectinload(Loom.reeds),
+            selectinload(Loom.loom_reference),
         )
     )
     if not (allow_superuser and user.is_superuser):
         stmt = stmt.where(Loom.owner_id == user.id)
+    if populate_existing:
+        stmt = stmt.execution_options(populate_existing=True)
     loom = await db.scalar(stmt)
     if loom is None:
         raise HTTPException(status_code=404, detail="Loom not found")
@@ -407,6 +427,7 @@ async def list_looms(
             selectinload(Loom.versions).selectinload(LoomVersion.receipts),
             selectinload(Loom.versions).selectinload(LoomVersion.accessories),
             selectinload(Loom.reeds),
+            selectinload(Loom.loom_reference),
         )
         .order_by(Loom.created_at.desc())
     )
@@ -917,5 +938,5 @@ async def link_loom_reference(
 
     loom.loom_reference_id = body.loom_reference_id
     await db.commit()
-    loom = await _get_owned_loom(loom_id, current_user, db)
+    loom = await _get_owned_loom(loom_id, current_user, db, populate_existing=True)
     return LoomDetail.from_loom(loom)

--- a/backend/tests/routers/test_loom_catalog.py
+++ b/backend/tests/routers/test_loom_catalog.py
@@ -263,3 +263,115 @@ async def test_link_nonexistent_reference_404(auth_client: AsyncClient, db_sessi
         json={"loom_reference_id": str(uuid.uuid4())},
     )
     assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_relink_to_different_catalog_entry(auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+    """A loom linked to entry A can be relinked to entry B via link-reference."""
+    ref_a = await _make_ref(db_session, brand="Louet", model="Spring 8")
+    ref_b = await _make_ref(db_session, brand="Louet", model="Spring 12")
+
+    loom = Loom(
+        owner_id=test_user.id,
+        loom_type="floor_loom",
+        manufacturer="Louet",
+        model_name="Spring 8",
+        loom_reference_id=ref_a.id,
+        supports_lift_tracking=False,
+        supports_treadle_tracking=True,
+    )
+    db_session.add(loom)
+    await db_session.flush()
+    db_session.add(LoomVersion(loom_id=loom.id, version_number=1, effective_date=date(2024, 1, 1)))
+    await db_session.commit()
+
+    resp = await auth_client.post(
+        f"/api/looms/{loom.id}/link-reference",
+        json={"loom_reference_id": str(ref_b.id)},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["loom_reference_id"] == str(ref_b.id)
+    assert data["loom_reference_brand"] == "Louet"
+    assert data["loom_reference_model_name"] == "Spring 12"
+
+
+@pytest.mark.anyio
+async def test_linked_loom_detail_includes_catalog_names(
+    auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+):
+    """GET /api/looms/{id} returns loom_reference_brand/model_name when linked."""
+    ref = await _make_ref(db_session, brand="Schacht", model="Baby Wolf")
+
+    loom = Loom(
+        owner_id=test_user.id,
+        loom_type="floor_loom",
+        manufacturer="Schacht",
+        model_name="Baby Wolf",
+        loom_reference_id=ref.id,
+        supports_lift_tracking=False,
+        supports_treadle_tracking=True,
+    )
+    db_session.add(loom)
+    await db_session.flush()
+    db_session.add(LoomVersion(loom_id=loom.id, version_number=1, effective_date=date(2024, 1, 1)))
+    await db_session.commit()
+
+    resp = await auth_client.get(f"/api/looms/{loom.id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["loom_reference_brand"] == "Schacht"
+    assert data["loom_reference_model_name"] == "Baby Wolf"
+
+
+@pytest.mark.anyio
+async def test_unlinked_loom_detail_has_null_catalog_names(
+    auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+):
+    """GET /api/looms/{id} returns null catalog names when not linked."""
+    loom = Loom(
+        owner_id=test_user.id,
+        loom_type="floor_loom",
+        manufacturer="Unknown",
+        model_name="Mystery",
+        supports_lift_tracking=False,
+        supports_treadle_tracking=True,
+    )
+    db_session.add(loom)
+    await db_session.flush()
+    db_session.add(LoomVersion(loom_id=loom.id, version_number=1, effective_date=date(2024, 1, 1)))
+    await db_session.commit()
+
+    resp = await auth_client.get(f"/api/looms/{loom.id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["loom_reference_brand"] is None
+    assert data["loom_reference_model_name"] is None
+
+
+@pytest.mark.anyio
+async def test_list_looms_includes_catalog_names(auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+    """GET /api/looms returns loom_reference_brand/model_name for linked looms."""
+    ref = await _make_ref(db_session, brand="Schacht", model="Mighty Wolf")
+
+    loom = Loom(
+        owner_id=test_user.id,
+        loom_type="floor_loom",
+        manufacturer="Schacht",
+        model_name="Mighty Wolf",
+        loom_reference_id=ref.id,
+        supports_lift_tracking=False,
+        supports_treadle_tracking=True,
+    )
+    db_session.add(loom)
+    await db_session.flush()
+    db_session.add(LoomVersion(loom_id=loom.id, version_number=1, effective_date=date(2024, 1, 1)))
+    await db_session.commit()
+
+    resp = await auth_client.get("/api/looms")
+    assert resp.status_code == 200
+    looms = resp.json()
+    linked = next((loom for loom in looms if loom["loom_reference_id"] == str(ref.id)), None)
+    assert linked is not None
+    assert linked["loom_reference_brand"] == "Schacht"
+    assert linked["loom_reference_model_name"] == "Mighty Wolf"

--- a/frontend/src/api/looms.ts
+++ b/frontend/src/api/looms.ts
@@ -80,6 +80,8 @@ export interface Loom {
   model_name: string;
   serial_number: string | null;
   loom_reference_id: string | null;
+  loom_reference_brand: string | null;
+  loom_reference_model_name: string | null;
   supports_lift_tracking: boolean;
   supports_treadle_tracking: boolean;
   notes: string | null;

--- a/frontend/src/components/looms/LinkToCatalogModal.tsx
+++ b/frontend/src/components/looms/LinkToCatalogModal.tsx
@@ -332,7 +332,9 @@ export function LinkToCatalogModal({ loom, onSuccess, onClose }: Props) {
       <div className="w-full max-w-lg rounded-lg border bg-background p-6 shadow-lg overflow-y-auto max-h-[90vh]">
         <div className="flex items-start justify-between mb-5">
           <div>
-            <h2 className="text-lg font-semibold">Update from catalog</h2>
+            <h2 className="text-lg font-semibold">
+              {loom.loom_reference_id ? "Change catalog link" : "Link to catalog"}
+            </h2>
             <p className="text-sm text-muted-foreground">
               {loom.manufacturer} {loom.model_name}
             </p>

--- a/frontend/src/pages/LoomDetailPage.tsx
+++ b/frontend/src/pages/LoomDetailPage.tsx
@@ -957,8 +957,16 @@ export function LoomDetailPage() {
               {loom.loom_reference_id ? (
                 <>
                   <span className="text-xs rounded-full bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 px-2 py-0.5 font-medium">
-                    Linked to catalog
+                    {loom.loom_reference_brand && loom.loom_reference_model_name
+                      ? `${loom.loom_reference_brand} ${loom.loom_reference_model_name}`
+                      : "Linked to catalog"}
                   </span>
+                  <button
+                    onClick={() => setShowLinkCatalog(true)}
+                    className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    Change
+                  </button>
                   <button
                     onClick={handleUnlink}
                     disabled={unlinking}


### PR DESCRIPTION
## Summary

- Adds `loom_reference_brand` and `loom_reference_model_name` to `LoomSummary` and `LoomDetail` API responses — populated via `selectinload(Loom.loom_reference)` in both `_get_owned_loom()` and `list_looms()`
- Fixes stale identity map issue in the `link-reference` endpoint: uses `populate_existing=True` on the post-commit re-fetch so relinking to a different catalog entry returns the new catalog names immediately
- LoomDetailPage: linked badge now shows the actual catalog brand + model name (e.g. "Schacht Baby Wolf"); adds a "Change" button alongside "Unlink" when linked
- LinkToCatalogModal: title changes to "Change catalog link" when the loom is already linked
- Frontend `Loom` interface: adds `loom_reference_brand` and `loom_reference_model_name` fields
- 4 new backend tests covering: relink to different entry, detail with catalog names, detail without link, list includes catalog names

## Test plan

- [ ] Link a loom to a catalog entry — badge shows brand + model name
- [ ] Click "Change" on a linked loom — modal opens with title "Change catalog link", select a different entry, confirm — badge updates to new entry's name
- [ ] Click "Unlink" on a linked loom — badge reverts to "Not in catalog"
- [ ] `GET /api/looms` and `GET /api/looms/{id}` return `loom_reference_brand`/`loom_reference_model_name` for linked looms (null when unlinked)
- [ ] `pytest tests/routers/test_loom_catalog.py` — all 4 new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)