### PR TITLE
feat: per-version catalog linkage for looms (#789)

### DIFF
--- a/backend/alembic/versions/0033_loom_version_catalog_link.py
+++ b/backend/alembic/versions/0033_loom_version_catalog_link.py
@@ -1,0 +1,86 @@
+"""move loom_reference_id from looms to loom_versions
+
+Revision ID: 0033_loom_version_catalog_link
+Revises: 0032_tags
+Create Date: 2026-05-19
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0033_loom_version_catalog_link"
+down_revision = "0032_tags"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "loom_versions",
+        sa.Column(
+            "loom_reference_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("loom_references.id", ondelete="SET NULL"),
+            nullable=True,
+            index=True,
+        ),
+    )
+
+    # Copy existing loom-level catalog link to the latest version of each loom
+    op.execute(
+        """
+        UPDATE loom_versions lv
+        SET loom_reference_id = l.loom_reference_id
+        FROM looms l
+        WHERE lv.loom_id = l.id
+          AND l.loom_reference_id IS NOT NULL
+          AND lv.version_number = (
+              SELECT MAX(v2.version_number)
+              FROM loom_versions v2
+              WHERE v2.loom_id = l.id
+          )
+        """
+    )
+
+    op.drop_constraint("fk_looms_loom_reference_id", "looms", type_="foreignkey")
+    op.drop_index("ix_looms_loom_reference_id", table_name="looms")
+    op.drop_column("looms", "loom_reference_id")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "looms",
+        sa.Column(
+            "loom_reference_id",
+            UUID(as_uuid=True),
+            nullable=True,
+        ),
+    )
+    op.create_foreign_key(
+        "fk_looms_loom_reference_id",
+        "looms",
+        "loom_references",
+        ["loom_reference_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index("ix_looms_loom_reference_id", "looms", ["loom_reference_id"])
+
+    # Restore from latest version (best-effort)
+    op.execute(
+        """
+        UPDATE looms l
+        SET loom_reference_id = lv.loom_reference_id
+        FROM loom_versions lv
+        WHERE lv.loom_id = l.id
+          AND lv.loom_reference_id IS NOT NULL
+          AND lv.version_number = (
+              SELECT MAX(v2.version_number)
+              FROM loom_versions v2
+              WHERE v2.loom_id = l.id
+          )
+        """
+    )
+
+    op.drop_column("loom_versions", "loom_reference_id")

--- a/backend/app/models/loom.py
+++ b/backend/app/models/loom.py
@@ -109,7 +109,7 @@ class LoomReference(Base, TimestampMixin):
     dobby_type: Mapped[str | None] = mapped_column(String(50), nullable=True)
     compatible_software: Mapped[list | None] = mapped_column(JSONB, nullable=True)
 
-    looms: Mapped[list["Loom"]] = relationship("Loom", back_populates="loom_reference")
+    loom_versions: Mapped[list["LoomVersion"]] = relationship("LoomVersion", back_populates="loom_reference")
 
 
 class Loom(Base, TimestampMixin, SoftDeleteMixin, RetireMixin):
@@ -117,9 +117,6 @@ class Loom(Base, TimestampMixin, SoftDeleteMixin, RetireMixin):
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     owner_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, index=True)
-    loom_reference_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("loom_references.id", ondelete="SET NULL"), nullable=True, index=True
-    )
 
     loom_type: Mapped[str] = mapped_column(String(30), nullable=False, default="floor_loom")
 
@@ -149,7 +146,6 @@ class Loom(Base, TimestampMixin, SoftDeleteMixin, RetireMixin):
         "LoomReed", back_populates="loom", order_by="LoomReed.dents_per_inch", cascade="all, delete-orphan"
     )
     owner: Mapped["User"] = relationship("User", foreign_keys=[owner_id])  # type: ignore[name-defined]
-    loom_reference: Mapped["LoomReference | None"] = relationship("LoomReference", back_populates="looms")
 
     @property
     def current_version(self) -> "LoomVersion | None":
@@ -161,6 +157,9 @@ class LoomVersion(Base, TimestampMixin):
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     loom_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("looms.id"), nullable=False, index=True)
+    loom_reference_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("loom_references.id", ondelete="SET NULL"), nullable=True, index=True
+    )
     version_number: Mapped[int] = mapped_column(Integer, nullable=False)
     name: Mapped[str | None] = mapped_column(String(255), nullable=True)
     effective_date: Mapped[date] = mapped_column(Date, nullable=False)
@@ -176,6 +175,7 @@ class LoomVersion(Base, TimestampMixin):
     warp_waste_unit: Mapped[str] = mapped_column(String(5), default="cm", nullable=False)
 
     loom: Mapped["Loom"] = relationship("Loom", back_populates="versions")
+    loom_reference: Mapped["LoomReference | None"] = relationship("LoomReference", back_populates="loom_versions")
     photos: Mapped[list["LoomVersionPhoto"]] = relationship(
         "LoomVersionPhoto",
         back_populates="version",

--- a/backend/app/routers/looms.py
+++ b/backend/app/routers/looms.py
@@ -100,6 +100,9 @@ class LoomReedSchema(BaseModel):
 
 class LoomVersionSchema(BaseModel):
     id: uuid.UUID
+    loom_reference_id: uuid.UUID | None
+    loom_reference_brand: str | None
+    loom_reference_model_name: str | None
     version_number: int
     name: str | None
     effective_date: date
@@ -118,6 +121,33 @@ class LoomVersionSchema(BaseModel):
 
     model_config = {"from_attributes": True}
 
+    @classmethod
+    def from_version(cls, v: LoomVersion) -> "LoomVersionSchema":
+        ref = v.loom_reference
+        return cls.model_validate(
+            {
+                "id": v.id,
+                "loom_reference_id": v.loom_reference_id,
+                "loom_reference_brand": ref.brand if ref else None,
+                "loom_reference_model_name": ref.model_name if ref else None,
+                "version_number": v.version_number,
+                "name": v.name,
+                "effective_date": v.effective_date,
+                "description": v.description,
+                "num_shafts": v.num_shafts,
+                "num_treadles": v.num_treadles,
+                "num_heddles": v.num_heddles,
+                "weaving_width": v.weaving_width,
+                "weaving_width_unit": v.weaving_width_unit,
+                "warp_waste_allowance": v.warp_waste_allowance,
+                "warp_waste_unit": v.warp_waste_unit,
+                "photos": v.photos,
+                "receipts": v.receipts,
+                "accessories": v.accessories,
+                "created_at": v.created_at,
+            }
+        )
+
 
 class LoomSummary(BaseModel):
     id: uuid.UUID
@@ -126,6 +156,8 @@ class LoomSummary(BaseModel):
     model_name: str
     serial_number: str | None
     loom_reference_id: uuid.UUID | None
+    loom_reference_brand: str | None
+    loom_reference_model_name: str | None
     supports_lift_tracking: bool
     supports_treadle_tracking: bool
     notes: str | None
@@ -139,23 +171,28 @@ class LoomSummary(BaseModel):
 
     @classmethod
     def from_loom(cls, loom: Loom) -> "LoomSummary":
-        data = {
-            "id": loom.id,
-            "loom_type": loom.loom_type,
-            "manufacturer": loom.manufacturer,
-            "model_name": loom.model_name,
-            "serial_number": loom.serial_number,
-            "loom_reference_id": loom.loom_reference_id,
-            "supports_lift_tracking": loom.supports_lift_tracking,
-            "supports_treadle_tracking": loom.supports_treadle_tracking,
-            "notes": loom.notes,
-            "has_photo": loom.photo_path is not None,
-            "current_version": loom.current_version,
-            "reeds": loom.reeds,
-            "retired_at": loom.retired_at,
-            "created_at": loom.created_at,
-        }
-        return cls.model_validate(data)
+        cv = loom.current_version
+        cv_ref = cv.loom_reference if cv else None
+        return cls.model_validate(
+            {
+                "id": loom.id,
+                "loom_type": loom.loom_type,
+                "manufacturer": loom.manufacturer,
+                "model_name": loom.model_name,
+                "serial_number": loom.serial_number,
+                "loom_reference_id": cv.loom_reference_id if cv else None,
+                "loom_reference_brand": cv_ref.brand if cv_ref else None,
+                "loom_reference_model_name": cv_ref.model_name if cv_ref else None,
+                "supports_lift_tracking": loom.supports_lift_tracking,
+                "supports_treadle_tracking": loom.supports_treadle_tracking,
+                "notes": loom.notes,
+                "has_photo": loom.photo_path is not None,
+                "current_version": LoomVersionSchema.from_version(cv) if cv else None,
+                "reeds": loom.reeds,
+                "retired_at": loom.retired_at,
+                "created_at": loom.created_at,
+            }
+        )
 
 
 class LoomDetail(BaseModel):
@@ -166,6 +203,8 @@ class LoomDetail(BaseModel):
     model_name: str
     serial_number: str | None
     loom_reference_id: uuid.UUID | None
+    loom_reference_brand: str | None
+    loom_reference_model_name: str | None
     purchase_date: date | None
     purchase_price: Decimal | None
     vendor: str | None
@@ -183,28 +222,33 @@ class LoomDetail(BaseModel):
 
     @classmethod
     def from_loom(cls, loom: Loom) -> "LoomDetail":
-        data = {
-            "id": loom.id,
-            "owner_id": loom.owner_id,
-            "loom_type": loom.loom_type,
-            "manufacturer": loom.manufacturer,
-            "model_name": loom.model_name,
-            "serial_number": loom.serial_number,
-            "loom_reference_id": loom.loom_reference_id,
-            "purchase_date": loom.purchase_date,
-            "purchase_price": loom.purchase_price,
-            "vendor": loom.vendor,
-            "supports_lift_tracking": loom.supports_lift_tracking,
-            "supports_treadle_tracking": loom.supports_treadle_tracking,
-            "notes": loom.notes,
-            "has_photo": loom.photo_path is not None,
-            "current_version": loom.current_version,
-            "versions": loom.versions,
-            "reeds": loom.reeds,
-            "retired_at": loom.retired_at,
-            "created_at": loom.created_at,
-        }
-        return cls.model_validate(data)
+        cv = loom.current_version
+        cv_ref = cv.loom_reference if cv else None
+        return cls.model_validate(
+            {
+                "id": loom.id,
+                "owner_id": loom.owner_id,
+                "loom_type": loom.loom_type,
+                "manufacturer": loom.manufacturer,
+                "model_name": loom.model_name,
+                "serial_number": loom.serial_number,
+                "loom_reference_id": cv.loom_reference_id if cv else None,
+                "loom_reference_brand": cv_ref.brand if cv_ref else None,
+                "loom_reference_model_name": cv_ref.model_name if cv_ref else None,
+                "purchase_date": loom.purchase_date,
+                "purchase_price": loom.purchase_price,
+                "vendor": loom.vendor,
+                "supports_lift_tracking": loom.supports_lift_tracking,
+                "supports_treadle_tracking": loom.supports_treadle_tracking,
+                "notes": loom.notes,
+                "has_photo": loom.photo_path is not None,
+                "current_version": LoomVersionSchema.from_version(cv) if cv else None,
+                "versions": [LoomVersionSchema.from_version(v) for v in loom.versions],
+                "reeds": loom.reeds,
+                "retired_at": loom.retired_at,
+                "created_at": loom.created_at,
+            }
+        )
 
 
 class CreateLoomRequest(BaseModel):
@@ -212,7 +256,7 @@ class CreateLoomRequest(BaseModel):
     manufacturer: str
     model_name: str
     serial_number: str | None = None
-    loom_reference_id: uuid.UUID | None = None
+    loom_reference_id: uuid.UUID | None = None  # assigned to initial version
     purchase_date: date | None = None
     purchase_price: Decimal | None = None
     vendor: str | None = None
@@ -287,7 +331,14 @@ class AddReedRequest(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-async def _get_owned_loom(loom_id: uuid.UUID, user: User, db: AsyncSession, *, allow_superuser: bool = False) -> Loom:
+async def _get_owned_loom(
+    loom_id: uuid.UUID,
+    user: User,
+    db: AsyncSession,
+    *,
+    allow_superuser: bool = False,
+    populate_existing: bool = False,
+) -> Loom:
     stmt = (
         select(Loom)
         .where(Loom.id == loom_id, Loom.deleted_at.is_(None))
@@ -295,11 +346,14 @@ async def _get_owned_loom(loom_id: uuid.UUID, user: User, db: AsyncSession, *, a
             selectinload(Loom.versions).selectinload(LoomVersion.photos),
             selectinload(Loom.versions).selectinload(LoomVersion.receipts),
             selectinload(Loom.versions).selectinload(LoomVersion.accessories),
+            selectinload(Loom.versions).selectinload(LoomVersion.loom_reference),
             selectinload(Loom.reeds),
         )
     )
     if not (allow_superuser and user.is_superuser):
         stmt = stmt.where(Loom.owner_id == user.id)
+    if populate_existing:
+        stmt = stmt.execution_options(populate_existing=True)
     loom = await db.scalar(stmt)
     if loom is None:
         raise HTTPException(status_code=404, detail="Loom not found")
@@ -362,7 +416,6 @@ async def create_loom(
         manufacturer=body.manufacturer,
         model_name=body.model_name,
         serial_number=body.serial_number,
-        loom_reference_id=body.loom_reference_id,
         purchase_date=body.purchase_date,
         purchase_price=body.purchase_price,
         vendor=body.vendor,
@@ -375,6 +428,7 @@ async def create_loom(
 
     version = LoomVersion(
         loom_id=loom.id,
+        loom_reference_id=body.loom_reference_id,
         version_number=1,
         effective_date=body.effective_date,
         description=body.version_description or "Initial configuration",
@@ -406,6 +460,7 @@ async def list_looms(
             selectinload(Loom.versions).selectinload(LoomVersion.photos),
             selectinload(Loom.versions).selectinload(LoomVersion.receipts),
             selectinload(Loom.versions).selectinload(LoomVersion.accessories),
+            selectinload(Loom.versions).selectinload(LoomVersion.loom_reference),
             selectinload(Loom.reeds),
         )
         .order_by(Loom.created_at.desc())
@@ -900,22 +955,23 @@ class LinkReferenceRequest(BaseModel):
     loom_reference_id: uuid.UUID | None
 
 
-@router.post("/{loom_id}/link-reference", response_model=LoomDetail)
-async def link_loom_reference(
+@router.post("/{loom_id}/versions/{version_id}/link-reference", response_model=LoomDetail)
+async def link_version_reference(
     loom_id: uuid.UUID,
+    version_id: uuid.UUID,
     body: LinkReferenceRequest,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> LoomDetail:
-    """Link (or unlink) an existing user loom to a catalog entry."""
-    loom = await _get_owned_loom(loom_id, current_user, db)
+    """Link (or unlink) a specific loom version to a catalog entry."""
+    loom, version = await _get_owned_version(loom_id, version_id, current_user, db)
 
     if body.loom_reference_id is not None:
         ref = await db.get(LoomReference, body.loom_reference_id)
         if ref is None:
             raise HTTPException(status_code=404, detail="Loom reference not found")
 
-    loom.loom_reference_id = body.loom_reference_id
+    version.loom_reference_id = body.loom_reference_id
     await db.commit()
-    loom = await _get_owned_loom(loom_id, current_user, db)
+    loom = await _get_owned_loom(loom_id, current_user, db, populate_existing=True)
     return LoomDetail.from_loom(loom)

--- a/backend/app/routers/looms.py
+++ b/backend/app/routers/looms.py
@@ -644,7 +644,7 @@ async def add_version(
     db.add(version)
     await db.commit()
     await db.refresh(version, ["photos", "receipts", "accessories"])
-    return LoomVersionSchema.model_validate(version)
+    return LoomVersionSchema.from_version(version)
 
 
 # ---------------------------------------------------------------------------
@@ -817,7 +817,7 @@ async def update_version(
         setattr(version, field, value)
     await db.commit()
     await db.refresh(version, ["photos", "receipts", "accessories"])
-    return LoomVersionSchema.model_validate(version)
+    return LoomVersionSchema.from_version(version)
 
 
 # ---------------------------------------------------------------------------
@@ -863,7 +863,7 @@ async def clone_version(
 
     await db.commit()
     await db.refresh(new_version, ["photos", "receipts", "accessories"])
-    return LoomVersionSchema.model_validate(new_version)
+    return LoomVersionSchema.from_version(new_version)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/routers/test_loom_catalog.py
+++ b/backend/tests/routers/test_loom_catalog.py
@@ -1,5 +1,6 @@
 """Tests for the loom catalog (loom_references) endpoints."""
 
+import uuid
 from datetime import date
 
 import pytest
@@ -180,61 +181,58 @@ async def test_non_admin_cannot_create(auth_client: AsyncClient, db_session: Asy
 
 
 # ---------------------------------------------------------------------------
-# Link-reference endpoint
+# Link-reference endpoint (per-version)
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.anyio
-async def test_link_loom_to_reference(auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
-    ref = await _make_ref(db_session)
-
+async def _make_loom_with_version(
+    db: AsyncSession,
+    user: "User",
+    loom_reference_id: "uuid.UUID | None" = None,
+) -> tuple[Loom, LoomVersion]:
     loom = Loom(
-        owner_id=test_user.id,
+        owner_id=user.id,
         loom_type="floor_loom",
         manufacturer="Schacht",
         model_name="Baby Wolf",
         supports_lift_tracking=False,
         supports_treadle_tracking=True,
     )
-    db_session.add(loom)
-    await db_session.flush()
+    db.add(loom)
+    await db.flush()
     version = LoomVersion(
         loom_id=loom.id,
+        loom_reference_id=loom_reference_id,
         version_number=1,
         effective_date=date(2024, 1, 1),
     )
-    db_session.add(version)
-    await db_session.commit()
+    db.add(version)
+    await db.commit()
+    return loom, version
+
+
+@pytest.mark.anyio
+async def test_link_version_to_reference(auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+    ref = await _make_ref(db_session)
+    loom, version = await _make_loom_with_version(db_session, test_user)
 
     resp = await auth_client.post(
-        f"/api/looms/{loom.id}/link-reference",
+        f"/api/looms/{loom.id}/versions/{version.id}/link-reference",
         json={"loom_reference_id": str(ref.id)},
     )
     assert resp.status_code == 200
     data = resp.json()
     assert data["loom_reference_id"] == str(ref.id)
+    assert data["current_version"]["loom_reference_id"] == str(ref.id)
 
 
 @pytest.mark.anyio
-async def test_unlink_loom_from_reference(auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+async def test_unlink_version_from_reference(auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
     ref = await _make_ref(db_session)
-
-    loom = Loom(
-        owner_id=test_user.id,
-        loom_type="floor_loom",
-        manufacturer="Schacht",
-        model_name="Baby Wolf",
-        loom_reference_id=ref.id,
-        supports_lift_tracking=False,
-        supports_treadle_tracking=True,
-    )
-    db_session.add(loom)
-    await db_session.flush()
-    db_session.add(LoomVersion(loom_id=loom.id, version_number=1, effective_date=date(2024, 1, 1)))
-    await db_session.commit()
+    loom, version = await _make_loom_with_version(db_session, test_user, loom_reference_id=ref.id)
 
     resp = await auth_client.post(
-        f"/api/looms/{loom.id}/link-reference",
+        f"/api/looms/{loom.id}/versions/{version.id}/link-reference",
         json={"loom_reference_id": None},
     )
     assert resp.status_code == 200
@@ -245,21 +243,117 @@ async def test_unlink_loom_from_reference(auth_client: AsyncClient, db_session: 
 async def test_link_nonexistent_reference_404(auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
     import uuid
 
+    loom, version = await _make_loom_with_version(db_session, test_user)
+
+    resp = await auth_client.post(
+        f"/api/looms/{loom.id}/versions/{version.id}/link-reference",
+        json={"loom_reference_id": str(uuid.uuid4())},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_relink_version_to_different_catalog_entry(
+    auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+):
+    """A version linked to entry A can be relinked to entry B."""
+    ref_a = await _make_ref(db_session, brand="Louet", model="Spring 8")
+    ref_b = await _make_ref(db_session, brand="Louet", model="Spring 16")
+    loom, version = await _make_loom_with_version(db_session, test_user, loom_reference_id=ref_a.id)
+
+    resp = await auth_client.post(
+        f"/api/looms/{loom.id}/versions/{version.id}/link-reference",
+        json={"loom_reference_id": str(ref_b.id)},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["loom_reference_id"] == str(ref_b.id)
+    assert data["loom_reference_brand"] == "Louet"
+    assert data["loom_reference_model_name"] == "Spring 16"
+    assert data["current_version"]["loom_reference_id"] == str(ref_b.id)
+
+
+@pytest.mark.anyio
+async def test_per_version_catalog_links_independent(
+    auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+):
+    """v1 and v2 can be linked to different catalog entries independently."""
+
+    ref_8 = await _make_ref(db_session, brand="Louet", model="Jane 8")
+    ref_16 = await _make_ref(db_session, brand="Louet", model="Jane 16")
+
     loom = Loom(
         owner_id=test_user.id,
         loom_type="floor_loom",
-        manufacturer="Unknown",
-        model_name="Mystery",
+        manufacturer="Louet",
+        model_name="Jane",
         supports_lift_tracking=False,
         supports_treadle_tracking=True,
     )
     db_session.add(loom)
     await db_session.flush()
-    db_session.add(LoomVersion(loom_id=loom.id, version_number=1, effective_date=date(2024, 1, 1)))
+
+    v1 = LoomVersion(loom_id=loom.id, loom_reference_id=ref_8.id, version_number=1, effective_date=date(2023, 1, 1))
+    v2 = LoomVersion(loom_id=loom.id, loom_reference_id=ref_16.id, version_number=2, effective_date=date(2024, 6, 1))
+    db_session.add_all([v1, v2])
     await db_session.commit()
 
-    resp = await auth_client.post(
-        f"/api/looms/{loom.id}/link-reference",
-        json={"loom_reference_id": str(uuid.uuid4())},
-    )
-    assert resp.status_code == 404
+    resp = await auth_client.get(f"/api/looms/{loom.id}")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # Top-level fields reflect the current (latest) version — v2 → ref_16
+    assert data["loom_reference_id"] == str(ref_16.id)
+    assert data["loom_reference_brand"] == "Louet"
+    assert data["loom_reference_model_name"] == "Jane 16"
+
+    # v1 still carries its own link
+    versions = {v["version_number"]: v for v in data["versions"]}
+    assert versions[1]["loom_reference_id"] == str(ref_8.id)
+    assert versions[1]["loom_reference_model_name"] == "Jane 8"
+    assert versions[2]["loom_reference_id"] == str(ref_16.id)
+    assert versions[2]["loom_reference_model_name"] == "Jane 16"
+
+
+@pytest.mark.anyio
+async def test_linked_loom_detail_includes_catalog_names(
+    auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+):
+    """GET /api/looms/{id} returns loom_reference_brand/model_name when current version is linked."""
+    ref = await _make_ref(db_session, brand="Schacht", model="Baby Wolf")
+    loom, _ = await _make_loom_with_version(db_session, test_user, loom_reference_id=ref.id)
+
+    resp = await auth_client.get(f"/api/looms/{loom.id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["loom_reference_brand"] == "Schacht"
+    assert data["loom_reference_model_name"] == "Baby Wolf"
+
+
+@pytest.mark.anyio
+async def test_unlinked_loom_detail_has_null_catalog_names(
+    auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+):
+    """GET /api/looms/{id} returns null catalog names when not linked."""
+    loom, _ = await _make_loom_with_version(db_session, test_user)
+
+    resp = await auth_client.get(f"/api/looms/{loom.id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["loom_reference_brand"] is None
+    assert data["loom_reference_model_name"] is None
+
+
+@pytest.mark.anyio
+async def test_list_looms_includes_catalog_names(auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+    """GET /api/looms returns catalog names from the current version for linked looms."""
+    ref = await _make_ref(db_session, brand="Schacht", model="Mighty Wolf")
+    loom, _ = await _make_loom_with_version(db_session, test_user, loom_reference_id=ref.id)
+
+    resp = await auth_client.get("/api/looms")
+    assert resp.status_code == 200
+    looms = resp.json()
+    linked = next((item for item in looms if item["loom_reference_id"] == str(ref.id)), None)
+    assert linked is not None
+    assert linked["loom_reference_brand"] == "Schacht"
+    assert linked["loom_reference_model_name"] == "Mighty Wolf"

--- a/frontend/src/api/looms.ts
+++ b/frontend/src/api/looms.ts
@@ -55,6 +55,9 @@ export interface LoomReed {
 
 export interface LoomVersion {
   id: string;
+  loom_reference_id: string | null;
+  loom_reference_brand: string | null;
+  loom_reference_model_name: string | null;
   version_number: number;
   name: string | null;
   effective_date: string;
@@ -80,6 +83,8 @@ export interface Loom {
   model_name: string;
   serial_number: string | null;
   loom_reference_id: string | null;
+  loom_reference_brand: string | null;
+  loom_reference_model_name: string | null;
   supports_lift_tracking: boolean;
   supports_treadle_tracking: boolean;
   notes: string | null;
@@ -457,8 +462,12 @@ export function getLoomCatalogEntry(id: string): Promise<LoomReferenceDetail> {
   return fetch(`/api/loom-catalog/${id}`).then((r) => r.json());
 }
 
-export function linkLoomReference(loomId: string, referenceId: string | null): Promise<LoomDetail> {
-  return req(`/api/looms/${loomId}/link-reference`, {
+export function linkVersionReference(
+  loomId: string,
+  versionId: string,
+  referenceId: string | null,
+): Promise<LoomDetail> {
+  return req(`/api/looms/${loomId}/versions/${versionId}/link-reference`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ loom_reference_id: referenceId }),

--- a/frontend/src/components/looms/LinkToCatalogModal.tsx
+++ b/frontend/src/components/looms/LinkToCatalogModal.tsx
@@ -2,9 +2,10 @@ import { useState, useRef, useEffect } from "react";
 import {
   searchLoomCatalog,
   updateLoom,
-  linkLoomReference,
+  linkVersionReference,
   updateVersion,
   type LoomDetail,
+  type LoomVersion,
   type LoomReferenceSummary,
   type LoomType,
   type UpdateVersionPayload,
@@ -99,11 +100,12 @@ function deriveTreadles(
 
 interface Props {
   loom: LoomDetail;
+  version: LoomVersion;
   onSuccess: () => void;
   onClose: () => void;
 }
 
-export function LinkToCatalogModal({ loom, onSuccess, onClose }: Props) {
+export function LinkToCatalogModal({ loom, version, onSuccess, onClose }: Props) {
   const [step, setStep] = useState<Step>("search");
 
   // Search state — displayQuery shown in input, searchQuery triggers API
@@ -195,13 +197,13 @@ export function LinkToCatalogModal({ loom, onSuccess, onClose }: Props) {
     const sOpts = ref.shaft_count_options ?? [];
     const wOpts = buildWidthOptions(ref);
 
-    // Auto-match shaft to current version
-    setSelectedShaftIdx(closestIdx(sOpts, loom.current_version?.num_shafts));
+    // Auto-match shaft to target version
+    setSelectedShaftIdx(closestIdx(sOpts, version.num_shafts));
 
-    // Auto-match width to current version (convert units if needed)
-    if (wOpts.length > 0 && loom.current_version?.weaving_width) {
-      const curVal = parseFloat(loom.current_version.weaving_width);
-      const curUnit = loom.current_version.weaving_width_unit as "cm" | "in";
+    // Auto-match width to target version (convert units if needed)
+    if (wOpts.length > 0 && version.weaving_width) {
+      const curVal = parseFloat(version.weaving_width);
+      const curUnit = version.weaving_width_unit as "cm" | "in";
       const targetUnit = wOpts[0].unit;
       const converted =
         curUnit === targetUnit
@@ -221,7 +223,7 @@ export function LinkToCatalogModal({ loom, onSuccess, onClose }: Props) {
   }
 
   // Diff rows for confirm step
-  const cv = loom.current_version;
+  const cv = version;
 
   interface DiffRow {
     label: string;
@@ -300,7 +302,7 @@ export function LinkToCatalogModal({ loom, onSuccess, onClose }: Props) {
         model_name: selectedRef.model_name,
         loom_type: newLoomType,
       });
-      await linkLoomReference(loom.id, selectedRef.id);
+      await linkVersionReference(loom.id, version.id, selectedRef.id);
 
       if (cv) {
         const versionPayload: UpdateVersionPayload = {};
@@ -332,9 +334,11 @@ export function LinkToCatalogModal({ loom, onSuccess, onClose }: Props) {
       <div className="w-full max-w-lg rounded-lg border bg-background p-6 shadow-lg overflow-y-auto max-h-[90vh]">
         <div className="flex items-start justify-between mb-5">
           <div>
-            <h2 className="text-lg font-semibold">Update from catalog</h2>
+            <h2 className="text-lg font-semibold">
+              {version.loom_reference_id ? "Change catalog link" : "Link to catalog"}
+            </h2>
             <p className="text-sm text-muted-foreground">
-              {loom.manufacturer} {loom.model_name}
+              {loom.manufacturer} {loom.model_name} — {version.name ?? `v${version.version_number}`}
             </p>
           </div>
           <button

--- a/frontend/src/pages/LoomDetailPage.tsx
+++ b/frontend/src/pages/LoomDetailPage.tsx
@@ -11,7 +11,7 @@ import {
   uploadVersionPhoto, deleteVersionPhoto, versionPhotoUrl,
   uploadVersionReceipt, deleteVersionReceipt, versionReceiptUrl,
   addAccessory, deleteAccessory, updateVersion,
-  addReed, deleteReed, linkLoomReference,
+  addReed, deleteReed, linkVersionReference,
   type LoomDetail, type LoomVersion, type LoomVersionPhoto,
   type LoomVersionReceipt, type LoomVersionAccessory, type LoomReed,
   LOOM_TYPE_LABELS, SUPPORTED_LOOM_TYPES,
@@ -630,6 +630,18 @@ function VersionCard({
   const displayUnit = measurementSystemToUnit(user?.measurement_system ?? "metric");
   const [open, setOpen] = useState(isCurrent);
   const [editing, setEditing] = useState(false);
+  const [showLinkCatalog, setShowLinkCatalog] = useState(false);
+  const [unlinking, setUnlinking] = useState(false);
+
+  const handleUnlink = async () => {
+    setUnlinking(true);
+    try {
+      await linkVersionReference(loom.id, version.id, null);
+      onChanged();
+    } finally {
+      setUnlinking(false);
+    }
+  };
   const [editName, setEditName] = useState(version.name ?? "");
   const [editDesc, setEditDesc] = useState(version.description ?? "");
   const [editWasteUnit, setEditWasteUnit] = useState<LengthUnit>(
@@ -794,16 +806,63 @@ function VersionCard({
           </div>
 
           {!isReadOnly && (
-            <div className="border-t pt-3">
-              <Button size="sm" variant="outline" onClick={() => onClone(version)}>
-                Clone this configuration
-              </Button>
-              <p className="mt-1 text-xs text-muted-foreground">
-                Creates a new configuration pre-filled with {displayName}'s spec and accessories.
-              </p>
+            <div className="border-t pt-3 space-y-3">
+              <div className="flex items-center gap-2 flex-wrap">
+                {version.loom_reference_id ? (
+                  <>
+                    <span className="text-xs rounded-full bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 px-2 py-0.5 font-medium">
+                      {version.loom_reference_brand && version.loom_reference_model_name
+                        ? `${version.loom_reference_brand} ${version.loom_reference_model_name}`
+                        : "Linked to catalog"}
+                    </span>
+                    <button
+                      onClick={() => setShowLinkCatalog(true)}
+                      className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      Change
+                    </button>
+                    <button
+                      onClick={handleUnlink}
+                      disabled={unlinking}
+                      className="text-xs text-muted-foreground hover:text-destructive transition-colors"
+                    >
+                      {unlinking ? "Unlinking…" : "Unlink"}
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <span className="text-xs rounded-full bg-muted text-muted-foreground px-2 py-0.5 font-medium">
+                      Not in catalog
+                    </span>
+                    <button
+                      onClick={() => setShowLinkCatalog(true)}
+                      className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      Link to catalog…
+                    </button>
+                    <CatalogRequestButton loom={loom} />
+                  </>
+                )}
+              </div>
+              <div>
+                <Button size="sm" variant="outline" onClick={() => onClone(version)}>
+                  Clone this configuration
+                </Button>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Creates a new configuration pre-filled with {displayName}'s spec and accessories.
+                </p>
+              </div>
             </div>
           )}
         </div>
+      )}
+      {showLinkCatalog && (
+        <LinkToCatalogModal
+          loom={loom}
+          version={version}
+          onSuccess={() => { setShowLinkCatalog(false); onChanged(); }}
+          onClose={() => setShowLinkCatalog(false)}
+        />
       )}
     </div>
   );
@@ -820,7 +879,6 @@ export function LoomDetailPage() {
   const { user } = useAuthContext();
   const [showAddVersion, setShowAddVersion] = useState(false);
   const [showEdit, setShowEdit] = useState(false);
-  const [showLinkCatalog, setShowLinkCatalog] = useState(false);
   const [cloneSource, setCloneSource] = useState<LoomVersion | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleteConflict, setDeleteConflict] = useState<DeleteConflict | null>(null);
@@ -829,7 +887,6 @@ export function LoomDetailPage() {
   const [retiring, setRetiring] = useState(false);
   const [confirmRetire, setConfirmRetire] = useState(false);
   const [dangerZoneOpen, setDangerZoneOpen] = useState(false);
-  const [unlinking, setUnlinking] = useState(false);
 
   const { data: loom, isLoading, error } = useQuery({
     queryKey: ["loom", id],
@@ -891,17 +948,6 @@ export function LoomDetailPage() {
     }
   };
 
-  const handleUnlink = async () => {
-    if (!loom) return;
-    setUnlinking(true);
-    try {
-      await linkLoomReference(loom.id, null);
-      invalidate();
-    } finally {
-      setUnlinking(false);
-    }
-  };
-
   if (isLoading) return <div className="flex min-h-screen items-center justify-center"><p className="text-muted-foreground text-sm">Loading…</p></div>;
   if (error || !loom) return <div className="flex min-h-screen items-center justify-center"><p className="text-destructive text-sm">Loom not found.</p></div>;
 
@@ -921,11 +967,6 @@ export function LoomDetailPage() {
           <span className="text-xs text-muted-foreground">{LOOM_TYPE_LABELS[loom.loom_type]}</span>
         </div>
         <div className="flex gap-2">
-          {!isReadOnly && (
-            <Button size="sm" variant="outline" onClick={() => setShowLinkCatalog(true)}>
-              Update from catalog
-            </Button>
-          )}
           {!isReadOnly && <Button size="sm" variant="outline" onClick={() => setShowEdit(true)}>Edit</Button>}
           {!isReadOnly && <Button size="sm" onClick={() => setShowAddVersion(true)}>Add version</Button>}
         </div>
@@ -952,31 +993,6 @@ export function LoomDetailPage() {
             </div>
           )}
           {loom.notes && <p className="text-sm text-muted-foreground whitespace-pre-wrap">{loom.notes}</p>}
-          {!isReadOnly && (
-            <div className="flex items-center gap-2 flex-wrap">
-              {loom.loom_reference_id ? (
-                <>
-                  <span className="text-xs rounded-full bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 px-2 py-0.5 font-medium">
-                    Linked to catalog
-                  </span>
-                  <button
-                    onClick={handleUnlink}
-                    disabled={unlinking}
-                    className="text-xs text-muted-foreground hover:text-destructive transition-colors"
-                  >
-                    {unlinking ? "Unlinking…" : "Unlink"}
-                  </button>
-                </>
-              ) : (
-                <>
-                  <span className="text-xs rounded-full bg-muted text-muted-foreground px-2 py-0.5 font-medium">
-                    Not in catalog
-                  </span>
-                  <CatalogRequestButton loom={loom} />
-                </>
-              )}
-            </div>
-          )}
           {activeProject && (
             <div className="rounded-md border border-green-300 bg-green-50 dark:bg-green-950/30 dark:border-green-700 px-3 py-2.5 text-sm flex items-center justify-between gap-4">
               <div>
@@ -1122,9 +1138,6 @@ export function LoomDetailPage() {
       )}
       {showEdit && (
         <EditLoomModal loom={loom} onSuccess={handleEditSaved} onClose={() => setShowEdit(false)} />
-      )}
-      {showLinkCatalog && (
-        <LinkToCatalogModal loom={loom} onSuccess={() => { setShowLinkCatalog(false); invalidate(); }} onClose={() => setShowLinkCatalog(false)} />
       )}
       {cloneSource && (
         <CloneVersionModal loomId={loom.id} source={cloneSource} onSuccess={handleCloned} onClose={() => setCloneSource(null)} />


### PR DESCRIPTION
## Summary

- Moves `loom_reference_id` from the `Loom` model to `LoomVersion`, so each hardware configuration version of a loom can independently reference a different catalog entry
- A user with a Louet Jane 8-shaft loom (v1) who later installs a 16-shaft upgrade kit can add a v2 loom config linked to the Jane 16 catalog entry — existing projects remain on v1 (8-shaft), new projects default to v2 (16-shaft)
- The loom-level link endpoint (`POST /api/looms/{id}/link-reference`) is replaced with a version-level endpoint: `POST /api/looms/{loom_id}/versions/{version_id}/link-reference`
- `LoomSummary` and `LoomDetail` still expose `loom_reference_id`, `loom_reference_brand`, `loom_reference_model_name` at the top level (derived from the current/latest version) for backwards-compatible list/detail views
- Migration `0033_loom_version_catalog_link` adds the FK to `loom_versions`, copies existing loom-level links to the latest version, then drops the old column from `looms`
- `LinkToCatalogModal` and the catalog link UI section moved from page-level into `VersionCard` so each version can be managed independently
- 8 new/updated tests covering link, unlink, relink, per-version independence, and catalog name propagation

Supersedes #786.

## Test plan
- [ ] pytest passes: `test_loom_catalog.py` — all 8 link-reference tests green
- [ ] Add a new loom → link v1 to catalog entry A
- [ ] Add v2 → link v2 to catalog entry B
- [ ] Confirm v1 still shows entry A, v2 shows entry B
- [ ] Confirm projects associated with v1 are unaffected
- [ ] `tsc` clean, no regressions in loom list/detail pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)