### PR TITLE
feat: increase task history cap to 500 and record post_migrate dispatches

### DIFF
--- a/backend/app/services/task_history.py
+++ b/backend/app/services/task_history.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 
 HISTORY_ZSET_KEY = "weftmark:task_history"
 HISTORY_META_PREFIX = "weftmark:task_history:meta:"
-HISTORY_MAX = 100
+HISTORY_MAX = 500
 META_TTL = 7 * 86400  # 7 days
 
 

--- a/backend/app/tasks/post_migrate.py
+++ b/backend/app/tasks/post_migrate.py
@@ -60,6 +60,7 @@ def _backfill_registry() -> list[dict]:
     return [
         {
             "name": "seed_loom_references",
+            "task_name": "app.tasks.seeds.seed_loom_references",
             "description": "Seed loom_references table from loom-data-master.json on first startup",
             # Returns 1 (empty) → dispatch; returns 0 (has rows) → skip.
             "condition": "SELECT CASE WHEN COUNT(*) = 0 THEN 1 ELSE 0 END FROM loom_references",
@@ -67,6 +68,7 @@ def _backfill_registry() -> list[dict]:
         },
         {
             "name": "reparse_drafts",
+            "task_name": "app.tasks.reparse.reparse_all_drafts",
             "description": "Backfill wif_colors, wif_measurements, warp_color_stats, weft_color_stats on drafts",
             "condition": (
                 "SELECT COUNT(*) FROM drafts WHERE wif_colors IS NULL AND wif_path IS NOT NULL AND deleted_at IS NULL"
@@ -75,6 +77,7 @@ def _backfill_registry() -> list[dict]:
         },
         {
             "name": "drawdown_preview",
+            "task_name": "app.tasks.preview.backfill_all_drawdown_previews",
             "description": "Pre-render drawdown_preview PNG for drafts missing it",
             "condition": (
                 "SELECT COUNT(*) FROM drafts"
@@ -84,12 +87,14 @@ def _backfill_registry() -> list[dict]:
         },
         {
             "name": "project_drawdown_preview",
+            "task_name": "app.tasks.preview.backfill_all_project_drawdown_previews",
             "description": "Pre-render drawdown_preview PNG for projects missing it",
             "condition": ("SELECT COUNT(*) FROM projects WHERE drawdown_preview_path IS NULL AND deleted_at IS NULL"),
             "dispatch": lambda: backfill_all_project_drawdown_previews.delay(),
         },
         {
             "name": "project_drawdown_svg",
+            "task_name": "app.tasks.preview.backfill_all_project_drawdown_svgs",
             "description": "Pre-render drawdown SVG for projects missing it",
             "condition": ("SELECT COUNT(*) FROM projects WHERE drawdown_svg_path IS NULL AND deleted_at IS NULL"),
             "dispatch": lambda: backfill_all_project_drawdown_svgs.delay(),
@@ -148,7 +153,19 @@ def _run() -> dict:
                         continue
 
                     try:
-                        entry["dispatch"]()
+                        result = entry["dispatch"]()
+                        if result is not None and hasattr(result, "id"):
+                            try:
+                                from app.services.task_history import record_queued
+
+                                record_queued(
+                                    settings,
+                                    result.id,
+                                    entry.get("task_name", name),
+                                    "post_migrate",
+                                )
+                            except Exception:
+                                pass
                         dispatched.append(f"{name}(null_rows={null_count})")
                         log.info(
                             "post_migrate_dispatch name=%s null_rows=%d description=%r",

--- a/backend/tests/tasks/test_post_migrate.py
+++ b/backend/tests/tasks/test_post_migrate.py
@@ -156,8 +156,10 @@ def _reparse_registry_entry(dispatch_fn):
 
 class TestNoNullRows:
     def test_skips_all_when_table_empty(self):
-        """With no drafts in the DB at all, backfill is skipped."""
-        result = _run()
+        """With no drafts in the DB, draft backfill is skipped."""
+        with patch("app.tasks.post_migrate._backfill_registry") as mock_registry:
+            mock_registry.return_value = [_reparse_registry_entry(lambda: None)]
+            result = _run()
         assert result["dispatched"] == []
         assert any("no_null_rows" in s for s in result["skipped"])
 
@@ -197,7 +199,9 @@ class TestNullRowsPresent:
         """Soft-deleted drafts with null wif_colors must not trigger dispatch."""
         await _seed_draft(db_session, test_user.id, wif_colors=None, deleted=True)
 
-        result = _run()
+        with patch("app.tasks.post_migrate._backfill_registry") as mock_registry:
+            mock_registry.return_value = [_reparse_registry_entry(lambda: None)]
+            result = _run()
         assert result["dispatched"] == []
         assert any("no_null_rows" in s for s in result["skipped"])
 


### PR DESCRIPTION
## Summary

- **`HISTORY_MAX` raised from 100 → 500** — the 100-item cap was being saturated in ~35 minutes under normal heartbeat + scheduler load, making recent history invisible. 500 entries covers several hours of activity at a negligible Redis memory cost (~250 KB).
- **post_migrate backfill dispatches now appear in task history** — after each successful backfill dispatch, `record_queued` is called with `caller=post_migrate` and the full dotted task name. Tasks like `seed_loom_references`, `reparse_all_drafts`, and the drawdown preview backfills will now show up in Workers → Task History with accurate queue/run/complete timing.
- Each registry entry now carries a `task_name` field (e.g. `app.tasks.seeds.seed_loom_references`) used for the history record.
- Two existing tests tightened to mock the registry instead of using the full real registry, so the new seed condition (fires when `loom_references` is empty, which is always true in the test DB) doesn't interfere.

## Test plan

- [ ] CI passes
- [ ] Deploy to dev → restart worker → check Workers → Task History shows `seeds.seed_loom_references` with `caller=post_migrate`
- [ ] Task History total no longer pegged at 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)