### PR TITLE
feat: task history improvements and loom seed on every startup

### DIFF
--- a/backend/app/tasks/post_migrate.py
+++ b/backend/app/tasks/post_migrate.py
@@ -61,9 +61,8 @@ def _backfill_registry() -> list[dict]:
         {
             "name": "seed_loom_references",
             "task_name": "app.tasks.seeds.seed_loom_references",
-            "description": "Seed loom_references table from loom-data-master.json on first startup",
-            # Returns 1 (empty) → dispatch; returns 0 (has rows) → skip.
-            "condition": "SELECT CASE WHEN COUNT(*) = 0 THEN 1 ELSE 0 END FROM loom_references",
+            "description": "Upsert loom_references from loom-data-master.json on every startup",
+            "condition": "SELECT 1",
             "dispatch": lambda: seed_loom_references.delay(),
         },
         {

--- a/backend/tests/tasks/test_seeds.py
+++ b/backend/tests/tasks/test_seeds.py
@@ -113,8 +113,8 @@ def _run_post_migrate(redis_client=None):
 
 
 class TestLoomSeedBackfill:
-    def test_dispatches_when_loom_references_empty(self, mock_redis):
-        """With an empty loom_references table, the seed task is dispatched."""
+    def test_dispatches_on_startup(self, mock_redis):
+        """Seed task is always dispatched on startup (SELECT 1 condition)."""
         dispatched: list[str] = []
 
         dispatch_fn = MagicMock(side_effect=lambda: dispatched.append("seed_loom_references"))
@@ -123,7 +123,7 @@ class TestLoomSeedBackfill:
                 {
                     "name": "seed_loom_references",
                     "description": "seed test",
-                    "condition": "SELECT CASE WHEN COUNT(*) = 0 THEN 1 ELSE 0 END FROM loom_references",
+                    "condition": "SELECT 1",
                     "dispatch": dispatch_fn,
                 }
             ]
@@ -133,8 +133,8 @@ class TestLoomSeedBackfill:
         assert "seed_loom_references" in result["dispatched"][0]
         assert "seed_loom_references" in dispatched
 
-    async def test_skips_when_loom_references_has_rows(self, db_session, mock_redis):
-        """When loom_references already has at least one row, the seed is skipped."""
+    async def test_dispatches_even_when_loom_references_has_rows(self, db_session, mock_redis):
+        """Seed is dispatched even when loom_references already has rows — it's an upsert."""
         from sqlalchemy import text
 
         await db_session.execute(
@@ -145,16 +145,19 @@ class TestLoomSeedBackfill:
         )
         await db_session.commit()
 
+        dispatched: list[str] = []
+        dispatch_fn = MagicMock(side_effect=lambda: dispatched.append("seed_loom_references"))
         with patch("app.tasks.post_migrate._backfill_registry") as mock_reg:
             mock_reg.return_value = [
                 {
                     "name": "seed_loom_references",
                     "description": "seed test",
-                    "condition": "SELECT CASE WHEN COUNT(*) = 0 THEN 1 ELSE 0 END FROM loom_references",
-                    "dispatch": lambda: (_ for _ in ()).throw(AssertionError("should not dispatch")),
+                    "condition": "SELECT 1",
+                    "dispatch": dispatch_fn,
                 }
             ]
             result = _run_post_migrate(mock_redis)
 
-        assert result["dispatched"] == []
-        assert any("seed_loom_references" in s for s in result["skipped"])
+        assert len(result["dispatched"]) == 1
+        assert "seed_loom_references" in result["dispatched"][0]
+        assert "seed_loom_references" in dispatched


### PR DESCRIPTION
## Summary

- Raised `HISTORY_MAX` from 100 → 500 so task history doesn't roll over under normal scheduler load (~100 entries per 35 min)
- Added `record_queued` calls in `post_migrate._run()` so functional backfill tasks (loom seed, reparse, previews) appear in Workers → Task History
- Changed loom seed condition from `CASE WHEN COUNT(*) = 0` to `SELECT 1` — seed upserts on every startup, so new loom entries in `loom-data-master.json` are picked up without a database wipe; existing rows update in place

## Test plan

- [ ] Deploy to dev — loom seed event appears in Task History on every worker restart
- [ ] Add a new entry to `loom-data-master.json`, deploy — new loom appears in catalog, existing 68 unchanged
- [ ] Confirm Redis SETNX lock prevents duplicate dispatches when multiple workers start simultaneously
- [ ] `pytest tests/tasks/test_seeds.py tests/tasks/test_post_migrate.py` — 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)