### PR TITLE
feat: i18n infrastructure, label extraction, language selector (issue #313)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
     container_name: ${STACK_NAME:-weftmark}_backend
     environment:
       APP_ENV: ${APP_ENV}
-          DEBUG: ${DEBUG}
+      DEBUG: ${DEBUG}
       LOG_LEVEL: ${LOG_LEVEL}
       SEED_ENABLED: ${SEED_ENABLED}
       CORS_ORIGINS: ${CORS_ORIGINS}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weaving-site",
-  "version": "0.170.5",
+  "version": "0.180.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weaving-site",
-      "version": "0.170.5",
+      "version": "0.180.0",
       "dependencies": {
         "@clerk/clerk-react": "^5.61.6",
         "@tanstack/react-query": "^5.100.9",
@@ -14,9 +14,11 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "dompurify": "^3.4.5",
+        "i18next": "^26.2.0",
         "lucide-react": "^1.14.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-i18next": "^17.0.8",
         "react-router-dom": "^7.0.0",
         "tailwind-merge": "^3.6.0"
       },
@@ -66,6 +68,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -227,6 +230,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -327,29 +339,6 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -1088,27 +1077,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "dev": true,
@@ -1276,6 +1244,7 @@
       "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1286,6 +1255,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1341,6 +1311,7 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -1584,6 +1555,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1674,6 +1646,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1875,6 +1848,7 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2215,6 +2189,44 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.2.0.tgz",
+      "integrity": "sha512-zwBHldHdTmwN7r6UNc7lC6GWNN+YYg3DrRSeHR5PRRBf5QnJZcYHrQc0uaU26qZeYxR7iFZD+Y315dPnKP47wA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/ignore": {
@@ -2857,6 +2869,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2866,11 +2879,39 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
         "react": "^19.2.6"
+      }
+    },
+    "node_modules/react-i18next": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.8.tgz",
+      "integrity": "sha512-0ooKbGLU8JXhe1zwpQUWIeXSgLPOfwJmgheWRIUpcoA0CpyabpGhayjdG+/eA5esC1AQ8h2jWpXjJfzQzeDOCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 26.2.0",
+        "react": ">= 16.8.0",
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router": {
@@ -3098,6 +3139,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3141,8 +3183,9 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3214,6 +3257,7 @@
       "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3299,6 +3343,15 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3351,6 +3404,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -68,7 +68,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -339,6 +338,29 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -1244,7 +1266,6 @@
       "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1255,7 +1276,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1311,7 +1331,6 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -1555,7 +1574,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1646,7 +1664,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1848,7 +1865,6 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2219,7 +2235,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6"
       },
@@ -2869,7 +2884,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2879,7 +2893,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3139,7 +3152,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3185,7 +3197,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3257,7 +3268,6 @@
       "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3404,7 +3414,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,9 +17,11 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "dompurify": "^3.4.5",
+    "i18next": "^26.2.0",
     "lucide-react": "^1.14.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-i18next": "^17.0.8",
     "react-router-dom": "^7.0.0",
     "tailwind-merge": "^3.6.0"
   },

--- a/frontend/src/api/feedback.ts
+++ b/frontend/src/api/feedback.ts
@@ -2,10 +2,12 @@ import { api } from "@/api/client";
 
 export type SubmissionType = "feedback" | "feature_request" | "bug_report";
 
+import i18next from "i18next";
+
 export const SUBMISSION_TYPE_LABELS: Record<SubmissionType, string> = {
-  feedback: "Feedback",
-  feature_request: "Feature Request",
-  bug_report: "Bug Report",
+  get feedback() { return i18next.t("feedbackType.feedback"); },
+  get feature_request() { return i18next.t("feedbackType.feature_request"); },
+  get bug_report() { return i18next.t("feedbackType.bug_report"); },
 };
 
 export interface FeedbackDiagnostics {

--- a/frontend/src/api/looms.ts
+++ b/frontend/src/api/looms.ts
@@ -9,16 +9,18 @@ export type LoomType =
   | "frame_loom"
   | "other";
 
+import i18next from "i18next";
+
 export const LOOM_TYPE_LABELS: Record<LoomType, string> = {
-  floor_loom: "Floor Loom — treadle tracking",
-  table_loom: "Table Loom — lift tracking",
-  rigid_heddle: "Rigid Heddle",
-  inkle: "Inkle",
-  dobby_floor_loom: "Dobby Floor Loom",
-  tapestry_loom: "Tapestry Loom — project tracking not currently supported",
-  rug_loom: "Rug Loom — project tracking not currently supported",
-  frame_loom: "Frame Loom — project tracking not currently supported",
-  other: "Other",
+  get floor_loom() { return i18next.t("loomTypes.floor_loom"); },
+  get table_loom() { return i18next.t("loomTypes.table_loom"); },
+  get rigid_heddle() { return i18next.t("loomTypes.rigid_heddle"); },
+  get inkle() { return i18next.t("loomTypes.inkle"); },
+  get dobby_floor_loom() { return i18next.t("loomTypes.dobby_floor_loom"); },
+  get tapestry_loom() { return i18next.t("loomTypes.tapestry_loom"); },
+  get rug_loom() { return i18next.t("loomTypes.rug_loom"); },
+  get frame_loom() { return i18next.t("loomTypes.frame_loom"); },
+  get other() { return i18next.t("loomTypes.other"); },
 };
 
 /** Loom types that support project tracking (treadle or lift). */

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -1,16 +1,18 @@
 export type ProjectType = "treadle" | "lift";
 export type ProjectStatus = "created" | "active" | "completed" | "abandoned";
 
+import i18next from "i18next";
+
 export const PROJECT_TYPE_LABELS: Record<ProjectType, string> = {
-  treadle: "Treadle tracking",
-  lift: "Lift tracking",
+  get treadle() { return i18next.t("projectType.treadle"); },
+  get lift() { return i18next.t("projectType.lift"); },
 };
 
 export const PROJECT_STATUS_LABELS: Record<ProjectStatus, string> = {
-  created: "Not started",
-  active: "Active",
-  completed: "Completed",
-  abandoned: "Abandoned",
+  get created() { return i18next.t("projectStatus.created"); },
+  get active() { return i18next.t("projectStatus.active"); },
+  get completed() { return i18next.t("projectStatus.completed"); },
+  get abandoned() { return i18next.t("projectStatus.abandoned"); },
 };
 
 export type ShareVisibility = "private" | "link" | "public";

--- a/frontend/src/api/yarn.ts
+++ b/frontend/src/api/yarn.ts
@@ -16,10 +16,12 @@ export function displayWeight(oz: string | null, g: string | null): string | nul
   return null;
 }
 
+import i18next from "i18next";
+
 export const SKEIN_STATUS_LABELS: Record<string, string> = {
-  available: "Available",
-  in_use: "In use",
-  consumed: "Consumed",
+  get available() { return i18next.t("skeinStatus.available"); },
+  get in_use() { return i18next.t("skeinStatus.in_use"); },
+  get consumed() { return i18next.t("skeinStatus.consumed"); },
 };
 
 export type SkeinStatus = "available" | "in_use" | "consumed";

--- a/frontend/src/components/LanguageSelector.tsx
+++ b/frontend/src/components/LanguageSelector.tsx
@@ -1,0 +1,99 @@
+import { useRef, useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { SUPPORTED_LANGUAGES } from "@/i18n/config";
+
+interface Props {
+  variant?: "public" | "app";
+}
+
+export function LanguageSelector({ variant = "app" }: Props) {
+  const { i18n } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const current = SUPPORTED_LANGUAGES.find((l) => l.code === i18n.language) ?? SUPPORTED_LANGUAGES[0];
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  function select(code: string) {
+    i18n.changeLanguage(code);
+    localStorage.setItem("wm_lang", code);
+    setOpen(false);
+  }
+
+  const triggerClass =
+    variant === "public"
+      ? "flex cursor-pointer items-center gap-1.5 text-sm font-medium text-stone-600 transition-colors hover:text-stone-900 select-none"
+      : "flex cursor-pointer items-center gap-1.5 rounded-md border border-border bg-background px-3 py-2 text-sm select-none hover:bg-accent";
+
+  const dropdownClass =
+    variant === "public"
+      ? "absolute right-0 top-full z-50 mt-1.5 min-w-[9rem] overflow-hidden rounded-lg border border-stone-200 bg-white py-1 shadow-lg"
+      : "absolute right-0 top-full z-50 mt-1.5 min-w-[9rem] overflow-hidden rounded-lg border border-border bg-popover py-1 shadow-lg";
+
+  const optionBase = "flex w-full cursor-pointer items-center gap-2.5 px-3 py-2 text-sm transition-colors";
+  const optionIdle =
+    variant === "public"
+      ? "text-stone-700 hover:bg-stone-100"
+      : "text-popover-foreground hover:bg-accent";
+  const optionActive =
+    variant === "public"
+      ? "bg-stone-100 font-medium text-stone-900"
+      : "bg-accent font-medium";
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className={triggerClass}
+      >
+        <span role="img" aria-label={current.label} className="text-base leading-none">
+          {current.flag}
+        </span>
+        <span>{current.label}</span>
+        <svg
+          className={`h-3.5 w-3.5 opacity-50 transition-transform ${open ? "rotate-180" : ""}`}
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fillRule="evenodd"
+            d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </button>
+
+      {open && (
+        <ul role="listbox" className={dropdownClass}>
+          {SUPPORTED_LANGUAGES.map((lang) => (
+            <li key={lang.code} role="option" aria-selected={lang.code === current.code}>
+              <button
+                type="button"
+                onClick={() => select(lang.code)}
+                className={`${optionBase} ${lang.code === current.code ? optionActive : optionIdle}`}
+              >
+                <span role="img" aria-label={lang.label} className="text-base leading-none">
+                  {lang.flag}
+                </span>
+                {lang.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { useClerk } from "@clerk/clerk-react";
+import { useTranslation } from "react-i18next";
 import { AppIcons, type LucideIcon } from "@/lib/icons";
 import { WeftmarkLogo } from "@/components/WeftmarkLogo";
 import { useAuth } from "@/hooks/useAuth";
@@ -14,38 +15,6 @@ interface NavItem {
   exact?: boolean;
 }
 
-const NAV_ITEMS: NavItem[] = [
-  { label: "Dashboard", href: "/home", icon: AppIcons.dashboard, exact: true },
-  { label: "Equipment", href: "/looms", icon: AppIcons.equipment },
-  { label: "Collections", href: "/collections", icon: AppIcons.collections },
-  { label: "Drafts", href: "/drafts", icon: AppIcons.drafts },
-  { label: "Projects", href: "/projects", icon: AppIcons.projects },
-];
-
-const SETTINGS_SECTIONS = [
-  { id: "appearance", label: "Appearance" },
-  { id: "preferences", label: "Preferences" },
-  { id: "privacy", label: "Privacy & data" },
-  { id: "terms", label: "Terms" },
-  { id: "account", label: "Account" },
-  { id: "feedback-history", label: "Feedback history" },
-];
-
-const ADMIN_SECTIONS = [
-  { id: "users", label: "Users" },
-  { id: "invites", label: "Invites" },
-  { id: "stats", label: "Stats" },
-  { id: "health", label: "Health" },
-  { id: "services", label: "Services" },
-  { id: "deps", label: "Dependencies" },
-  { id: "audit", label: "Audit log" },
-  { id: "feedback", label: "Feedback" },
-  { id: "credentials", label: "Credentials" },
-  { id: "slugs", label: "Share links" },
-  { id: "looms", label: "Loom database" },
-  { id: "superuser", label: "Superuser", superuserOnly: true },
-];
-
 interface Props {
   open: boolean;
   onClose: () => void;
@@ -57,7 +26,40 @@ export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpa
   const location = useLocation();
   const { user } = useAuth();
   const { signOut } = useClerk();
+  const { t } = useTranslation();
   const [feedbackOpen, setFeedbackOpen] = useState(false);
+
+  const NAV_ITEMS: NavItem[] = [
+    { label: t("nav.dashboard"), href: "/home", icon: AppIcons.dashboard, exact: true },
+    { label: t("nav.equipment"), href: "/looms", icon: AppIcons.equipment },
+    { label: t("nav.collections"), href: "/collections", icon: AppIcons.collections },
+    { label: t("nav.drafts"), href: "/drafts", icon: AppIcons.drafts },
+    { label: t("nav.projects"), href: "/projects", icon: AppIcons.projects },
+  ];
+
+  const SETTINGS_SECTIONS = [
+    { id: "appearance", label: t("settingsSections.appearance") },
+    { id: "preferences", label: t("settingsSections.preferences") },
+    { id: "privacy", label: t("settingsSections.privacy") },
+    { id: "terms", label: t("settingsSections.terms") },
+    { id: "account", label: t("settingsSections.account") },
+    { id: "feedback-history", label: t("settingsSections.feedbackHistory") },
+  ];
+
+  const ADMIN_SECTIONS = [
+    { id: "users", label: t("adminSections.users") },
+    { id: "invites", label: t("adminSections.invites") },
+    { id: "stats", label: t("adminSections.stats") },
+    { id: "health", label: t("adminSections.health") },
+    { id: "services", label: t("adminSections.services") },
+    { id: "deps", label: t("adminSections.deps") },
+    { id: "audit", label: t("adminSections.audit") },
+    { id: "feedback", label: t("adminSections.feedback") },
+    { id: "credentials", label: t("adminSections.credentials") },
+    { id: "slugs", label: t("adminSections.slugs") },
+    { id: "looms", label: t("adminSections.looms") },
+    { id: "superuser", label: t("adminSections.superuser"), superuserOnly: true },
+  ];
 
   function isActive(href: string, exact = false) {
     if (exact) return location.pathname === href;
@@ -161,10 +163,10 @@ export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpa
             to="/settings/appearance"
             onClick={onClose}
             className={navCls("/settings")}
-            title={desktopCollapsed ? "Settings" : undefined}
+            title={desktopCollapsed ? t("nav.settings") : undefined}
           >
             <AppIcons.settings className={iconCls("/settings")} strokeWidth={1.75} />
-            <span className={desktopCollapsed ? "lg:hidden" : ""}>Settings</span>
+            <span className={desktopCollapsed ? "lg:hidden" : ""}>{t("nav.settings")}</span>
           </Link>
 
           {isActive("/settings") && !desktopCollapsed && (
@@ -195,10 +197,10 @@ export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpa
               to="/admin/users"
               onClick={onClose}
               className={navCls("/admin")}
-              title={desktopCollapsed ? "Admin" : undefined}
+              title={desktopCollapsed ? t("nav.admin") : undefined}
             >
               <AppIcons.admin className={iconCls("/admin")} strokeWidth={1.75} />
-              <span className={desktopCollapsed ? "lg:hidden" : ""}>Admin</span>
+              <span className={desktopCollapsed ? "lg:hidden" : ""}>{t("nav.admin")}</span>
             </Link>
           )}
 
@@ -228,29 +230,29 @@ export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpa
           <button
             onClick={() => setFeedbackOpen(true)}
             className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground ${desktopCollapsed ? "lg:justify-center lg:px-2" : ""}`}
-            title={desktopCollapsed ? "Send Feedback" : undefined}
+            title={desktopCollapsed ? t("nav.sendFeedback") : undefined}
           >
             <AppIcons.feedback className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} />
-            <span className={desktopCollapsed ? "lg:hidden" : ""}>Send Feedback</span>
+            <span className={desktopCollapsed ? "lg:hidden" : ""}>{t("nav.sendFeedback")}</span>
           </button>
 
           <Link
             to="/costs"
             onClick={onClose}
             className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground ${desktopCollapsed ? "lg:justify-center lg:px-2" : ""}`}
-            title={desktopCollapsed ? "Support weftmark" : undefined}
+            title={desktopCollapsed ? t("nav.supportWeftmark") : undefined}
           >
             <AppIcons.support className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} />
-            <span className={desktopCollapsed ? "lg:hidden" : ""}>Support weftmark</span>
+            <span className={desktopCollapsed ? "lg:hidden" : ""}>{t("nav.supportWeftmark")}</span>
           </Link>
 
           <button
             onClick={() => signOut()}
             className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-subdued transition-colors hover:bg-muted hover:text-foreground ${desktopCollapsed ? "lg:justify-center lg:px-2" : ""}`}
-            title={desktopCollapsed ? "Sign out" : undefined}
+            title={desktopCollapsed ? t("nav.signOut") : undefined}
           >
             <AppIcons.logout className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} />
-            <span className={desktopCollapsed ? "lg:hidden" : ""}>Sign out</span>
+            <span className={desktopCollapsed ? "lg:hidden" : ""}>{t("nav.signOut")}</span>
           </button>
         </div>
 

--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -1,0 +1,16 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import en from "@/locales/en/translation.json";
+
+i18n.use(initReactI18next).init({
+  lng: "en",
+  fallbackLng: "en",
+  resources: {
+    en: { translation: en },
+  },
+  interpolation: {
+    escapeValue: false,
+  },
+});
+
+export default i18n;

--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -7,11 +7,11 @@ import es from "@/locales/es/translation.json";
 import nl from "@/locales/nl/translation.json";
 
 export const SUPPORTED_LANGUAGES = [
-  { code: "en", label: "English" },
-  { code: "de", label: "Deutsch" },
-  { code: "fr", label: "Français" },
-  { code: "es", label: "Español" },
-  { code: "nl", label: "Nederlands" },
+  { code: "en", label: "English", flag: "🇺🇸" },
+  { code: "de", label: "Deutsch", flag: "🇩🇪" },
+  { code: "fr", label: "Français", flag: "🇫🇷" },
+  { code: "es", label: "Español", flag: "🇪🇸" },
+  { code: "nl", label: "Nederlands", flag: "🇳🇱" },
 ] as const;
 
 export type LanguageCode = (typeof SUPPORTED_LANGUAGES)[number]["code"];

--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -4,15 +4,27 @@ import en from "@/locales/en/translation.json";
 import de from "@/locales/de/translation.json";
 import fr from "@/locales/fr/translation.json";
 import es from "@/locales/es/translation.json";
+import nl from "@/locales/nl/translation.json";
+
+export const SUPPORTED_LANGUAGES = [
+  { code: "en", label: "English" },
+  { code: "de", label: "Deutsch" },
+  { code: "fr", label: "Français" },
+  { code: "es", label: "Español" },
+  { code: "nl", label: "Nederlands" },
+] as const;
+
+export type LanguageCode = (typeof SUPPORTED_LANGUAGES)[number]["code"];
 
 i18n.use(initReactI18next).init({
-  lng: "en",
+  lng: localStorage.getItem("wm_lang") ?? "en",
   fallbackLng: "en",
   resources: {
     en: { translation: en },
     de: { translation: de },
     fr: { translation: fr },
     es: { translation: es },
+    nl: { translation: nl },
   },
   interpolation: {
     escapeValue: false,

--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -1,12 +1,18 @@
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 import en from "@/locales/en/translation.json";
+import de from "@/locales/de/translation.json";
+import fr from "@/locales/fr/translation.json";
+import es from "@/locales/es/translation.json";
 
 i18n.use(initReactI18next).init({
   lng: "en",
   fallbackLng: "en",
   resources: {
     en: { translation: en },
+    de: { translation: de },
+    fr: { translation: fr },
+    es: { translation: es },
   },
   interpolation: {
     escapeValue: false,

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -1,0 +1,92 @@
+{
+  "nav": {
+    "dashboard": "Dashboard",
+    "equipment": "Ausrüstung",
+    "collections": "Sammlungen",
+    "drafts": "Entwürfe",
+    "projects": "Projekte",
+    "settings": "Einstellungen",
+    "admin": "Admin",
+    "sendFeedback": "Feedback senden",
+    "supportWeftmark": "weftmark unterstützen",
+    "signOut": "Abmelden"
+  },
+  "settingsSections": {
+    "appearance": "Darstellung",
+    "preferences": "Einstellungen",
+    "privacy": "Datenschutz",
+    "terms": "Nutzungsbedingungen",
+    "account": "Konto",
+    "feedbackHistory": "Feedback-Verlauf"
+  },
+  "adminSections": {
+    "users": "Benutzer",
+    "invites": "Einladungen",
+    "stats": "Statistiken",
+    "health": "Status",
+    "services": "Dienste",
+    "deps": "Abhängigkeiten",
+    "audit": "Protokoll",
+    "feedback": "Feedback",
+    "credentials": "Zugangsdaten",
+    "slugs": "Freigabelinks",
+    "looms": "Webstuhldatenbank",
+    "superuser": "Superuser"
+  },
+  "loomTypes": {
+    "floor_loom": "Trittwebstuhl – Trittfolge-Tracking",
+    "table_loom": "Tischwebstuhl – Schafthebel-Tracking",
+    "rigid_heddle": "Starrblatt-Webstuhl",
+    "inkle": "Inkle-Webstuhl",
+    "dobby_floor_loom": "Dobby-Trittwebstuhl",
+    "tapestry_loom": "Bildwirkerei-Webstuhl – Projekt-Tracking derzeit nicht unterstützt",
+    "rug_loom": "Teppichwebstuhl – Projekt-Tracking derzeit nicht unterstützt",
+    "frame_loom": "Rahmenwebstuhl – Projekt-Tracking derzeit nicht unterstützt",
+    "other": "Sonstige"
+  },
+  "projectStatus": {
+    "created": "Nicht begonnen",
+    "active": "Aktiv",
+    "completed": "Abgeschlossen",
+    "abandoned": "Abgebrochen"
+  },
+  "projectType": {
+    "treadle": "Trittfolge-Tracking",
+    "lift": "Schafthebel-Tracking"
+  },
+  "skeinStatus": {
+    "available": "Verfügbar",
+    "in_use": "In Verwendung",
+    "consumed": "Verbraucht"
+  },
+  "feedbackType": {
+    "feedback": "Feedback",
+    "feature_request": "Funktionswunsch",
+    "bug_report": "Fehlermeldung"
+  },
+  "landing": {
+    "navLoomCatalog": "Webstuh-Katalog",
+    "navSignIn": "Anmelden",
+    "tagline": "Webbegleiter für Handweber",
+    "heroTitle": "Dein Weben,",
+    "heroTitleHighlight": "Reihe für Reihe.",
+    "heroBody": "Lade deinen WIF-Entwurf hoch, folge Pick für Pick, und behalte eine vollständige Aufzeichnung von jedem Entwurf – vom ersten Aufzug bis zum letzten Pick.",
+    "ctaSignIn": "Anmelden",
+    "ctaCreateAccount": "Konto erstellen",
+    "featuresHeading": "Alles, was du am Webstuhl brauchst",
+    "features": {
+      "trackWeaves": {
+        "title": "Webprojekte verfolgen",
+        "body": "Lade deinen WIF-Entwurf hoch und gehe jeden Pick durch. weftmark merkt dir die Stelle, damit du das Schiffchen ablegen und nahtlos weitermachen kannst."
+      },
+      "recordPicks": {
+        "title": "Jeden Pick festhalten",
+        "body": "Vorwärts, rückwärts oder zu einer beliebigen Reihe springen. Markiere ein Projekt als abgeschlossen, wenn der letzte Pick eingewebt ist."
+      },
+      "manageTools": {
+        "title": "Werkzeuge verwalten",
+        "body": "Behalte den Überblick über deine Webstühle und dein Garn. Weise einem Entwurf einen Webstuhl zu und verfolge, was auf dem Baum ist."
+      }
+    }
+  }
+}

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -34,14 +34,14 @@
     "superuser": "Superuser"
   },
   "loomTypes": {
-    "floor_loom": "Trittwebstuhl – Trittfolge-Tracking",
-    "table_loom": "Tischwebstuhl – Schafthebel-Tracking",
+    "floor_loom": "Trittwebstuhl - Trittfolge-Tracking",
+    "table_loom": "Tischwebstuhl - Schafthebel-Tracking",
     "rigid_heddle": "Starrblatt-Webstuhl",
     "inkle": "Inkle-Webstuhl",
     "dobby_floor_loom": "Dobby-Trittwebstuhl",
-    "tapestry_loom": "Bildwirkerei-Webstuhl – Projekt-Tracking derzeit nicht unterstützt",
-    "rug_loom": "Teppichwebstuhl – Projekt-Tracking derzeit nicht unterstützt",
-    "frame_loom": "Rahmenwebstuhl – Projekt-Tracking derzeit nicht unterstützt",
+    "tapestry_loom": "Bildwirkerei-Webstuhl - Projekt-Tracking derzeit nicht unterstützt",
+    "rug_loom": "Teppichwebstuhl - Projekt-Tracking derzeit nicht unterstützt",
+    "frame_loom": "Rahmenwebstuhl - Projekt-Tracking derzeit nicht unterstützt",
     "other": "Sonstige"
   },
   "projectStatus": {
@@ -64,13 +64,118 @@
     "feature_request": "Funktionswunsch",
     "bug_report": "Fehlermeldung"
   },
+  "common": {
+    "save": "Speichern",
+    "cancel": "Abbrechen",
+    "loading": "Lädt …"
+  },
+  "settings": {
+    "saved": "Gespeichert",
+    "sections": {
+      "appearance": "Darstellung",
+      "diagnostics": "Diagnose",
+      "preferences": "Einstellungen",
+      "privacy": "Datenschutz",
+      "terms": "Nutzungsbedingungen",
+      "feedbackHistory": "Feedback-Verlauf",
+      "account": "Kontoverwaltung"
+    },
+    "appearance": {
+      "theme": "Design",
+      "activityTrackerStyle": "Aktivitäts-Tracker-Stil",
+      "trackerDefaults": "Tracker-Standardwerte",
+      "trackerDefaultsHelp": "Standardansichtsoptionen beim Öffnen des Aktivitäts-Trackers. Diese können pro Projekt in den Tracker-Einstellungen überschrieben werden.",
+      "colorMode": "Farbmodus",
+      "progressBar": "Fortschrittsbalken",
+      "drawdownPattern": "Patrone",
+      "weftColorBar": "Schussfarbenleiste",
+      "prevNextPickCards": "Vorherige/nächste Eintrags­karten",
+      "hideUnusedShaftsTreadles": "Ungenutzte Schäfte und Tritte ausblenden",
+      "hideUnusedHelp": "Wenn aktiviert, werden im Patron-Viewer Schäfte und Tritte, die im Muster nicht verwendet werden, ausgeblendet. Neue Projekte übernehmen diese Einstellung. Standard: aus (alle Schäfte/Tritte sichtbar).",
+      "hidden": "Ausgeblendet",
+      "shown": "Angezeigt",
+      "styleVariantNote": "Stilabweichungen werden in einem zukünftigen Update visuell unterschieden.",
+      "active": "— aktiv",
+      "activityStyles": {
+        "default": { "label": "Standard", "desc": "Standardlayout mit großen Eintrags­karten und Patron-Vorschau." },
+        "compact": { "label": "Kompakt", "desc": "Dichteres Layout für intensives Tracking mit weniger vertikalem Platz." },
+        "high_contrast": { "label": "Hoher Kontrast", "desc": "Höherer visueller Kontrast für einfacheres Lesen bei hellem Licht oder für Barrierefreiheit." }
+      }
+    },
+    "diagnostics": {
+      "showVersionNumbers": "Versionsnummern anzeigen",
+      "showVersionNumbersHelp": "Anzeige oder Ausblendung des Versions-Badges für UI, API und Worker in der unteren rechten Ecke.",
+      "visible": "Sichtbar",
+      "hidden": "Ausgeblendet"
+    },
+    "preferences": {
+      "displayName": "Anzeigename",
+      "measurementSystem": "Maßsystem",
+      "sessionIdleTimeout": "Sitzungs-Leerlauf-Timeout",
+      "timeout15min": "15 Minuten",
+      "timeout30min": "30 Minuten",
+      "timeout1hr": "1 Stunde",
+      "timeout2hr": "2 Stunden"
+    },
+    "privacy": {
+      "optOut": "Datennutzung ablehnen",
+      "optOutHelp": "Gemäß unseren Nutzungsbedingungen werden deine Daten standardmäßig zur Plattformverbesserung genutzt. Aktiviere diesen Schalter, um abzulehnen.",
+      "optedOut": "Abgelehnt",
+      "participating": "Teilnehmend (Standard)",
+      "dataUseNote": "Deine Inhalte, Einstellungen und Tags – einschließlich WIF-Dateien, Fotos und Projektdaten – können gemäß den Nutzungsbedingungen für KI/ML-Modelltraining und Funktionsverbesserungen verwendet werden.",
+      "sharingNote": "Die Ablehnung deaktiviert auch alle öffentlichen Freigabelinks für deine Entwürfe.",
+      "whatWeStore": "Was wir über dich speichern",
+      "storeEmail": "E-Mail-Adresse und Anzeigename (von deinem Anmeldeanbieter)",
+      "storeFiles": "Von dir erstellte WIF-Dateien, Webstuhleinträge, Projekte, Fotos und Garne",
+      "storeSettings": "Einstellungen, Tags und Metadaten, die du deinen Inhalten zuweist",
+      "storeTimestamp": "Zeitstempel der letzten Aktivität",
+      "noSell": "Wir verkaufen deine Daten nicht. Die vollständige Richtlinie findest du in unseren Nutzungsbedingungen.",
+      "optOutModal": {
+        "title": "Datennutzung ablehnen?",
+        "body": "Die Ablehnung stoppt die zukünftige Nutzung deiner Daten für KI/ML-Modelltraining und Funktionsverbesserungen. Bereits in das Modelltraining eingeflossene Daten können nicht rückwirkend entfernt werden.",
+        "warningTitle": "Folgendes wird sofort deaktiviert:",
+        "sharingLinks": "Öffentliche Freigabelinks für alle deine Entwürfe",
+        "currentlyActive": "({{count}} derzeit aktiv)",
+        "futureSharing": "Alle zukünftigen Freigabefunktionen, die mit deinem Konto verknüpft sind",
+        "loseAccess": "Alle Personen mit deinen aktuellen Freigabelinks verlieren sofort den Zugriff.",
+        "reOptInNote": "Du kannst jederzeit auf dieser Seite wieder zustimmen. Das erneute Zustimmen stellt den Freigabezugriff wieder her, aktiviert jedoch keine einzelnen Entwurfslinks erneut – diese müssen manuell erneut geteilt werden.",
+        "confirmButton": "Ablehnen und Freigabe deaktivieren",
+        "cancelButton": "Abbrechen"
+      }
+    },
+    "terms": {
+      "tosTitle": "weftmark Nutzungsbedingungen v{{version}}",
+      "accepted": "Du hast die aktuelle Version akzeptiert.",
+      "notAccepted": "Du hast die aktuelle Version noch nicht akzeptiert.",
+      "hide": "Ausblenden",
+      "readTerms": "Bedingungen lesen"
+    },
+    "feedbackHistory": {
+      "description": "Deine gesendeten Einsendungen, einschließlich anonymer. Nur du kannst diese Liste sehen.",
+      "noSubmissions": "Noch keine Einsendungen.",
+      "anonymous": "(anonym)",
+      "viewDiscussion": "Diskussion auf GitHub anzeigen"
+    },
+    "account": {
+      "downloadData": "Meine Daten herunterladen",
+      "requestArchive": "Datenarchiv anfordern",
+      "exportNote": "Datenexport ist für Meilenstein 2 geplant. Gibt derzeit nur den Status zurück.",
+      "dangerZone": "Gefahrenzone",
+      "dangerDescription": "Konto und alle Daten dauerhaft löschen: WIF-Dateien, Fotos, Projekteinträge, Webstühle, Garne und Entwürfe. Dies kann nicht rückgängig gemacht werden.",
+      "deleteAccount": "Mein Konto löschen",
+      "deleteConfirmInstruction": "Gib DELETE MY ACCOUNT zur Bestätigung ein:",
+      "deleteConfirmPlaceholder": "DELETE MY ACCOUNT",
+      "deleting": "Wird gelöscht …",
+      "permanentDelete": "Mein Konto dauerhaft löschen"
+    }
+  },
   "landing": {
     "navLoomCatalog": "Webstuh-Katalog",
     "navSignIn": "Anmelden",
     "tagline": "Webbegleiter für Handweber",
     "heroTitle": "Dein Weben,",
     "heroTitleHighlight": "Reihe für Reihe.",
-    "heroBody": "Lade deinen WIF-Entwurf hoch, folge Pick für Pick, und behalte eine vollständige Aufzeichnung von jedem Entwurf – vom ersten Aufzug bis zum letzten Pick.",
+    "heroBody": "Lade deinen WIF-Entwurf hoch, folge Pick für Pick, und behalte eine vollständige Aufzeichnung von jedem Entwurf - vom ersten Aufzug bis zum letzten Pick.",
     "ctaSignIn": "Anmelden",
     "ctaCreateAccount": "Konto erstellen",
     "featuresHeading": "Alles, was du am Webstuhl brauchst",

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -111,6 +111,7 @@
     "preferences": {
       "displayName": "Anzeigename",
       "measurementSystem": "Maßsystem",
+      "language": "Sprache",
       "sessionIdleTimeout": "Sitzungs-Leerlauf-Timeout",
       "timeout15min": "15 Minuten",
       "timeout30min": "30 Minuten",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1,0 +1,92 @@
+{
+  "nav": {
+    "dashboard": "Dashboard",
+    "equipment": "Equipment",
+    "collections": "Collections",
+    "drafts": "Drafts",
+    "projects": "Projects",
+    "settings": "Settings",
+    "admin": "Admin",
+    "sendFeedback": "Send Feedback",
+    "supportWeftmark": "Support weftmark",
+    "signOut": "Sign out"
+  },
+  "settingsSections": {
+    "appearance": "Appearance",
+    "preferences": "Preferences",
+    "privacy": "Privacy & data",
+    "terms": "Terms",
+    "account": "Account",
+    "feedbackHistory": "Feedback history"
+  },
+  "adminSections": {
+    "users": "Users",
+    "invites": "Invites",
+    "stats": "Stats",
+    "health": "Health",
+    "services": "Services",
+    "deps": "Dependencies",
+    "audit": "Audit log",
+    "feedback": "Feedback",
+    "credentials": "Credentials",
+    "slugs": "Share links",
+    "looms": "Loom database",
+    "superuser": "Superuser"
+  },
+  "loomTypes": {
+    "floor_loom": "Floor Loom — treadle tracking",
+    "table_loom": "Table Loom — lift tracking",
+    "rigid_heddle": "Rigid Heddle",
+    "inkle": "Inkle",
+    "dobby_floor_loom": "Dobby Floor Loom",
+    "tapestry_loom": "Tapestry Loom — project tracking not currently supported",
+    "rug_loom": "Rug Loom — project tracking not currently supported",
+    "frame_loom": "Frame Loom — project tracking not currently supported",
+    "other": "Other"
+  },
+  "projectStatus": {
+    "created": "Not started",
+    "active": "Active",
+    "completed": "Completed",
+    "abandoned": "Abandoned"
+  },
+  "projectType": {
+    "treadle": "Treadle tracking",
+    "lift": "Lift tracking"
+  },
+  "skeinStatus": {
+    "available": "Available",
+    "in_use": "In use",
+    "consumed": "Consumed"
+  },
+  "feedbackType": {
+    "feedback": "Feedback",
+    "feature_request": "Feature Request",
+    "bug_report": "Bug Report"
+  },
+  "landing": {
+    "navLoomCatalog": "Loom catalog",
+    "navSignIn": "Sign in",
+    "tagline": "Weaving companion for handweavers",
+    "heroTitle": "Your weaving,",
+    "heroTitleHighlight": "row by row.",
+    "heroBody": "Upload your WIF draft, follow along pick by pick, and keep a complete record of every draft from first warp to last pick.",
+    "ctaSignIn": "Sign In",
+    "ctaCreateAccount": "Create Account",
+    "featuresHeading": "Everything you need at the loom",
+    "features": {
+      "trackWeaves": {
+        "title": "Track your weaves",
+        "body": "Upload your WIF draft and step through every pick. weftmark keeps your place so you can put down the shuttle and pick it right back up."
+      },
+      "recordPicks": {
+        "title": "Record every pick",
+        "body": "Advance, reverse, or jump to any row. Mark a project complete when the last pick is woven in."
+      },
+      "manageTools": {
+        "title": "Manage your tools",
+        "body": "Keep a record of your looms and yarn. Assign a loom to a draft and track what's on the beam."
+      }
+    }
+  }
+}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -111,6 +111,7 @@
     "preferences": {
       "displayName": "Display name",
       "measurementSystem": "Measurement system",
+      "language": "Language",
       "sessionIdleTimeout": "Session idle timeout",
       "timeout15min": "15 minutes",
       "timeout30min": "30 minutes",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -64,6 +64,111 @@
     "feature_request": "Feature Request",
     "bug_report": "Bug Report"
   },
+  "common": {
+    "save": "Save",
+    "cancel": "Cancel",
+    "loading": "Loading…"
+  },
+  "settings": {
+    "saved": "Saved",
+    "sections": {
+      "appearance": "Appearance",
+      "diagnostics": "Diagnostics",
+      "preferences": "Preferences",
+      "privacy": "Privacy & data",
+      "terms": "Terms of Service",
+      "feedbackHistory": "Feedback history",
+      "account": "Account management"
+    },
+    "appearance": {
+      "theme": "Theme",
+      "activityTrackerStyle": "Activity tracker style",
+      "trackerDefaults": "Tracker defaults",
+      "trackerDefaultsHelp": "Default view options when opening the activity tracker. You can still override these per-project in the tracker settings panel.",
+      "colorMode": "Color mode",
+      "progressBar": "Progress bar",
+      "drawdownPattern": "Drawdown pattern",
+      "weftColorBar": "Weft color bar",
+      "prevNextPickCards": "Prev/next pick cards",
+      "hideUnusedShaftsTreadles": "Hide unused shafts and treadles",
+      "hideUnusedHelp": "When enabled, shafts and treadles not used by the design are hidden in the drawdown viewer. New projects inherit this setting. Default is off (all shafts/treadles shown).",
+      "hidden": "Hidden",
+      "shown": "Shown",
+      "styleVariantNote": "Style variants will be visually differentiated in a future update.",
+      "active": "— active",
+      "activityStyles": {
+        "default": { "label": "Default", "desc": "Standard layout with full-size pick cards and drawdown preview." },
+        "compact": { "label": "Compact", "desc": "Denser layout for tracking-heavy sessions with less vertical space." },
+        "high_contrast": { "label": "High contrast", "desc": "Higher visual contrast for easier reading under bright light or for accessibility." }
+      }
+    },
+    "diagnostics": {
+      "showVersionNumbers": "Show version numbers",
+      "showVersionNumbersHelp": "Show or hide the UI, API, and worker version badge in the bottom-right corner.",
+      "visible": "Visible",
+      "hidden": "Hidden"
+    },
+    "preferences": {
+      "displayName": "Display name",
+      "measurementSystem": "Measurement system",
+      "sessionIdleTimeout": "Session idle timeout",
+      "timeout15min": "15 minutes",
+      "timeout30min": "30 minutes",
+      "timeout1hr": "1 hour",
+      "timeout2hr": "2 hours"
+    },
+    "privacy": {
+      "optOut": "Opt out of data use",
+      "optOutHelp": "Per our Terms of Service, your data is used for platform improvements by default. Toggle on to opt out.",
+      "optedOut": "Opted out",
+      "participating": "Participating (default)",
+      "dataUseNote": "Your content, settings, and tags — including WIF files, photos, and project data — may be used for AI/ML model training and feature improvements as described in the Terms of Service.",
+      "sharingNote": "Opting out also disables all public sharing links for your drafts.",
+      "whatWeStore": "What we store about you",
+      "storeEmail": "Email address and display name (from your sign-in provider)",
+      "storeFiles": "WIF files, loom records, projects, photos, and yarn you create",
+      "storeSettings": "Settings, tags, and metadata you assign to your content",
+      "storeTimestamp": "Last active timestamp",
+      "noSell": "We never sell your data. See our Terms of Service for the full policy.",
+      "optOutModal": {
+        "title": "Opt out of data use?",
+        "body": "Opting out stops future use of your data for AI/ML model training and feature improvements. Data already used in model training cannot be retroactively removed.",
+        "warningTitle": "The following will be disabled immediately:",
+        "sharingLinks": "Public sharing links for all your drafts",
+        "currentlyActive": "({{count}} currently active)",
+        "futureSharing": "Any future sharing features tied to your account",
+        "loseAccess": "Anyone with your current sharing links will immediately lose access.",
+        "reOptInNote": "You can opt back in at any time from this page. Re-opting in restores sharing access but does not re-enable individual draft links — you will need to re-share those manually.",
+        "confirmButton": "Opt out and disable sharing",
+        "cancelButton": "Cancel"
+      }
+    },
+    "terms": {
+      "tosTitle": "weftmark Terms of Service v{{version}}",
+      "accepted": "You have accepted the current version.",
+      "notAccepted": "You have not yet accepted the current version.",
+      "hide": "Hide",
+      "readTerms": "Read terms"
+    },
+    "feedbackHistory": {
+      "description": "Submissions you've sent, including anonymous ones. Only you can see this list.",
+      "noSubmissions": "No submissions yet.",
+      "anonymous": "(anonymous)",
+      "viewDiscussion": "View discussion on GitHub"
+    },
+    "account": {
+      "downloadData": "Download my data",
+      "requestArchive": "Request data archive",
+      "exportNote": "Data export is planned for Milestone 2. Currently returns status only.",
+      "dangerZone": "Danger zone",
+      "dangerDescription": "Permanently delete your account and all data: WIF files, photos, project records, looms, yarn, and drafts. This cannot be undone.",
+      "deleteAccount": "Delete my account",
+      "deleteConfirmInstruction": "Type DELETE MY ACCOUNT to confirm:",
+      "deleteConfirmPlaceholder": "DELETE MY ACCOUNT",
+      "deleting": "Deleting…",
+      "permanentDelete": "Permanently delete my account"
+    }
+  },
   "landing": {
     "navLoomCatalog": "Loom catalog",
     "navSignIn": "Sign in",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -1,0 +1,92 @@
+{
+  "nav": {
+    "dashboard": "Panel",
+    "equipment": "Equipamiento",
+    "collections": "Colecciones",
+    "drafts": "Ligamentos",
+    "projects": "Proyectos",
+    "settings": "Configuración",
+    "admin": "Admin",
+    "sendFeedback": "Enviar comentarios",
+    "supportWeftmark": "Apoyar weftmark",
+    "signOut": "Cerrar sesión"
+  },
+  "settingsSections": {
+    "appearance": "Apariencia",
+    "preferences": "Preferencias",
+    "privacy": "Privacidad",
+    "terms": "Términos",
+    "account": "Cuenta",
+    "feedbackHistory": "Historial de comentarios"
+  },
+  "adminSections": {
+    "users": "Usuarios",
+    "invites": "Invitaciones",
+    "stats": "Estadísticas",
+    "health": "Estado",
+    "services": "Servicios",
+    "deps": "Dependencias",
+    "audit": "Registro de auditoría",
+    "feedback": "Comentarios",
+    "credentials": "Credenciales",
+    "slugs": "Enlaces compartidos",
+    "looms": "Base de telares",
+    "superuser": "Superusuario"
+  },
+  "loomTypes": {
+    "floor_loom": "Telar de piso – seguimiento de pedales",
+    "table_loom": "Telar de mesa – seguimiento de palancas",
+    "rigid_heddle": "Telar de lizos rígidos",
+    "inkle": "Telar inkle",
+    "dobby_floor_loom": "Telar dobby de piso",
+    "tapestry_loom": "Telar de tapiz – seguimiento de proyectos no disponible",
+    "rug_loom": "Telar de alfombras – seguimiento de proyectos no disponible",
+    "frame_loom": "Telar de marco – seguimiento de proyectos no disponible",
+    "other": "Otro"
+  },
+  "projectStatus": {
+    "created": "No iniciado",
+    "active": "Activo",
+    "completed": "Completado",
+    "abandoned": "Abandonado"
+  },
+  "projectType": {
+    "treadle": "Seguimiento de pedales",
+    "lift": "Seguimiento de palancas"
+  },
+  "skeinStatus": {
+    "available": "Disponible",
+    "in_use": "En uso",
+    "consumed": "Consumido"
+  },
+  "feedbackType": {
+    "feedback": "Comentario",
+    "feature_request": "Solicitud de función",
+    "bug_report": "Reporte de error"
+  },
+  "landing": {
+    "navLoomCatalog": "Catálogo de telares",
+    "navSignIn": "Iniciar sesión",
+    "tagline": "Compañero de tejido para tejedores manuales",
+    "heroTitle": "Tu tejido,",
+    "heroTitleHighlight": "pasada a pasada.",
+    "heroBody": "Sube tu ligamento WIF, sigue cada pasada, y mantén un registro completo de cada proyecto – desde el primer urdido hasta la última pasada.",
+    "ctaSignIn": "Iniciar sesión",
+    "ctaCreateAccount": "Crear cuenta",
+    "featuresHeading": "Todo lo que necesitas junto al telar",
+    "features": {
+      "trackWeaves": {
+        "title": "Sigue tus tejidos",
+        "body": "Sube tu ligamento WIF y avanza pasada por pasada. weftmark guarda tu lugar para que puedas dejar la lanzadera y retomarlo exactamente donde lo dejaste."
+      },
+      "recordPicks": {
+        "title": "Registra cada pasada",
+        "body": "Avanza, retrocede o salta a cualquier fila. Marca un proyecto como completado cuando se teja la última pasada."
+      },
+      "manageTools": {
+        "title": "Gestiona tus herramientas",
+        "body": "Lleva un registro de tus telares e hilos. Asigna un telar a un ligamento y rastrea lo que está en el plegador."
+      }
+    }
+  }
+}

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -111,6 +111,7 @@
     "preferences": {
       "displayName": "Nombre de pantalla",
       "measurementSystem": "Sistema de medidas",
+      "language": "Idioma",
       "sessionIdleTimeout": "Tiempo de espera de inactividad",
       "timeout15min": "15 minutos",
       "timeout30min": "30 minutos",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -34,14 +34,14 @@
     "superuser": "Superusuario"
   },
   "loomTypes": {
-    "floor_loom": "Telar de piso – seguimiento de pedales",
-    "table_loom": "Telar de mesa – seguimiento de palancas",
+    "floor_loom": "Telar de piso - seguimiento de pedales",
+    "table_loom": "Telar de mesa - seguimiento de palancas",
     "rigid_heddle": "Telar de lizos rígidos",
     "inkle": "Telar inkle",
     "dobby_floor_loom": "Telar dobby de piso",
-    "tapestry_loom": "Telar de tapiz – seguimiento de proyectos no disponible",
-    "rug_loom": "Telar de alfombras – seguimiento de proyectos no disponible",
-    "frame_loom": "Telar de marco – seguimiento de proyectos no disponible",
+    "tapestry_loom": "Telar de tapiz - seguimiento de proyectos no disponible",
+    "rug_loom": "Telar de alfombras - seguimiento de proyectos no disponible",
+    "frame_loom": "Telar de marco - seguimiento de proyectos no disponible",
     "other": "Otro"
   },
   "projectStatus": {
@@ -64,13 +64,118 @@
     "feature_request": "Solicitud de función",
     "bug_report": "Reporte de error"
   },
+  "common": {
+    "save": "Guardar",
+    "cancel": "Cancelar",
+    "loading": "Cargando…"
+  },
+  "settings": {
+    "saved": "Guardado",
+    "sections": {
+      "appearance": "Apariencia",
+      "diagnostics": "Diagnóstico",
+      "preferences": "Preferencias",
+      "privacy": "Privacidad",
+      "terms": "Términos de uso",
+      "feedbackHistory": "Historial de comentarios",
+      "account": "Gestión de cuenta"
+    },
+    "appearance": {
+      "theme": "Tema",
+      "activityTrackerStyle": "Estilo del seguidor de actividad",
+      "trackerDefaults": "Valores predeterminados del seguidor",
+      "trackerDefaultsHelp": "Opciones de vista predeterminadas al abrir el seguidor de actividad. Puedes anularlas por proyecto en el panel de configuración del seguidor.",
+      "colorMode": "Modo de color",
+      "progressBar": "Barra de progreso",
+      "drawdownPattern": "Ligamento",
+      "weftColorBar": "Barra de color de trama",
+      "prevNextPickCards": "Tarjetas de pasada anterior/siguiente",
+      "hideUnusedShaftsTreadles": "Ocultar marcos y pedales no utilizados",
+      "hideUnusedHelp": "Cuando está activado, los marcos y pedales no usados por el diseño se ocultan en el visor. Los nuevos proyectos heredan esta configuración. Desactivado por defecto (todos los marcos/pedales visibles).",
+      "hidden": "Oculto",
+      "shown": "Visible",
+      "styleVariantNote": "Las variantes de estilo se diferenciarán visualmente en una futura actualización.",
+      "active": "— activo",
+      "activityStyles": {
+        "default": { "label": "Predeterminado", "desc": "Diseño estándar con tarjetas de pasada de tamaño completo y vista previa del ligamento." },
+        "compact": { "label": "Compacto", "desc": "Diseño más denso para sesiones de seguimiento intensivo con menos espacio vertical." },
+        "high_contrast": { "label": "Alto contraste", "desc": "Mayor contraste visual para una lectura más fácil bajo luz intensa o por accesibilidad." }
+      }
+    },
+    "diagnostics": {
+      "showVersionNumbers": "Mostrar números de versión",
+      "showVersionNumbersHelp": "Mostrar u ocultar el distintivo de versión de UI, API y worker en la esquina inferior derecha.",
+      "visible": "Visible",
+      "hidden": "Oculto"
+    },
+    "preferences": {
+      "displayName": "Nombre de pantalla",
+      "measurementSystem": "Sistema de medidas",
+      "sessionIdleTimeout": "Tiempo de espera de inactividad",
+      "timeout15min": "15 minutos",
+      "timeout30min": "30 minutos",
+      "timeout1hr": "1 hora",
+      "timeout2hr": "2 horas"
+    },
+    "privacy": {
+      "optOut": "Rechazar el uso de datos",
+      "optOutHelp": "Según nuestros términos de uso, tus datos se utilizan de forma predeterminada para mejorar la plataforma. Activa esta opción para rechazarlo.",
+      "optedOut": "Rechazado",
+      "participating": "Participando (predeterminado)",
+      "dataUseNote": "Tu contenido, configuración y etiquetas — incluidos archivos WIF, fotos y datos de proyectos — pueden usarse para entrenamiento de modelos IA/ML y mejoras de funciones según se describe en los términos de uso.",
+      "sharingNote": "Rechazar también desactiva todos los enlaces de uso compartido público de tus ligamentos.",
+      "whatWeStore": "Qué almacenamos sobre ti",
+      "storeEmail": "Dirección de correo electrónico y nombre de pantalla (de tu proveedor de inicio de sesión)",
+      "storeFiles": "Archivos WIF, registros de telares, proyectos, fotos e hilos que creas",
+      "storeSettings": "Configuración, etiquetas y metadatos que asignas a tu contenido",
+      "storeTimestamp": "Marca de tiempo de última actividad",
+      "noSell": "Nunca vendemos tus datos. Consulta nuestros términos de uso para conocer la política completa.",
+      "optOutModal": {
+        "title": "¿Rechazar el uso de datos?",
+        "body": "Rechazar detiene el uso futuro de tus datos para entrenamiento de modelos IA/ML y mejoras de funciones. Los datos ya utilizados en el entrenamiento no pueden eliminarse retroactivamente.",
+        "warningTitle": "Lo siguiente se desactivará inmediatamente:",
+        "sharingLinks": "Enlaces de uso compartido público para todos tus ligamentos",
+        "currentlyActive": "({{count}} activos actualmente)",
+        "futureSharing": "Cualquier función futura de uso compartido vinculada a tu cuenta",
+        "loseAccess": "Cualquier persona con tus enlaces de uso compartido actuales perderá el acceso de inmediato.",
+        "reOptInNote": "Puedes volver a participar en cualquier momento desde esta página. Volver a participar restaura el acceso al uso compartido pero no reactiva los enlaces individuales de ligamentos — tendrás que compartirlos de nuevo manualmente.",
+        "confirmButton": "Rechazar y desactivar uso compartido",
+        "cancelButton": "Cancelar"
+      }
+    },
+    "terms": {
+      "tosTitle": "Términos de uso de weftmark v{{version}}",
+      "accepted": "Has aceptado la versión actual.",
+      "notAccepted": "Aún no has aceptado la versión actual.",
+      "hide": "Ocultar",
+      "readTerms": "Leer términos"
+    },
+    "feedbackHistory": {
+      "description": "Tus envíos, incluidos los anónimos. Solo tú puedes ver esta lista.",
+      "noSubmissions": "Sin envíos todavía.",
+      "anonymous": "(anónimo)",
+      "viewDiscussion": "Ver discusión en GitHub"
+    },
+    "account": {
+      "downloadData": "Descargar mis datos",
+      "requestArchive": "Solicitar archivo de datos",
+      "exportNote": "La exportación de datos está planificada para el Hito 2. Actualmente solo devuelve el estado.",
+      "dangerZone": "Zona de peligro",
+      "dangerDescription": "Eliminar permanentemente tu cuenta y todos los datos: archivos WIF, fotos, registros de proyectos, telares, hilos y ligamentos. Esta acción no se puede deshacer.",
+      "deleteAccount": "Eliminar mi cuenta",
+      "deleteConfirmInstruction": "Escribe DELETE MY ACCOUNT para confirmar:",
+      "deleteConfirmPlaceholder": "DELETE MY ACCOUNT",
+      "deleting": "Eliminando…",
+      "permanentDelete": "Eliminar permanentemente mi cuenta"
+    }
+  },
   "landing": {
     "navLoomCatalog": "Catálogo de telares",
     "navSignIn": "Iniciar sesión",
     "tagline": "Compañero de tejido para tejedores manuales",
     "heroTitle": "Tu tejido,",
     "heroTitleHighlight": "pasada a pasada.",
-    "heroBody": "Sube tu ligamento WIF, sigue cada pasada, y mantén un registro completo de cada proyecto – desde el primer urdido hasta la última pasada.",
+    "heroBody": "Sube tu ligamento WIF, sigue cada pasada, y mantén un registro completo de cada proyecto - desde el primer urdido hasta la última pasada.",
     "ctaSignIn": "Iniciar sesión",
     "ctaCreateAccount": "Crear cuenta",
     "featuresHeading": "Todo lo que necesitas junto al telar",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -34,14 +34,14 @@
     "superuser": "Superutilisateur"
   },
   "loomTypes": {
-    "floor_loom": "Métier de basse lisse – suivi des marches",
-    "table_loom": "Métier de table – suivi des leviers",
+    "floor_loom": "Métier de basse lisse - suivi des marches",
+    "table_loom": "Métier de table - suivi des leviers",
     "rigid_heddle": "Métier à cadre rigide",
     "inkle": "Métier inkle",
     "dobby_floor_loom": "Métier dobby",
-    "tapestry_loom": "Métier à tapisserie – suivi de projet non disponible",
-    "rug_loom": "Métier à tapis – suivi de projet non disponible",
-    "frame_loom": "Métier à cadre – suivi de projet non disponible",
+    "tapestry_loom": "Métier à tapisserie - suivi de projet non disponible",
+    "rug_loom": "Métier à tapis - suivi de projet non disponible",
+    "frame_loom": "Métier à cadre - suivi de projet non disponible",
     "other": "Autre"
   },
   "projectStatus": {
@@ -64,13 +64,118 @@
     "feature_request": "Demande de fonctionnalité",
     "bug_report": "Signalement de bug"
   },
+  "common": {
+    "save": "Enregistrer",
+    "cancel": "Annuler",
+    "loading": "Chargement…"
+  },
+  "settings": {
+    "saved": "Enregistré",
+    "sections": {
+      "appearance": "Apparence",
+      "diagnostics": "Diagnostics",
+      "preferences": "Préférences",
+      "privacy": "Confidentialité",
+      "terms": "Conditions d'utilisation",
+      "feedbackHistory": "Historique des retours",
+      "account": "Gestion du compte"
+    },
+    "appearance": {
+      "theme": "Thème",
+      "activityTrackerStyle": "Style du suivi d'activité",
+      "trackerDefaults": "Paramètres par défaut du suivi",
+      "trackerDefaultsHelp": "Options d'affichage par défaut lors de l'ouverture du suivi d'activité. Vous pouvez les modifier par projet dans le panneau de paramètres du suivi.",
+      "colorMode": "Mode couleur",
+      "progressBar": "Barre de progression",
+      "drawdownPattern": "Armure",
+      "weftColorBar": "Barre de couleur de trame",
+      "prevNextPickCards": "Cartes duite précédente/suivante",
+      "hideUnusedShaftsTreadles": "Masquer les cadres et marches inutilisés",
+      "hideUnusedHelp": "Quand activé, les cadres et marches non utilisés par le motif sont masqués dans la visionneuse. Les nouveaux projets héritent de ce réglage. Par défaut désactivé (tous les cadres/marches affichés).",
+      "hidden": "Masqué",
+      "shown": "Affiché",
+      "styleVariantNote": "Les variantes de style seront visuellement différenciées dans une prochaine mise à jour.",
+      "active": "— actif",
+      "activityStyles": {
+        "default": { "label": "Par défaut", "desc": "Disposition standard avec cartes de duite en taille réelle et aperçu de l'armure." },
+        "compact": { "label": "Compact", "desc": "Disposition plus dense pour les sessions de suivi intensif avec moins d'espace vertical." },
+        "high_contrast": { "label": "Contraste élevé", "desc": "Contraste visuel plus élevé pour une lecture facilitée sous forte luminosité ou pour l'accessibilité." }
+      }
+    },
+    "diagnostics": {
+      "showVersionNumbers": "Afficher les numéros de version",
+      "showVersionNumbersHelp": "Afficher ou masquer le badge de version UI, API et worker dans le coin inférieur droit.",
+      "visible": "Visible",
+      "hidden": "Masqué"
+    },
+    "preferences": {
+      "displayName": "Nom d'affichage",
+      "measurementSystem": "Système de mesure",
+      "sessionIdleTimeout": "Délai d'inactivité de session",
+      "timeout15min": "15 minutes",
+      "timeout30min": "30 minutes",
+      "timeout1hr": "1 heure",
+      "timeout2hr": "2 heures"
+    },
+    "privacy": {
+      "optOut": "Refuser l'utilisation des données",
+      "optOutHelp": "Conformément à nos conditions d'utilisation, vos données sont utilisées par défaut pour améliorer la plateforme. Activez ce bouton pour refuser.",
+      "optedOut": "Refusé",
+      "participating": "Participant (par défaut)",
+      "dataUseNote": "Votre contenu, vos paramètres et vos tags — y compris les fichiers WIF, les photos et les données de projet — peuvent être utilisés pour l'entraînement de modèles IA/ML et l'amélioration des fonctionnalités, comme décrit dans les conditions d'utilisation.",
+      "sharingNote": "Le refus désactive également tous les liens de partage public pour vos armures.",
+      "whatWeStore": "Ce que nous conservons à votre sujet",
+      "storeEmail": "Adresse e-mail et nom d'affichage (de votre fournisseur de connexion)",
+      "storeFiles": "Fichiers WIF, métiers, projets, photos et fils que vous créez",
+      "storeSettings": "Paramètres, tags et métadonnées que vous attribuez à votre contenu",
+      "storeTimestamp": "Horodatage de dernière activité",
+      "noSell": "Nous ne vendons jamais vos données. Consultez nos conditions d'utilisation pour la politique complète.",
+      "optOutModal": {
+        "title": "Refuser l'utilisation des données ?",
+        "body": "Le refus arrête l'utilisation future de vos données pour l'entraînement de modèles IA/ML et l'amélioration des fonctionnalités. Les données déjà utilisées dans l'entraînement ne peuvent pas être supprimées rétroactivement.",
+        "warningTitle": "Les éléments suivants seront désactivés immédiatement :",
+        "sharingLinks": "Liens de partage public pour toutes vos armures",
+        "currentlyActive": "({{count}} actuellement actifs)",
+        "futureSharing": "Toutes les fonctionnalités de partage futures liées à votre compte",
+        "loseAccess": "Toute personne disposant de vos liens de partage actuels perdra immédiatement l'accès.",
+        "reOptInNote": "Vous pouvez vous réinscrire à tout moment depuis cette page. La réinscription rétablit l'accès au partage mais ne réactive pas les liens individuels d'armures — vous devrez les repartager manuellement.",
+        "confirmButton": "Refuser et désactiver le partage",
+        "cancelButton": "Annuler"
+      }
+    },
+    "terms": {
+      "tosTitle": "Conditions d'utilisation weftmark v{{version}}",
+      "accepted": "Vous avez accepté la version actuelle.",
+      "notAccepted": "Vous n'avez pas encore accepté la version actuelle.",
+      "hide": "Masquer",
+      "readTerms": "Lire les conditions"
+    },
+    "feedbackHistory": {
+      "description": "Vos soumissions envoyées, y compris les anonymes. Vous seul pouvez voir cette liste.",
+      "noSubmissions": "Aucune soumission pour l'instant.",
+      "anonymous": "(anonyme)",
+      "viewDiscussion": "Voir la discussion sur GitHub"
+    },
+    "account": {
+      "downloadData": "Télécharger mes données",
+      "requestArchive": "Demander une archive de données",
+      "exportNote": "L'export de données est prévu pour le Milestone 2. Retourne actuellement uniquement le statut.",
+      "dangerZone": "Zone de danger",
+      "dangerDescription": "Supprimer définitivement votre compte et toutes les données : fichiers WIF, photos, projets, métiers, fils et armures. Cette action est irréversible.",
+      "deleteAccount": "Supprimer mon compte",
+      "deleteConfirmInstruction": "Tapez DELETE MY ACCOUNT pour confirmer :",
+      "deleteConfirmPlaceholder": "DELETE MY ACCOUNT",
+      "deleting": "Suppression…",
+      "permanentDelete": "Supprimer définitivement mon compte"
+    }
+  },
   "landing": {
     "navLoomCatalog": "Catalogue de métiers",
     "navSignIn": "Se connecter",
     "tagline": "Compagnon de tissage pour tisserands",
     "heroTitle": "Votre tissage,",
     "heroTitleHighlight": "rang par rang.",
-    "heroBody": "Importez votre armure WIF, suivez chaque duite, et gardez un historique complet de chaque projet – du premier montage au dernier passage.",
+    "heroBody": "Importez votre armure WIF, suivez chaque duite, et gardez un historique complet de chaque projet - du premier montage au dernier passage.",
     "ctaSignIn": "Se connecter",
     "ctaCreateAccount": "Créer un compte",
     "featuresHeading": "Tout ce dont vous avez besoin au métier",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -111,6 +111,7 @@
     "preferences": {
       "displayName": "Nom d'affichage",
       "measurementSystem": "Système de mesure",
+      "language": "Langue",
       "sessionIdleTimeout": "Délai d'inactivité de session",
       "timeout15min": "15 minutes",
       "timeout30min": "30 minutes",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -1,0 +1,92 @@
+{
+  "nav": {
+    "dashboard": "Tableau de bord",
+    "equipment": "Équipement",
+    "collections": "Collections",
+    "drafts": "Armures",
+    "projects": "Projets",
+    "settings": "Paramètres",
+    "admin": "Admin",
+    "sendFeedback": "Envoyer un retour",
+    "supportWeftmark": "Soutenir weftmark",
+    "signOut": "Se déconnecter"
+  },
+  "settingsSections": {
+    "appearance": "Apparence",
+    "preferences": "Préférences",
+    "privacy": "Confidentialité",
+    "terms": "Conditions d'utilisation",
+    "account": "Compte",
+    "feedbackHistory": "Historique des retours"
+  },
+  "adminSections": {
+    "users": "Utilisateurs",
+    "invites": "Invitations",
+    "stats": "Statistiques",
+    "health": "État",
+    "services": "Services",
+    "deps": "Dépendances",
+    "audit": "Journal d'audit",
+    "feedback": "Retours",
+    "credentials": "Identifiants",
+    "slugs": "Liens de partage",
+    "looms": "Base de métiers",
+    "superuser": "Superutilisateur"
+  },
+  "loomTypes": {
+    "floor_loom": "Métier de basse lisse – suivi des marches",
+    "table_loom": "Métier de table – suivi des leviers",
+    "rigid_heddle": "Métier à cadre rigide",
+    "inkle": "Métier inkle",
+    "dobby_floor_loom": "Métier dobby",
+    "tapestry_loom": "Métier à tapisserie – suivi de projet non disponible",
+    "rug_loom": "Métier à tapis – suivi de projet non disponible",
+    "frame_loom": "Métier à cadre – suivi de projet non disponible",
+    "other": "Autre"
+  },
+  "projectStatus": {
+    "created": "Non commencé",
+    "active": "En cours",
+    "completed": "Terminé",
+    "abandoned": "Abandonné"
+  },
+  "projectType": {
+    "treadle": "Suivi des marches",
+    "lift": "Suivi des leviers"
+  },
+  "skeinStatus": {
+    "available": "Disponible",
+    "in_use": "En cours d'utilisation",
+    "consumed": "Consommé"
+  },
+  "feedbackType": {
+    "feedback": "Retour",
+    "feature_request": "Demande de fonctionnalité",
+    "bug_report": "Signalement de bug"
+  },
+  "landing": {
+    "navLoomCatalog": "Catalogue de métiers",
+    "navSignIn": "Se connecter",
+    "tagline": "Compagnon de tissage pour tisserands",
+    "heroTitle": "Votre tissage,",
+    "heroTitleHighlight": "rang par rang.",
+    "heroBody": "Importez votre armure WIF, suivez chaque duite, et gardez un historique complet de chaque projet – du premier montage au dernier passage.",
+    "ctaSignIn": "Se connecter",
+    "ctaCreateAccount": "Créer un compte",
+    "featuresHeading": "Tout ce dont vous avez besoin au métier",
+    "features": {
+      "trackWeaves": {
+        "title": "Suivez vos tissages",
+        "body": "Importez votre armure WIF et avancez duite par duite. weftmark retient votre place pour que vous puissiez poser la navette et reprendre exactement où vous en étiez."
+      },
+      "recordPicks": {
+        "title": "Enregistrez chaque duite",
+        "body": "Avancez, reculez ou sautez à n'importe quel rang. Marquez un projet comme terminé quand la dernière duite est tissée."
+      },
+      "manageTools": {
+        "title": "Gérez votre matériel",
+        "body": "Tenez un registre de vos métiers et de vos fils. Associez un métier à une armure et suivez ce qui est sur l'ensouple."
+      }
+    }
+  }
+}

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -1,0 +1,198 @@
+{
+  "nav": {
+    "dashboard": "Dashboard",
+    "equipment": "Apparatuur",
+    "collections": "Collecties",
+    "drafts": "Bindingen",
+    "projects": "Projecten",
+    "settings": "Instellingen",
+    "admin": "Admin",
+    "sendFeedback": "Feedback sturen",
+    "supportWeftmark": "weftmark steunen",
+    "signOut": "Afmelden"
+  },
+  "settingsSections": {
+    "appearance": "Weergave",
+    "preferences": "Voorkeuren",
+    "privacy": "Privacy",
+    "terms": "Gebruiksvoorwaarden",
+    "account": "Account",
+    "feedbackHistory": "Feedbackgeschiedenis"
+  },
+  "adminSections": {
+    "users": "Gebruikers",
+    "invites": "Uitnodigingen",
+    "stats": "Statistieken",
+    "health": "Status",
+    "services": "Diensten",
+    "deps": "Afhankelijkheden",
+    "audit": "Auditlogboek",
+    "feedback": "Feedback",
+    "credentials": "Inloggegevens",
+    "slugs": "Deellinks",
+    "looms": "Weefstoel­database",
+    "superuser": "Supergebruiker"
+  },
+  "loomTypes": {
+    "floor_loom": "Vloerweefstoel — trapper-tracking",
+    "table_loom": "Tafelweefstoel — hefinrichting-tracking",
+    "rigid_heddle": "Rigid heddle weefstoel",
+    "inkle": "Inkle weefstoel",
+    "dobby_floor_loom": "Dobby vloerweefstoel",
+    "tapestry_loom": "Wandtapijt weefstoel — project­tracking momenteel niet ondersteund",
+    "rug_loom": "Kleed­weefstoel — project­tracking momenteel niet ondersteund",
+    "frame_loom": "Raam­weefstoel — project­tracking momenteel niet ondersteund",
+    "other": "Overig"
+  },
+  "projectStatus": {
+    "created": "Niet gestart",
+    "active": "Actief",
+    "completed": "Voltooid",
+    "abandoned": "Gestopt"
+  },
+  "projectType": {
+    "treadle": "Trapper-tracking",
+    "lift": "Hefinrichting-tracking"
+  },
+  "skeinStatus": {
+    "available": "Beschikbaar",
+    "in_use": "In gebruik",
+    "consumed": "Opgebruikt"
+  },
+  "feedbackType": {
+    "feedback": "Feedback",
+    "feature_request": "Functieverzoek",
+    "bug_report": "Foutmelding"
+  },
+  "common": {
+    "save": "Opslaan",
+    "cancel": "Annuleren",
+    "loading": "Laden…"
+  },
+  "settings": {
+    "saved": "Opgeslagen",
+    "sections": {
+      "appearance": "Weergave",
+      "diagnostics": "Diagnostiek",
+      "preferences": "Voorkeuren",
+      "privacy": "Privacy",
+      "terms": "Gebruiksvoorwaarden",
+      "feedbackHistory": "Feedbackgeschiedenis",
+      "account": "Accountbeheer"
+    },
+    "appearance": {
+      "theme": "Thema",
+      "activityTrackerStyle": "Stijl van de activiteits­tracker",
+      "trackerDefaults": "Standaard­instellingen tracker",
+      "trackerDefaultsHelp": "Standaard weergave­opties bij het openen van de activiteits­tracker. Deze kunnen per project overschreven worden in het instellingen­paneel van de tracker.",
+      "colorMode": "Kleurmodus",
+      "progressBar": "Voortgangs­balk",
+      "drawdownPattern": "Bindingspatroon",
+      "weftColorBar": "Inslagkleur­balk",
+      "prevNextPickCards": "Kaarten vorige/volgende inslag",
+      "hideUnusedShaftsTreadles": "Ongebruikte schachten en trappers verbergen",
+      "hideUnusedHelp": "Wanneer ingeschakeld, worden schachten en trappers die niet gebruikt worden door het ontwerp verborgen in de bindingskijker. Nieuwe projecten erven deze instelling. Standaard uit (alle schachten/trappers zichtbaar).",
+      "hidden": "Verborgen",
+      "shown": "Zichtbaar",
+      "styleVariantNote": "Stijl­varianten worden visueel onderscheiden in een toekomstige update.",
+      "active": "— actief",
+      "activityStyles": {
+        "default": { "label": "Standaard", "desc": "Standaard indeling met kaarten op volledige grootte en bindingsvoorbeeld." },
+        "compact": { "label": "Compact", "desc": "Dichtere indeling voor intensieve tracking­sessies met minder verticale ruimte." },
+        "high_contrast": { "label": "Hoog contrast", "desc": "Hoger visueel contrast voor gemakkelijker lezen bij fel licht of voor toegankelijkheid." }
+      }
+    },
+    "diagnostics": {
+      "showVersionNumbers": "Versie­nummers tonen",
+      "showVersionNumbersHelp": "De versie­badge voor UI, API en worker in de rechter­onderhoek tonen of verbergen.",
+      "visible": "Zichtbaar",
+      "hidden": "Verborgen"
+    },
+    "preferences": {
+      "displayName": "Weergavenaam",
+      "measurementSystem": "Meetsysteem",
+      "language": "Taal",
+      "sessionIdleTimeout": "Time-out bij inactiviteit",
+      "timeout15min": "15 minuten",
+      "timeout30min": "30 minuten",
+      "timeout1hr": "1 uur",
+      "timeout2hr": "2 uur"
+    },
+    "privacy": {
+      "optOut": "Gegevens­gebruik weigeren",
+      "optOutHelp": "Volgens onze gebruiksvoorwaarden worden uw gegevens standaard gebruikt voor platformverbetering. Zet dit aan om te weigeren.",
+      "optedOut": "Geweigerd",
+      "participating": "Deelnemend (standaard)",
+      "dataUseNote": "Uw inhoud, instellingen en tags — inclusief WIF-bestanden, foto's en projectgegevens — kunnen worden gebruikt voor AI/ML-modeltraining en functieverbeteringen zoals beschreven in de gebruiksvoorwaarden.",
+      "sharingNote": "Weigeren schakelt ook alle openbare deel­links voor uw bindingen uit.",
+      "whatWeStore": "Wat we van u opslaan",
+      "storeEmail": "E-mailadres en weergavenaam (van uw aanmeld­provider)",
+      "storeFiles": "WIF-bestanden, weefstoel­records, projecten, foto's en garen die u aanmaakt",
+      "storeSettings": "Instellingen, tags en metadata die u aan uw inhoud toevoegt",
+      "storeTimestamp": "Tijdstempel van laatste activiteit",
+      "noSell": "Wij verkopen uw gegevens nooit. Zie onze gebruiksvoorwaarden voor het volledige beleid.",
+      "optOutModal": {
+        "title": "Gegevens­gebruik weigeren?",
+        "body": "Weigeren stopt toekomstig gebruik van uw gegevens voor AI/ML-modeltraining en functieverbeteringen. Gegevens die al zijn gebruikt voor modeltraining kunnen niet achteraf worden verwijderd.",
+        "warningTitle": "Het volgende wordt onmiddellijk uitgeschakeld:",
+        "sharingLinks": "Openbare deel­links voor al uw bindingen",
+        "currentlyActive": "({{count}} momenteel actief)",
+        "futureSharing": "Toekomstige deel­functies gekoppeld aan uw account",
+        "loseAccess": "Iedereen met uw huidige deel­links verliest onmiddellijk de toegang.",
+        "reOptInNote": "U kunt zich op elk moment op deze pagina opnieuw aanmelden. Opnieuw aanmelden herstelt deeltoegang maar activeert individuele bindingslinks niet opnieuw — u moet ze handmatig opnieuw delen.",
+        "confirmButton": "Weigeren en delen uitschakelen",
+        "cancelButton": "Annuleren"
+      }
+    },
+    "terms": {
+      "tosTitle": "weftmark Gebruiksvoorwaarden v{{version}}",
+      "accepted": "U heeft de huidige versie geaccepteerd.",
+      "notAccepted": "U heeft de huidige versie nog niet geaccepteerd.",
+      "hide": "Verbergen",
+      "readTerms": "Voorwaarden lezen"
+    },
+    "feedbackHistory": {
+      "description": "Uw ingediende berichten, inclusief anonieme. Alleen u kunt deze lijst zien.",
+      "noSubmissions": "Nog geen berichten.",
+      "anonymous": "(anoniem)",
+      "viewDiscussion": "Discussie bekijken op GitHub"
+    },
+    "account": {
+      "downloadData": "Mijn gegevens downloaden",
+      "requestArchive": "Gegevens­archief aanvragen",
+      "exportNote": "Gegevens­export is gepland voor Mijlpaal 2. Geeft momenteel alleen de status terug.",
+      "dangerZone": "Gevaren­zone",
+      "dangerDescription": "Uw account en alle gegevens permanent verwijderen: WIF-bestanden, foto's, project­records, weefstoel­en, garen en bindingen. Dit kan niet ongedaan worden gemaakt.",
+      "deleteAccount": "Mijn account verwijderen",
+      "deleteConfirmInstruction": "Typ DELETE MY ACCOUNT ter bevestiging:",
+      "deleteConfirmPlaceholder": "DELETE MY ACCOUNT",
+      "deleting": "Verwijderen…",
+      "permanentDelete": "Mijn account permanent verwijderen"
+    }
+  },
+  "landing": {
+    "navLoomCatalog": "Weefstoel­catalogus",
+    "navSignIn": "Aanmelden",
+    "tagline": "Weefbegeleider voor hand­wevers",
+    "heroTitle": "Uw weefwerk,",
+    "heroTitleHighlight": "rij voor rij.",
+    "heroBody": "Upload uw WIF-binding, volg elke inslag en houd een volledig overzicht bij van elk project — van de eerste schering tot de laatste inslag.",
+    "ctaSignIn": "Aanmelden",
+    "ctaCreateAccount": "Account aanmaken",
+    "featuresHeading": "Alles wat u nodig heeft aan het weefgetouw",
+    "features": {
+      "trackWeaves": {
+        "title": "Volg uw weefprojecten",
+        "body": "Upload uw WIF-binding en ga inslag voor inslag verder. weftmark onthoudt uw positie zodat u het schietspoel neer kunt leggen en precies verder kunt gaan waar u was gebleven."
+      },
+      "recordPicks": {
+        "title": "Leg elke inslag vast",
+        "body": "Vooruit, achteruit of naar elke rij springen. Markeer een project als voltooid wanneer de laatste inslag is geweven."
+      },
+      "manageTools": {
+        "title": "Beheer uw gereedschap",
+        "body": "Houd een overzicht bij van uw weefstoel­en en garen. Koppel een weefstoel aan een binding en volg wat er op de boom zit."
+      }
+    }
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
+import "./i18n/config";
 import App from "./App.tsx";
 import { initLogger } from "./lib/logger";
 

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -3,9 +3,16 @@ import { useTranslation } from "react-i18next";
 import { AppIcons } from "@/lib/icons";
 import { WeftmarkLogo } from "@/components/WeftmarkLogo";
 import { PublicFooter } from "@/components/PublicFooter";
+import { SUPPORTED_LANGUAGES } from "@/i18n/config";
 
 export function LandingPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+
+  function handleLangChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const code = e.target.value;
+    i18n.changeLanguage(code);
+    localStorage.setItem("wm_lang", code);
+  }
 
   const FEATURES = [
     {
@@ -52,6 +59,18 @@ export function LandingPage() {
             >
               {t("landing.navLoomCatalog")}
             </Link>
+            <select
+              value={i18n.language}
+              onChange={handleLangChange}
+              className="cursor-pointer rounded border-0 bg-transparent text-sm font-medium text-stone-600 transition-colors hover:text-stone-900 focus:outline-none focus:ring-0"
+              aria-label="Language"
+            >
+              {SUPPORTED_LANGUAGES.map((lang) => (
+                <option key={lang.code} value={lang.code}>
+                  {lang.label}
+                </option>
+              ))}
+            </select>
             <Link
               to="/login"
               className="text-sm font-medium text-stone-600 transition-colors hover:text-stone-900"

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,27 +1,30 @@
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { AppIcons } from "@/lib/icons";
 import { WeftmarkLogo } from "@/components/WeftmarkLogo";
 import { PublicFooter } from "@/components/PublicFooter";
 
-const FEATURES = [
-  {
-    title: "Track your weaves",
-    body: "Upload your WIF draft and step through every pick. weftmark keeps your place so you can put down the shuttle and pick it right back up.",
-    Icon: AppIcons.designLibrary,
-  },
-  {
-    title: "Record every pick",
-    body: "Advance, reverse, or jump to any row. Mark a project complete when the last pick is woven in.",
-    Icon: AppIcons.pickTracking,
-  },
-  {
-    title: "Manage your tools",
-    body: "Keep a record of your looms and yarn. Assign a loom to a draft and track what's on the beam.",
-    Icon: AppIcons.toolManagement,
-  },
-];
-
 export function LandingPage() {
+  const { t } = useTranslation();
+
+  const FEATURES = [
+    {
+      title: t("landing.features.trackWeaves.title"),
+      body: t("landing.features.trackWeaves.body"),
+      Icon: AppIcons.designLibrary,
+    },
+    {
+      title: t("landing.features.recordPicks.title"),
+      body: t("landing.features.recordPicks.body"),
+      Icon: AppIcons.pickTracking,
+    },
+    {
+      title: t("landing.features.manageTools.title"),
+      body: t("landing.features.manageTools.body"),
+      Icon: AppIcons.toolManagement,
+    },
+  ];
+
   return (
     <div className="flex min-h-screen flex-col bg-stone-50 text-stone-900">
       {/* Grain texture overlay */}
@@ -47,13 +50,13 @@ export function LandingPage() {
               to="/catalog/looms"
               className="text-sm font-medium text-stone-600 transition-colors hover:text-stone-900"
             >
-              Loom catalog
+              {t("landing.navLoomCatalog")}
             </Link>
             <Link
               to="/login"
               className="text-sm font-medium text-stone-600 transition-colors hover:text-stone-900"
             >
-              Sign in
+              {t("landing.navSignIn")}
             </Link>
           </div>
         </div>
@@ -69,29 +72,28 @@ export function LandingPage() {
             <div className="grid items-center gap-12 lg:grid-cols-[1fr_1.4fr]">
               <div className="order-2 lg:order-1">
                 <span className="mb-5 inline-block rounded-full bg-amber-100 px-3.5 py-1 text-xs font-medium tracking-wide text-amber-700">
-                  Weaving companion for handweavers
+                  {t("landing.tagline")}
                 </span>
                 <h1 className="mb-5 text-4xl font-bold tracking-tight text-stone-900 sm:text-5xl lg:text-6xl">
-                  Your weaving,
+                  {t("landing.heroTitle")}
                   <br />
-                  <span className="text-amber-600">row by row.</span>
+                  <span className="text-amber-600">{t("landing.heroTitleHighlight")}</span>
                 </h1>
                 <p className="mb-8 max-w-lg text-lg leading-relaxed text-stone-600">
-                  Upload your WIF draft, follow along pick by pick, and keep a complete record of every
-                  draft from first warp to last pick.
+                  {t("landing.heroBody")}
                 </p>
                 <div className="flex flex-col gap-3 sm:flex-row">
                   <Link
                     to="/login"
                     className="rounded-lg bg-zinc-800 px-6 py-3 text-center text-sm font-semibold text-white shadow-md shadow-zinc-900/30 transition-colors hover:bg-zinc-900"
                   >
-                    Sign In
+                    {t("landing.ctaSignIn")}
                   </Link>
                   <Link
                     to="/register"
                     className="rounded-lg border border-stone-300 bg-white/60 px-6 py-3 text-center text-sm font-semibold text-stone-700 transition-colors hover:bg-white"
                   >
-                    Create Account
+                    {t("landing.ctaCreateAccount")}
                   </Link>
                 </div>
               </div>
@@ -120,7 +122,7 @@ export function LandingPage() {
         <section className="relative z-10 -mt-12 px-6 pb-20">
           <div className="mx-auto max-w-6xl">
             <h2 className="mb-10 text-center text-2xl font-bold tracking-tight text-stone-900">
-              Everything you need at the loom
+              {t("landing.featuresHeading")}
             </h2>
             <div className="grid gap-6 sm:grid-cols-3">
               {FEATURES.map(({ title, body, Icon }) => (

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -3,16 +3,10 @@ import { useTranslation } from "react-i18next";
 import { AppIcons } from "@/lib/icons";
 import { WeftmarkLogo } from "@/components/WeftmarkLogo";
 import { PublicFooter } from "@/components/PublicFooter";
-import { SUPPORTED_LANGUAGES } from "@/i18n/config";
+import { LanguageSelector } from "@/components/LanguageSelector";
 
 export function LandingPage() {
-  const { t, i18n } = useTranslation();
-
-  function handleLangChange(e: React.ChangeEvent<HTMLSelectElement>) {
-    const code = e.target.value;
-    i18n.changeLanguage(code);
-    localStorage.setItem("wm_lang", code);
-  }
+  const { t } = useTranslation();
 
   const FEATURES = [
     {
@@ -59,18 +53,7 @@ export function LandingPage() {
             >
               {t("landing.navLoomCatalog")}
             </Link>
-            <select
-              value={i18n.language}
-              onChange={handleLangChange}
-              className="cursor-pointer rounded border-0 bg-transparent text-sm font-medium text-stone-600 transition-colors hover:text-stone-900 focus:outline-none focus:ring-0"
-              aria-label="Language"
-            >
-              {SUPPORTED_LANGUAGES.map((lang) => (
-                <option key={lang.code} value={lang.code}>
-                  {lang.label}
-                </option>
-              ))}
-            </select>
+            <LanguageSelector variant="public" />
             <Link
               to="/login"
               className="text-sm font-medium text-stone-600 transition-colors hover:text-stone-900"

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { SUPPORTED_LANGUAGES } from "@/i18n/config";
 import { useAuth } from "@/hooks/useAuth";
 import { useQuery } from "@tanstack/react-query";
 import { updateSettings, deleteAccount, getDataExport, getCurrentEula } from "@/api/users";
@@ -14,7 +15,7 @@ import { TrackerStylePreview, TrackerLivePreview } from "@/components/TrackerSty
 type Section = "appearance" | "preferences" | "privacy" | "terms" | "account" | "feedback-history";
 
 export function SettingsPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { user, refetch } = useAuth();
   const { section } = useParams<{ section: string }>();
   const activeSection: Section = (section as Section) ?? "appearance";
@@ -355,6 +356,24 @@ export function SettingsPage() {
                       </button>
                     ))}
                   </div>
+                </Field>
+
+                <Field label={t("settings.preferences.language")}>
+                  <select
+                    value={i18n.language}
+                    onChange={(e) => {
+                      const code = e.target.value;
+                      i18n.changeLanguage(code);
+                      localStorage.setItem("wm_lang", code);
+                    }}
+                    className="rounded-md border border-border bg-background px-3 py-2 text-sm"
+                  >
+                    {SUPPORTED_LANGUAGES.map((lang) => (
+                      <option key={lang.code} value={lang.code}>
+                        {lang.label}
+                      </option>
+                    ))}
+                  </select>
                 </Field>
 
                 <Field label={t("settings.preferences.sessionIdleTimeout")}>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { SUPPORTED_LANGUAGES } from "@/i18n/config";
+import { LanguageSelector } from "@/components/LanguageSelector";
 import { useAuth } from "@/hooks/useAuth";
 import { useQuery } from "@tanstack/react-query";
 import { updateSettings, deleteAccount, getDataExport, getCurrentEula } from "@/api/users";
@@ -15,7 +15,7 @@ import { TrackerStylePreview, TrackerLivePreview } from "@/components/TrackerSty
 type Section = "appearance" | "preferences" | "privacy" | "terms" | "account" | "feedback-history";
 
 export function SettingsPage() {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const { user, refetch } = useAuth();
   const { section } = useParams<{ section: string }>();
   const activeSection: Section = (section as Section) ?? "appearance";
@@ -359,21 +359,7 @@ export function SettingsPage() {
                 </Field>
 
                 <Field label={t("settings.preferences.language")}>
-                  <select
-                    value={i18n.language}
-                    onChange={(e) => {
-                      const code = e.target.value;
-                      i18n.changeLanguage(code);
-                      localStorage.setItem("wm_lang", code);
-                    }}
-                    className="rounded-md border border-border bg-background px-3 py-2 text-sm"
-                  >
-                    {SUPPORTED_LANGUAGES.map((lang) => (
-                      <option key={lang.code} value={lang.code}>
-                        {lang.label}
-                      </option>
-                    ))}
-                  </select>
+                  <LanguageSelector variant="app" />
                 </Field>
 
                 <Field label={t("settings.preferences.sessionIdleTimeout")}>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { useAuth } from "@/hooks/useAuth";
 import { useQuery } from "@tanstack/react-query";
 import { updateSettings, deleteAccount, getDataExport, getCurrentEula } from "@/api/users";
@@ -13,6 +14,7 @@ import { TrackerStylePreview, TrackerLivePreview } from "@/components/TrackerSty
 type Section = "appearance" | "preferences" | "privacy" | "terms" | "account" | "feedback-history";
 
 export function SettingsPage() {
+  const { t } = useTranslation();
   const { user, refetch } = useAuth();
   const { section } = useParams<{ section: string }>();
   const activeSection: Section = (section as Section) ?? "appearance";
@@ -114,7 +116,7 @@ export function SettingsPage() {
       const result = await getDataExport();
       setExportInfo(result.message);
     } catch {
-      setExportInfo("Could not fetch export status.");
+      setExportInfo(t("common.loading"));
     }
   }
 
@@ -128,7 +130,7 @@ export function SettingsPage() {
                 : "bg-destructive/10 text-destructive"
             }`}
           >
-            {saveSuccess ? "Saved" : saveError}
+            {saveSuccess ? t("settings.saved") : saveError}
           </div>
         )}
         <div className="space-y-6">
@@ -136,8 +138,8 @@ export function SettingsPage() {
             {/* ── Appearance ── */}
             {activeSection === "appearance" && (
               <>
-              <Section title="Appearance">
-                <Field label="Theme">
+              <Section title={t("settings.sections.appearance")}>
+                <Field label={t("settings.appearance.theme")}>
                   <div className="flex gap-2">
                     {(["light", "dark", "system"] as const).map((t) => (
                       <button
@@ -158,13 +160,13 @@ export function SettingsPage() {
                   </div>
                 </Field>
 
-                <Field label="Activity tracker style">
+                <Field label={t("settings.appearance.activityTrackerStyle")}>
                   <div className="flex flex-col gap-3 mt-1">
                     {(["default", "compact", "high_contrast"] as const).map((s) => {
                       const meta: Record<string, { label: string; desc: string }> = {
-                        default: { label: "Default", desc: "Standard layout with full-size pick cards and drawdown preview." },
-                        compact: { label: "Compact", desc: "Denser layout for tracking-heavy sessions with less vertical space." },
-                        high_contrast: { label: "High contrast", desc: "Higher visual contrast for easier reading under bright light or for accessibility." },
+                        default: { label: t("settings.appearance.activityStyles.default.label"), desc: t("settings.appearance.activityStyles.default.desc") },
+                        compact: { label: t("settings.appearance.activityStyles.compact.label"), desc: t("settings.appearance.activityStyles.compact.desc") },
+                        high_contrast: { label: t("settings.appearance.activityStyles.high_contrast.label"), desc: t("settings.appearance.activityStyles.high_contrast.desc") },
                       };
                       const selected = activityTheme === s;
                       return (
@@ -178,7 +180,7 @@ export function SettingsPage() {
                           <div className="mb-2">
                             <p className={`text-sm font-semibold ${selected ? "text-primary" : "text-foreground"}`}>
                               {meta[s].label}
-                              {selected && <span className="ml-2 text-xs font-normal text-primary/70">— active</span>}
+                              {selected && <span className="ml-2 text-xs font-normal text-primary/70">{t("settings.appearance.active")}</span>}
                             </p>
                             <p className="text-xs text-muted-foreground mt-0.5">{meta[s].desc}</p>
                           </div>
@@ -188,18 +190,18 @@ export function SettingsPage() {
                     })}
                   </div>
                   <p className="text-xs text-muted-foreground mt-2">
-                    Style variants will be visually differentiated in a future update.
+                    {t("settings.appearance.styleVariantNote")}
                   </p>
                 </Field>
 
-                <Field label="Tracker defaults">
+                <Field label={t("settings.appearance.trackerDefaults")}>
                   <p className="text-xs text-muted-foreground mb-3">
-                    Default view options when opening the activity tracker. You can still override these per-project in the tracker settings panel.
+                    {t("settings.appearance.trackerDefaultsHelp")}
                   </p>
 
                   {/* Color mode */}
                   <div className="mb-4">
-                    <p className="text-xs font-medium text-muted-foreground mb-1.5">Color mode</p>
+                    <p className="text-xs font-medium text-muted-foreground mb-1.5">{t("settings.appearance.colorMode")}</p>
                     <div className="inline-flex rounded-md border border-input overflow-hidden text-sm">
                       {(["theme", "strip", "filled"] as const).map((mode) => (
                         <button
@@ -220,10 +222,10 @@ export function SettingsPage() {
                   {/* Show/hide toggles */}
                   <div className="space-y-2.5">
                     {([
-                      { label: "Progress bar", value: trackerShowProgress, setter: setTrackerShowProgress, key: "tracker_show_progress" as const },
-                      { label: "Drawdown pattern", value: trackerShowDrawdown, setter: setTrackerShowDrawdown, key: "tracker_show_drawdown" as const },
-                      { label: "Weft color bar", value: trackerShowWeftColor, setter: setTrackerShowWeftColor, key: "tracker_show_weft_color" as const },
-                      { label: "Prev/next pick cards", value: trackerShowPickCards, setter: setTrackerShowPickCards, key: "tracker_show_pick_cards" as const },
+                      { label: t("settings.appearance.progressBar"), value: trackerShowProgress, setter: setTrackerShowProgress, key: "tracker_show_progress" as const },
+                      { label: t("settings.appearance.drawdownPattern"), value: trackerShowDrawdown, setter: setTrackerShowDrawdown, key: "tracker_show_drawdown" as const },
+                      { label: t("settings.appearance.weftColorBar"), value: trackerShowWeftColor, setter: setTrackerShowWeftColor, key: "tracker_show_weft_color" as const },
+                      { label: t("settings.appearance.prevNextPickCards"), value: trackerShowPickCards, setter: setTrackerShowPickCards, key: "tracker_show_pick_cards" as const },
                     ] as { label: string; value: boolean; setter: (v: boolean) => void; key: "tracker_show_progress" | "tracker_show_drawdown" | "tracker_show_weft_color" | "tracker_show_pick_cards" }[]).map(({ label, value, setter, key }) => (
                       <div key={key} className="flex items-center justify-between">
                         <span className="text-sm">{label}</span>
@@ -253,7 +255,7 @@ export function SettingsPage() {
                   </div>
                 </Field>
 
-                <Field label="Hide unused shafts and treadles">
+                <Field label={t("settings.appearance.hideUnusedShaftsTreadles")}>
                   <div className="flex items-center gap-3">
                     <button
                       role="switch"
@@ -273,17 +275,16 @@ export function SettingsPage() {
                         }`}
                       />
                     </button>
-                    <span className="text-sm">{hideUnusedShaftsTreadles ? "Hidden" : "Shown"}</span>
+                    <span className="text-sm">{hideUnusedShaftsTreadles ? t("settings.appearance.hidden") : t("settings.appearance.shown")}</span>
                   </div>
                   <p className="text-xs text-muted-foreground mt-1">
-                    When enabled, shafts and treadles not used by the design are hidden in the drawdown
-                    viewer. New projects inherit this setting. Default is off (all shafts/treadles shown).
+                    {t("settings.appearance.hideUnusedHelp")}
                   </p>
                 </Field>
               </Section>
 
-              <Section title="Diagnostics">
-                <Field label="Show version numbers">
+              <Section title={t("settings.sections.diagnostics")}>
+                <Field label={t("settings.diagnostics.showVersionNumbers")}>
                   <div className="flex items-center gap-3">
                     <button
                       role="switch"
@@ -303,10 +304,10 @@ export function SettingsPage() {
                         }`}
                       />
                     </button>
-                    <span className="text-sm">{showVersionNumbers ? "Visible" : "Hidden"}</span>
+                    <span className="text-sm">{showVersionNumbers ? t("settings.diagnostics.visible") : t("settings.diagnostics.hidden")}</span>
                   </div>
                   <p className="text-xs text-muted-foreground mt-1">
-                    Show or hide the UI, API, and worker version badge in the bottom-right corner.
+                    {t("settings.diagnostics.showVersionNumbersHelp")}
                   </p>
                 </Field>
               </Section>
@@ -315,8 +316,8 @@ export function SettingsPage() {
 
             {/* ── Preferences ── */}
             {activeSection === "preferences" && (
-              <Section title="Preferences">
-                <Field label="Display name">
+              <Section title={t("settings.sections.preferences")}>
+                <Field label={t("settings.preferences.displayName")}>
                   <div className="flex gap-2">
                     <input
                       type="text"
@@ -330,12 +331,12 @@ export function SettingsPage() {
                       onClick={() => save({ display_name: displayName })}
                       disabled={saving || displayName === user.display_name}
                     >
-                      Save
+                      {t("common.save")}
                     </Button>
                   </div>
                 </Field>
 
-                <Field label="Measurement system">
+                <Field label={t("settings.preferences.measurementSystem")}>
                   <div className="flex gap-2">
                     {(["metric", "imperial"] as const).map((m) => (
                       <button
@@ -356,7 +357,7 @@ export function SettingsPage() {
                   </div>
                 </Field>
 
-                <Field label="Session idle timeout">
+                <Field label={t("settings.preferences.sessionIdleTimeout")}>
                   <select
                     value={idleTimeout}
                     onChange={(e) => {
@@ -366,10 +367,10 @@ export function SettingsPage() {
                     }}
                     className="rounded-md border border-border bg-background px-3 py-2 text-sm"
                   >
-                    <option value={15}>15 minutes</option>
-                    <option value={30}>30 minutes</option>
-                    <option value={60}>1 hour</option>
-                    <option value={120}>2 hours</option>
+                    <option value={15}>{t("settings.preferences.timeout15min")}</option>
+                    <option value={30}>{t("settings.preferences.timeout30min")}</option>
+                    <option value={60}>{t("settings.preferences.timeout1hr")}</option>
+                    <option value={120}>{t("settings.preferences.timeout2hr")}</option>
                   </select>
                 </Field>
               </Section>
@@ -377,11 +378,10 @@ export function SettingsPage() {
 
             {/* ── Privacy & data ── */}
             {activeSection === "privacy" && (
-              <Section title="Privacy & data">
-                <Field label="Opt out of data use">
+              <Section title={t("settings.sections.privacy")}>
+                <Field label={t("settings.privacy.optOut")}>
                   <p className="text-xs text-muted-foreground">
-                    Per our Terms of Service, your data is used for platform improvements by default.
-                    Toggle on to opt out.
+                    {t("settings.privacy.optOutHelp")}
                   </p>
                   <div className="flex items-center gap-3 mt-2">
                     <button
@@ -398,67 +398,61 @@ export function SettingsPage() {
                         }`}
                       />
                     </button>
-                    <span className="text-sm">{!dataConsent ? "Opted out" : "Participating (default)"}</span>
+                    <span className="text-sm">{!dataConsent ? t("settings.privacy.optedOut") : t("settings.privacy.participating")}</span>
                   </div>
                   <p className="text-xs text-muted-foreground mt-2">
-                    Your content, settings, and tags — including WIF files, photos, and project
-                    data — may be used for AI/ML model training and feature improvements as described
-                    in the Terms of Service.
+                    {t("settings.privacy.dataUseNote")}
                   </p>
                   <p className="text-xs text-muted-foreground mt-1">
-                    <strong>Note:</strong> Opting out also disables all public sharing links for your drafts.
+                    <strong>Note:</strong> {t("settings.privacy.sharingNote")}
                   </p>
                 </Field>
 
                 {showConsentWarning && (
                   <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
                     <div className="w-full max-w-md rounded-xl border bg-background shadow-xl space-y-4 p-6">
-                      <h2 className="text-base font-semibold">Opt out of data use?</h2>
+                      <h2 className="text-base font-semibold">{t("settings.privacy.optOutModal.title")}</h2>
 
                       <p className="text-sm text-muted-foreground">
-                        Opting out stops future use of your data for AI/ML model training and
-                        feature improvements. Data already used in model training cannot be
-                        retroactively removed.
+                        {t("settings.privacy.optOutModal.body")}
                       </p>
 
                       <div className="rounded-md bg-amber-500/10 border border-amber-500/30 px-4 py-3 space-y-1.5">
                         <p className="text-sm font-medium text-amber-700 dark:text-amber-400">
-                          The following will be disabled immediately:
+                          {t("settings.privacy.optOutModal.warningTitle")}
                         </p>
                         <ul className="text-sm text-muted-foreground list-disc list-inside space-y-1">
                           <li>
-                            Public sharing links for all your drafts
+                            {t("settings.privacy.optOutModal.sharingLinks")}
                             {sharedDraftCount > 0 && (
                               <span className="font-medium text-foreground">
-                                {" "}({sharedDraftCount} currently active)
+                                {" "}{t("settings.privacy.optOutModal.currentlyActive", { count: sharedDraftCount })}
                               </span>
                             )}
                           </li>
-                          <li>Any future sharing features tied to your account</li>
+                          <li>{t("settings.privacy.optOutModal.futureSharing")}</li>
                         </ul>
                         {sharedDraftCount > 0 && (
                           <p className="text-xs text-amber-700 dark:text-amber-400 pt-1">
-                            Anyone with your current sharing links will immediately lose access.
+                            {t("settings.privacy.optOutModal.loseAccess")}
                           </p>
                         )}
                       </div>
 
                       <p className="text-xs text-muted-foreground">
-                        You can opt back in at any time from this page. Re-opting in restores
-                        sharing access but does not re-enable individual draft links — you will
-                        need to re-share those manually.
+                        {t("settings.privacy.optOutModal.reOptInNote")}
                       </p>
 
                       <div className="flex gap-2 pt-1">
                         <Button variant="destructive" size="sm" onClick={confirmConsentOptOut}>
-                          Opt out and disable sharing
+                          {t("settings.privacy.optOutModal.confirmButton")}
                         </Button>
                         <Button
                           variant="outline"
                           size="sm"
                           onClick={() => setShowConsentWarning(false)}
                         >
-                          Cancel
+                          {t("settings.privacy.optOutModal.cancelButton")}
                         </Button>
                       </div>
                     </div>
@@ -466,35 +460,35 @@ export function SettingsPage() {
                 )}
 
                 <div className="rounded-md bg-muted px-4 py-3 text-xs text-muted-foreground space-y-1">
-                  <p className="font-medium text-foreground">What we store about you</p>
+                  <p className="font-medium text-foreground">{t("settings.privacy.whatWeStore")}</p>
                   <ul className="list-disc list-inside space-y-0.5">
-                    <li>Email address and display name (from your sign-in provider)</li>
-                    <li>WIF files, loom records, projects, photos, and yarn you create</li>
-                    <li>Settings, tags, and metadata you assign to your content</li>
-                    <li>Last active timestamp</li>
+                    <li>{t("settings.privacy.storeEmail")}</li>
+                    <li>{t("settings.privacy.storeFiles")}</li>
+                    <li>{t("settings.privacy.storeSettings")}</li>
+                    <li>{t("settings.privacy.storeTimestamp")}</li>
                   </ul>
-                  <p className="pt-1">We never sell your data. See our Terms of Service for the full policy.</p>
+                  <p className="pt-1">{t("settings.privacy.noSell")}</p>
                 </div>
               </Section>
             )}
 
             {/* ── Terms ── */}
             {activeSection === "terms" && (
-              <Section title="Terms of Service">
+              <Section title={t("settings.sections.terms")}>
                 <div className="space-y-3">
                   <div className="flex items-center justify-between rounded-lg border p-4">
                     <div>
                       <p className="text-sm font-medium">
-                        WeftMark Terms of Service v{user.current_eula_version}
+                        {t("settings.terms.tosTitle", { version: user.current_eula_version })}
                       </p>
                       <p className="text-xs text-muted-foreground mt-0.5">
                         {user.eula_accepted_version === user.current_eula_version
-                          ? "You have accepted the current version."
-                          : "You have not yet accepted the current version."}
+                          ? t("settings.terms.accepted")
+                          : t("settings.terms.notAccepted")}
                       </p>
                     </div>
                     <Button variant="outline" size="sm" onClick={() => setShowEula(!showEula)}>
-                      {showEula ? "Hide" : "Read terms"}
+                      {showEula ? t("settings.terms.hide") : t("settings.terms.readTerms")}
                     </Button>
                   </div>
 
@@ -512,24 +506,23 @@ export function SettingsPage() {
 
             {/* ── Account ── */}
             {activeSection === "account" && (
-              <Section title="Account management">
-                <Field label="Download my data">
+              <Section title={t("settings.sections.account")}>
+                <Field label={t("settings.account.downloadData")}>
                   <Button variant="outline" size="sm" onClick={handleDataExport}>
-                    Request data archive
+                    {t("settings.account.requestArchive")}
                   </Button>
                   {exportInfo && (
                     <p className="text-xs text-muted-foreground mt-2">{exportInfo}</p>
                   )}
                   <p className="text-xs text-muted-foreground mt-1">
-                    Data export is planned for Milestone 2. Currently returns status only.
+                    {t("settings.account.exportNote")}
                   </p>
                 </Field>
 
                 <div className="rounded-lg border border-destructive/30 p-4 space-y-3">
-                  <p className="text-sm font-medium text-destructive">Danger zone</p>
+                  <p className="text-sm font-medium text-destructive">{t("settings.account.dangerZone")}</p>
                   <p className="text-sm text-muted-foreground">
-                    Permanently delete your account and all data: WIF files, photos, project
-                    records, looms, yarn, and drafts. This cannot be undone.
+                    {t("settings.account.dangerDescription")}
                   </p>
 
                   {!showDeleteConfirm ? (
@@ -538,18 +531,18 @@ export function SettingsPage() {
                       size="sm"
                       onClick={() => setShowDeleteConfirm(true)}
                     >
-                      Delete my account
+                      {t("settings.account.deleteAccount")}
                     </Button>
                   ) : (
                     <div className="space-y-3">
                       <p className="text-sm">
-                        Type <strong>DELETE MY ACCOUNT</strong> to confirm:
+                        {t("settings.account.deleteConfirmInstruction")}
                       </p>
                       <input
                         type="text"
                         value={deleteInput}
                         onChange={(e) => setDeleteInput(e.target.value)}
-                        placeholder="DELETE MY ACCOUNT"
+                        placeholder={t("settings.account.deleteConfirmPlaceholder")}
                         className="w-full rounded-md border border-destructive/50 bg-background px-3 py-2 text-sm"
                       />
                       {deleteError && (
@@ -562,7 +555,7 @@ export function SettingsPage() {
                           onClick={handleDeleteAccount}
                           disabled={deleteInput !== "DELETE MY ACCOUNT" || deleting}
                         >
-                          {deleting ? "Deleting…" : "Permanently delete my account"}
+                          {deleting ? t("settings.account.deleting") : t("settings.account.permanentDelete")}
                         </Button>
                         <Button
                           variant="outline"
@@ -574,7 +567,7 @@ export function SettingsPage() {
                           }}
                           disabled={deleting}
                         >
-                          Cancel
+                          {t("common.cancel")}
                         </Button>
                       </div>
                     </div>
@@ -595,6 +588,7 @@ const DISPATCH_BADGE: Record<string, string> = {
 };
 
 function FeedbackHistorySection() {
+  const { t } = useTranslation();
   const [expanded, setExpanded] = useState<string | null>(null);
 
   const { data: submissions = [], isLoading } = useQuery({
@@ -603,15 +597,15 @@ function FeedbackHistorySection() {
   });
 
   return (
-    <Section title="Feedback history">
+    <Section title={t("settings.sections.feedbackHistory")}>
       <p className="text-sm text-muted-foreground">
-        Submissions you've sent, including anonymous ones. Only you can see this list.
+        {t("settings.feedbackHistory.description")}
       </p>
 
       {isLoading ? (
-        <p className="text-sm text-muted-foreground">Loading…</p>
+        <p className="text-sm text-muted-foreground">{t("common.loading")}</p>
       ) : submissions.length === 0 ? (
-        <p className="text-sm text-muted-foreground">No submissions yet.</p>
+        <p className="text-sm text-muted-foreground">{t("settings.feedbackHistory.noSubmissions")}</p>
       ) : (
         <div className="divide-y divide-border rounded-lg border">
           {submissions.map((s: FeedbackRecord) => (
@@ -626,7 +620,7 @@ function FeedbackHistorySection() {
                       {SUBMISSION_TYPE_LABELS[s.submission_type as keyof typeof SUBMISSION_TYPE_LABELS] ?? s.submission_type}
                     </span>
                     {s.is_anonymous && (
-                      <span className="text-xs text-muted-foreground shrink-0">(anonymous)</span>
+                      <span className="text-xs text-muted-foreground shrink-0">{t("settings.feedbackHistory.anonymous")}</span>
                     )}
                     {s.subject && (
                       <span className="text-sm text-foreground truncate">{s.subject}</span>
@@ -657,7 +651,7 @@ function FeedbackHistorySection() {
                       className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
                     >
                       <AppIcons.externalLink className="h-3.5 w-3.5" />
-                      View discussion on GitHub
+                      {t("settings.feedbackHistory.viewDiscussion")}
                     </a>
                   )}
                 </div>

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -17,6 +17,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
+    "resolveJsonModule": true,
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary

- Installs i18next + react-i18next; initializes with bundled JSON resources (no HTTP backend)
- Supports **English, German, French, Spanish, Dutch** with full weaving-domain terminology
- Converts all label constant objects (loom types, project status/type, skein status, feedback type) to ES getter properties — zero changes to 30+ consumer call sites
- Extracts all copy from Sidebar, LandingPage, and SettingsPage to translation keys with interpolation for dynamic values (opt-out modal count, ToS version)
- Language persists to `localStorage` (`wm_lang`) and is read on i18n init
- Adds a language selector dropdown to the landing page nav and to the Settings → Preferences section
- `DELETE MY ACCOUNT` confirmation string left hardcoded in the comparison (API contract); only the placeholder label is translated

## Test plan

- [ ] Open landing page — language selector appears in nav between "Loom catalog" and "Sign in"
- [ ] Switch to Deutsch — all landing page copy updates immediately; reload retains the selection
- [ ] Open Settings → Preferences — Language field appears; switching updates the entire UI immediately
- [ ] Open Settings → Appearance/Privacy/Account — all copy is translated
- [ ] Verify the opt-out modal renders correctly in each language (count interpolation)
- [ ] Verify Terms section renders ToS version interpolation correctly
- [ ] `tsc --noEmit` passes (already confirmed clean in CI hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)