### PR TITLE
docs: update architecture, overview, and add i18n pattern guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ WeftMark: multi-user web platform for managing weaving drafts. Private by defaul
 
 | Layer | Choice |
 | --- | --- |
-| Frontend | React + Vite + TypeScript + Tailwind CSS + shadcn/ui + TanStack Query + React Router |
+| Frontend | React + Vite + TypeScript + Tailwind CSS + shadcn/ui + TanStack Query + React Router + react-i18next |
 | Backend | FastAPI (Python) + SQLAlchemy + Alembic |
 | Database | PostgreSQL (Neon in prod, local container in dev) |
 | Task queue | Celery + Redis |
@@ -170,6 +170,21 @@ Dark mode is class-based (`darkMode: ["class"]` in `tailwind.config.ts`); applie
 
 Full design reference (layout patterns, component snippets, palette previews): `docs/design-system.md`
 
+## Internationalization (i18n)
+
+**Every new user-facing string must be translated.** The app supports 5 languages: `en`, `de`, `fr`, `es`, `nl`.
+
+**Rules:**
+
+- Use `useTranslation()` and `t("namespace.key")` in every page and component — no hardcoded strings
+- Add keys to **all five** locale files (`frontend/src/locales/{lang}/translation.json`) in the same commit
+- Group keys by page/feature: `loginPage.signIn`, `myNewPage.title`
+- Interpolation: `t("key", { name })` with `{{name}}` in the JSON value
+- Plurals: `key_one` / `key_other` — pass `{ count }` to select the right form
+- Do **not** translate: long prose pages (About, Privacy, Costs), admin/superuser tooling, API-stored enum values
+
+Full pattern reference: `docs/features/i18n.md`
+
 ## Feature requirements map
 
 Read the listed spec **before** touching any of these feature areas:
@@ -185,6 +200,7 @@ Read the listed spec **before** touching any of these feature areas:
 | User sharing / profiles | `docs/requirements/sharing-profiles.md` | `app/routers/drafts.py` |
 | Admin capabilities | `docs/requirements/admin.md` | `app/routers/admin.py` |
 | User settings / EULA | `docs/features/user-settings-eula.md` | `app/routers/users.py` |
+| i18n / localization | `docs/features/i18n.md` | `frontend/src/i18n/config.ts`, `frontend/src/locales/` |
 | Test coverage gaps | `docs/testing.md` | `backend/tests/` |
 | Environments / staging | `docs/deployment/environments.md` | `docker-compose.build.yml` |
 | Phase 2 ideas | `docs/requirements/phase2.md` | **Do not implement unless explicitly directed** |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,6 +11,7 @@ Technical reference for the stack, repo layout, services, API security model, an
 | **Frontend** | React 18 + Vite + TypeScript + Tailwind CSS |
 | **UI components** | shadcn/ui (Radix primitives) |
 | **Data fetching** | TanStack Query v5 + React Router v6 |
+| **Internationalization** | react-i18next — 5 locales (en, de, fr, es, nl) |
 | **Backend** | FastAPI (Python 3.12) |
 | **ORM / migrations** | SQLAlchemy 2 (async) + Alembic |
 | **Database** | PostgreSQL 17 (Neon in prod; local container in dev) |
@@ -66,6 +67,14 @@ weaving_site/
 │   │   │   ├── yarn/
 │   │   │   └── ui/           # shadcn/ui primitives
 │   │   ├── api/              # API client functions (all use authed client)
+│   │   ├── i18n/
+│   │   │   └── config.ts     # react-i18next init + SUPPORTED_LANGUAGES
+│   │   ├── locales/
+│   │   │   ├── en/translation.json
+│   │   │   ├── de/translation.json
+│   │   │   ├── fr/translation.json
+│   │   │   ├── es/translation.json
+│   │   │   └── nl/translation.json
 │   │   └── lib/
 │   │       └── client.ts     # Axios instance configured with Bearer auth
 │   └── Dockerfile

--- a/docs/features/i18n.md
+++ b/docs/features/i18n.md
@@ -1,0 +1,178 @@
+# Internationalization (i18n) — Pattern Reference
+
+Implemented in: **#313** (v0.182.0)
+
+---
+
+## Stack
+
+- **Library:** `react-i18next` + `i18next`
+- **Config:** `frontend/src/i18n/config.ts`
+- **Locale files:** `frontend/src/locales/{lang}/translation.json`
+- **Languages:** `en` (English), `de` (Deutsch), `fr` (Français), `es` (Español), `nl` (Nederlands)
+- **Language persistence:** `localStorage("wm_lang")` — set by the Language preference in Settings
+
+---
+
+## File Structure
+
+```
+frontend/src/
+├── i18n/
+│   └── config.ts              # i18next init + SUPPORTED_LANGUAGES export
+└── locales/
+    ├── en/translation.json    # Source of truth — add keys here first
+    ├── de/translation.json
+    ├── fr/translation.json
+    ├── es/translation.json
+    └── nl/translation.json
+```
+
+All translation files are imported statically at bundle time (no lazy loading). Adding a new locale requires updating `config.ts`.
+
+---
+
+## Adding i18n to a New Page or Feature
+
+### 1. Add keys to the English file first
+
+Keys are grouped by page or feature area at the top level of `translation.json`. Use camelCase for the namespace and for individual keys.
+
+```json
+"myNewPage": {
+  "title": "My Page Title",
+  "loading": "Loading…",
+  "empty": "Nothing here yet.",
+  "saveButton": "Save",
+  "welcomeUser": "Welcome, {{name}}!",
+  "itemCount_one": "{{count}} item",
+  "itemCount_other": "{{count}} items"
+}
+```
+
+**Naming conventions:**
+- Namespace = page name or feature name (`myNewPage`, `projectDetailPage`, `loomsPage`)
+- Simple string → plain key (`title`, `loading`, `empty`)
+- Interpolated string → `{{variableName}}` in the value
+- Plural forms → `_one` / `_other` suffix (i18next standard)
+
+### 2. Add translations to all four other locales
+
+After writing the English keys, add equivalent blocks to `de`, `fr`, `es`, and `nl`. All five files must have the same keys — missing keys fall back to English (via `fallbackLng: "en"`) but that's a gap, not a feature.
+
+### 3. Wire the hook in the component
+
+```tsx
+import { useTranslation } from "react-i18next";
+
+export function MyNewPage() {
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      <h1>{t("myNewPage.title")}</h1>
+      <p>{t("myNewPage.welcomeUser", { name: user.displayName })}</p>
+      <p>{t("myNewPage.itemCount", { count: items.length })}</p>
+    </div>
+  );
+}
+```
+
+---
+
+## Usage Patterns
+
+### Simple string
+
+```tsx
+t("myNewPage.title")
+```
+
+### Interpolation
+
+The value uses `{{variableName}}` double-brace syntax. Pass variables as the second argument:
+
+```tsx
+// JSON: "welcome": "Welcome, {{name}}!"
+t("myNewPage.welcome", { name: user.displayName })
+
+// JSON: "picks": "{{done}} / {{total}} picks · {{pct}}%"
+t("myNewPage.picks", { done: current, total: total, pct: pct })
+```
+
+### Plural forms
+
+i18next uses `_one` and `_other` suffixes. Pass `count` as the interpolation variable — i18next selects the correct form automatically:
+
+```tsx
+// JSON:
+// "itemCount_one": "{{count}} item"
+// "itemCount_other": "{{count}} items"
+t("myNewPage.itemCount", { count: items.length })
+```
+
+### Conditional strings (inline)
+
+For two-value conditions (e.g. label that changes based on state), use a ternary directly — don't create a separate key for each branch:
+
+```tsx
+{isAuthenticated ? t("myNewPage.backToHome") : t("myNewPage.signIn")}
+```
+
+### JSX mixed with translated text
+
+When a translation key contains a link or other inline element, split the translation at the element boundary:
+
+```tsx
+// Don't try to embed JSX in a translation string.
+// Instead split it:
+<>
+  {t("registerPage.alreadyHaveAccount")}{" "}
+  <Link to="/login">{t("registerPage.signIn")}</Link>
+</>
+```
+
+---
+
+## What to Translate
+
+| Translate | Don't translate |
+|---|---|
+| All user-visible text in authenticated pages | Long prose content (About, Privacy, Costs pages) |
+| Auth and error page copy | Admin / Superuser tooling (admin-only audience) |
+| Labels, buttons, headings, toasts | API values stored in the database (status codes, type strings) |
+| Empty state and loading messages | Code-facing strings (CSS class names, API keys) |
+| Locale-specific date formats (use `toLocaleDateString` with a fixed locale arg) | Error messages that are never shown to users |
+
+---
+
+## Language Switching
+
+Language switching is in Settings → Preferences → Language. Calling `i18n.changeLanguage(code)` and persisting to `localStorage("wm_lang")` is handled by SettingsPage. Nothing in individual pages needs to handle language switching explicitly — changing the language re-renders all `t()` calls automatically.
+
+---
+
+## Adding a New Language
+
+1. Create `frontend/src/locales/{code}/translation.json` with a full copy of the English file, translated.
+2. Import and register it in `frontend/src/i18n/config.ts`:
+   ```ts
+   import xx from "@/locales/xx/translation.json";
+   // Add to SUPPORTED_LANGUAGES and resources
+   ```
+3. tsc and ESLint must pass before committing.
+
+---
+
+## Coverage Status (v0.182.0)
+
+| Area | Status |
+|---|---|
+| All authenticated app pages | Translated |
+| Auth/error pages (Login, Register, Pending, SignOut, Unauthorized, Uninitialized, VersionError) | Translated |
+| TermsPage | Translated |
+| Sidebar nav, section labels | Translated |
+| LoomCatalogPage (public) | Translated |
+| SharedProjectPage (public) | Translated |
+| AboutPage, PrivacyPage, CostsPage | Not translated — long prose, English-only |
+| AdminPage, SuperuserPage | Not translated — admin-only tooling |

--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -17,6 +17,13 @@ This directory contains the formal requirements for the WeftMark platform.
 | [admin.md](admin.md) | Admin capabilities — invites, monitoring, WIF records |
 | [phase2.md](phase2.md) | Deferred features for future consideration |
 
+## Feature Guides
+
+| Document | Description |
+| --- | --- |
+| [features/i18n.md](../features/i18n.md) | i18n pattern reference — how to add translations to new features |
+| [features/user-settings-eula.md](../features/user-settings-eula.md) | User settings and EULA acceptance gate |
+
 ## Supporting Files
 
 - `docs/standard/standard-wif1-1.txt` — WIF 1.1 specification (authoritative reference)

--- a/docs/requirements/overview.md
+++ b/docs/requirements/overview.md
@@ -113,11 +113,11 @@ Portrait orientation is preferred for the project (loom-side) interface.
 
 ## Theme and Localization
 
-- Light mode is the default
-- Users can switch to dark mode via a preference setting
+- Light mode is the default; users can switch to dark mode via Settings → Appearance
 - Users can configure their preferred measurement system: `metric`, `imperial`, or `both`
 - Measurement values are stored with their unit on each record (mixed units are supported per field)
 - All calculations normalize to a common unit internally and convert to the user's display preference for presentation
+- **Internationalization:** All user-facing UI strings are translated via `react-i18next`. Supported languages: English, Deutsch, Français, Español, Nederlands. Language is user-selectable in Settings → Preferences and persisted in `localStorage`. New features must include translations for all five locales — see `docs/features/i18n.md`.
 
 ---
 
@@ -169,7 +169,7 @@ Portrait orientation is preferred for the project (loom-side) interface.
 
 ## Feature Highlights (Current)
 
-The following features are implemented and live as of v0.145.0:
+The following features are implemented and live as of v0.182.0:
 
 - WIF 1.1 import with detailed lint report
 - Draft library with threading, tie-up, drawdown preview, and color palette display
@@ -184,8 +184,11 @@ The following features are implemented and live as of v0.145.0:
 - Photo documentation with captions, auto-stamped step/session metadata
 - Project completion summary with design preview, session metrics, and warp setup details
 - Yarn inventory (products + physical units)
+- Collections — named groups of drafts and projects for organizing related work
 - Admin console: user management, approval queue, platform health, audit log, maintenance
+- Superuser console: EULA management, storage audit, CVE scanning, worker monitoring, scheduled tasks, reconciliation, maintenance (dedicated `/superuser` route, visible only to superusers)
 - OpenTelemetry observability (traces, metrics, structured logs)
 - GeoIP geolocation for audit logs and metrics (MaxMind GeoLite2)
 - EULA acceptance gate with versioned EULA content
 - Light and dark mode; metric and imperial measurement support
+- Internationalization (i18n): 5 languages (en, de, fr, es, nl), user-selectable in Settings


### PR DESCRIPTION
## Summary

- Creates `docs/features/i18n.md` — full i18n pattern reference for all future features (how to add keys, translate all 5 locales, use `useTranslation`, interpolation, plurals, what not to translate)
- Updates `CLAUDE.md` — adds react-i18next to tech stack, new i18n section with rules, i18n entry in feature requirements map
- Updates `docs/architecture.md` — react-i18next in tech stack table, `locales/` in repo structure
- Updates `docs/requirements/overview.md` — feature highlights updated to v0.182.0 (adds Collections, Superuser Console, i18n); localization section updated to describe i18n implementation
- Updates `docs/requirements/README.md` — adds Feature Guides section

## Test plan

- [ ] Docs-only change — no code modified
- [ ] Verify links in README.md resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)