### PR TITLE
feat: data export — My Data section with ZIP archive download (#816)

### DIFF
--- a/backend/alembic/versions/0034_user_export_requests.py
+++ b/backend/alembic/versions/0034_user_export_requests.py
@@ -1,0 +1,36 @@
+"""add user_export_requests table
+
+Revision ID: 0034_user_export_requests
+Revises: 0033_loom_version_catalog_link
+Create Date: 2026-05-20
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0034_user_export_requests"
+down_revision = "0033_loom_version_catalog_link"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_export_requests",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("user_id", UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("requested_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("status", sa.String(10), nullable=False, server_default="pending"),
+        sa.Column("archive_path", sa.String(512), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("error", sa.Text, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index("ix_user_export_requests_user_id", "user_export_requests", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_user_export_requests_user_id", table_name="user_export_requests")
+    op.drop_table("user_export_requests")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -20,6 +20,7 @@ from app.models.scheduled_task import ScheduledTask
 from app.models.seed_run import SeedRun
 from app.models.server_event import ServerEvent
 from app.models.user import User
+from app.models.user_export import UserExportRequest
 from app.models.user_identity import UserIdentity
 from app.models.yarn import Skein, Yarn
 
@@ -32,6 +33,7 @@ __all__ = [
     "AuditLog",
     "CredentialExpiry",
     "User",
+    "UserExportRequest",
     "UserFeedback",
     "UserIdentity",
     "Invite",

--- a/backend/app/models/user_export.py
+++ b/backend/app/models/user_export.py
@@ -1,0 +1,26 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, TimestampMixin
+
+EXPORT_STATUSES = ("pending", "complete", "failed")
+
+
+class UserExportRequest(Base, TimestampMixin):
+    __tablename__ = "user_export_requests"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    requested_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    status: Mapped[str] = mapped_column(String(10), nullable=False, default="pending")
+    archive_path: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    user: Mapped["User"] = relationship("User", foreign_keys=[user_id])  # type: ignore[name-defined]

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,12 +1,14 @@
 """User settings, EULA acceptance, and account management.
 
 Routes:
-  GET    /api/eula/current           — current EULA version + HTML body (public)
-  GET    /api/users/me/settings      — current user settings (same as /auth/me but explicit)
-  PATCH  /api/users/me               — update settings
-  POST   /api/users/me/eula          — accept the current EULA version
-  DELETE /api/users/me               — hard-delete account + all data from DB and storage
-  GET    /api/users/me/data-export   — Phase 2 stub
+  GET    /api/eula/current                        — current EULA version + HTML body (public)
+  GET    /api/users/me/settings                   — current user settings
+  PATCH  /api/users/me                            — update settings
+  POST   /api/users/me/eula                       — accept the current EULA version
+  DELETE /api/users/me                            — hard-delete account + all data
+  POST   /api/users/me/data-export                — queue a data export archive task
+  GET    /api/users/me/data-export/status         — most recent export request status
+  GET    /api/users/me/data-export/download/{id}  — stream the archive (auth-gated)
 """
 
 import logging
@@ -15,6 +17,7 @@ from datetime import date as date_cls
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import Date, and_, cast, delete, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -27,6 +30,7 @@ from app.models.invite import Invite
 from app.models.loom import Loom, LoomVersion, LoomVersionAccessory, LoomVersionPhoto, LoomVersionReceipt
 from app.models.project import Project, ProjectPhoto, ProjectStep
 from app.models.user import User
+from app.models.user_export import UserExportRequest
 from app.models.user_identity import UserIdentity
 from app.models.yarn import Skein, Yarn
 from app.services import storage
@@ -312,16 +316,112 @@ async def delete_account(
     response.delete_cookie(_SESSION_COOKIE)
 
 
-@router.get("/me/data-export")
-async def data_export(_: User = Depends(get_current_user)) -> dict:
-    return {
-        "status": "not_implemented",
-        "milestone": "2",
-        "message": (
-            "Data export is planned for Milestone 2. "
-            "It will package your WIF files, photos, and project history into a downloadable archive."
-        ),
-    }
+class ExportStatusResponse(BaseModel):
+    request_id: str | None = None
+    status: str | None = None
+    requested_at: str | None = None
+    expires_at: str | None = None
+    error: str | None = None
+
+
+_EXPORT_COOLDOWN_HOURS = 24
+
+
+@router.post("/me/data-export", status_code=202)
+async def request_data_export(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ExportStatusResponse:
+    """Queue a data export task. De-duplicated: one request per 24 h."""
+    from datetime import timedelta
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=_EXPORT_COOLDOWN_HOURS)
+    existing = await db.scalar(
+        select(UserExportRequest)
+        .where(
+            UserExportRequest.user_id == current_user.id,
+            UserExportRequest.requested_at >= cutoff,
+            UserExportRequest.status.in_(("pending", "complete")),
+        )
+        .order_by(UserExportRequest.requested_at.desc())
+        .limit(1)
+    )
+    if existing:
+        return ExportStatusResponse(
+            request_id=str(existing.id),
+            status=existing.status,
+            requested_at=existing.requested_at.isoformat(),
+            expires_at=existing.expires_at.isoformat() if existing.expires_at else None,
+        )
+
+    req = UserExportRequest(
+        id=uuid.uuid4(),
+        user_id=current_user.id,
+        requested_at=datetime.now(timezone.utc),
+        status="pending",
+    )
+    db.add(req)
+    await db.commit()
+    await db.refresh(req)
+
+    from app.tasks.export import run_user_export
+
+    run_user_export.delay(str(current_user.id), str(req.id))
+
+    return ExportStatusResponse(
+        request_id=str(req.id),
+        status="pending",
+        requested_at=req.requested_at.isoformat(),
+    )
+
+
+@router.get("/me/data-export/status", response_model=ExportStatusResponse)
+async def get_export_status(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ExportStatusResponse:
+    """Return the most recent export request for the current user."""
+    req = await db.scalar(
+        select(UserExportRequest)
+        .where(UserExportRequest.user_id == current_user.id)
+        .order_by(UserExportRequest.requested_at.desc())
+        .limit(1)
+    )
+    if req is None:
+        return ExportStatusResponse()
+    return ExportStatusResponse(
+        request_id=str(req.id),
+        status=req.status,
+        requested_at=req.requested_at.isoformat(),
+        expires_at=req.expires_at.isoformat() if req.expires_at else None,
+        error=req.error,
+    )
+
+
+@router.get("/me/data-export/download/{request_id}")
+async def download_data_export(
+    request_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> StreamingResponse:
+    """Stream the export archive. Auth-gated; returns 404 after expiry."""
+    req = await db.get(UserExportRequest, request_id)
+    if req is None or req.user_id != current_user.id:
+        raise HTTPException(status_code=404, detail="Export not found")
+    if req.status != "complete" or not req.archive_path:
+        raise HTTPException(status_code=404, detail="Export not ready")
+    if req.expires_at and req.expires_at < datetime.now(timezone.utc):
+        raise HTTPException(status_code=410, detail="Export has expired")
+
+    archive_bytes = storage.read_file(req.archive_path)
+    date_str = req.requested_at.strftime("%Y%m%d")
+    filename = f"weftmark-export-{date_str}.zip"
+
+    return StreamingResponse(
+        iter([archive_bytes]),
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 class OnboardingStatusResponse(BaseModel):

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -474,3 +474,15 @@ async def send_admin_digest_email(
     )
     subject = f"{settings.app_name} — Weekly Admin Digest ({week_start} – {week_end})"
     await _send(admin_emails, subject, txt, html)
+
+
+async def send_export_ready(to_email: str, display_name: str, ttl_days: int) -> None:
+    settings = get_settings()
+    download_url = f"{settings.frontend_url}/settings/account"
+    txt, html = _render(
+        "export_ready",
+        display_name=display_name,
+        download_url=download_url,
+        ttl_days=ttl_days,
+    )
+    await _send([to_email], f"Your {settings.app_name} data archive is ready", txt, html)

--- a/backend/app/tasks/export.py
+++ b/backend/app/tasks/export.py
@@ -1,0 +1,249 @@
+"""Celery task: build a data export archive for a user.
+
+Packages WIF files, project photos, and JSON records for all user data
+into a ZIP archive, uploads it to storage, and emails the user a download link.
+"""
+
+import asyncio
+import io
+import json
+import logging
+import re
+import uuid
+import zipfile
+from datetime import datetime, timedelta, timezone
+
+from celery import Task
+from celery.exceptions import SoftTimeLimitExceeded
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.celery_app import celery_app
+
+log = logging.getLogger(__name__)
+
+EXPORT_TTL_DAYS = 7
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=1,
+    default_retry_delay=120,
+    soft_time_limit=300,
+    time_limit=360,
+    name="app.tasks.export.run_user_export",
+)
+def run_user_export(self: Task, user_id: str, request_id: str) -> None:
+    asyncio.run(_build_export(uuid.UUID(user_id), uuid.UUID(request_id)))
+
+
+async def _build_export(user_id: uuid.UUID, request_id: uuid.UUID) -> None:
+    from sqlalchemy import select
+
+    from app.config import get_settings
+    from app.models.collection import Collection
+    from app.models.draft import Draft
+    from app.models.loom import Loom
+    from app.models.project import Project, ProjectPhoto
+    from app.models.user import User
+    from app.models.user_export import UserExportRequest
+    from app.models.yarn import Yarn
+    from app.services import storage
+
+    settings = get_settings()
+    engine = create_async_engine(settings.database_url, echo=False)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as db:
+        req = await db.get(UserExportRequest, request_id)
+        if req is None:
+            log.warning("export_task_skip request_id=%s reason=not_found", request_id)
+            return
+
+        user = await db.get(User, user_id)
+        if user is None:
+            req.status = "failed"
+            req.error = "User not found"
+            await db.commit()
+            return
+
+        try:
+            date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+            prefix = f"weftmark-export-{date_str}"
+            buf = io.BytesIO()
+
+            with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+                # ── Drafts ────────────────────────────────────────────────────
+                drafts = (
+                    await db.scalars(select(Draft).where(Draft.owner_id == user_id, Draft.deleted_at.is_(None)))
+                ).all()
+
+                drafts_json = []
+                for d in drafts:
+                    drafts_json.append(
+                        {
+                            "id": str(d.id),
+                            "title": d.title,
+                            "created_at": d.created_at.isoformat(),
+                            "updated_at": d.updated_at.isoformat(),
+                        }
+                    )
+                    if d.wif_path:
+                        try:
+                            wif_bytes = await storage.aread_file(d.wif_path)
+                            safe = _safe_filename(d.title or str(d.id))
+                            zf.writestr(f"{prefix}/drafts/{safe}.wif", wif_bytes)
+                        except Exception as exc:
+                            log.warning("export_skip_wif draft_id=%s error=%s", d.id, exc)
+
+                zf.writestr(f"{prefix}/data/drafts.json", json.dumps(drafts_json, indent=2))
+
+                # ── Projects + photos ─────────────────────────────────────────
+                projects = (
+                    await db.scalars(select(Project).where(Project.owner_id == user_id, Project.deleted_at.is_(None)))
+                ).all()
+
+                projects_json = []
+                for p in projects:
+                    projects_json.append(
+                        {
+                            "id": str(p.id),
+                            "title": p.title,
+                            "status": p.status,
+                            "start_date": p.start_date.isoformat() if p.start_date else None,
+                            "end_date": p.end_date.isoformat() if p.end_date else None,
+                            "notes": p.notes,
+                            "created_at": p.created_at.isoformat(),
+                        }
+                    )
+                    photos = (await db.scalars(select(ProjectPhoto).where(ProjectPhoto.project_id == p.id))).all()
+                    safe_proj = _safe_filename(p.title or str(p.id))
+                    for i, photo in enumerate(photos):
+                        try:
+                            photo_bytes = await storage.aread_file(photo.file_path)
+                            ext = photo.file_path.rsplit(".", 1)[-1] if "." in photo.file_path else "jpg"
+                            zf.writestr(f"{prefix}/projects/{safe_proj}/photos/{i + 1}.{ext}", photo_bytes)
+                        except Exception as exc:
+                            log.warning("export_skip_photo photo_id=%s error=%s", photo.id, exc)
+
+                zf.writestr(f"{prefix}/data/projects.json", json.dumps(projects_json, indent=2))
+
+                # ── Yarn ─────────────────────────────────────────────────────
+                yarns = (
+                    await db.scalars(select(Yarn).where(Yarn.owner_id == user_id, Yarn.deleted_at.is_(None)))
+                ).all()
+                yarns_json = [
+                    {
+                        "id": str(y.id),
+                        "name": y.name,
+                        "brand": y.brand,
+                        "colorway": y.colorway,
+                        "fiber_content": y.fiber_content,
+                        "weight": y.weight,
+                        "created_at": y.created_at.isoformat(),
+                    }
+                    for y in yarns
+                ]
+                zf.writestr(f"{prefix}/data/yarn.json", json.dumps(yarns_json, indent=2))
+
+                # ── Looms ─────────────────────────────────────────────────────
+                looms = (
+                    await db.scalars(select(Loom).where(Loom.owner_id == user_id, Loom.deleted_at.is_(None)))
+                ).all()
+                looms_json = [
+                    {
+                        "id": str(lo.id),
+                        "name": lo.name,
+                        "loom_type": lo.loom_type,
+                        "created_at": lo.created_at.isoformat(),
+                    }
+                    for lo in looms
+                ]
+                zf.writestr(f"{prefix}/data/looms.json", json.dumps(looms_json, indent=2))
+
+                # ── Collections ───────────────────────────────────────────────
+                collections = (
+                    await db.scalars(
+                        select(Collection).where(Collection.owner_id == user_id, Collection.deleted_at.is_(None))
+                    )
+                ).all()
+                collections_json = [
+                    {
+                        "id": str(c.id),
+                        "name": c.name,
+                        "created_at": c.created_at.isoformat(),
+                    }
+                    for c in collections
+                ]
+                zf.writestr(f"{prefix}/data/collections.json", json.dumps(collections_json, indent=2))
+
+                # ── Profile ───────────────────────────────────────────────────
+                zf.writestr(
+                    f"{prefix}/data/profile.json",
+                    json.dumps(
+                        {
+                            "display_name": user.display_name,
+                            "email": user.email,
+                            "created_at": user.created_at.isoformat(),
+                            "exported_at": datetime.now(timezone.utc).isoformat(),
+                        },
+                        indent=2,
+                    ),
+                )
+
+                # ── README ────────────────────────────────────────────────────
+                zf.writestr(f"{prefix}/README.txt", _readme(user, date_str))
+
+            archive_key = f"exports/{user_id}/{request_id}.zip"
+            await asyncio.to_thread(storage._put, archive_key, buf.getvalue())
+
+            req.status = "complete"
+            req.archive_path = archive_key
+            req.expires_at = datetime.now(timezone.utc) + timedelta(days=EXPORT_TTL_DAYS)
+            await db.commit()
+
+            log.info("export_complete user_id=%s request_id=%s", user_id, request_id)
+
+            try:
+                from app.services.email import send_export_ready
+
+                await send_export_ready(user.email, user.display_name or "there", EXPORT_TTL_DAYS)
+            except Exception as exc:
+                log.warning("export_email_failed user_id=%s error=%s", user_id, exc)
+
+        except SoftTimeLimitExceeded:
+            req.status = "failed"
+            req.error = "Task timed out"
+            await db.commit()
+            raise
+
+        except Exception as exc:
+            log.error("export_failed user_id=%s request_id=%s error=%s", user_id, request_id, exc, exc_info=True)
+            req.status = "failed"
+            req.error = str(exc)[:500]
+            await db.commit()
+
+
+def _safe_filename(name: str) -> str:
+    safe = re.sub(r'[<>:"/\\|?*\x00-\x1f]', "_", name)
+    return safe[:80].strip("._") or "untitled"
+
+
+def _readme(user, date_str: str) -> str:
+    return (
+        "weftmark Data Export\n"
+        "====================\n\n"
+        f"Exported:  {date_str}\n"
+        f"Account:   {user.display_name} <{user.email}>\n\n"
+        "Contents\n"
+        "--------\n"
+        "  drafts/                  WIF files for each of your drafts\n"
+        "  projects/<name>/photos/  Project photos\n"
+        "  data/profile.json        Account details\n"
+        "  data/drafts.json         Draft metadata\n"
+        "  data/projects.json       Project records\n"
+        "  data/yarn.json           Yarn inventory\n"
+        "  data/looms.json          Loom inventory\n"
+        "  data/collections.json    Collections\n\n"
+        f"This archive is valid for {EXPORT_TTL_DAYS} days from the export date.\n"
+    )

--- a/backend/app/templates/email/export_ready.html
+++ b/backend/app/templates/email/export_ready.html
@@ -1,0 +1,10 @@
+<p style="margin:0 0 16px;">Hi <strong>{display_name}</strong>,</p>
+<p style="margin:0 0 20px;">Your <strong>{app_name}</strong> data archive is ready to download. It includes your WIF files, project photos, and a JSON export of all your records.</p>
+<table cellpadding="0" cellspacing="0" role="presentation" style="margin:0 0 24px;">
+  <tr>
+    <td style="background:#1d3557;border-radius:6px;">
+      <a href="{download_url}" style="display:inline-block;padding:12px 28px;color:#ffffff;font-weight:bold;text-decoration:none;font-size:15px;font-family:Arial,Helvetica,sans-serif;">Download archive</a>
+    </td>
+  </tr>
+</table>
+<p style="margin:0 0 16px;font-size:14px;color:#6b7280;">This link expires in <strong>{ttl_days} days</strong>. If the button above doesn't work, copy and paste this link: {download_url}</p>

--- a/backend/app/templates/email/export_ready.txt
+++ b/backend/app/templates/email/export_ready.txt
@@ -1,0 +1,9 @@
+Hi {display_name},
+
+Your {app_name} data archive is ready to download.
+
+Download your archive: {download_url}
+
+This link will expire in {ttl_days} days. The archive includes your WIF
+files, project photos, and a JSON export of all your records.
+

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -416,23 +416,7 @@ class TestAcceptEula:
 
 
 # ---------------------------------------------------------------------------
-# GET /api/users/me/data-export
-# ---------------------------------------------------------------------------
-
-
-class TestDataExport:
-    async def test_returns_200(self, auth_client: AsyncClient):
-        resp = await auth_client.get("/api/users/me/data-export")
-        assert resp.status_code == 200
-
-    async def test_returns_not_implemented_status(self, auth_client: AsyncClient):
-        data = (await auth_client.get("/api/users/me/data-export")).json()
-        assert data["status"] == "not_implemented"
-        assert data["milestone"] == "2"
-
-    async def test_unauthenticated_returns_401(self, client: AsyncClient):
-        resp = await client.get("/api/users/me/data-export")
-        assert resp.status_code == 401
+# Data export endpoints are covered by tests/routers/test_users_export.py
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/routers/test_users_export.py
+++ b/backend/tests/routers/test_users_export.py
@@ -1,0 +1,246 @@
+"""Tests for data export endpoints.
+
+POST   /api/users/me/data-export
+GET    /api/users/me/data-export/status
+GET    /api/users/me/data-export/download/{request_id}
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import User
+from app.models.user_export import UserExportRequest
+
+# ---------------------------------------------------------------------------
+# POST /api/users/me/data-export
+# ---------------------------------------------------------------------------
+
+
+class TestRequestDataExport:
+    async def test_unauthenticated_returns_401(self, client: AsyncClient):
+        resp = await client.post("/api/users/me/data-export")
+        assert resp.status_code == 401
+
+    async def test_queues_export_and_returns_202(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        with patch("app.tasks.export.run_user_export.delay") as mock_delay:
+            resp = await auth_client.post("/api/users/me/data-export")
+        assert resp.status_code == 202
+        data = resp.json()
+        assert data["status"] == "pending"
+        assert data["request_id"] is not None
+        mock_delay.assert_called_once()
+
+    async def test_creates_db_row(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        with patch("app.tasks.export.run_user_export.delay"):
+            resp = await auth_client.post("/api/users/me/data-export")
+        request_id = uuid.UUID(resp.json()["request_id"])
+        req = await db_session.get(UserExportRequest, request_id)
+        assert req is not None
+        assert req.user_id == test_user.id
+        assert req.status == "pending"
+
+    async def test_deduplicates_within_24h(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        existing = UserExportRequest(
+            id=uuid.uuid4(),
+            user_id=test_user.id,
+            requested_at=datetime.now(timezone.utc) - timedelta(hours=2),
+            status="pending",
+        )
+        db_session.add(existing)
+        await db_session.commit()
+
+        with patch("app.tasks.export.run_user_export.delay") as mock_delay:
+            resp = await auth_client.post("/api/users/me/data-export")
+        assert resp.status_code == 202
+        assert resp.json()["request_id"] == str(existing.id)
+        mock_delay.assert_not_called()
+
+    async def test_new_request_after_cooldown(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        old = UserExportRequest(
+            id=uuid.uuid4(),
+            user_id=test_user.id,
+            requested_at=datetime.now(timezone.utc) - timedelta(hours=25),
+            status="complete",
+            archive_path="exports/old.zip",
+            expires_at=datetime.now(timezone.utc) + timedelta(days=6),
+        )
+        db_session.add(old)
+        await db_session.commit()
+
+        with patch("app.tasks.export.run_user_export.delay") as mock_delay:
+            resp = await auth_client.post("/api/users/me/data-export")
+        assert resp.status_code == 202
+        assert resp.json()["request_id"] != str(old.id)
+        mock_delay.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/users/me/data-export/status
+# ---------------------------------------------------------------------------
+
+
+class TestExportStatus:
+    async def test_unauthenticated_returns_401(self, client: AsyncClient):
+        resp = await client.get("/api/users/me/data-export/status")
+        assert resp.status_code == 401
+
+    async def test_returns_none_when_no_export(self, auth_client: AsyncClient):
+        resp = await auth_client.get("/api/users/me/data-export/status")
+        assert resp.status_code == 200
+        assert resp.json()["request_id"] is None
+
+    async def test_returns_most_recent_pending(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        req = UserExportRequest(
+            id=uuid.uuid4(),
+            user_id=test_user.id,
+            requested_at=datetime.now(timezone.utc),
+            status="pending",
+        )
+        db_session.add(req)
+        await db_session.commit()
+
+        resp = await auth_client.get("/api/users/me/data-export/status")
+        data = resp.json()
+        assert data["status"] == "pending"
+        assert data["request_id"] == str(req.id)
+
+    async def test_returns_complete_with_expiry(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        expires = datetime.now(timezone.utc) + timedelta(days=7)
+        req = UserExportRequest(
+            id=uuid.uuid4(),
+            user_id=test_user.id,
+            requested_at=datetime.now(timezone.utc),
+            status="complete",
+            archive_path="exports/test.zip",
+            expires_at=expires,
+        )
+        db_session.add(req)
+        await db_session.commit()
+
+        resp = await auth_client.get("/api/users/me/data-export/status")
+        data = resp.json()
+        assert data["status"] == "complete"
+        assert data["expires_at"] is not None
+
+    async def test_returns_most_recent_of_multiple(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        old = UserExportRequest(
+            id=uuid.uuid4(),
+            user_id=test_user.id,
+            requested_at=datetime.now(timezone.utc) - timedelta(days=2),
+            status="complete",
+            archive_path="exports/old.zip",
+        )
+        new = UserExportRequest(
+            id=uuid.uuid4(),
+            user_id=test_user.id,
+            requested_at=datetime.now(timezone.utc),
+            status="pending",
+        )
+        db_session.add_all([old, new])
+        await db_session.commit()
+
+        resp = await auth_client.get("/api/users/me/data-export/status")
+        assert resp.json()["request_id"] == str(new.id)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/users/me/data-export/download/{request_id}
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadExport:
+    async def test_unauthenticated_returns_401(self, client: AsyncClient):
+        resp = await client.get(f"/api/users/me/data-export/download/{uuid.uuid4()}")
+        assert resp.status_code == 401
+
+    async def test_unknown_id_returns_404(self, auth_client: AsyncClient):
+        resp = await auth_client.get(f"/api/users/me/data-export/download/{uuid.uuid4()}")
+        assert resp.status_code == 404
+
+    async def test_pending_export_returns_404(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        req = UserExportRequest(
+            id=uuid.uuid4(),
+            user_id=test_user.id,
+            requested_at=datetime.now(timezone.utc),
+            status="pending",
+        )
+        db_session.add(req)
+        await db_session.commit()
+
+        resp = await auth_client.get(f"/api/users/me/data-export/download/{req.id}")
+        assert resp.status_code == 404
+
+    async def test_expired_export_returns_410(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        req = UserExportRequest(
+            id=uuid.uuid4(),
+            user_id=test_user.id,
+            requested_at=datetime.now(timezone.utc) - timedelta(days=8),
+            status="complete",
+            archive_path="exports/old.zip",
+            expires_at=datetime.now(timezone.utc) - timedelta(days=1),
+        )
+        db_session.add(req)
+        await db_session.commit()
+
+        resp = await auth_client.get(f"/api/users/me/data-export/download/{req.id}")
+        assert resp.status_code == 410
+
+    async def test_another_users_export_returns_404(
+        self,
+        auth_client: AsyncClient,
+        db_session: AsyncSession,
+        admin_user: User,
+    ):
+        req = UserExportRequest(
+            id=uuid.uuid4(),
+            user_id=admin_user.id,
+            requested_at=datetime.now(timezone.utc),
+            status="complete",
+            archive_path="exports/admin.zip",
+            expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+        )
+        db_session.add(req)
+        await db_session.commit()
+
+        resp = await auth_client.get(f"/api/users/me/data-export/download/{req.id}")
+        assert resp.status_code == 404
+
+    async def test_complete_export_streams_zip(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        req = UserExportRequest(
+            id=uuid.uuid4(),
+            user_id=test_user.id,
+            requested_at=datetime.now(timezone.utc),
+            status="complete",
+            archive_path="exports/test.zip",
+            expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+        )
+        db_session.add(req)
+        await db_session.commit()
+
+        fake_zip = b"PK\x03\x04"  # ZIP magic bytes
+        with patch("app.services.storage.read_file", return_value=fake_zip):
+            resp = await auth_client.get(f"/api/users/me/data-export/download/{req.id}")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "application/zip"
+        assert "attachment" in resp.headers["content-disposition"]
+        assert resp.content == fake_zip

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -40,8 +40,24 @@ export async function deleteAccount(confirm: string): Promise<void> {
   return api.delete<void>("/api/users/me", { confirm });
 }
 
-export async function getDataExport(): Promise<{ status: string; milestone: string; message: string }> {
-  return api.get("/api/users/me/data-export");
+export interface ExportStatus {
+  request_id: string | null;
+  status: string | null;
+  requested_at: string | null;
+  expires_at: string | null;
+  error: string | null;
+}
+
+export async function requestDataExport(): Promise<ExportStatus> {
+  return api.post<ExportStatus>("/api/users/me/data-export", {});
+}
+
+export async function getDataExportStatus(): Promise<ExportStatus> {
+  return api.get<ExportStatus>("/api/users/me/data-export/status");
+}
+
+export function getDataExportDownloadUrl(requestId: string): string {
+  return `/api/users/me/data-export/download/${requestId}`;
 }
 
 export interface HeatmapProject {

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -17,7 +17,7 @@
     "preferences": "Einstellungen",
     "privacy": "Datenschutz",
     "terms": "Nutzungsbedingungen",
-    "account": "Konto",
+    "account": "Meine Daten",
     "feedbackHistory": "Feedback-Verlauf"
   },
   "adminSections": {
@@ -168,9 +168,15 @@
       "viewDiscussion": "Diskussion auf GitHub anzeigen"
     },
     "account": {
-      "downloadData": "Meine Daten herunterladen",
-      "requestArchive": "Datenarchiv anfordern",
-      "exportNote": "Datenexport ist für Meilenstein 2 geplant. Gibt derzeit nur den Status zurück.",
+      "downloadData": "Datenarchiv anfordern",
+      "requestArchive": "Archiv anfordern",
+      "archivePending": "Archiv wird erstellt …",
+      "archiveReady": "Dein Archiv ist bereit",
+      "archiveExpires": "Verfügbar bis {{date}}",
+      "downloadArchive": "Archiv herunterladen",
+      "archiveFailed": "Export fehlgeschlagen — bitte erneut versuchen",
+      "archiveEmailNotice": "Wir senden dir eine E-Mail, wenn dein Archiv zum Download bereit ist.",
+      "archiveNote": "Enthält deine WIF-Dateien, Projektfotos und einen JSON-Export aller Einträge.",
       "dangerZone": "Gefahrenzone",
       "dangerDescription": "Konto und alle Daten dauerhaft löschen: WIF-Dateien, Fotos, Projekteinträge, Webstühle, Garne und Entwürfe. Dies kann nicht rückgängig gemacht werden.",
       "deleteAccount": "Mein Konto löschen",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -17,7 +17,7 @@
     "preferences": "Preferences",
     "privacy": "Privacy & data",
     "terms": "Terms",
-    "account": "Account",
+    "account": "My Data",
     "feedbackHistory": "Feedback history"
   },
   "adminSections": {
@@ -168,9 +168,15 @@
       "viewDiscussion": "View discussion on GitHub"
     },
     "account": {
-      "downloadData": "Download my data",
-      "requestArchive": "Request data archive",
-      "exportNote": "Data export is planned for Milestone 2. Currently returns status only.",
+      "downloadData": "Request a data archive",
+      "requestArchive": "Request archive",
+      "archivePending": "Building your archive…",
+      "archiveReady": "Your archive is ready",
+      "archiveExpires": "Available until {{date}}",
+      "downloadArchive": "Download archive",
+      "archiveFailed": "Export failed — please try again",
+      "archiveEmailNotice": "We'll send you an email when your archive is ready to download.",
+      "archiveNote": "Includes your WIF files, project photos, and a JSON export of all your records.",
       "dangerZone": "Danger zone",
       "dangerDescription": "Permanently delete your account and all data: WIF files, photos, project records, looms, yarn, and drafts. This cannot be undone.",
       "deleteAccount": "Delete my account",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -17,7 +17,7 @@
     "preferences": "Preferencias",
     "privacy": "Privacidad",
     "terms": "Términos",
-    "account": "Cuenta",
+    "account": "Mis datos",
     "feedbackHistory": "Historial de comentarios"
   },
   "adminSections": {
@@ -168,9 +168,15 @@
       "viewDiscussion": "Ver discusión en GitHub"
     },
     "account": {
-      "downloadData": "Descargar mis datos",
-      "requestArchive": "Solicitar archivo de datos",
-      "exportNote": "La exportación de datos está planificada para el Hito 2. Actualmente solo devuelve el estado.",
+      "downloadData": "Solicitar un archivo de datos",
+      "requestArchive": "Solicitar archivo",
+      "archivePending": "Creando tu archivo…",
+      "archiveReady": "Tu archivo está listo",
+      "archiveExpires": "Disponible hasta el {{date}}",
+      "downloadArchive": "Descargar archivo",
+      "archiveFailed": "Error en la exportación — inténtalo de nuevo",
+      "archiveEmailNotice": "Te enviaremos un correo electrónico cuando tu archivo esté listo para descargar.",
+      "archiveNote": "Incluye tus archivos WIF, fotos de proyectos y una exportación JSON de todos tus registros.",
       "dangerZone": "Zona de peligro",
       "dangerDescription": "Eliminar permanentemente tu cuenta y todos los datos: archivos WIF, fotos, registros de proyectos, telares, hilos y ligamentos. Esta acción no se puede deshacer.",
       "deleteAccount": "Eliminar mi cuenta",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -17,7 +17,7 @@
     "preferences": "Préférences",
     "privacy": "Confidentialité",
     "terms": "Conditions d'utilisation",
-    "account": "Compte",
+    "account": "Mes données",
     "feedbackHistory": "Historique des retours"
   },
   "adminSections": {
@@ -168,9 +168,15 @@
       "viewDiscussion": "Voir la discussion sur GitHub"
     },
     "account": {
-      "downloadData": "Télécharger mes données",
-      "requestArchive": "Demander une archive de données",
-      "exportNote": "L'export de données est prévu pour le Milestone 2. Retourne actuellement uniquement le statut.",
+      "downloadData": "Demander une archive de données",
+      "requestArchive": "Demander une archive",
+      "archivePending": "Création de votre archive en cours…",
+      "archiveReady": "Votre archive est prête",
+      "archiveExpires": "Disponible jusqu'au {{date}}",
+      "downloadArchive": "Télécharger l'archive",
+      "archiveFailed": "L'export a échoué — veuillez réessayer",
+      "archiveEmailNotice": "Nous vous enverrons un e-mail lorsque votre archive sera prête à télécharger.",
+      "archiveNote": "Inclut vos fichiers WIF, les photos de projets et un export JSON de tous vos enregistrements.",
       "dangerZone": "Zone de danger",
       "dangerDescription": "Supprimer définitivement votre compte et toutes les données : fichiers WIF, photos, projets, métiers, fils et armures. Cette action est irréversible.",
       "deleteAccount": "Supprimer mon compte",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -17,7 +17,7 @@
     "preferences": "Voorkeuren",
     "privacy": "Privacy",
     "terms": "Gebruiksvoorwaarden",
-    "account": "Account",
+    "account": "Mijn gegevens",
     "feedbackHistory": "Feedbackgeschiedenis"
   },
   "adminSections": {
@@ -168,9 +168,15 @@
       "viewDiscussion": "Discussie bekijken op GitHub"
     },
     "account": {
-      "downloadData": "Mijn gegevens downloaden",
-      "requestArchive": "Gegevens­archief aanvragen",
-      "exportNote": "Gegevens­export is gepland voor Mijlpaal 2. Geeft momenteel alleen de status terug.",
+      "downloadData": "Een gegevensarchief aanvragen",
+      "requestArchive": "Archief aanvragen",
+      "archivePending": "Uw archief wordt gemaakt…",
+      "archiveReady": "Uw archief is klaar",
+      "archiveExpires": "Beschikbaar tot {{date}}",
+      "downloadArchive": "Archief downloaden",
+      "archiveFailed": "Export mislukt — probeer het opnieuw",
+      "archiveEmailNotice": "We sturen u een e-mail wanneer uw archief klaar is om te downloaden.",
+      "archiveNote": "Bevat uw WIF-bestanden, projectfoto's en een JSON-export van al uw gegevens.",
       "dangerZone": "Gevaren­zone",
       "dangerDescription": "Uw account en alle gegevens permanent verwijderen: WIF-bestanden, foto's, project­records, weefstoel­en, garen en bindingen. Dit kan niet ongedaan worden gemaakt.",
       "deleteAccount": "Mijn account verwijderen",

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -3,8 +3,9 @@ import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { LanguageSelector } from "@/components/LanguageSelector";
 import { useAuth } from "@/hooks/useAuth";
-import { useQuery } from "@tanstack/react-query";
-import { updateSettings, deleteAccount, getDataExport, getCurrentEula } from "@/api/users";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { updateSettings, deleteAccount, requestDataExport, getDataExportStatus, getDataExportDownloadUrl, getCurrentEula } from "@/api/users";
+import { downloadAuthed } from "@/api/client";
 import { listDrafts } from "@/api/drafts";
 import { listMyFeedback, SUBMISSION_TYPE_LABELS, type FeedbackRecord } from "@/api/feedback";
 import { Button } from "@/components/ui/button";
@@ -30,6 +31,18 @@ export function SettingsPage() {
     queryKey: ["eula", "current"],
     queryFn: getCurrentEula,
     staleTime: 5 * 60 * 1000,
+  });
+
+  const queryClient = useQueryClient();
+  const { data: exportStatus } = useQuery({
+    queryKey: ["export-status"],
+    queryFn: getDataExportStatus,
+    refetchInterval: (query) => (query.state.data?.status === "pending" ? 5000 : false),
+    enabled: activeSection === "account",
+  });
+  const requestExportMutation = useMutation({
+    mutationFn: requestDataExport,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["export-status"] }),
   });
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -63,7 +76,6 @@ export function SettingsPage() {
   const [deleteInput, setDeleteInput] = useState("");
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
-  const [exportInfo, setExportInfo] = useState<string | null>(null);
 
   if (!user) return null;
 
@@ -109,15 +121,6 @@ export function SettingsPage() {
     } catch (e: unknown) {
       setDeleteError(e instanceof Error ? e.message : "Failed to delete account");
       setDeleting(false);
-    }
-  }
-
-  async function handleDataExport() {
-    try {
-      const result = await getDataExport();
-      setExportInfo(result.message);
-    } catch {
-      setExportInfo(t("common.loading"));
     }
   }
 
@@ -513,14 +516,58 @@ export function SettingsPage() {
             {activeSection === "account" && (
               <Section title={t("settings.sections.account")}>
                 <Field label={t("settings.account.downloadData")}>
-                  <Button variant="outline" size="sm" onClick={handleDataExport}>
-                    {t("settings.account.requestArchive")}
-                  </Button>
-                  {exportInfo && (
-                    <p className="text-xs text-muted-foreground mt-2">{exportInfo}</p>
+                  {exportStatus?.status === "pending" ? (
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <AppIcons.spinner className="h-4 w-4 animate-spin" />
+                      {t("settings.account.archivePending")}
+                    </div>
+                  ) : exportStatus?.status === "complete" && exportStatus.request_id ? (
+                    <div className="space-y-1">
+                      <p className="text-sm text-muted-foreground">{t("settings.account.archiveReady")}</p>
+                      {exportStatus.expires_at && (
+                        <p className="text-xs text-muted-foreground">
+                          {t("settings.account.archiveExpires", {
+                            date: new Date(exportStatus.expires_at).toLocaleDateString(),
+                          })}
+                        </p>
+                      )}
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() =>
+                          downloadAuthed(
+                            getDataExportDownloadUrl(exportStatus.request_id!),
+                            "weftmark-data-export.zip"
+                          ).catch(() => {})
+                        }
+                      >
+                        {t("settings.account.downloadArchive")}
+                      </Button>
+                    </div>
+                  ) : (
+                    <>
+                      {exportStatus?.status === "failed" && (
+                        <p className="text-xs text-destructive mb-1">
+                          {t("settings.account.archiveFailed")}
+                        </p>
+                      )}
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => requestExportMutation.mutate()}
+                        disabled={requestExportMutation.isPending}
+                      >
+                        {t("settings.account.requestArchive")}
+                      </Button>
+                    </>
+                  )}
+                  {exportStatus?.status === "pending" && (
+                    <p className="text-xs text-muted-foreground mt-1">
+                      {t("settings.account.archiveEmailNotice")}
+                    </p>
                   )}
                   <p className="text-xs text-muted-foreground mt-1">
-                    {t("settings.account.exportNote")}
+                    {t("settings.account.archiveNote")}
                   </p>
                 </Field>
 


### PR DESCRIPTION
## Summary

- Renames the Settings "Account" section to **My Data** across all 5 locales (en, de, fr, es, nl)
- Implements full data export: `UserExportRequest` model + Alembic migration `0034`, Celery task building in-memory ZIP (WIF files, project photos, JSON records for drafts/projects/yarn/looms/collections/profile), three endpoints (POST request, GET status, GET download/stream)
- 24-hour de-duplication: re-requesting within 24h returns the existing job ID; failed requests allow immediate retry
- 7-day archive TTL; expired downloads return HTTP 410
- Email notification sent when archive is ready (`send_export_ready`)
- Frontend state machine: idle → pending (5s polling) → complete (download link + expiry date) / failed (retry button)
- 16 backend tests covering all endpoints and edge cases (auth, dedup, expiry, cross-user access)

## Test plan

- [ ] `pytest backend/tests/routers/test_users_export.py` — 16 tests pass
- [ ] `tsc --noEmit` — clean
- [ ] Settings → My Data: "Request archive" button appears
- [ ] Click button → status shows spinner + email notice while pending
- [ ] On completion → download link with expiry date appears
- [ ] Requesting again within 24h returns same job (no new task queued)
- [ ] Expired archive returns 410 on download attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)