### PR TITLE
feat: soft-delete queue and user deletion queue in superuser console (#812)

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -2186,6 +2186,96 @@ async def run_purge_soft_deleted(
     return {"status": "queued", "task_id": task.id}
 
 
+class SoftDeleteBucket(BaseModel):
+    drafts: int
+    projects: int
+    yarn: int
+    looms: int
+    total: int
+
+
+class SoftDeleteQueueResponse(BaseModel):
+    retention_days: int
+    cutoff: datetime
+    ready_to_purge: SoftDeleteBucket
+    in_retention_window: SoftDeleteBucket
+
+
+@router.get("/soft-delete-queue", response_model=SoftDeleteQueueResponse)
+async def get_soft_delete_queue(
+    _: User = Depends(require_superuser),
+    db: AsyncSession = Depends(get_db),
+) -> SoftDeleteQueueResponse:
+    settings = get_settings()
+    retention_days = settings.soft_delete_retention_days
+    cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
+
+    async def _count(model, before_cutoff: bool) -> int:
+        if before_cutoff:
+            condition = model.deleted_at.is_not(None) & (model.deleted_at < cutoff)
+        else:
+            condition = model.deleted_at.is_not(None) & (model.deleted_at >= cutoff)
+        result = await db.scalar(select(func.count()).select_from(model).where(condition))
+        return result or 0
+
+    ready_drafts = await _count(Draft, True)
+    ready_projects = await _count(Project, True)
+    ready_yarn = await _count(Yarn, True)
+    ready_looms = await _count(Loom, True)
+
+    window_drafts = await _count(Draft, False)
+    window_projects = await _count(Project, False)
+    window_yarn = await _count(Yarn, False)
+    window_looms = await _count(Loom, False)
+
+    return SoftDeleteQueueResponse(
+        retention_days=retention_days,
+        cutoff=cutoff,
+        ready_to_purge=SoftDeleteBucket(
+            drafts=ready_drafts,
+            projects=ready_projects,
+            yarn=ready_yarn,
+            looms=ready_looms,
+            total=ready_drafts + ready_projects + ready_yarn + ready_looms,
+        ),
+        in_retention_window=SoftDeleteBucket(
+            drafts=window_drafts,
+            projects=window_projects,
+            yarn=window_yarn,
+            looms=window_looms,
+            total=window_drafts + window_projects + window_yarn + window_looms,
+        ),
+    )
+
+
+class DeletionQueueUser(BaseModel):
+    id: uuid.UUID
+    display_name: str
+    email: str
+    deletion_state: str
+    deletion_initiated_at: datetime | None
+
+
+@router.get("/deletion-queue", response_model=list[DeletionQueueUser])
+async def get_deletion_queue(
+    _: User = Depends(require_superuser),
+    db: AsyncSession = Depends(get_db),
+) -> list[DeletionQueueUser]:
+    rows = await db.scalars(
+        select(User).where(User.deletion_state.is_not(None)).order_by(User.deletion_initiated_at.desc())
+    )
+    return [
+        DeletionQueueUser(
+            id=u.id,
+            display_name=u.display_name,
+            email=u.email,
+            deletion_state=u.deletion_state,
+            deletion_initiated_at=u.deletion_initiated_at,
+        )
+        for u in rows.all()
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Scheduled tasks (superuser only)
 # ---------------------------------------------------------------------------

--- a/backend/tests/routers/test_admin.py
+++ b/backend/tests/routers/test_admin.py
@@ -1961,3 +1961,187 @@ class TestCveScan:
     async def test_summary_requires_superuser(self, admin_client: AsyncClient):
         resp = await admin_client.get("/api/admin/cve-scan/summary")
         assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# GET /api/admin/soft-delete-queue
+# ---------------------------------------------------------------------------
+
+
+class TestSoftDeleteQueue:
+    async def test_requires_superuser(self, admin_client: AsyncClient):
+        resp = await admin_client.get("/api/admin/soft-delete-queue")
+        assert resp.status_code == 403
+
+    async def test_requires_auth(self, client: AsyncClient):
+        resp = await client.get("/api/admin/soft-delete-queue")
+        assert resp.status_code == 401
+
+    async def test_empty_queue_returns_zeros(self, superuser_client: AsyncClient, superuser_user: User):
+        resp = await superuser_client.get("/api/admin/soft-delete-queue")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ready_to_purge"]["total"] == 0
+        assert data["in_retention_window"]["total"] == 0
+        assert data["retention_days"] > 0
+        assert "cutoff" in data
+
+    async def test_counts_ready_to_purge(
+        self,
+        superuser_client: AsyncClient,
+        superuser_user: User,
+        db_session: AsyncSession,
+        test_user: User,
+    ):
+        old_cutoff = datetime.now(timezone.utc) - timedelta(days=400)
+        draft = Draft(
+            owner_id=test_user.id,
+            name="Old draft",
+            wif_filename="old.wif",
+            wif_path="drafts/old.wif",
+            deleted_at=old_cutoff,
+        )
+        db_session.add(draft)
+        await db_session.commit()
+
+        resp = await superuser_client.get("/api/admin/soft-delete-queue")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ready_to_purge"]["drafts"] >= 1
+        assert data["ready_to_purge"]["total"] >= 1
+        assert data["in_retention_window"]["drafts"] == 0
+
+    async def test_counts_in_retention_window(
+        self,
+        superuser_client: AsyncClient,
+        superuser_user: User,
+        db_session: AsyncSession,
+        test_user: User,
+    ):
+        recent = datetime.now(timezone.utc) - timedelta(days=5)
+        draft = Draft(
+            owner_id=test_user.id,
+            name="Recent draft",
+            wif_filename="recent.wif",
+            wif_path="drafts/recent.wif",
+            deleted_at=recent,
+        )
+        db_session.add(draft)
+        await db_session.commit()
+
+        resp = await superuser_client.get("/api/admin/soft-delete-queue")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["in_retention_window"]["drafts"] >= 1
+        assert data["in_retention_window"]["total"] >= 1
+        assert data["ready_to_purge"]["drafts"] == 0
+
+    async def test_non_deleted_records_not_counted(
+        self,
+        superuser_client: AsyncClient,
+        superuser_user: User,
+        db_session: AsyncSession,
+        test_user: User,
+    ):
+        draft = Draft(
+            owner_id=test_user.id,
+            name="Active draft",
+            wif_filename="active.wif",
+            wif_path="drafts/active.wif",
+        )
+        db_session.add(draft)
+        await db_session.commit()
+
+        resp = await superuser_client.get("/api/admin/soft-delete-queue")
+        data = resp.json()
+        assert data["ready_to_purge"]["total"] == 0
+        assert data["in_retention_window"]["total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# GET /api/admin/deletion-queue
+# ---------------------------------------------------------------------------
+
+
+class TestDeletionQueue:
+    async def test_requires_superuser(self, admin_client: AsyncClient):
+        resp = await admin_client.get("/api/admin/deletion-queue")
+        assert resp.status_code == 403
+
+    async def test_requires_auth(self, client: AsyncClient):
+        resp = await client.get("/api/admin/deletion-queue")
+        assert resp.status_code == 401
+
+    async def test_empty_when_no_deletions(self, superuser_client: AsyncClient, superuser_user: User):
+        resp = await superuser_client.get("/api/admin/deletion-queue")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    async def test_returns_users_in_deletion_pipeline(
+        self,
+        superuser_client: AsyncClient,
+        superuser_user: User,
+        db_session: AsyncSession,
+        test_user: User,
+    ):
+        test_user.deletion_state = "pending"
+        test_user.deletion_initiated_at = datetime.now(timezone.utc)
+        db_session.add(test_user)
+        await db_session.commit()
+
+        resp = await superuser_client.get("/api/admin/deletion-queue")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["deletion_state"] == "pending"
+        assert data[0]["email"] == test_user.email
+
+    async def test_excludes_users_without_deletion_state(
+        self,
+        superuser_client: AsyncClient,
+        superuser_user: User,
+        db_session: AsyncSession,
+        test_user: User,
+    ):
+        assert test_user.deletion_state is None
+        resp = await superuser_client.get("/api/admin/deletion-queue")
+        assert resp.json() == []
+
+    async def test_ordered_by_initiated_at_desc(
+        self,
+        superuser_client: AsyncClient,
+        superuser_user: User,
+        db_session: AsyncSession,
+        test_user: User,
+        admin_user: User,
+    ):
+        now = datetime.now(timezone.utc)
+        test_user.deletion_state = "pending"
+        test_user.deletion_initiated_at = now - timedelta(hours=2)
+        admin_user.deletion_state = "in_progress"
+        admin_user.deletion_initiated_at = now
+        db_session.add_all([test_user, admin_user])
+        await db_session.commit()
+
+        resp = await superuser_client.get("/api/admin/deletion-queue")
+        data = resp.json()
+        assert len(data) == 2
+        assert data[0]["deletion_state"] == "in_progress"
+        assert data[1]["deletion_state"] == "pending"
+
+    async def test_stalled_state_included(
+        self,
+        superuser_client: AsyncClient,
+        superuser_user: User,
+        db_session: AsyncSession,
+        test_user: User,
+    ):
+        test_user.deletion_state = "stalled"
+        test_user.deletion_initiated_at = datetime.now(timezone.utc)
+        db_session.add(test_user)
+        await db_session.commit()
+
+        resp = await superuser_client.get("/api/admin/deletion-queue")
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["deletion_state"] == "stalled"

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -358,6 +358,35 @@ export const revokeTask = (taskId: string) =>
 export const runPurgeSoftDeleted = () =>
   api.post<{ status: string; task_id: string }>("/api/admin/purge-soft-deleted", {});
 
+export interface SoftDeleteBucket {
+  drafts: number;
+  projects: number;
+  yarn: number;
+  looms: number;
+  total: number;
+}
+
+export interface SoftDeleteQueue {
+  retention_days: number;
+  cutoff: string;
+  ready_to_purge: SoftDeleteBucket;
+  in_retention_window: SoftDeleteBucket;
+}
+
+export const getSoftDeleteQueue = () =>
+  api.get<SoftDeleteQueue>("/api/admin/soft-delete-queue");
+
+export interface DeletionQueueUser {
+  id: string;
+  display_name: string;
+  email: string;
+  deletion_state: string;
+  deletion_initiated_at: string | null;
+}
+
+export const getDeletionQueue = () =>
+  api.get<DeletionQueueUser[]>("/api/admin/deletion-queue");
+
 export interface ScheduledTask {
   name: string;
   display_name: string;

--- a/frontend/src/pages/SuperuserPage.tsx
+++ b/frontend/src/pages/SuperuserPage.tsx
@@ -17,6 +17,8 @@ import {
   getTaskHistory,
   revokeTask,
   runPurgeSoftDeleted,
+  getSoftDeleteQueue,
+  getDeletionQueue,
   listScheduledTasks,
   patchScheduledTask,
   type ScheduledTask,
@@ -27,6 +29,7 @@ import {
   type CveFinding,
   type WorkerStatus,
   type WorkerInfo,
+  type DeletionQueueUser,
 } from "@/api/admin";
 import { EulaContent } from "@/components/EulaContent";
 import { CveBanner } from "@/components/admin/CveBanner";
@@ -919,11 +922,78 @@ function TaskHistoryTable() {
   );
 }
 
-function DeletionTab() {
+const DELETION_STATE_STYLE: Record<string, string> = {
+  pending: "border-border text-muted-foreground",
+  in_progress: "border-blue-500/40 bg-blue-500/10 text-blue-700 dark:text-blue-300",
+  stalled: "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  complete: "border-green-500/40 bg-green-500/10 text-green-700 dark:text-green-300",
+};
+
+function DeletionStateBadge({ state }: { state: string }) {
   return (
-    <div className="rounded-lg border border-dashed p-8 text-center">
-      <p className="text-sm font-medium text-muted-foreground">Deletion Queue</p>
-      <p className="text-xs text-muted-foreground mt-1">Coming soon — in-progress and pending user deletion states.</p>
+    <span className={`text-xs px-2 py-0.5 rounded border font-medium ${DELETION_STATE_STYLE[state] ?? "border-border text-muted-foreground"}`}>
+      {state}
+    </span>
+  );
+}
+
+function DeletionTab() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["admin", "deletion-queue"],
+    queryFn: getDeletionQueue,
+    refetchInterval: 10_000,
+  });
+
+  if (isLoading) return <p className="text-sm text-muted-foreground">Loading…</p>;
+  if (error) return <p className="text-sm text-destructive">Failed to load deletion queue.</p>;
+
+  const users = data ?? [];
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <h2 className="text-sm font-medium">User Deletion Queue</h2>
+        <p className="text-xs text-muted-foreground">
+          Users currently in the deletion pipeline. Auto-refreshes every 10s.
+          Stalled entries indicate a Celery task that errored mid-cascade and requires investigation.
+        </p>
+      </div>
+
+      {users.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No users in the deletion queue.</p>
+      ) : (
+        <div className="rounded-md border overflow-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-muted">
+              <tr>
+                <th className="px-3 py-2 text-left font-medium">Display name</th>
+                <th className="px-3 py-2 text-left font-medium">Email</th>
+                <th className="px-3 py-2 text-left font-medium">State</th>
+                <th className="px-3 py-2 text-left font-medium whitespace-nowrap">Initiated</th>
+              </tr>
+            </thead>
+            <tbody>
+              {users.map((u: DeletionQueueUser) => (
+                <tr key={u.id} className={`border-t ${u.deletion_state === "stalled" ? "bg-amber-500/5" : ""}`}>
+                  <td className="px-3 py-2 font-medium">{u.display_name}</td>
+                  <td className="px-3 py-2 text-muted-foreground font-mono text-xs">{u.email}</td>
+                  <td className="px-3 py-2">
+                    <DeletionStateBadge state={u.deletion_state} />
+                    {u.deletion_state === "stalled" && (
+                      <span className="ml-1 text-xs text-amber-600 dark:text-amber-400">⚠ check logs</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 text-muted-foreground text-xs whitespace-nowrap">
+                    {u.deletion_initiated_at
+                      ? new Date(u.deletion_initiated_at).toLocaleString()
+                      : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }
@@ -932,18 +1002,83 @@ function MaintenanceTab() {
   const queryClient = useQueryClient();
   const [purging, setPurging] = useState(false);
 
+  const { data: queue, isLoading: queueLoading } = useQuery({
+    queryKey: ["admin", "soft-delete-queue"],
+    queryFn: getSoftDeleteQueue,
+  });
+
+  const nothingEligible = queue != null && queue.ready_to_purge.total === 0;
+
   function triggerPurge() {
     setPurging(true);
     runPurgeSoftDeleted()
       .then(() => {
         setPurging(false);
         queryClient.invalidateQueries({ queryKey: ["admin", "task-history"] });
+        queryClient.invalidateQueries({ queryKey: ["admin", "soft-delete-queue"] });
       })
       .catch(() => setPurging(false));
   }
 
   return (
     <div className="space-y-6">
+      {/* Soft-delete queue summary */}
+      <div className="rounded-lg border p-5 space-y-3">
+        <div>
+          <p className="text-sm font-medium">Soft-Delete Queue</p>
+          {queue && (
+            <p className="text-xs text-muted-foreground mt-1">
+              Items deleted before{" "}
+              <span className="font-mono">{new Date(queue.cutoff).toLocaleDateString()}</span>
+              {" "}are eligible for purge (retention: {queue.retention_days} days).
+            </p>
+          )}
+        </div>
+
+        {queueLoading && <p className="text-xs text-muted-foreground">Loading…</p>}
+
+        {queue && (
+          nothingEligible && queue.in_retention_window.total === 0 ? (
+            <p className="text-xs text-muted-foreground">No soft-deleted records found.</p>
+          ) : (
+            <div className="rounded-md border overflow-auto">
+              <table className="w-full text-xs">
+                <thead className="bg-muted">
+                  <tr>
+                    <th className="px-3 py-2 text-left font-medium">Type</th>
+                    <th className="px-3 py-2 text-right font-medium text-destructive">Ready to purge</th>
+                    <th className="px-3 py-2 text-right font-medium">In retention window</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(["drafts", "projects", "yarn", "looms"] as const).map((key) => (
+                    <tr key={key} className="border-t">
+                      <td className="px-3 py-2 capitalize">{key}</td>
+                      <td className={`px-3 py-2 text-right tabular-nums font-medium ${queue.ready_to_purge[key] > 0 ? "text-destructive" : "text-muted-foreground"}`}>
+                        {queue.ready_to_purge[key]}
+                      </td>
+                      <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">
+                        {queue.in_retention_window[key]}
+                      </td>
+                    </tr>
+                  ))}
+                  <tr className="border-t bg-muted/40 font-medium">
+                    <td className="px-3 py-2">Total</td>
+                    <td className={`px-3 py-2 text-right tabular-nums ${queue.ready_to_purge.total > 0 ? "text-destructive" : "text-muted-foreground"}`}>
+                      {queue.ready_to_purge.total}
+                    </td>
+                    <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">
+                      {queue.in_retention_window.total}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          )
+        )}
+      </div>
+
+      {/* Purge action */}
       <div className="rounded-lg border p-5 space-y-3">
         <div>
           <p className="text-sm font-medium">Purge Soft-Deleted Records</p>
@@ -958,12 +1093,17 @@ function MaintenanceTab() {
           <Button
             size="sm"
             variant="destructive"
-            disabled={purging}
+            disabled={purging || nothingEligible}
             onClick={triggerPurge}
+            title={nothingEligible ? "Nothing is eligible for purge yet" : undefined}
           >
             {purging ? "Queuing…" : "Run Purge Now"}
           </Button>
-          <p className="text-xs text-muted-foreground">Results appear in the Workers → Task History table.</p>
+          {nothingEligible ? (
+            <p className="text-xs text-muted-foreground">Nothing eligible for purge yet.</p>
+          ) : (
+            <p className="text-xs text-muted-foreground">Results appear in the Workers → Task History table.</p>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Adds `GET /admin/soft-delete-queue` — returns item counts split into two buckets: **ready to purge** (`deleted_at < cutoff`) and **in retention window** (`deleted_at >= cutoff`) for Draft, Project, Yarn, and Loom
- Adds `GET /admin/deletion-queue` — returns users with `deletion_state IS NOT NULL`, ordered by `deletion_initiated_at desc`
- **Maintenance tab**: new two-column summary table above the purge button showing counts per type; purge button disabled with tooltip when nothing is eligible; invalidates queue summary after purge
- **Deletion tab**: replaces stub with an auto-refreshing table (10s interval) showing display name, email, state badge, and initiated date; stalled rows highlighted amber with "⚠ check logs" note

## State badges
| State | Style |
|---|---|
| `pending` | muted |
| `in_progress` | blue |
| `stalled` | amber (+ warning note) |
| `complete` | green |

## Test plan

- [ ] 13 backend tests pass (`pytest tests/routers/test_admin.py::TestSoftDeleteQueue tests/routers/test_admin.py::TestDeletionQueue`)
- [ ] `tsc --noEmit` clean
- [ ] Superuser → Maintenance: summary table shows zeros when nothing deleted; purge button disabled
- [ ] Superuser → Deletion: empty state when no users in pipeline; populated table auto-refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)