### PR TITLE
feat: move Last Fired inline with Next on scheduled task cards (#813)

### DIFF
--- a/frontend/src/pages/SuperuserPage.tsx
+++ b/frontend/src/pages/SuperuserPage.tsx
@@ -1214,16 +1214,18 @@ function ScheduledTaskCard({ task, onSaved }: { task: ScheduledTask; onSaved: ()
           )}
         </div>
 
-        {task.next_runs.length > 0 && (
-          <p className="text-xs text-muted-foreground">
-            Next: {task.next_runs.slice(0, 3).map((r) => new Date(r).toLocaleString()).join(" · ")}
-          </p>
-        )}
-        {task.last_fired_at && (
-          <p className="text-xs text-muted-foreground">
-            Last fired: {new Date(task.last_fired_at).toLocaleString()}
-          </p>
-        )}
+        <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-muted-foreground">
+          {task.next_runs.length > 0 && (
+            <span>
+              Next: {task.next_runs.slice(0, 3).map((r) => new Date(r).toLocaleString()).join(" · ")}
+            </span>
+          )}
+          {task.last_fired_at && (
+            <span>
+              Last fired: {new Date(task.last_fired_at).toLocaleString()}
+            </span>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Replaces the two stacked `<p>` elements (Next / Last fired) in `ScheduledTaskCard` with a single `flex flex-wrap` row
- On wide screens: Next and Last fired appear side by side with `gap-x-4` breathing room
- On narrow screens: items wrap to separate lines naturally — no truncation

## Test plan

- [ ] `tsc --noEmit` clean
- [ ] Superuser → Scheduled Tasks: Next and Last fired on same line when space allows
- [ ] Narrow viewport: items wrap cleanly to separate lines
- [ ] Card with no last-fired date: only Next shown, no blank space

🤖 Generated with [Claude Code](https://claude.com/claude-code)