### PR TITLE
feat: compact tracker theme suppresses progress bar (#815)

### DIFF
--- a/frontend/src/components/TrackerStylePreview.tsx
+++ b/frontend/src/components/TrackerStylePreview.tsx
@@ -49,12 +49,16 @@ export function TrackerStylePreview({ style }: { style: TrackerStyle }) {
 
   return (
     <div className="pointer-events-none select-none space-y-1.5 p-3 rounded-lg bg-muted/30 border border-border/50">
-      <div className="h-1.5 rounded-full bg-muted overflow-hidden">
-        <div className={`h-full rounded-full ${isHighContrast ? "bg-foreground" : "bg-primary"}`} style={{ width: `${(DEMO_PICK / DEMO_TOTAL) * 100}%` }} />
-      </div>
-      <div className={`text-center font-semibold ${isCompact ? "text-[10px]" : "text-xs"} text-muted-foreground`}>
-        Pick {DEMO_PICK} / {DEMO_TOTAL}
-      </div>
+      {!isCompact && (
+        <>
+          <div className="h-1.5 rounded-full bg-muted overflow-hidden">
+            <div className={`h-full rounded-full ${isHighContrast ? "bg-foreground" : "bg-primary"}`} style={{ width: `${(DEMO_PICK / DEMO_TOTAL) * 100}%` }} />
+          </div>
+          <div className="text-center font-semibold text-xs text-muted-foreground">
+            Pick {DEMO_PICK} / {DEMO_TOTAL}
+          </div>
+        </>
+      )}
       <div className="grid grid-cols-[1fr_2fr_1fr] gap-1 items-center">
         <DemoPickCard compact style={style} />
         <DemoPickCard style={style} />

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -97,6 +97,7 @@
       "trackerDefaultsHelp": "Standardansichtsoptionen beim Öffnen des Aktivitäts-Trackers. Diese können pro Projekt in den Tracker-Einstellungen überschrieben werden.",
       "colorMode": "Farbmodus",
       "progressBar": "Fortschrittsbalken",
+      "hiddenInCompact": "Im kompakten Modus ausgeblendet",
       "drawdownPattern": "Patrone",
       "weftColorBar": "Schussfarbenleiste",
       "prevNextPickCards": "Vorherige/nächste Eintrags­karten",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -97,6 +97,7 @@
       "trackerDefaultsHelp": "Default view options when opening the activity tracker. You can still override these per-project in the tracker settings panel.",
       "colorMode": "Color mode",
       "progressBar": "Progress bar",
+      "hiddenInCompact": "Hidden in compact mode",
       "drawdownPattern": "Drawdown pattern",
       "weftColorBar": "Weft color bar",
       "prevNextPickCards": "Prev/next pick cards",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -97,6 +97,7 @@
       "trackerDefaultsHelp": "Opciones de vista predeterminadas al abrir el seguidor de actividad. Puedes anularlas por proyecto en el panel de configuración del seguidor.",
       "colorMode": "Modo de color",
       "progressBar": "Barra de progreso",
+      "hiddenInCompact": "Oculto en modo compacto",
       "drawdownPattern": "Ligamento",
       "weftColorBar": "Barra de color de trama",
       "prevNextPickCards": "Tarjetas de pasada anterior/siguiente",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -97,6 +97,7 @@
       "trackerDefaultsHelp": "Options d'affichage par défaut lors de l'ouverture du suivi d'activité. Vous pouvez les modifier par projet dans le panneau de paramètres du suivi.",
       "colorMode": "Mode couleur",
       "progressBar": "Barre de progression",
+      "hiddenInCompact": "Masqué en mode compact",
       "drawdownPattern": "Armure",
       "weftColorBar": "Barre de couleur de trame",
       "prevNextPickCards": "Cartes duite précédente/suivante",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -97,6 +97,7 @@
       "trackerDefaultsHelp": "Standaard weergave­opties bij het openen van de activiteits­tracker. Deze kunnen per project overschreven worden in het instellingen­paneel van de tracker.",
       "colorMode": "Kleurmodus",
       "progressBar": "Voortgangs­balk",
+      "hiddenInCompact": "Verborgen in compacte modus",
       "drawdownPattern": "Bindingspatroon",
       "weftColorBar": "Inslagkleur­balk",
       "prevNextPickCards": "Kaarten vorige/volgende inslag",

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1579,7 +1579,7 @@ export function ProjectDetailPage() {
         )}
 
         {/* Progress bar + item indicator */}
-        {showProgress && !isPlanning && !isCompleted && (
+        {showProgress && !isPlanning && !isCompleted && user?.activity_theme !== "compact" && (
           <div className="w-full px-8 pt-6">
             {isMultiItem && (
               <div className="flex items-center justify-between mb-2">
@@ -2098,16 +2098,17 @@ export function ProjectDetailPage() {
               <div className="space-y-3">
                 <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{t("projectDetailPage.showHide")}</p>
                 {([
-                  { label: t("projectDetailPage.progressBar"), value: showProgress, key: "proj-view:showProgress", setter: setShowProgress },
+                  { label: t("projectDetailPage.progressBar"), value: showProgress, key: "proj-view:showProgress", setter: setShowProgress, disabled: user?.activity_theme === "compact", disabledTitle: t("settings.appearance.hiddenInCompact") },
                   { label: t("projectDetailPage.drawdownPattern"), value: showDrawdown, key: "proj-view:showDrawdown", setter: setShowDrawdown },
                   { label: t("projectDetailPage.weftColorToggle"), value: showWeftColor, key: "proj-view:showWeftColor", setter: setShowWeftColor },
                   { label: t("projectDetailPage.prevNextCards"), value: showPickCards, key: "proj-view:showPickCards", setter: setShowPickCards },
-                ] as { label: string; value: boolean; key: string; setter: (v: boolean) => void }[]).map(({ label, value, key, setter }) => (
-                  <div key={label} className="flex items-center justify-between">
+                ] as { label: string; value: boolean; key: string; setter: (v: boolean) => void; disabled?: boolean; disabledTitle?: string }[]).map(({ label, value, key, setter, disabled, disabledTitle }) => (
+                  <div key={label} className={`flex items-center justify-between${disabled ? " opacity-40" : ""}`} title={disabled ? disabledTitle : undefined}>
                     <span className="text-sm">{label}</span>
                     <button
                       role="switch"
                       aria-checked={value}
+                      disabled={disabled}
                       onClick={() => { setter(!value); localStorage.setItem(key, String(!value)); }}
                       className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-ring ${value ? "bg-primary" : "bg-input"}`}
                     >

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -223,18 +223,19 @@ export function SettingsPage() {
                   {/* Show/hide toggles */}
                   <div className="space-y-2.5">
                     {([
-                      { label: t("settings.appearance.progressBar"), value: trackerShowProgress, setter: setTrackerShowProgress, key: "tracker_show_progress" as const },
+                      { label: t("settings.appearance.progressBar"), value: trackerShowProgress, setter: setTrackerShowProgress, key: "tracker_show_progress" as const, disabled: activityTheme === "compact", disabledTitle: t("settings.appearance.hiddenInCompact") },
                       { label: t("settings.appearance.drawdownPattern"), value: trackerShowDrawdown, setter: setTrackerShowDrawdown, key: "tracker_show_drawdown" as const },
                       { label: t("settings.appearance.weftColorBar"), value: trackerShowWeftColor, setter: setTrackerShowWeftColor, key: "tracker_show_weft_color" as const },
                       { label: t("settings.appearance.prevNextPickCards"), value: trackerShowPickCards, setter: setTrackerShowPickCards, key: "tracker_show_pick_cards" as const },
-                    ] as { label: string; value: boolean; setter: (v: boolean) => void; key: "tracker_show_progress" | "tracker_show_drawdown" | "tracker_show_weft_color" | "tracker_show_pick_cards" }[]).map(({ label, value, setter, key }) => (
-                      <div key={key} className="flex items-center justify-between">
+                    ] as { label: string; value: boolean; setter: (v: boolean) => void; key: "tracker_show_progress" | "tracker_show_drawdown" | "tracker_show_weft_color" | "tracker_show_pick_cards"; disabled?: boolean; disabledTitle?: string }[]).map(({ label, value, setter, key, disabled, disabledTitle }) => (
+                      <div key={key} className={`flex items-center justify-between ${disabled ? "opacity-40" : ""}`} title={disabledTitle}>
                         <span className="text-sm">{label}</span>
                         <button
                           role="switch"
                           aria-checked={value}
+                          disabled={disabled}
                           onClick={() => { setter(!value); save({ [key]: !value }); }}
-                          className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-ring ${value ? "bg-primary" : "bg-input"}`}
+                          className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-ring ${value ? "bg-primary" : "bg-input"} disabled:cursor-not-allowed`}
                         >
                           <span className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform ${value ? "translate-x-4" : "translate-x-1"}`} />
                         </button>
@@ -247,7 +248,7 @@ export function SettingsPage() {
                     <TrackerLivePreview
                       style={activityTheme}
                       colorMode={trackerColorMode}
-                      showProgress={trackerShowProgress}
+                      showProgress={activityTheme === "compact" ? false : trackerShowProgress}
                       showDrawdown={trackerShowDrawdown}
                       showWeftColor={trackerShowWeftColor}
                       showPickCards={trackerShowPickCards}


### PR DESCRIPTION
## Summary
- Hides the progress bar and pick counter in the compact style's static preview card (`TrackerStylePreview`)
- In Settings, the progress bar toggle greys out with a tooltip ("Hidden in compact mode") when compact theme is selected; live preview also ignores the toggle
- In the Project detail tracker, the progress bar is hidden at runtime when `activity_theme === "compact"`, and its sidebar toggle is disabled the same way
- Added `settings.appearance.hiddenInCompact` i18n key across all five locales (en/de/fr/es/nl)

## Test plan
- [ ] Switch to Compact theme in Settings → progress bar toggle dims and has tooltip; preview has no progress bar
- [ ] Switch back to Default/High contrast → toggle re-enables, preview shows bar
- [ ] Open a project tracker with Compact theme → no progress bar shown
- [ ] Open a project tracker with Default theme → progress bar shown per toggle

Closes #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)