### PR TITLE
feat: show GitHub discussion open/closed state in feedback history (#818)

### DIFF
--- a/backend/alembic/versions/0035_feedback_discussion_state.py
+++ b/backend/alembic/versions/0035_feedback_discussion_state.py
@@ -1,0 +1,25 @@
+"""add github_discussion_state to user_feedback
+
+Revision ID: 0035
+Revises: 0034
+Create Date: 2026-05-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0035"
+down_revision = "0034"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_feedback",
+        sa.Column("github_discussion_state", sa.String(10), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_feedback", "github_discussion_state")

--- a/backend/alembic/versions/0035_feedback_discussion_state.py
+++ b/backend/alembic/versions/0035_feedback_discussion_state.py
@@ -8,8 +8,8 @@ Create Date: 2026-05-21
 from alembic import op
 import sqlalchemy as sa
 
-revision = "0035"
-down_revision = "0034"
+revision = "0035_feedback_discussion_state"
+down_revision = "0034_user_export_requests"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/models/feedback.py
+++ b/backend/app/models/feedback.py
@@ -29,6 +29,7 @@ class UserFeedback(Base, TimestampMixin, SoftDeleteMixin):
     # Auto-collected: environment, page_url, user_agent, app_version, project_id, draft_id
     diagnostics: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     github_discussion_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    github_discussion_state: Mapped[str | None] = mapped_column(String(10), nullable=True)
     dispatch_status: Mapped[str] = mapped_column(String(10), nullable=False, default="pending")
     dispatch_error: Mapped[str | None] = mapped_column(Text, nullable=True)
 

--- a/backend/app/routers/feedback.py
+++ b/backend/app/routers/feedback.py
@@ -62,6 +62,7 @@ class FeedbackResponse(BaseModel):
     is_anonymous: bool
     diagnostics: dict | None
     github_discussion_url: str | None
+    github_discussion_state: str | None
     dispatch_status: str
     user_email: str | None
     deleted_at: str | None
@@ -90,6 +91,7 @@ def _serialize(row: UserFeedback, include_user_email: bool = False) -> FeedbackR
         is_anonymous=row.is_anonymous,
         diagnostics=row.diagnostics,
         github_discussion_url=row.github_discussion_url,
+        github_discussion_state=row.github_discussion_state,
         dispatch_status=row.dispatch_status,
         user_email=user_email,
         deleted_at=row.deleted_at.isoformat() if row.deleted_at else None,
@@ -173,6 +175,7 @@ async def list_my_feedback(
 class FeedbackStatusResponse(BaseModel):
     dispatch_status: str
     github_discussion_url: str | None
+    github_discussion_state: str | None
 
 
 @router.get("/{feedback_id}/status")
@@ -187,6 +190,7 @@ async def get_feedback_status(
     return FeedbackStatusResponse(
         dispatch_status=row.dispatch_status,
         github_discussion_url=row.github_discussion_url,
+        github_discussion_state=row.github_discussion_state,
     )
 
 

--- a/backend/app/services/github_discussions.py
+++ b/backend/app/services/github_discussions.py
@@ -34,6 +34,27 @@ async def _graphql(token: str, query: str, variables: dict) -> dict:
     return data["data"]
 
 
+async def get_discussion_state(token: str, discussion_url: str) -> str | None:
+    """Return "OPEN" or "CLOSED" for a discussion URL, or None on error."""
+    query = """
+    query($url: URI!) {
+      resource(url: $url) {
+        ... on Discussion { closed }
+      }
+    }
+    """
+    try:
+        data = await _graphql(token, query, {"url": discussion_url})
+        resource = data.get("resource") or {}
+        closed = resource.get("closed")
+        if closed is None:
+            return None
+        return "CLOSED" if closed else "OPEN"
+    except Exception as exc:
+        log.warning("get_discussion_state failed url=%s error=%s", discussion_url, exc)
+        return None
+
+
 async def get_repo_and_category_id(token: str, repo: str, submission_type: str) -> tuple[str, str]:
     """Return (repositoryId, categoryId) for the given repo and submission type."""
     owner, name = repo.split("/", 1)

--- a/backend/app/tasks/feedback_dispatch.py
+++ b/backend/app/tasks/feedback_dispatch.py
@@ -32,6 +32,7 @@ async def _dispatch(task, feedback_id: str) -> dict:
         build_discussion_body,
         build_discussion_title,
         create_discussion,
+        get_discussion_state,
     )
 
     settings = get_settings()
@@ -76,6 +77,7 @@ async def _dispatch(task, feedback_id: str) -> dict:
             row.github_discussion_url = url
             row.dispatch_status = "sent"
             row.dispatch_error = None
+            row.github_discussion_state = await get_discussion_state(settings.github_feedback_token, url)
             await db.commit()
             log.info("feedback_dispatch sent feedback_id=%s url=%s", feedback_id, url)
 
@@ -226,3 +228,56 @@ async def _purge_deleted(retention_days: int) -> dict:
     deleted = result.rowcount
     log.info("purge_deleted_feedback deleted=%d retention_days=%d", deleted, retention_days)
     return {"deleted": deleted}
+
+
+@celery_app.task(
+    bind=True,
+    name="app.tasks.feedback_dispatch.sync_discussion_states",
+    max_retries=0,
+    soft_time_limit=120,
+    time_limit=150,
+)
+def sync_discussion_states(self, limit: int = 100) -> dict:
+    """Sync github_discussion_state for all sent feedback with a discussion URL."""
+    return asyncio.run(_sync_states(limit))
+
+
+async def _sync_states(limit: int) -> dict:
+    from sqlalchemy import select
+
+    from app.config import get_settings
+    from app.database import CeleryAsyncSession
+    from app.models.feedback import UserFeedback
+    from app.services.github_discussions import get_discussion_state
+
+    settings = get_settings()
+    if not settings.github_feedback_token:
+        return {"updated": 0, "reason": "no_token"}
+
+    async with CeleryAsyncSession() as db:
+        rows = (
+            (
+                await db.execute(
+                    select(UserFeedback)
+                    .where(UserFeedback.deleted_at.is_(None))
+                    .where(UserFeedback.dispatch_status == "sent")
+                    .where(UserFeedback.github_discussion_url.is_not(None))
+                    .limit(limit)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        updated = 0
+        for row in rows:
+            state = await get_discussion_state(settings.github_feedback_token, row.github_discussion_url)
+            if state is not None and state != row.github_discussion_state:
+                row.github_discussion_state = state
+                updated += 1
+
+        if updated:
+            await db.commit()
+
+    log.info("sync_discussion_states updated=%d", updated)
+    return {"updated": updated}

--- a/backend/app/tasks/scheduler.py
+++ b/backend/app/tasks/scheduler.py
@@ -145,6 +145,16 @@ REGISTRY: dict[str, dict] = {
         "default_cron": "30 4 * * *",
         "default_config": {"retention_days": 7},
     },
+    "discussion_state_sync": {
+        "display_name": "Discussion State Sync",
+        "description": (
+            "Syncs the open/closed state of GitHub Discussions linked to feedback submissions. "
+            "Updates github_discussion_state for all sent feedback with a discussion URL. "
+            "No-op when GITHUB_FEEDBACK_TOKEN is not configured."
+        ),
+        "default_cron": "0 3 * * *",
+        "default_config": {"limit": 100},
+    },
 }
 
 
@@ -291,6 +301,19 @@ def _dispatch_feedback_purge(settings, task=None):
     return t
 
 
+def _dispatch_discussion_state_sync(settings, task=None):
+    from app.services.task_history import record_queued
+    from app.tasks.feedback_dispatch import sync_discussion_states
+
+    cfg = (task.config or {}) if task else {}
+    limit = int(cfg.get("limit", 100))
+    t = sync_discussion_states.delay(limit=limit)
+    record_queued(
+        settings, t.id, "app.tasks.feedback_dispatch.sync_discussion_states", "scheduled:discussion_state_sync"
+    )
+    return t
+
+
 DISPATCH_FNS: dict[str, object] = {
     "cve_scan": _dispatch_cve_scan,
     "s3_audit": _dispatch_s3_audit,
@@ -306,6 +329,7 @@ DISPATCH_FNS: dict[str, object] = {
     "tile_prune": _dispatch_tile_prune,
     "feedback_retry": _dispatch_feedback_retry,
     "feedback_purge": _dispatch_feedback_purge,
+    "discussion_state_sync": _dispatch_discussion_state_sync,
 }
 
 

--- a/backend/tests/routers/test_feedback.py
+++ b/backend/tests/routers/test_feedback.py
@@ -377,7 +377,7 @@ class TestAdminRetryDispatch:
 class TestDiscussionState:
     async def test_discussion_state_null_by_default(self, auth_client: AsyncClient):
         sub = await auth_client.post("/api/feedback", json=_feedback_payload())
-        assert sub.status_code == 200
+        assert sub.status_code == 201
         data = sub.json()
         assert "github_discussion_state" in data
         assert data["github_discussion_state"] is None

--- a/backend/tests/routers/test_feedback.py
+++ b/backend/tests/routers/test_feedback.py
@@ -366,3 +366,89 @@ class TestAdminRetryDispatch:
         fid = sub.json()["id"]
         resp = await auth_client.post(f"/api/admin/feedback/{fid}/retry-dispatch")
         assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# github_discussion_state field
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestDiscussionState:
+    async def test_discussion_state_null_by_default(self, auth_client: AsyncClient):
+        sub = await auth_client.post("/api/feedback", json=_feedback_payload())
+        assert sub.status_code == 200
+        data = sub.json()
+        assert "github_discussion_state" in data
+        assert data["github_discussion_state"] is None
+
+    async def test_mine_includes_discussion_state(self, auth_client: AsyncClient):
+        await auth_client.post("/api/feedback", json=_feedback_payload())
+        resp = await auth_client.get("/api/feedback/mine")
+        assert resp.status_code == 200
+        items = resp.json()
+        assert len(items) >= 1
+        assert "github_discussion_state" in items[0]
+
+    async def test_status_endpoint_includes_discussion_state(self, auth_client: AsyncClient):
+        sub = await auth_client.post("/api/feedback", json=_feedback_payload())
+        fid = sub.json()["id"]
+        resp = await auth_client.get(f"/api/feedback/{fid}/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "github_discussion_state" in data
+        assert data["github_discussion_state"] is None
+
+    async def test_admin_list_includes_discussion_state(self, auth_client: AsyncClient, admin_client: AsyncClient):
+        await auth_client.post("/api/feedback", json=_feedback_payload())
+        resp = await admin_client.get("/api/admin/feedback")
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        assert len(items) >= 1
+        assert "github_discussion_state" in items[0]
+
+    async def test_stored_state_returned_correctly(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        from app.models.feedback import UserFeedback
+
+        row = UserFeedback(
+            id=uuid.uuid4(),
+            user_id=test_user.id,
+            submission_type="feedback",
+            body="discussion state test",
+            dispatch_status="sent",
+            github_discussion_url="https://github.com/example/repo/discussions/1",
+            github_discussion_state="OPEN",
+        )
+        db_session.add(row)
+        await db_session.commit()
+
+        resp = await auth_client.get("/api/feedback/mine")
+        assert resp.status_code == 200
+        items = resp.json()
+        match = next((i for i in items if i["id"] == str(row.id)), None)
+        assert match is not None
+        assert match["github_discussion_state"] == "OPEN"
+
+    async def test_closed_state_returned_correctly(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        from app.models.feedback import UserFeedback
+
+        row = UserFeedback(
+            id=uuid.uuid4(),
+            user_id=test_user.id,
+            submission_type="feedback",
+            body="closed discussion test",
+            dispatch_status="sent",
+            github_discussion_url="https://github.com/example/repo/discussions/2",
+            github_discussion_state="CLOSED",
+        )
+        db_session.add(row)
+        await db_session.commit()
+
+        resp = await auth_client.get(f"/api/feedback/{row.id}/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["github_discussion_state"] == "CLOSED"

--- a/frontend/src/api/feedback.ts
+++ b/frontend/src/api/feedback.ts
@@ -35,6 +35,7 @@ export interface FeedbackRecord {
   is_anonymous: boolean;
   diagnostics: Record<string, unknown> | null;
   github_discussion_url: string | null;
+  github_discussion_state: "OPEN" | "CLOSED" | null;
   dispatch_status: "pending" | "sent" | "failed" | "skipped";
   user_email: string | null;
   deleted_at: string | null;
@@ -87,6 +88,7 @@ export const retryFeedbackDispatch = (id: string) =>
 export interface FeedbackStatus {
   dispatch_status: string;
   github_discussion_url: string | null;
+  github_discussion_state: "OPEN" | "CLOSED" | null;
 }
 
 export const getFeedbackStatus = (id: string) =>

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -165,7 +165,9 @@
       "description": "Deine gesendeten Einsendungen, einschließlich anonymer. Nur du kannst diese Liste sehen.",
       "noSubmissions": "Noch keine Einsendungen.",
       "anonymous": "(anonym)",
-      "viewDiscussion": "Diskussion auf GitHub anzeigen"
+      "viewDiscussion": "Diskussion auf GitHub anzeigen",
+      "discussionOpen": "Offen",
+      "discussionClosed": "Geschlossen"
     },
     "account": {
       "downloadData": "Datenarchiv anfordern",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -165,7 +165,9 @@
       "description": "Submissions you've sent, including anonymous ones. Only you can see this list.",
       "noSubmissions": "No submissions yet.",
       "anonymous": "(anonymous)",
-      "viewDiscussion": "View discussion on GitHub"
+      "viewDiscussion": "View discussion on GitHub",
+      "discussionOpen": "Open",
+      "discussionClosed": "Closed"
     },
     "account": {
       "downloadData": "Request a data archive",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -165,7 +165,9 @@
       "description": "Tus envíos, incluidos los anónimos. Solo tú puedes ver esta lista.",
       "noSubmissions": "Sin envíos todavía.",
       "anonymous": "(anónimo)",
-      "viewDiscussion": "Ver discusión en GitHub"
+      "viewDiscussion": "Ver discusión en GitHub",
+      "discussionOpen": "Abierta",
+      "discussionClosed": "Cerrada"
     },
     "account": {
       "downloadData": "Solicitar un archivo de datos",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -165,7 +165,9 @@
       "description": "Vos soumissions envoyées, y compris les anonymes. Vous seul pouvez voir cette liste.",
       "noSubmissions": "Aucune soumission pour l'instant.",
       "anonymous": "(anonyme)",
-      "viewDiscussion": "Voir la discussion sur GitHub"
+      "viewDiscussion": "Voir la discussion sur GitHub",
+      "discussionOpen": "Ouverte",
+      "discussionClosed": "Fermée"
     },
     "account": {
       "downloadData": "Demander une archive de données",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -165,7 +165,9 @@
       "description": "Uw ingediende berichten, inclusief anonieme. Alleen u kunt deze lijst zien.",
       "noSubmissions": "Nog geen berichten.",
       "anonymous": "(anoniem)",
-      "viewDiscussion": "Discussie bekijken op GitHub"
+      "viewDiscussion": "Discussie bekijken op GitHub",
+      "discussionOpen": "Open",
+      "discussionClosed": "Gesloten"
     },
     "account": {
       "downloadData": "Een gegevensarchief aanvragen",

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -696,15 +696,27 @@ function FeedbackHistorySection() {
                 <div className="pt-2 space-y-2">
                   <p className="text-sm whitespace-pre-wrap text-foreground">{s.body}</p>
                   {s.github_discussion_url && (
-                    <a
-                      href={s.github_discussion_url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
-                    >
-                      <AppIcons.externalLink className="h-3.5 w-3.5" />
-                      {t("settings.feedbackHistory.viewDiscussion")}
-                    </a>
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <a
+                        href={s.github_discussion_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+                      >
+                        <AppIcons.externalLink className="h-3.5 w-3.5" />
+                        {t("settings.feedbackHistory.viewDiscussion")}
+                      </a>
+                      {s.github_discussion_state === "OPEN" && (
+                        <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-green-500/10 text-green-600 dark:text-green-400 border border-green-500/20">
+                          {t("settings.feedbackHistory.discussionOpen")}
+                        </span>
+                      )}
+                      {s.github_discussion_state === "CLOSED" && (
+                        <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground border border-border">
+                          {t("settings.feedbackHistory.discussionClosed")}
+                        </span>
+                      )}
+                    </div>
                   )}
                 </div>
               )}


### PR DESCRIPTION
## Summary
- Adds `github_discussion_state` (`"OPEN"` | `"CLOSED"` | `null`) column to `user_feedback` (migration 0035)
- `get_discussion_state` GraphQL query fetches the state from GitHub when a discussion URL is available
- Dispatch task seeds the state immediately after creating a discussion
- New `sync_discussion_states` Celery task + `discussion_state_sync` scheduled task (daily 03:00) keeps states current for all sent feedback
- `FeedbackResponse` and `FeedbackStatusResponse` both expose the new field
- Settings Feedback History section shows a green "Open" chip or muted "Closed" chip inline with the "View discussion" link; no badge when state is unknown
- `discussionOpen` / `discussionClosed` i18n keys added to all 5 locales

## Test plan
- [ ] Submit feedback → `github_discussion_state` is `null` in response (no token in test)
- [ ] `GET /api/feedback/mine` includes `github_discussion_state` field
- [ ] `GET /api/feedback/{id}/status` includes `github_discussion_state` field
- [ ] Admin feedback list includes `github_discussion_state` field
- [ ] Manually set state to `"OPEN"` in DB → green badge appears in Settings > Feedback History
- [ ] Manually set state to `"CLOSED"` in DB → muted badge appears
- [ ] State `null` → no badge shown

Closes #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)