### PR TITLE
feat: page headers with descriptions for settings, admin, and superuser sections (#814)

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -83,12 +83,18 @@
     "saved": "Gespeichert",
     "sections": {
       "appearance": "Darstellung",
+      "appearanceDesc": "Wähle dein Farbthema und passe das Aussehen des Aktivitäts-Trackers an.",
       "diagnostics": "Diagnose",
+      "diagnosticsDesc": "Entwickleroptionen wie Versionsnummern konfigurieren.",
       "preferences": "Einstellungen",
+      "preferencesDesc": "Anzeigename und Standardeinheiten für Maßangaben aktualisieren.",
       "privacy": "Datenschutz",
+      "privacyDesc": "Steuere, welche Informationen für andere auf der Plattform sichtbar sind.",
       "terms": "Nutzungsbedingungen",
+      "termsDesc": "Überprüfe die akzeptierten Nutzungsbedingungen.",
       "feedbackHistory": "Feedback-Verlauf",
-      "account": "Kontoverwaltung"
+      "account": "Kontoverwaltung",
+      "accountDesc": "Daten herunterladen oder Konto dauerhaft löschen."
     },
     "appearance": {
       "theme": "Design",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -83,12 +83,18 @@
     "saved": "Saved",
     "sections": {
       "appearance": "Appearance",
+      "appearanceDesc": "Choose your color theme and customize how the activity tracker looks.",
       "diagnostics": "Diagnostics",
+      "diagnosticsDesc": "Configure developer-facing display options like version numbers.",
       "preferences": "Preferences",
+      "preferencesDesc": "Update your display name and default units for measurements.",
       "privacy": "Privacy & data",
+      "privacyDesc": "Control what information is visible to others on the platform.",
       "terms": "Terms of Service",
+      "termsDesc": "Review the terms of service you have accepted.",
       "feedbackHistory": "Feedback history",
-      "account": "Account management"
+      "account": "Account management",
+      "accountDesc": "Download your data or permanently delete your account."
     },
     "appearance": {
       "theme": "Theme",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -83,12 +83,18 @@
     "saved": "Guardado",
     "sections": {
       "appearance": "Apariencia",
+      "appearanceDesc": "Elige tu tema de color y personaliza el aspecto del rastreador de actividad.",
       "diagnostics": "Diagnóstico",
+      "diagnosticsDesc": "Configura opciones para desarrolladores como los números de versión.",
       "preferences": "Preferencias",
+      "preferencesDesc": "Actualiza tu nombre de visualización y las unidades predeterminadas para medidas.",
       "privacy": "Privacidad",
+      "privacyDesc": "Controla qué información es visible para otros usuarios de la plataforma.",
       "terms": "Términos de uso",
+      "termsDesc": "Revisa los términos de uso que has aceptado.",
       "feedbackHistory": "Historial de comentarios",
-      "account": "Gestión de cuenta"
+      "account": "Gestión de cuenta",
+      "accountDesc": "Descarga tus datos o elimina permanentemente tu cuenta."
     },
     "appearance": {
       "theme": "Tema",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -83,12 +83,18 @@
     "saved": "Enregistré",
     "sections": {
       "appearance": "Apparence",
+      "appearanceDesc": "Choisissez votre thème de couleur et personnalisez l'affichage du suivi d'activité.",
       "diagnostics": "Diagnostics",
+      "diagnosticsDesc": "Configurer les options développeur comme les numéros de version.",
       "preferences": "Préférences",
+      "preferencesDesc": "Mettez à jour votre nom d'affichage et les unités par défaut pour les mesures.",
       "privacy": "Confidentialité",
+      "privacyDesc": "Contrôlez les informations visibles par les autres utilisateurs de la plateforme.",
       "terms": "Conditions d'utilisation",
+      "termsDesc": "Consultez les conditions d'utilisation que vous avez acceptées.",
       "feedbackHistory": "Historique des retours",
-      "account": "Gestion du compte"
+      "account": "Gestion du compte",
+      "accountDesc": "Téléchargez vos données ou supprimez définitivement votre compte."
     },
     "appearance": {
       "theme": "Thème",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -83,12 +83,18 @@
     "saved": "Opgeslagen",
     "sections": {
       "appearance": "Weergave",
+      "appearanceDesc": "Kies je kleurthema en pas de weergave van de activiteitstracker aan.",
       "diagnostics": "Diagnostiek",
+      "diagnosticsDesc": "Ontwikkelaarsopties zoals versienummers instellen.",
       "preferences": "Voorkeuren",
+      "preferencesDesc": "Werk je weergavenaam en standaardeenheden voor metingen bij.",
       "privacy": "Privacy",
+      "privacyDesc": "Bepaal welke informatie zichtbaar is voor anderen op het platform.",
       "terms": "Gebruiksvoorwaarden",
+      "termsDesc": "Bekijk de gebruiksvoorwaarden die je hebt geaccepteerd.",
       "feedbackHistory": "Feedbackgeschiedenis",
-      "account": "Accountbeheer"
+      "account": "Accountbeheer",
+      "accountDesc": "Download je gegevens of verwijder je account permanent."
     },
     "appearance": {
       "theme": "Thema",

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -298,7 +298,11 @@ function UsersTab() {
     return <p className="text-sm text-muted-foreground">Loading…</p>;
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-6">
+      <div className="space-y-1 pb-2 border-b">
+        <h1 className="text-lg font-semibold">Users</h1>
+        <p className="text-sm text-muted-foreground">Manage all registered accounts — approve, adjust roles, and ban or delete users.</p>
+      </div>
       {/* Filter bar */}
       <div className="flex flex-wrap gap-2">
         <input
@@ -499,6 +503,10 @@ function InvitesTab() {
 
   return (
     <div className="space-y-6">
+      <div className="space-y-1 pb-2 border-b">
+        <h1 className="text-lg font-semibold">Invites</h1>
+        <p className="text-sm text-muted-foreground">Create invite codes for new users and manage pending self-registration requests.</p>
+      </div>
       {pendingSignups.length > 0 && (
         <div className="space-y-2">
           <h2 className="text-sm font-medium">Waiting to join ({pendingSignups.length})</h2>
@@ -720,7 +728,11 @@ function StatsTab() {
   ];
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
+      <div className="space-y-1 pb-2 border-b">
+        <h1 className="text-lg font-semibold">Stats</h1>
+        <p className="text-sm text-muted-foreground">Aggregate counts across users and content in the database.</p>
+      </div>
       <StatTable title="Users" rows={userRows} />
       <StatTable title="Content" rows={contentRows} />
     </div>
@@ -806,6 +818,10 @@ function HealthTab() {
 
   return (
     <div className="space-y-6">
+      <div className="space-y-1 pb-2 border-b">
+        <h1 className="text-lg font-semibold">System Health</h1>
+        <p className="text-sm text-muted-foreground">Live metrics for CPU, memory, and database response time, sampled every 3 seconds.</p>
+      </div>
       <div className="flex items-center gap-2">
         <span className="inline-block w-2 h-2 rounded-full bg-green-500 animate-pulse" />
         <span className="text-xs text-muted-foreground">
@@ -947,7 +963,11 @@ function VersionsTable() {
 
 function DepsTab() {
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
+      <div className="space-y-1 pb-2 border-b">
+        <h1 className="text-lg font-semibold">Dependencies</h1>
+        <p className="text-sm text-muted-foreground">Installed package versions for the backend runtime and worker.</p>
+      </div>
       <VersionsTable />
     </div>
   );
@@ -1176,7 +1196,11 @@ function ServicesTab() {
   const getDetail = (name: string) => diagnostics?.find((d) => d.service === name);
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
+      <div className="space-y-1 pb-2 border-b">
+        <h1 className="text-lg font-semibold">Services</h1>
+        <p className="text-sm text-muted-foreground">Connectivity checks and diagnostics for external services and infrastructure components.</p>
+      </div>
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <span className="inline-block w-2 h-2 rounded-full bg-green-500 animate-pulse" />
@@ -1369,19 +1393,16 @@ function SlugsTab() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["admin", "project-slugs"] }),
   });
 
-  if (isLoading) {
-    return <div className="text-sm text-muted-foreground py-8 text-center">Loading…</div>;
-  }
-
-  if (slugs.length === 0) {
-    return <div className="text-sm text-muted-foreground py-8 text-center">No active share links.</div>;
-  }
-
   return (
-    <div className="space-y-8">
-      <div className="space-y-3">
-      <div className="flex items-center justify-between">
-        <h2 className="text-base font-semibold">Active share links</h2>
+    <div className="space-y-6">
+      <div className="space-y-1 pb-2 border-b">
+        <h1 className="text-lg font-semibold">Share Links</h1>
+        <p className="text-sm text-muted-foreground">All active project share links across users, with options to revoke.</p>
+      </div>
+      {isLoading && <div className="text-sm text-muted-foreground py-8 text-center">Loading…</div>}
+      {!isLoading && slugs.length === 0 && <div className="text-sm text-muted-foreground py-8 text-center">No active share links.</div>}
+      {!isLoading && slugs.length > 0 && (<div className="space-y-3">
+      <div className="flex items-center justify-end">
         <span className="text-xs text-muted-foreground">{slugs.length} link{slugs.length !== 1 ? "s" : ""}</span>
       </div>
       <div className="rounded-lg border border-border overflow-x-auto">
@@ -1445,7 +1466,7 @@ function SlugsTab() {
           </tbody>
         </table>
       </div>
-    </div>
+    </div>)}
       <StepLogSection />
     </div>
   );
@@ -1580,9 +1601,12 @@ function FeedbackTab() {
   };
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between flex-wrap gap-2">
-        <h2 className="text-base font-semibold">Feedback submissions</h2>
+    <div className="space-y-6">
+      <div className="space-y-1 pb-2 border-b">
+        <h1 className="text-lg font-semibold">Feedback</h1>
+        <p className="text-sm text-muted-foreground">Review all user-submitted feedback, bug reports, and feature requests.</p>
+      </div>
+      <div className="flex items-center justify-end flex-wrap gap-2">
         <div className="flex items-center gap-2 text-sm">
           <select
             className="rounded-md border border-border bg-background px-2 py-1 text-sm"
@@ -1824,11 +1848,11 @@ function CredentialsTab() {
   });
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-base font-semibold">Managed credentials</h2>
-          <p className="text-xs text-muted-foreground mt-0.5">Track expiration dates for secrets and service credentials.</p>
+        <div className="space-y-1 pb-2 border-b flex-1 mr-4">
+          <h1 className="text-lg font-semibold">Credentials</h1>
+          <p className="text-sm text-muted-foreground">Track expiration dates for secrets and third-party service credentials.</p>
         </div>
         {isSuperuser && (
           <Button size="sm" onClick={openAdd}>Add credential</Button>
@@ -1985,8 +2009,11 @@ function AuditLogTab() {
   });
 
   return (
-    <div className="space-y-4">
-      <h2 className="text-lg font-semibold">Audit Log</h2>
+    <div className="space-y-6">
+      <div className="space-y-1 pb-2 border-b">
+        <h1 className="text-lg font-semibold">Audit Log</h1>
+        <p className="text-sm text-muted-foreground">Immutable record of admin actions and significant account events.</p>
+      </div>
 
       <div className="flex gap-2 flex-wrap">
         <select
@@ -2367,13 +2394,11 @@ function LoomDatabaseTab() {
   }
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between gap-3">
-        <div>
-          <h2 className="text-base font-semibold">Loom database</h2>
-          <p className="text-xs text-muted-foreground mt-0.5">
-            Admin-maintained catalog of commercially available looms. Used for typeahead in loom creation.
-          </p>
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="space-y-1 pb-2 border-b flex-1 mr-4">
+          <h1 className="text-lg font-semibold">Loom Database</h1>
+          <p className="text-sm text-muted-foreground">Admin-maintained catalog of commercially available looms, used for typeahead in loom creation.</p>
         </div>
         <Button size="sm" onClick={openAdd}>Add loom</Button>
       </div>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -142,7 +142,7 @@ export function SettingsPage() {
             {/* ── Appearance ── */}
             {activeSection === "appearance" && (
               <>
-              <Section title={t("settings.sections.appearance")}>
+              <Section title={t("settings.sections.appearance")} description={t("settings.sections.appearanceDesc")}>
                 <Field label={t("settings.appearance.theme")}>
                   <div className="flex gap-2">
                     {(["light", "dark", "system"] as const).map((t) => (
@@ -288,7 +288,7 @@ export function SettingsPage() {
                 </Field>
               </Section>
 
-              <Section title={t("settings.sections.diagnostics")}>
+              <Section title={t("settings.sections.diagnostics")} description={t("settings.sections.diagnosticsDesc")}>
                 <Field label={t("settings.diagnostics.showVersionNumbers")}>
                   <div className="flex items-center gap-3">
                     <button
@@ -321,7 +321,7 @@ export function SettingsPage() {
 
             {/* ── Preferences ── */}
             {activeSection === "preferences" && (
-              <Section title={t("settings.sections.preferences")}>
+              <Section title={t("settings.sections.preferences")} description={t("settings.sections.preferencesDesc")}>
                 <Field label={t("settings.preferences.displayName")}>
                   <div className="flex gap-2">
                     <input
@@ -387,7 +387,7 @@ export function SettingsPage() {
 
             {/* ── Privacy & data ── */}
             {activeSection === "privacy" && (
-              <Section title={t("settings.sections.privacy")}>
+              <Section title={t("settings.sections.privacy")} description={t("settings.sections.privacyDesc")}>
                 <Field label={t("settings.privacy.optOut")}>
                   <p className="text-xs text-muted-foreground">
                     {t("settings.privacy.optOutHelp")}
@@ -483,7 +483,7 @@ export function SettingsPage() {
 
             {/* ── Terms ── */}
             {activeSection === "terms" && (
-              <Section title={t("settings.sections.terms")}>
+              <Section title={t("settings.sections.terms")} description={t("settings.sections.termsDesc")}>
                 <div className="space-y-3">
                   <div className="flex items-center justify-between rounded-lg border p-4">
                     <div>
@@ -515,7 +515,7 @@ export function SettingsPage() {
 
             {/* ── Account ── */}
             {activeSection === "account" && (
-              <Section title={t("settings.sections.account")}>
+              <Section title={t("settings.sections.account")} description={t("settings.sections.accountDesc")}>
                 <Field label={t("settings.account.downloadData")}>
                   {exportStatus?.status === "pending" ? (
                     <div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -650,11 +650,7 @@ function FeedbackHistorySection() {
   });
 
   return (
-    <Section title={t("settings.sections.feedbackHistory")}>
-      <p className="text-sm text-muted-foreground">
-        {t("settings.feedbackHistory.description")}
-      </p>
-
+    <Section title={t("settings.sections.feedbackHistory")} description={t("settings.feedbackHistory.description")}>
       {isLoading ? (
         <p className="text-sm text-muted-foreground">{t("common.loading")}</p>
       ) : submissions.length === 0 ? (
@@ -729,10 +725,13 @@ function FeedbackHistorySection() {
   );
 }
 
-function Section({ title, children }: { title: string; children: ReactNode }) {
+function Section({ title, description, children }: { title: string; description?: string; children: ReactNode }) {
   return (
     <div className="space-y-5">
-      <h2 className="text-base font-semibold border-b pb-2">{title}</h2>
+      <div className="border-b pb-2 space-y-0.5">
+        <h2 className="text-base font-semibold">{title}</h2>
+        {description && <p className="text-sm text-muted-foreground">{description}</p>}
+      </div>
       {children}
     </div>
   );

--- a/frontend/src/pages/SuperuserPage.tsx
+++ b/frontend/src/pages/SuperuserPage.tsx
@@ -170,6 +170,10 @@ function EulaTab() {
 
   return (
     <div className="space-y-6">
+      <div className="space-y-1 pb-2 border-b">
+        <h1 className="text-lg font-semibold">Terms of Service</h1>
+        <p className="text-sm text-muted-foreground">View the current published EULA version and publish a new version that will require all users to re-accept on next login.</p>
+      </div>
       {/* Current version */}
       <div className="space-y-2">
         <h2 className="text-sm font-medium">Current version: {current?.version}</h2>
@@ -388,6 +392,10 @@ function StorageAuditTab() {
 
   return (
     <div className="space-y-4">
+      <div className="space-y-1 pb-2 border-b">
+        <h1 className="text-lg font-semibold">Storage Audit</h1>
+        <p className="text-sm text-muted-foreground">Scan R2/S3 for orphaned files that are no longer referenced by any database record and permanently delete them.</p>
+      </div>
       <div className="flex items-center gap-3">
         <Button onClick={startScan} disabled={scanStatus === "running"} size="sm">
           {scanStatus === "running" ? "Scanning…" : "Scan S3 for Orphaned Files"}
@@ -561,6 +569,10 @@ function CveScanTab() {
 
   return (
     <div className="space-y-4">
+      <div className="space-y-1 pb-2 border-b">
+        <h1 className="text-lg font-semibold">CVE Scanner</h1>
+        <p className="text-sm text-muted-foreground">Run pip-audit and OSV.dev scans against Python and npm dependencies. Results populate the warning banner shown on all admin pages.</p>
+      </div>
       <div className="space-y-1">
         <p className="text-xs text-muted-foreground">
           Scans Python dependencies via pip-audit and npm packages via OSV.dev.
@@ -721,6 +733,10 @@ function WorkersTab() {
 
   return (
     <div className="space-y-4">
+      <div className="space-y-1 pb-2 border-b">
+        <h1 className="text-lg font-semibold">Worker Status</h1>
+        <p className="text-sm text-muted-foreground">Live view of Celery worker health, queue depths, active and reserved tasks, and recent task history.</p>
+      </div>
       <div className="flex items-center justify-between gap-3">
         <div className="flex items-center gap-2">
           <span className="inline-block w-2 h-2 rounded-full bg-green-500 animate-pulse" />
@@ -951,12 +967,9 @@ function DeletionTab() {
 
   return (
     <div className="space-y-4">
-      <div className="space-y-1">
-        <h2 className="text-sm font-medium">User Deletion Queue</h2>
-        <p className="text-xs text-muted-foreground">
-          Users currently in the deletion pipeline. Auto-refreshes every 10s.
-          Stalled entries indicate a Celery task that errored mid-cascade and requires investigation.
-        </p>
+      <div className="space-y-1 pb-2 border-b">
+        <h1 className="text-lg font-semibold">Deletion Queue</h1>
+        <p className="text-sm text-muted-foreground">Users currently in the deletion pipeline and soft-deleted content items awaiting hard purge.</p>
       </div>
 
       {users.length === 0 ? (
@@ -1022,6 +1035,10 @@ function MaintenanceTab() {
 
   return (
     <div className="space-y-6">
+      <div className="space-y-1 pb-2 border-b">
+        <h1 className="text-lg font-semibold">Maintenance</h1>
+        <p className="text-sm text-muted-foreground">Manual maintenance operations including hard-purging soft-deleted records that have passed the retention window.</p>
+      </div>
       {/* Soft-delete queue summary */}
       <div className="rounded-lg border p-5 space-y-3">
         <div>
@@ -1153,12 +1170,9 @@ function ReconcileTab() {
 
   return (
     <div className="space-y-6">
-      <div className="space-y-1">
-        <h2 className="text-sm font-medium">Clerk ↔ DB Reconciliation</h2>
-        <p className="text-xs text-muted-foreground">
-          Cross-references Clerk accounts against the database. Use this to backfill users created
-          directly in the Clerk dashboard.
-        </p>
+      <div className="space-y-1 pb-2 border-b">
+        <h1 className="text-lg font-semibold">Clerk Reconciliation</h1>
+        <p className="text-sm text-muted-foreground">Cross-reference Clerk accounts against the database to find and backfill users created directly in the Clerk dashboard.</p>
       </div>
 
       <Button onClick={runReconcile} disabled={loading} size="sm">
@@ -1382,11 +1396,11 @@ function ScheduledTasksTab() {
   if (error) return <p className="text-sm text-destructive">Failed to load scheduled tasks.</p>;
 
   return (
-    <div className="space-y-4">
-      <p className="text-xs text-muted-foreground">
-        Configure recurring background tasks. Settings are stored in Postgres and survive restarts.
-        The scheduler tick runs every 60 seconds via Celery Beat.
-      </p>
+    <div className="space-y-6">
+      <div className="space-y-1 pb-2 border-b">
+        <h1 className="text-lg font-semibold">Scheduled Tasks</h1>
+        <p className="text-sm text-muted-foreground">Configure recurring background tasks. Schedules are stored in Postgres and survive restarts; the scheduler tick runs every 60 seconds via Celery Beat.</p>
+      </div>
       {data && data.length === 0 && (
         <p className="text-sm text-muted-foreground">No scheduled tasks configured.</p>
       )}


### PR DESCRIPTION
## Summary
- Adds consistent `h1` + muted description header blocks to every major section across all three admin/settings pages
- **SettingsPage**: Updated `Section` component to accept optional `description` prop; added descriptions to all 7 sections with i18n keys in all 5 locales (en/de/fr/es/nl)
- **AdminPage**: Headers added to all 11 tab functions (UsersTab, InvitesTab, StatsTab, HealthTab, DepsTab, ServicesTab, SlugsTab, FeedbackTab, CredentialsTab, AuditLogTab, LoomDatabaseTab); existing inline `h2` sub-headers replaced
- **SuperuserPage**: Headers added to all 8 tab functions; leftover orphaned markup from prior ReconcileTab edit cleaned up

Admin/superuser headers use plain strings per the i18n exemption for tooling pages.

Closes #814

## Test plan
- [ ] Visit `/settings/appearance`, `/settings/preferences`, `/settings/privacy`, `/settings/terms`, `/settings/account`, `/settings/feedback-history` — each section shows title + description below the border
- [ ] Visit `/settings/appearance` in DE/FR/ES/NL — descriptions render in each language
- [ ] Visit `/admin` and cycle through all tabs — each shows a consistent `h1` header block at the top
- [ ] Visit `/superuser` and cycle through all sections — same consistent header pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)