### PR TITLE
fix: purge collections, sign out Clerk, and delete Clerk user on account deletion (#817)

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -24,6 +24,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.deps import get_current_user, get_db
 from app.metrics import eula_accepted_total
+from app.models.collection import Collection, CollectionDraft, CollectionProject
 from app.models.draft import Draft
 from app.models.eula_version import EulaVersion
 from app.models.invite import Invite
@@ -309,6 +310,12 @@ async def delete_account(
         )
 
     user_id = current_user.id
+
+    if current_user.clerk_user_id:
+        from app.services.clerk import delete_clerk_user
+
+        await delete_clerk_user(current_user.clerk_user_id)
+
     await _purge_user_storage(db, user_id)
     await _purge_user_db(db, user_id, current_user)
     await db.commit()
@@ -596,6 +603,11 @@ async def _purge_user_db(db: AsyncSession, user_id: uuid.UUID, user: User) -> No
     await db.execute(delete(LoomVersionPhoto).where(LoomVersionPhoto.loom_version_id.in_(version_ids_subq)))
     await db.execute(delete(LoomVersion).where(LoomVersion.loom_id.in_(loom_ids_subq)))
     await db.execute(delete(Loom).where(Loom.owner_id == user_id))
+
+    collection_ids_subq = select(Collection.id).where(Collection.owner_id == user_id)
+    await db.execute(delete(CollectionDraft).where(CollectionDraft.collection_id.in_(collection_ids_subq)))
+    await db.execute(delete(CollectionProject).where(CollectionProject.collection_id.in_(collection_ids_subq)))
+    await db.execute(delete(Collection).where(Collection.owner_id == user_id))
 
     await db.execute(delete(Draft).where(Draft.owner_id == user_id))
 

--- a/backend/app/services/clerk.py
+++ b/backend/app/services/clerk.py
@@ -84,3 +84,14 @@ async def unban_clerk_user(clerk_user_id: str) -> None:
     async with httpx.AsyncClient() as client:
         r = await client.post(f"{_BASE}/users/{clerk_user_id}/unban", headers=_headers(), timeout=10)
         r.raise_for_status()
+
+
+async def delete_clerk_user(clerk_user_id: str) -> None:
+    """Delete a Clerk user via the Management API. Logs failure but does not raise."""
+    try:
+        async with httpx.AsyncClient() as client:
+            r = await client.delete(f"{_BASE}/users/{clerk_user_id}", headers=_headers(), timeout=10)
+            if not r.is_success:
+                log.warning("clerk_delete_failed user_id=%s status=%s", clerk_user_id, r.status_code)
+    except Exception:
+        log.exception("Failed to delete Clerk user %s", clerk_user_id)

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -5,6 +5,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.audit_log import AuditLog
+from app.models.collection import Collection, CollectionDraft, CollectionProject
 from app.models.draft import Draft
 from app.models.loom import Loom, LoomVersion, LoomVersionPhoto, LoomVersionReceipt
 from app.models.project import Project, ProjectPhoto, ProjectStep
@@ -360,6 +361,50 @@ class TestDeleteAccount:
         await auth_client.request("DELETE", "/api/users/me", json={"confirm": "DELETE MY ACCOUNT"})
         assert wif_path not in mock_storage
         assert preview_path not in mock_storage
+
+    async def test_deletes_collections_and_join_rows(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        from datetime import datetime, timezone
+
+        draft = Draft(owner_id=test_user.id, name="D", wif_filename="d.wif", wif_path="drafts/d.wif")
+        db_session.add(draft)
+        await db_session.flush()
+
+        project = Project(
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="P",
+            project_type="treadle",
+            status="planning",
+            current_pick=1,
+            total_picks=10,
+        )
+        db_session.add(project)
+        await db_session.flush()
+
+        collection = Collection(owner_id=test_user.id, name="My Collection")
+        db_session.add(collection)
+        await db_session.flush()
+
+        now = datetime.now(timezone.utc)
+        cd = CollectionDraft(collection_id=collection.id, draft_id=draft.id, added_at=now)
+        cp = CollectionProject(collection_id=collection.id, project_id=project.id, added_at=now)
+        db_session.add_all([cd, cp])
+        await db_session.commit()
+
+        collection_id = collection.id
+        await auth_client.request("DELETE", "/api/users/me", json={"confirm": "DELETE MY ACCOUNT"})
+
+        assert await db_session.scalar(select(Collection).where(Collection.id == collection_id)) is None
+        assert (
+            await db_session.scalar(select(CollectionDraft).where(CollectionDraft.collection_id == collection_id))
+            is None
+        )
+        assert (
+            await db_session.scalar(select(CollectionProject).where(CollectionProject.collection_id == collection_id))
+            is None
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { useClerk } from "@clerk/clerk-react";
 import { LanguageSelector } from "@/components/LanguageSelector";
 import { useAuth } from "@/hooks/useAuth";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -17,6 +18,7 @@ type Section = "appearance" | "preferences" | "privacy" | "terms" | "account" | 
 
 export function SettingsPage() {
   const { t } = useTranslation();
+  const { signOut } = useClerk();
   const { user, refetch } = useAuth();
   const { section } = useParams<{ section: string }>();
   const activeSection: Section = (section as Section) ?? "appearance";
@@ -117,7 +119,8 @@ export function SettingsPage() {
     setDeleteError(null);
     try {
       await deleteAccount("DELETE MY ACCOUNT");
-      window.location.href = "/login";
+      await signOut();
+      window.location.href = "/";
     } catch (e: unknown) {
       setDeleteError(e instanceof Error ? e.message : "Failed to delete account");
       setDeleting(false);


### PR DESCRIPTION
## Summary
- **Collections not purged** — `_purge_user_db` now deletes `CollectionDraft`, `CollectionProject`, and `Collection` rows before deleting `Draft` rows, closing the orphan gap introduced when Collections were added after the purge was written
- **Clerk session not cleared** — `handleDeleteAccount` in `SettingsPage.tsx` now calls `await signOut()` before redirecting, so the Clerk session token is invalidated immediately rather than expiring naturally
- **Clerk user not deleted** — `delete_account` now calls `delete_clerk_user()` (new helper in `services/clerk.py`) via the Clerk Management API before purging DB rows; failures are logged but do not block deletion

## Test plan
- [ ] Delete account with a collection (containing a draft link and a project link) — verify no orphaned rows in `collections`, `collection_drafts`, or `collection_projects`
- [ ] Delete account and confirm browser session is cleared (Clerk sign-in prompt appears on next visit to `/`)
- [ ] Verify the test `test_deletes_collections_and_join_rows` passes in CI

Closes #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)