### PR TITLE
feat: move data export into Privacy & data settings section

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -89,12 +89,12 @@
       "preferences": "Einstellungen",
       "preferencesDesc": "Anzeigename und Standardeinheiten für Maßangaben aktualisieren.",
       "privacy": "Datenschutz",
-      "privacyDesc": "Steuere, welche Informationen für andere auf der Plattform sichtbar sind.",
+      "privacyDesc": "Datenweitergabe-Einstellungen verwalten und eine Kopie deiner Daten herunterladen.",
       "terms": "Nutzungsbedingungen",
       "termsDesc": "Überprüfe die akzeptierten Nutzungsbedingungen.",
       "feedbackHistory": "Feedback-Verlauf",
       "account": "Kontoverwaltung",
-      "accountDesc": "Daten herunterladen oder Konto dauerhaft löschen."
+      "accountDesc": "Konto und alle zugehörigen Daten dauerhaft löschen."
     },
     "appearance": {
       "theme": "Design",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -89,12 +89,12 @@
       "preferences": "Preferences",
       "preferencesDesc": "Update your display name and default units for measurements.",
       "privacy": "Privacy & data",
-      "privacyDesc": "Control what information is visible to others on the platform.",
+      "privacyDesc": "Control your data sharing preferences and download a copy of your data.",
       "terms": "Terms of Service",
       "termsDesc": "Review the terms of service you have accepted.",
       "feedbackHistory": "Feedback history",
       "account": "Account management",
-      "accountDesc": "Download your data or permanently delete your account."
+      "accountDesc": "Permanently delete your account and all associated data."
     },
     "appearance": {
       "theme": "Theme",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -89,12 +89,12 @@
       "preferences": "Preferencias",
       "preferencesDesc": "Actualiza tu nombre de visualización y las unidades predeterminadas para medidas.",
       "privacy": "Privacidad",
-      "privacyDesc": "Controla qué información es visible para otros usuarios de la plataforma.",
+      "privacyDesc": "Gestiona tus preferencias de uso de datos y descarga una copia de tus datos.",
       "terms": "Términos de uso",
       "termsDesc": "Revisa los términos de uso que has aceptado.",
       "feedbackHistory": "Historial de comentarios",
       "account": "Gestión de cuenta",
-      "accountDesc": "Descarga tus datos o elimina permanentemente tu cuenta."
+      "accountDesc": "Elimina permanentemente tu cuenta y todos los datos asociados."
     },
     "appearance": {
       "theme": "Tema",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -89,12 +89,12 @@
       "preferences": "Préférences",
       "preferencesDesc": "Mettez à jour votre nom d'affichage et les unités par défaut pour les mesures.",
       "privacy": "Confidentialité",
-      "privacyDesc": "Contrôlez les informations visibles par les autres utilisateurs de la plateforme.",
+      "privacyDesc": "Gérez vos préférences de partage de données et téléchargez une copie de vos données.",
       "terms": "Conditions d'utilisation",
       "termsDesc": "Consultez les conditions d'utilisation que vous avez acceptées.",
       "feedbackHistory": "Historique des retours",
       "account": "Gestion du compte",
-      "accountDesc": "Téléchargez vos données ou supprimez définitivement votre compte."
+      "accountDesc": "Supprimez définitivement votre compte et toutes les données associées."
     },
     "appearance": {
       "theme": "Thème",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -89,12 +89,12 @@
       "preferences": "Voorkeuren",
       "preferencesDesc": "Werk je weergavenaam en standaardeenheden voor metingen bij.",
       "privacy": "Privacy",
-      "privacyDesc": "Bepaal welke informatie zichtbaar is voor anderen op het platform.",
+      "privacyDesc": "Beheer je instellingen voor gegevensdeling en download een kopie van je gegevens.",
       "terms": "Gebruiksvoorwaarden",
       "termsDesc": "Bekijk de gebruiksvoorwaarden die je hebt geaccepteerd.",
       "feedbackHistory": "Feedbackgeschiedenis",
       "account": "Accountbeheer",
-      "accountDesc": "Download je gegevens of verwijder je account permanent."
+      "accountDesc": "Verwijder je account en alle bijbehorende gegevens permanent."
     },
     "appearance": {
       "theme": "Thema",

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -40,7 +40,7 @@ export function SettingsPage() {
     queryKey: ["export-status"],
     queryFn: getDataExportStatus,
     refetchInterval: (query) => (query.state.data?.status === "pending" ? 5000 : false),
-    enabled: activeSection === "account",
+    enabled: activeSection === "privacy",
   });
   const requestExportMutation = useMutation({
     mutationFn: requestDataExport,
@@ -481,44 +481,7 @@ export function SettingsPage() {
                   </ul>
                   <p className="pt-1">{t("settings.privacy.noSell")}</p>
                 </div>
-              </Section>
-            )}
 
-            {/* ── Terms ── */}
-            {activeSection === "terms" && (
-              <Section title={t("settings.sections.terms")} description={t("settings.sections.termsDesc")}>
-                <div className="space-y-3">
-                  <div className="flex items-center justify-between rounded-lg border p-4">
-                    <div>
-                      <p className="text-sm font-medium">
-                        {t("settings.terms.tosTitle", { version: user.current_eula_version })}
-                      </p>
-                      <p className="text-xs text-muted-foreground mt-0.5">
-                        {user.eula_accepted_version === user.current_eula_version
-                          ? t("settings.terms.accepted")
-                          : t("settings.terms.notAccepted")}
-                      </p>
-                    </div>
-                    <Button variant="outline" size="sm" onClick={() => setShowEula(!showEula)}>
-                      {showEula ? t("settings.terms.hide") : t("settings.terms.readTerms")}
-                    </Button>
-                  </div>
-
-                  {showEula && currentEula && (
-                    <div className="rounded-lg border p-4 max-h-[50vh] overflow-y-auto">
-                      <EulaContent bodyHtml={currentEula.body_html} />
-                    </div>
-                  )}
-                </div>
-              </Section>
-            )}
-
-            {/* ── Feedback history ── */}
-            {activeSection === "feedback-history" && <FeedbackHistorySection />}
-
-            {/* ── Account ── */}
-            {activeSection === "account" && (
-              <Section title={t("settings.sections.account")} description={t("settings.sections.accountDesc")}>
                 <Field label={t("settings.account.downloadData")}>
                   {exportStatus?.status === "pending" ? (
                     <div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -574,7 +537,44 @@ export function SettingsPage() {
                     {t("settings.account.archiveNote")}
                   </p>
                 </Field>
+              </Section>
+            )}
 
+            {/* ── Terms ── */}
+            {activeSection === "terms" && (
+              <Section title={t("settings.sections.terms")} description={t("settings.sections.termsDesc")}>
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between rounded-lg border p-4">
+                    <div>
+                      <p className="text-sm font-medium">
+                        {t("settings.terms.tosTitle", { version: user.current_eula_version })}
+                      </p>
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        {user.eula_accepted_version === user.current_eula_version
+                          ? t("settings.terms.accepted")
+                          : t("settings.terms.notAccepted")}
+                      </p>
+                    </div>
+                    <Button variant="outline" size="sm" onClick={() => setShowEula(!showEula)}>
+                      {showEula ? t("settings.terms.hide") : t("settings.terms.readTerms")}
+                    </Button>
+                  </div>
+
+                  {showEula && currentEula && (
+                    <div className="rounded-lg border p-4 max-h-[50vh] overflow-y-auto">
+                      <EulaContent bodyHtml={currentEula.body_html} />
+                    </div>
+                  )}
+                </div>
+              </Section>
+            )}
+
+            {/* ── Feedback history ── */}
+            {activeSection === "feedback-history" && <FeedbackHistorySection />}
+
+            {/* ── Account ── */}
+            {activeSection === "account" && (
+              <Section title={t("settings.sections.account")} description={t("settings.sections.accountDesc")}>
                 <div className="rounded-lg border border-destructive/30 p-4 space-y-3">
                   <p className="text-sm font-medium text-destructive">{t("settings.account.dangerZone")}</p>
                   <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- Moves the "Download your data" (data export) field from **Account management** into **Privacy & data**, where it belongs as a GDPR-style data portability control alongside the AI training consent toggle
- Account management now contains only the danger zone (delete account)
- `exportStatus` query `enabled` condition updated from `activeSection === "account"` → `"privacy"`
- Section descriptions updated in all 5 locales (en/de/fr/es/nl) to reflect the new content split

## Test plan
- [ ] Visit `/settings/privacy` — "Download your data" field appears below "What we store" box
- [ ] Requesting an export from the Privacy section triggers the export job and shows pending state
- [ ] Visit `/settings/account` — only the delete account danger zone remains
- [ ] Verify in DE/FR/ES/NL that the Privacy & data description reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)