### PR TITLE
feat: superuser Data Exports tab (#827)

### DIFF
--- a/backend/alembic/versions/0036_export_archive_size.py
+++ b/backend/alembic/versions/0036_export_archive_size.py
@@ -1,0 +1,25 @@
+"""add archive_size_bytes to user_export_requests
+
+Revision ID: 0036_export_archive_size
+Revises: 0035_feedback_discussion_state
+Create Date: 2026-05-21
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0036_export_archive_size"
+down_revision = "0035_feedback_discussion_state"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_export_requests",
+        sa.Column("archive_size_bytes", sa.BigInteger, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_export_requests", "archive_size_bytes")

--- a/backend/app/models/user_export.py
+++ b/backend/app/models/user_export.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, String, Text
+from sqlalchemy import BigInteger, DateTime, ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -20,6 +20,7 @@ class UserExportRequest(Base, TimestampMixin):
     requested_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     status: Mapped[str] = mapped_column(String(10), nullable=False, default="pending")
     archive_path: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    archive_size_bytes: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
     expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     error: Mapped[str | None] = mapped_column(Text, nullable=True)
 

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -28,6 +28,7 @@ from app.models.pending_signup import PendingSignup
 from app.models.project import Project, ProjectPhoto, ProjectStep
 from app.models.server_event import ServerEvent
 from app.models.user import User
+from app.models.user_export import UserExportRequest
 from app.models.yarn import Yarn
 from app.services.audit import write_audit_log
 from app.services.clerk import ban_clerk_user, get_clerk_user, list_clerk_users, set_user_metadata, unban_clerk_user
@@ -2643,3 +2644,71 @@ async def admin_list_project_steps(
         )
         for s in rows.all()
     ]
+
+
+# ---------------------------------------------------------------------------
+# Data exports
+# ---------------------------------------------------------------------------
+
+
+class AdminExportRecord(BaseModel):
+    id: str
+    user_id: str
+    user_email: str
+    user_display_name: str | None
+    status: str
+    requested_at: datetime
+    completed_at: datetime | None
+    expires_at: datetime | None
+    archive_size_bytes: int | None
+    error: str | None
+
+
+@router.get("/exports", response_model=list[AdminExportRecord])
+async def list_exports(
+    _: User = Depends(require_superuser),
+    db: AsyncSession = Depends(get_db),
+) -> list[AdminExportRecord]:
+    rows = await db.execute(
+        select(UserExportRequest, User)
+        .join(User, User.id == UserExportRequest.user_id)
+        .order_by(UserExportRequest.requested_at.desc())
+        .limit(200)
+    )
+    return [
+        AdminExportRecord(
+            id=str(req.id),
+            user_id=str(req.user_id),
+            user_email=user.email,
+            user_display_name=user.display_name,
+            status=req.status,
+            requested_at=req.requested_at,
+            completed_at=req.updated_at if req.status == "complete" else None,
+            expires_at=req.expires_at,
+            archive_size_bytes=req.archive_size_bytes,
+            error=req.error,
+        )
+        for req, user in rows.all()
+    ]
+
+
+@router.delete("/exports/{export_id}", status_code=204)
+async def delete_export(
+    export_id: uuid.UUID,
+    _: User = Depends(require_superuser),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    req = await db.get(UserExportRequest, export_id)
+    if req is None:
+        raise HTTPException(status_code=404, detail="Export not found")
+
+    if req.archive_path:
+        try:
+            from app.services import storage
+
+            await asyncio.to_thread(storage._delete, req.archive_path)
+        except Exception:
+            log.warning("export_delete_storage_failed export_id=%s", export_id)
+
+    await db.delete(req)
+    await db.commit()

--- a/backend/app/tasks/export.py
+++ b/backend/app/tasks/export.py
@@ -195,10 +195,12 @@ async def _build_export(user_id: uuid.UUID, request_id: uuid.UUID) -> None:
                 zf.writestr(f"{prefix}/README.txt", _readme(user, date_str))
 
             archive_key = f"exports/{user_id}/{request_id}.zip"
-            await asyncio.to_thread(storage._put, archive_key, buf.getvalue())
+            archive_bytes = buf.getvalue()
+            await asyncio.to_thread(storage._put, archive_key, archive_bytes)
 
             req.status = "complete"
             req.archive_path = archive_key
+            req.archive_size_bytes = len(archive_bytes)
             req.expires_at = datetime.now(timezone.utc) + timedelta(days=EXPORT_TTL_DAYS)
             await db.commit()
 

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -493,3 +493,19 @@ export interface AdminProjectStep {
 
 export const listProjectSteps = (projectId: string, limit = 200) =>
   api.get<AdminProjectStep[]>(`/api/admin/project-steps?project_id=${projectId}&limit=${limit}`);
+
+export interface AdminExportRecord {
+  id: string;
+  user_id: string;
+  user_email: string;
+  user_display_name: string | null;
+  status: "pending" | "complete" | "failed";
+  requested_at: string;
+  completed_at: string | null;
+  expires_at: string | null;
+  archive_size_bytes: number | null;
+  error: string | null;
+}
+
+export const listExports = () => api.get<AdminExportRecord[]>("/api/admin/exports");
+export const deleteExport = (id: string) => api.delete<void>(`/api/admin/exports/${id}`);

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -69,6 +69,7 @@ export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpa
     { id: "reconcile", label: t("superuserSections.reconcile") },
     { id: "maintenance", label: t("superuserSections.maintenance") },
     { id: "schedule", label: t("superuserSections.schedule") },
+    { id: "exports", label: t("superuserSections.exports") },
   ];
 
   function isActive(href: string, exact = false) {

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -41,7 +41,8 @@
     "deletion": "Löschung",
     "reconcile": "Abgleich",
     "maintenance": "Wartung",
-    "schedule": "Geplante Aufgaben"
+    "schedule": "Geplante Aufgaben",
+    "exports": "Datenexporte"
   },
   "loomTypes": {
     "floor_loom": "Trittwebstuhl - Trittfolge-Tracking",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -41,7 +41,8 @@
     "deletion": "Deletion",
     "reconcile": "Reconcile",
     "maintenance": "Maintenance",
-    "schedule": "Scheduled Tasks"
+    "schedule": "Scheduled Tasks",
+    "exports": "Data Exports"
   },
   "loomTypes": {
     "floor_loom": "Floor Loom — treadle tracking",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -41,7 +41,8 @@
     "deletion": "Eliminación",
     "reconcile": "Reconciliación",
     "maintenance": "Mantenimiento",
-    "schedule": "Tareas programadas"
+    "schedule": "Tareas programadas",
+    "exports": "Exportaciones de datos"
   },
   "loomTypes": {
     "floor_loom": "Telar de piso - seguimiento de pedales",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -41,7 +41,8 @@
     "deletion": "Suppression",
     "reconcile": "Réconciliation",
     "maintenance": "Maintenance",
-    "schedule": "Tâches planifiées"
+    "schedule": "Tâches planifiées",
+    "exports": "Exports de données"
   },
   "loomTypes": {
     "floor_loom": "Métier de basse lisse - suivi des marches",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -41,7 +41,8 @@
     "deletion": "Verwijdering",
     "reconcile": "Afstemming",
     "maintenance": "Onderhoud",
-    "schedule": "Geplande taken"
+    "schedule": "Geplande taken",
+    "exports": "Gegevensexports"
   },
   "loomTypes": {
     "floor_loom": "Vloerweefstoel — trapper-tracking",

--- a/frontend/src/pages/SuperuserPage.tsx
+++ b/frontend/src/pages/SuperuserPage.tsx
@@ -21,6 +21,8 @@ import {
   getDeletionQueue,
   listScheduledTasks,
   patchScheduledTask,
+  listExports,
+  deleteExport,
   type ScheduledTask,
   type TaskHistoryItem,
   type ReconcileReport,
@@ -30,6 +32,7 @@ import {
   type WorkerStatus,
   type WorkerInfo,
   type DeletionQueueUser,
+  type AdminExportRecord,
 } from "@/api/admin";
 import { EulaContent } from "@/components/EulaContent";
 import { CveBanner } from "@/components/admin/CveBanner";
@@ -49,7 +52,7 @@ function formatUptime(seconds: number): string {
   return parts.join(", ");
 }
 
-type SuperuserSection = "eula" | "storage" | "cve" | "workers" | "deletion" | "reconcile" | "maintenance" | "schedule";
+type SuperuserSection = "eula" | "storage" | "cve" | "workers" | "deletion" | "reconcile" | "maintenance" | "schedule" | "exports";
 
 // ---------------------------------------------------------------------------
 // EULA tab
@@ -1416,6 +1419,131 @@ function ScheduledTasksTab() {
 }
 
 
+// ---------------------------------------------------------------------------
+// Data Exports tab
+// ---------------------------------------------------------------------------
+
+function ExportStatusBadge({ status }: { status: AdminExportRecord["status"] }) {
+  const cls =
+    status === "complete"
+      ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300"
+      : status === "failed"
+        ? "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300"
+        : "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300";
+  return (
+    <span className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${cls}`}>{status}</span>
+  );
+}
+
+function ExportRow({ record, onDeleted }: { record: AdminExportRecord; onDeleted: () => void }) {
+  const [confirming, setConfirming] = useState(false);
+  const mutation = useMutation({
+    mutationFn: () => deleteExport(record.id),
+    onSuccess: onDeleted,
+  });
+
+  const sizeMb =
+    record.archive_size_bytes != null
+      ? `${(record.archive_size_bytes / 1_048_576).toFixed(2)} MB`
+      : "—";
+
+  const fmt = (iso: string | null) =>
+    iso ? new Date(iso).toLocaleString() : "—";
+
+  return (
+    <div className="rounded-lg border bg-card p-4 space-y-3">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <p className="font-medium truncate">
+            {record.user_display_name || <span className="text-muted-foreground italic">no name</span>}
+          </p>
+          <p className="text-sm text-muted-foreground truncate">{record.user_email}</p>
+        </div>
+        <ExportStatusBadge status={record.status} />
+      </div>
+
+      <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-sm">
+        <span className="text-muted-foreground">Requested</span>
+        <span>{fmt(record.requested_at)}</span>
+        <span className="text-muted-foreground">Generated</span>
+        <span>{fmt(record.completed_at)}</span>
+        <span className="text-muted-foreground">Expires</span>
+        <span>{fmt(record.expires_at)}</span>
+        <span className="text-muted-foreground">Size</span>
+        <span>{sizeMb}</span>
+      </div>
+
+      {record.status === "failed" && record.error && (
+        <p className="text-xs text-destructive font-mono bg-destructive/10 rounded px-2 py-1 break-all">
+          {record.error}
+        </p>
+      )}
+
+      <div className="flex justify-end">
+        {confirming ? (
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-muted-foreground">Delete this record and archive?</span>
+            <Button
+              size="sm"
+              variant="destructive"
+              disabled={mutation.isPending}
+              onClick={() => mutation.mutate()}
+            >
+              {mutation.isPending ? "Deleting…" : "Confirm"}
+            </Button>
+            <Button size="sm" variant="outline" onClick={() => setConfirming(false)}>
+              Cancel
+            </Button>
+          </div>
+        ) : (
+          <Button size="sm" variant="outline" onClick={() => setConfirming(true)}>
+            Delete
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ExportsTab() {
+  const qc = useQueryClient();
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["admin", "exports"],
+    queryFn: listExports,
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1 pb-2 border-b">
+        <h1 className="text-lg font-semibold">Data Exports</h1>
+        <p className="text-sm text-muted-foreground">
+          All user data export requests. Archives are stored in R2 and expire after 7 days. Delete a record to
+          immediately remove both the DB row and the archive object.
+        </p>
+      </div>
+
+      {isLoading && <p className="text-sm text-muted-foreground py-8 text-center">Loading…</p>}
+      {error && <p className="text-sm text-destructive">Failed to load exports.</p>}
+
+      {!isLoading && data && data.length === 0 && (
+        <p className="text-sm text-muted-foreground py-8 text-center">No export requests found.</p>
+      )}
+
+      {data && data.length > 0 && (
+        <div className="space-y-3">
+          {data.map((record) => (
+            <ExportRow
+              key={record.id}
+              record={record}
+              onDeleted={() => qc.invalidateQueries({ queryKey: ["admin", "exports"] })}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function SuperuserPage() {
   const { section = "eula" } = useParams<{ section: string }>();
   const activeSection = section as SuperuserSection;
@@ -1431,6 +1559,7 @@ export function SuperuserPage() {
       {activeSection === "reconcile" && <ReconcileTab />}
       {activeSection === "maintenance" && <MaintenanceTab />}
       {activeSection === "schedule" && <ScheduledTasksTab />}
+      {activeSection === "exports" && <ExportsTab />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds a **Data Exports** tab to the superuser console (`/superuser/exports`) with full visibility into all user data export requests
- Stores archive size in the DB so it persists for the life of the record
- Provides a delete action that removes both the DB row and the R2 archive object

## Changes

**Backend**
- `UserExportRequest` model: new `archive_size_bytes` (BigInteger, nullable) field
- Migration `0036`: adds the column
- `export.py` task: captures `len(buf.getvalue())` and writes it to `archive_size_bytes` on success
- `GET /api/admin/exports`: list all export requests joined with user, newest first (superuser only)
- `DELETE /api/admin/exports/{id}`: deletes R2 archive + DB row (superuser only)

**Frontend**
- `ExportsTab` component: card per record showing user (name + email), status badge (green/yellow/red), requested / generated / expires timestamps, archive size in MB, error text for failed rows
- Delete button with inline confirmation before calling the API
- New sidebar entry "Data Exports" under superuser sections
- i18n key `superuserSections.exports` added to all 5 locales

## Test plan

- [ ] Navigate to `/superuser/exports` — should see the existing export record for the test user
- [ ] Verify columns: user email, status=complete, requested/generated/expires dates, size in MB
- [ ] Click Delete → confirm → record disappears from list
- [ ] Trigger a new export from settings → verify it appears as pending, then complete with size populated
- [ ] Verify failed exports show the error text in red

Closes #827

🤖 Generated with [Claude Code](https://claude.com/claude-code)