### PR TITLE
fix: rename settings nav "My Data" → "Account", fix archive button position

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -17,7 +17,7 @@
     "preferences": "Einstellungen",
     "privacy": "Datenschutz",
     "terms": "Nutzungsbedingungen",
-    "account": "Meine Daten",
+    "account": "Konto",
     "feedbackHistory": "Feedback-Verlauf"
   },
   "adminSections": {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -17,7 +17,7 @@
     "preferences": "Preferences",
     "privacy": "Privacy & data",
     "terms": "Terms",
-    "account": "My Data",
+    "account": "Account",
     "feedbackHistory": "Feedback history"
   },
   "adminSections": {

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -17,7 +17,7 @@
     "preferences": "Preferencias",
     "privacy": "Privacidad",
     "terms": "Términos",
-    "account": "Mis datos",
+    "account": "Cuenta",
     "feedbackHistory": "Historial de comentarios"
   },
   "adminSections": {

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -17,7 +17,7 @@
     "preferences": "Préférences",
     "privacy": "Confidentialité",
     "terms": "Conditions d'utilisation",
-    "account": "Mes données",
+    "account": "Compte",
     "feedbackHistory": "Historique des retours"
   },
   "adminSections": {

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -17,7 +17,7 @@
     "preferences": "Voorkeuren",
     "privacy": "Privacy",
     "terms": "Gebruiksvoorwaarden",
-    "account": "Mijn gegevens",
+    "account": "Account",
     "feedbackHistory": "Feedbackgeschiedenis"
   },
   "adminSections": {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -483,12 +483,26 @@ export function SettingsPage() {
                 </div>
 
                 <Field label={t("settings.account.downloadData")}>
-                  {exportStatus?.status === "pending" ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => requestExportMutation.mutate()}
+                    disabled={requestExportMutation.isPending || exportStatus?.status === "pending"}
+                  >
+                    {t("settings.account.requestArchive")}
+                  </Button>
+                  {exportStatus?.status === "pending" && (
                     <div className="flex items-center gap-2 text-sm text-muted-foreground">
                       <AppIcons.spinner className="h-4 w-4 animate-spin" />
                       {t("settings.account.archivePending")}
                     </div>
-                  ) : exportStatus?.status === "complete" && exportStatus.request_id ? (
+                  )}
+                  {exportStatus?.status === "pending" && (
+                    <p className="text-xs text-muted-foreground">
+                      {t("settings.account.archiveEmailNotice")}
+                    </p>
+                  )}
+                  {exportStatus?.status === "complete" && exportStatus.request_id && (
                     <div className="space-y-1">
                       <p className="text-sm text-muted-foreground">{t("settings.account.archiveReady")}</p>
                       {exportStatus.expires_at && (
@@ -511,29 +525,13 @@ export function SettingsPage() {
                         {t("settings.account.downloadArchive")}
                       </Button>
                     </div>
-                  ) : (
-                    <>
-                      {exportStatus?.status === "failed" && (
-                        <p className="text-xs text-destructive mb-1">
-                          {t("settings.account.archiveFailed")}
-                        </p>
-                      )}
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => requestExportMutation.mutate()}
-                        disabled={requestExportMutation.isPending}
-                      >
-                        {t("settings.account.requestArchive")}
-                      </Button>
-                    </>
                   )}
-                  {exportStatus?.status === "pending" && (
-                    <p className="text-xs text-muted-foreground mt-1">
-                      {t("settings.account.archiveEmailNotice")}
+                  {exportStatus?.status === "failed" && (
+                    <p className="text-xs text-destructive">
+                      {t("settings.account.archiveFailed")}
                     </p>
                   )}
-                  <p className="text-xs text-muted-foreground mt-1">
+                  <p className="text-xs text-muted-foreground">
                     {t("settings.account.archiveNote")}
                   </p>
                 </Field>


### PR DESCRIPTION
## Summary

- The "My Data" nav label in Settings was stale — the data content (download archive) was already moved to **Privacy & data** in a prior PR, leaving only the delete-account danger zone under "My Data"
- Renames the nav entry to **Account** across all 5 locales (en/de/fr/es/nl), matching the section heading which already said "Account management"
- Fixes the archive request button layout: **Request archive** now always appears directly below the "Request a data archive" label in all states (previously it was hidden when an archive was available or pending), disabled only while a build is in progress; status info (pending spinner, archive-ready + download link, failed error) renders below it

## Test plan

- [ ] Navigate to Settings sidebar — entry reads "Account" not "My Data"
- [ ] `/settings/account` shows "Account management" heading with danger zone only
- [ ] `/settings/privacy` shows "Request archive" button directly below the section label in all states: no export, pending, complete (download also shown below), failed
- [ ] Verify German/French/Spanish/Dutch nav labels show "Konto"/"Compte"/"Cuenta"/"Account" respectively

Closes N/A (follow-up to #816 / #826)

🤖 Generated with [Claude Code](https://claude.com/claude-code)