### PR TITLE
feat: edit colorway on yarn detail page — rename or link to Ravelry colorway

### DIFF
--- a/backend/app/routers/yarn.py
+++ b/backend/app/routers/yarn.py
@@ -411,6 +411,36 @@ async def update_yarn(
     return YarnDetail.from_yarn(yarn)
 
 
+class PatchColorwayRequest(BaseModel):
+    color_name: str | None = None
+    colorway_photo_url: str | None = None
+    colorway_thumbnail_url: str | None = None
+    clear_photos: bool = False
+
+
+@router.patch("/{yarn_id}/colorway", response_model=YarnDetail)
+async def patch_yarn_colorway(
+    yarn_id: uuid.UUID,
+    body: PatchColorwayRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> YarnDetail:
+    yarn = await _get_owned_yarn(yarn_id, current_user, db)
+    if body.color_name is not None:
+        yarn.color_name = body.color_name or None
+    if body.clear_photos:
+        yarn.ravelry_colorway_photo_url = None
+        yarn.ravelry_colorway_thumbnail_url = None
+    else:
+        if body.colorway_photo_url is not None:
+            yarn.ravelry_colorway_photo_url = body.colorway_photo_url or None
+        if body.colorway_thumbnail_url is not None:
+            yarn.ravelry_colorway_thumbnail_url = body.colorway_thumbnail_url or None
+    await db.commit()
+    yarn = await _get_owned_yarn(yarn_id, current_user, db)
+    return YarnDetail.from_yarn(yarn)
+
+
 @router.delete("/{yarn_id}", status_code=204)
 async def delete_yarn(
     yarn_id: uuid.UUID,

--- a/frontend/src/api/yarn.ts
+++ b/frontend/src/api/yarn.ts
@@ -213,6 +213,21 @@ export function deleteSkein(yarnId: string, skeinId: string): Promise<void> {
   return req(`/api/yarn/${yarnId}/skeins/${skeinId}`, { method: "DELETE" });
 }
 
+export interface PatchColorwayPayload {
+  color_name?: string | null;
+  colorway_photo_url?: string | null;
+  colorway_thumbnail_url?: string | null;
+  clear_photos?: boolean;
+}
+
+export function patchYarnColorway(id: string, payload: PatchColorwayPayload): Promise<YarnDetail> {
+  return req(`/api/yarn/${id}/colorway`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}
+
 export interface CloneYarnPayload {
   color_name?: string;
   color_hex?: string;

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -84,7 +84,9 @@
     "back": "Zurück",
     "dismiss": "Schließen",
     "clear": "Löschen",
-    "loading": "Lädt …"
+    "loading": "Lädt …",
+    "saving": "Wird gespeichert…",
+    "error": "Etwas ist schiefgelaufen."
   },
   "settings": {
     "saved": "Gespeichert",
@@ -123,9 +125,18 @@
       "styleVariantNote": "Stilabweichungen werden in einem zukünftigen Update visuell unterschieden.",
       "active": "— aktiv",
       "activityStyles": {
-        "default": { "label": "Standard", "desc": "Standardlayout mit großen Eintrags­karten und Patron-Vorschau." },
-        "compact": { "label": "Kompakt", "desc": "Dichteres Layout für intensives Tracking mit weniger vertikalem Platz." },
-        "high_contrast": { "label": "Hoher Kontrast", "desc": "Höherer visueller Kontrast für einfacheres Lesen bei hellem Licht oder für Barrierefreiheit." }
+        "default": {
+          "label": "Standard",
+          "desc": "Standardlayout mit großen Eintrags­karten und Patron-Vorschau."
+        },
+        "compact": {
+          "label": "Kompakt",
+          "desc": "Dichteres Layout für intensives Tracking mit weniger vertikalem Platz."
+        },
+        "high_contrast": {
+          "label": "Hoher Kontrast",
+          "desc": "Höherer visueller Kontrast für einfacheres Lesen bei hellem Licht oder für Barrierefreiheit."
+        }
       }
     },
     "diagnostics": {
@@ -859,7 +870,17 @@
     "rating": "★ {{avg}} / 5 ({{count}} Bewertungen)",
     "viewOnRavelry": "Auf Ravelry ansehen",
     "manufacturerWebsite": "{{company}} Website",
-    "manufacturerWebsiteFallback": "Hersteller-Website"
+    "manufacturerWebsiteFallback": "Hersteller-Website",
+    "editColorway": "Farbvariante bearbeiten",
+    "editColorwayTitle": "Farbvariante bearbeiten",
+    "noColorway": "Keine Farbvariante",
+    "renameTab": "Umbenennen",
+    "linkRavelryTab": "Mit Ravelry verknüpfen",
+    "colorNameLabel": "Name der Farbvariante",
+    "colorNamePlaceholder": "z. B. Kaki",
+    "colorwayFilter": "Farbvarianten filtern…",
+    "noColorways": "Keine Farbvarianten für dieses Garn gefunden.",
+    "colorwayLoadError": "Farbvarianten konnten nicht geladen werden."
   },
   "loomDetailPage": {
     "loading": "Laden…",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -84,7 +84,9 @@
     "back": "Back",
     "dismiss": "Dismiss",
     "clear": "Clear",
-    "loading": "Loading…"
+    "loading": "Loading…",
+    "saving": "Saving…",
+    "error": "Something went wrong."
   },
   "settings": {
     "saved": "Saved",
@@ -123,9 +125,18 @@
       "styleVariantNote": "Style variants will be visually differentiated in a future update.",
       "active": "— active",
       "activityStyles": {
-        "default": { "label": "Default", "desc": "Standard layout with full-size pick cards and drawdown preview." },
-        "compact": { "label": "Compact", "desc": "Denser layout for tracking-heavy sessions with less vertical space." },
-        "high_contrast": { "label": "High contrast", "desc": "Higher visual contrast for easier reading under bright light or for accessibility." }
+        "default": {
+          "label": "Default",
+          "desc": "Standard layout with full-size pick cards and drawdown preview."
+        },
+        "compact": {
+          "label": "Compact",
+          "desc": "Denser layout for tracking-heavy sessions with less vertical space."
+        },
+        "high_contrast": {
+          "label": "High contrast",
+          "desc": "Higher visual contrast for easier reading under bright light or for accessibility."
+        }
       }
     },
     "diagnostics": {
@@ -859,7 +870,17 @@
     "rating": "★ {{avg}} / 5 ({{count}} ratings)",
     "viewOnRavelry": "View on Ravelry",
     "manufacturerWebsite": "{{company}} website",
-    "manufacturerWebsiteFallback": "Manufacturer website"
+    "manufacturerWebsiteFallback": "Manufacturer website",
+    "editColorway": "Edit colorway",
+    "editColorwayTitle": "Edit Colorway",
+    "noColorway": "No colorway",
+    "renameTab": "Rename",
+    "linkRavelryTab": "Link to Ravelry",
+    "colorNameLabel": "Colorway name",
+    "colorNamePlaceholder": "e.g. Kaki",
+    "colorwayFilter": "Filter colorways…",
+    "noColorways": "No colorways found for this yarn.",
+    "colorwayLoadError": "Failed to load colorways."
   },
   "loomDetailPage": {
     "loading": "Loading…",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -83,7 +83,9 @@
     "cancel": "Cancelar",
     "back": "Atrás",
     "clear": "Borrar",
-    "loading": "Cargando…"
+    "loading": "Cargando…",
+    "saving": "Guardando…",
+    "error": "Algo salió mal."
   },
   "settings": {
     "saved": "Guardado",
@@ -122,9 +124,18 @@
       "styleVariantNote": "Las variantes de estilo se diferenciarán visualmente en una futura actualización.",
       "active": "— activo",
       "activityStyles": {
-        "default": { "label": "Predeterminado", "desc": "Diseño estándar con tarjetas de pasada de tamaño completo y vista previa del ligamento." },
-        "compact": { "label": "Compacto", "desc": "Diseño más denso para sesiones de seguimiento intensivo con menos espacio vertical." },
-        "high_contrast": { "label": "Alto contraste", "desc": "Mayor contraste visual para una lectura más fácil bajo luz intensa o por accesibilidad." }
+        "default": {
+          "label": "Predeterminado",
+          "desc": "Diseño estándar con tarjetas de pasada de tamaño completo y vista previa del ligamento."
+        },
+        "compact": {
+          "label": "Compacto",
+          "desc": "Diseño más denso para sesiones de seguimiento intensivo con menos espacio vertical."
+        },
+        "high_contrast": {
+          "label": "Alto contraste",
+          "desc": "Mayor contraste visual para una lectura más fácil bajo luz intensa o por accesibilidad."
+        }
       }
     },
     "diagnostics": {
@@ -858,7 +869,17 @@
     "rating": "★ {{avg}} / 5 ({{count}} valoraciones)",
     "viewOnRavelry": "Ver en Ravelry",
     "manufacturerWebsite": "Web de {{company}}",
-    "manufacturerWebsiteFallback": "Web del fabricante"
+    "manufacturerWebsiteFallback": "Web del fabricante",
+    "editColorway": "Editar colorway",
+    "editColorwayTitle": "Editar colorway",
+    "noColorway": "Sin colorway",
+    "renameTab": "Renombrar",
+    "linkRavelryTab": "Vincular a Ravelry",
+    "colorNameLabel": "Nombre del colorway",
+    "colorNamePlaceholder": "ej. Kaki",
+    "colorwayFilter": "Filtrar colorways…",
+    "noColorways": "No se encontraron colorways para este hilo.",
+    "colorwayLoadError": "Error al cargar los colorways."
   },
   "loomDetailPage": {
     "loading": "Cargando…",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -83,7 +83,9 @@
     "cancel": "Annuler",
     "back": "Retour",
     "clear": "Effacer",
-    "loading": "Chargement…"
+    "loading": "Chargement…",
+    "saving": "Enregistrement…",
+    "error": "Une erreur est survenue."
   },
   "settings": {
     "saved": "Enregistré",
@@ -122,9 +124,18 @@
       "styleVariantNote": "Les variantes de style seront visuellement différenciées dans une prochaine mise à jour.",
       "active": "— actif",
       "activityStyles": {
-        "default": { "label": "Par défaut", "desc": "Disposition standard avec cartes de duite en taille réelle et aperçu de l'armure." },
-        "compact": { "label": "Compact", "desc": "Disposition plus dense pour les sessions de suivi intensif avec moins d'espace vertical." },
-        "high_contrast": { "label": "Contraste élevé", "desc": "Contraste visuel plus élevé pour une lecture facilitée sous forte luminosité ou pour l'accessibilité." }
+        "default": {
+          "label": "Par défaut",
+          "desc": "Disposition standard avec cartes de duite en taille réelle et aperçu de l'armure."
+        },
+        "compact": {
+          "label": "Compact",
+          "desc": "Disposition plus dense pour les sessions de suivi intensif avec moins d'espace vertical."
+        },
+        "high_contrast": {
+          "label": "Contraste élevé",
+          "desc": "Contraste visuel plus élevé pour une lecture facilitée sous forte luminosité ou pour l'accessibilité."
+        }
       }
     },
     "diagnostics": {
@@ -858,7 +869,17 @@
     "rating": "★ {{avg}} / 5 ({{count}} avis)",
     "viewOnRavelry": "Voir sur Ravelry",
     "manufacturerWebsite": "Site de {{company}}",
-    "manufacturerWebsiteFallback": "Site du fabricant"
+    "manufacturerWebsiteFallback": "Site du fabricant",
+    "editColorway": "Modifier le coloris",
+    "editColorwayTitle": "Modifier le coloris",
+    "noColorway": "Aucun coloris",
+    "renameTab": "Renommer",
+    "linkRavelryTab": "Lier à Ravelry",
+    "colorNameLabel": "Nom du coloris",
+    "colorNamePlaceholder": "ex. Kaki",
+    "colorwayFilter": "Filtrer les coloris…",
+    "noColorways": "Aucun coloris trouvé pour ce fil.",
+    "colorwayLoadError": "Impossible de charger les coloris."
   },
   "loomDetailPage": {
     "loading": "Chargement…",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -83,7 +83,9 @@
     "cancel": "Annuleren",
     "back": "Terug",
     "clear": "Wissen",
-    "loading": "Laden…"
+    "loading": "Laden…",
+    "saving": "Opslaan…",
+    "error": "Er is iets misgegaan."
   },
   "settings": {
     "saved": "Opgeslagen",
@@ -122,9 +124,18 @@
       "styleVariantNote": "Stijl­varianten worden visueel onderscheiden in een toekomstige update.",
       "active": "— actief",
       "activityStyles": {
-        "default": { "label": "Standaard", "desc": "Standaard indeling met kaarten op volledige grootte en bindingsvoorbeeld." },
-        "compact": { "label": "Compact", "desc": "Dichtere indeling voor intensieve tracking­sessies met minder verticale ruimte." },
-        "high_contrast": { "label": "Hoog contrast", "desc": "Hoger visueel contrast voor gemakkelijker lezen bij fel licht of voor toegankelijkheid." }
+        "default": {
+          "label": "Standaard",
+          "desc": "Standaard indeling met kaarten op volledige grootte en bindingsvoorbeeld."
+        },
+        "compact": {
+          "label": "Compact",
+          "desc": "Dichtere indeling voor intensieve tracking­sessies met minder verticale ruimte."
+        },
+        "high_contrast": {
+          "label": "Hoog contrast",
+          "desc": "Hoger visueel contrast voor gemakkelijker lezen bij fel licht of voor toegankelijkheid."
+        }
       }
     },
     "diagnostics": {
@@ -858,7 +869,17 @@
     "rating": "★ {{avg}} / 5 ({{count}} beoordelingen)",
     "viewOnRavelry": "Bekijk op Ravelry",
     "manufacturerWebsite": "Website van {{company}}",
-    "manufacturerWebsiteFallback": "Website fabrikant"
+    "manufacturerWebsiteFallback": "Website fabrikant",
+    "editColorway": "Kleurweg bewerken",
+    "editColorwayTitle": "Kleurweg bewerken",
+    "noColorway": "Geen kleurweg",
+    "renameTab": "Hernoemen",
+    "linkRavelryTab": "Koppelen aan Ravelry",
+    "colorNameLabel": "Naam van de kleurweg",
+    "colorNamePlaceholder": "bijv. Kaki",
+    "colorwayFilter": "Kleurwegen filteren…",
+    "noColorways": "Geen kleurwegen gevonden voor dit garen.",
+    "colorwayLoadError": "Kleurwegen konden niet worden geladen."
   },
   "loomDetailPage": {
     "loading": "Laden…",

--- a/frontend/src/pages/YarnDetailPage.tsx
+++ b/frontend/src/pages/YarnDetailPage.tsx
@@ -1,9 +1,9 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams, Link } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { getYarn, updateYarn } from "@/api/yarn";
-import { getRavelryYarnDetail, type RavelryYarnApiDetail } from "@/api/ravelry";
+import { getYarn, updateYarn, patchYarnColorway } from "@/api/yarn";
+import { getRavelryYarnDetail, type RavelryColorway, type RavelryYarnApiDetail } from "@/api/ravelry";
 import { Button } from "@/components/ui/button";
 import { ColorPicker } from "@/components/ui/ColorPicker";
 
@@ -40,6 +40,178 @@ const WEIGHT_LABELS: Record<string, string> = {
   bulky: "Bulky",
   super_bulky: "Super Bulky",
 };
+
+// ---------------------------------------------------------------------------
+// Edit colorway modal
+// ---------------------------------------------------------------------------
+
+function EditColorwayModal({
+  yarn,
+  onClose,
+  onSaved,
+}: {
+  yarn: { id: string; color_name: string | null; ravelry_yarn_id: number | null };
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const { t } = useTranslation();
+  const [tab, setTab] = useState<"rename" | "link">("rename");
+  const [colorName, setColorName] = useState(yarn.color_name ?? "");
+  const [colorways, setColorways] = useState<RavelryColorway[]>([]);
+  const [colorwaysLoading, setColorwaysLoading] = useState(false);
+  const [colorwayFilter, setColorwayFilter] = useState("");
+  const [selectedColorway, setSelectedColorway] = useState<RavelryColorway | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const filteredColorways = useMemo(() => {
+    if (!colorwayFilter.trim()) return colorways;
+    const q = colorwayFilter.toLowerCase();
+    return colorways.filter((cw) => cw.name.toLowerCase().includes(q));
+  }, [colorways, colorwayFilter]);
+
+  async function loadColorways() {
+    if (!yarn.ravelry_yarn_id || colorways.length > 0) return;
+    setColorwaysLoading(true);
+    try {
+      const { getRavelryYarnDetail: _getRavelryYarnDetail } = await import("@/api/ravelry");
+      const resp = await _getRavelryYarnDetail(yarn.ravelry_yarn_id);
+      setColorways(resp.colorways ?? []);
+    } catch {
+      setError(t("yarnDetailPage.colorwayLoadError"));
+    } finally {
+      setColorwaysLoading(false);
+    }
+  }
+
+  function handleTabChange(next: "rename" | "link") {
+    setTab(next);
+    if (next === "link") loadColorways();
+  }
+
+  function pickColorway(cw: RavelryColorway) {
+    setSelectedColorway(cw);
+    setColorName(cw.name);
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    try {
+      const payload: Parameters<typeof patchYarnColorway>[1] = {
+        color_name: colorName.trim() || null,
+      };
+      if (tab === "link" && selectedColorway) {
+        payload.colorway_photo_url = selectedColorway.photos?.[0]?.square_url ?? null;
+        payload.colorway_thumbnail_url = selectedColorway.photos?.[0]?.thumbnail_url ?? null;
+      } else if (tab === "rename") {
+        payload.clear_photos = true;
+      }
+      await patchYarnColorway(yarn.id, payload);
+      onSaved();
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t("common.error"));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const inputCls = "w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" onClick={onClose}>
+      <div className="w-full max-w-sm rounded-xl border border-border bg-card shadow-xl" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+          <h2 className="text-sm font-semibold">{t("yarnDetailPage.editColorwayTitle")}</h2>
+          <button onClick={onClose} className="text-muted-foreground hover:text-foreground text-lg leading-none">×</button>
+        </div>
+
+        {yarn.ravelry_yarn_id && (
+          <div className="flex border-b border-border">
+            {(["rename", "link"] as const).map((t_) => (
+              <button
+                key={t_}
+                onClick={() => handleTabChange(t_)}
+                className={`flex-1 px-4 py-2.5 text-xs font-medium transition-colors ${
+                  tab === t_
+                    ? "border-b-2 border-accent text-accent"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {t_ === "rename" ? t("yarnDetailPage.renameTab") : t("yarnDetailPage.linkRavelryTab")}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <div className="px-5 py-4 space-y-3 max-h-[60vh] overflow-y-auto">
+          {tab === "link" && (
+            <>
+              {colorwaysLoading && <p className="text-xs text-muted-foreground">{t("common.loading")}</p>}
+              {!colorwaysLoading && colorways.length > 6 && (
+                <div className="relative">
+                  <input
+                    className={inputCls}
+                    placeholder={t("yarnDetailPage.colorwayFilter")}
+                    value={colorwayFilter}
+                    onChange={(e) => setColorwayFilter(e.target.value)}
+                  />
+                  {colorwayFilter && (
+                    <button className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground text-xs" onClick={() => setColorwayFilter("")}>✕</button>
+                  )}
+                </div>
+              )}
+              {!colorwaysLoading && filteredColorways.length === 0 && (
+                <p className="text-xs text-muted-foreground">{t("yarnDetailPage.noColorways")}</p>
+              )}
+              {filteredColorways.length > 0 && (
+                <div className="grid grid-cols-3 gap-1.5">
+                  {filteredColorways.map((cw) => (
+                    <button
+                      key={cw.id}
+                      className={`text-left rounded-md border p-1.5 text-xs transition-colors ${
+                        selectedColorway?.id === cw.id
+                          ? "border-ring bg-accent/10 text-accent"
+                          : "border-border hover:border-ring text-card-foreground"
+                      }`}
+                      onClick={() => pickColorway(cw)}
+                    >
+                      {cw.photos?.[0]?.square_url && (
+                        <img src={cw.photos[0].square_url} alt={cw.name} className="h-10 w-full rounded object-cover mb-1" />
+                      )}
+                      <span className="truncate block leading-tight">{cw.name}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+
+          <div>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">{t("yarnDetailPage.colorNameLabel")}</label>
+            <input
+              className={inputCls}
+              placeholder={t("yarnDetailPage.colorNamePlaceholder")}
+              value={colorName}
+              onChange={(e) => setColorName(e.target.value)}
+              autoFocus={tab === "rename"}
+            />
+          </div>
+
+          {error && <p className="text-xs text-destructive">{error}</p>}
+        </div>
+
+        <div className="flex justify-end gap-2 px-5 py-4 border-t border-border">
+          <Button variant="outline" size="sm" onClick={onClose} disabled={saving}>{t("common.cancel")}</Button>
+          <Button size="sm" onClick={handleSave} disabled={saving}>
+            {saving ? t("common.saving") : t("common.save")}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Color picker section
@@ -193,6 +365,7 @@ export function YarnDetailPage() {
   const { id } = useParams<{ id: string }>();
   const queryClient = useQueryClient();
   const [showDebug, setShowDebug] = useState(false);
+  const [showEditColorway, setShowEditColorway] = useState(false);
   const [ravelryRawData, setRavelryRawData] = useState<unknown>(null);
   const [ravelryLoading, setRavelryLoading] = useState(false);
 
@@ -273,6 +446,13 @@ export function YarnDetailPage() {
 
       {showDebug && <DevJsonModal data={yarn} onClose={() => setShowDebug(false)} />}
       {ravelryRawData !== null && <DevJsonModal data={ravelryRawData} onClose={() => setRavelryRawData(null)} />}
+      {showEditColorway && (
+        <EditColorwayModal
+          yarn={yarn}
+          onClose={() => setShowEditColorway(false)}
+          onSaved={() => queryClient.invalidateQueries({ queryKey: ["yarn", id] })}
+        />
+      )}
 
       {/* Hero: photo + title block */}
       <div className="flex gap-5 items-start">
@@ -298,12 +478,17 @@ export function YarnDetailPage() {
           <p className="text-muted-foreground">{yarn.name}</p>
 
           {/* Tags row */}
-          <div className="flex flex-wrap gap-1.5 pt-0.5">
-            {yarn.color_name && (
-              <span className="rounded-full bg-muted text-muted-foreground px-2.5 py-0.5 text-xs">
-                {yarn.color_name}
-              </span>
-            )}
+          <div className="flex flex-wrap gap-1.5 pt-0.5 items-center">
+            <button
+              onClick={() => setShowEditColorway(true)}
+              title={t("yarnDetailPage.editColorway")}
+              className="flex items-center gap-1 rounded-full bg-muted text-muted-foreground px-2.5 py-0.5 text-xs hover:bg-accent/20 hover:text-foreground transition-colors"
+            >
+              {yarn.color_name ?? <span className="italic">{t("yarnDetailPage.noColorway")}</span>}
+              <svg className="h-3 w-3 shrink-0" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <path d="M11.5 2.5a1.414 1.414 0 0 1 2 2L5 13H3v-2L11.5 2.5Z" strokeLinejoin="round"/>
+              </svg>
+            </button>
             {yarn.ravelry_discontinued && (
               <span className="rounded-full bg-destructive/10 text-destructive px-2.5 py-0.5 text-xs font-medium">
                 {t("yarnDetailPage.discontinued")}


### PR DESCRIPTION
Closes #833

## Summary

- New `PATCH /api/yarn/{yarn_id}/colorway` endpoint — updates `color_name`, `ravelry_colorway_photo_url`, `ravelry_colorway_thumbnail_url`; `clear_photos` flag wipes stored photo URLs on a plain rename
- Colorway name tag on the Yarn Detail page is now a clickable button with an inline pencil icon
- **EditColorwayModal** with two tabs:
  - **Rename** — free-text input; saves `color_name` and clears any stored colorway photos
  - **Link to Ravelry** — colorway grid (thumbnail photos + filter) fetched from Ravelry using the yarn's `ravelry_yarn_id`; selecting a colorway updates `color_name` and saves colorway photo URLs for the hero image
  - Link tab only shown when `ravelry_yarn_id` is set (manually-entered yarn shows Rename only)
- "No colorway" placeholder on the tag when `color_name` is unset
- i18n keys added to all 5 locales (en, de, fr, es, nl)

## Test plan

- [ ] Yarn with a colorway name — tag shows name with pencil icon; clicking opens modal on Rename tab
- [ ] Rename tab — edit name, save; tag updates, hero photo unchanged
- [ ] Ravelry-linked yarn — Link to Ravelry tab appears; colorway grid loads with thumbnails
- [ ] Select a colorway — name field updates; save sets colorway photo as hero image
- [ ] Filter input appears when >6 colorways; filters correctly
- [ ] Manually-entered yarn — no Link to Ravelry tab shown
- [ ] Yarn with no colorway — tag shows "No colorway"; rename sets it
- [ ] Cancel dismisses without saving

🤖 Generated with [Claude Code](https://claude.com/claude-code)