### PR TITLE
chore: add Dependabot for pip + npm grouped weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+# Dependabot configuration — keeps pip and npm dependencies fresh.
+#
+# Both ecosystems use weekly grouped updates to minimise PR volume.
+# PRs target dev and run through ci-dev-pr.yml (full test suite).
+#
+# Auto-merge is intentionally not configured — review manually until
+# the cadence and false-positive rate are understood.
+#
+# The version-bump job in ci-dev-push.yml guards on weftmark-bot[bot];
+# Dependabot's actor is dependabot[bot] — no guard extension needed.
+
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /backend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: America/Denver
+    open-pull-requests-limit: 5
+    target-branch: dev
+    labels:
+      - dependencies
+      - backend
+    groups:
+      backend-deps:
+        patterns:
+          - "*"
+    assignees:
+      - gx1400
+
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: America/Denver
+    open-pull-requests-limit: 5
+    target-branch: dev
+    labels:
+      - dependencies
+      - frontend
+    groups:
+      frontend-deps:
+        patterns:
+          - "*"
+    assignees:
+      - gx1400


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` configuring Dependabot for both `pip` (backend) and `npm` (frontend)
- Weekly grouped updates (Monday 04:00 MDT), 5 open PR limit per ecosystem, all PRs target `dev`
- Auto-merge intentionally omitted — review cadence manually first
- `weftmark-bot[bot]` guard in `ci-dev-push.yml` is unaffected; Dependabot uses a different actor (`dependabot[bot]`)

Closes #846.

> **Note:** GitHub flagged 1 high-severity vulnerability on the default branch during push (`/security/dependabot/7`) — Dependabot will likely open a security PR immediately after merge.

## Test plan

- [ ] Merge to `dev` and confirm Dependabot appears active under repo Insights → Dependency graph → Dependabot
- [ ] Confirm first Dependabot PR targets `dev` and triggers `ci-dev-pr.yml`
- [ ] Confirm version bump job does not fire on Dependabot-merged PRs (actor guard check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)