### PR TITLE
fix: ignore redis>=7 in Dependabot until Celery supports it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,11 @@ updates:
     labels:
       - dependencies
       - backend
+    ignore:
+      # kombu[redis] (pulled in by celery[redis]) caps redis at <6.5.
+      # redis 7.x cannot be used until Celery ships a compatible kombu version.
+      - dependency-name: redis
+        versions: [">=7.0"]
     groups:
       backend-deps:
         patterns:


### PR DESCRIPTION
## Summary

- Adds a `redis` ignore rule to `.github/dependabot.yml` capping updates at `<7.0`
- Closes #856 (Dependabot bumped redis to 7.4.0, breaking the build)

## Root cause

`celery[redis]==5.6.3` pulls in `kombu[redis]==5.6.x`, which requires `redis<6.5`. Dependabot grouped redis into the weekly backend-deps bump without knowing about the transitive constraint — the result was an unresolvable dependency conflict that failed the Docker build and pytest steps.

## Fix

```yaml
ignore:
  - dependency-name: redis
    versions: [">=7.0"]
```

redis will continue to receive patch/minor updates within the `<7.0` range. Remove this ignore rule once Celery ships a kombu version that lifts the `<6.5` cap.

## Test plan

- [ ] Merge to `dev` — next Dependabot pip run should produce a PR that excludes redis 7.x
- [ ] Confirm CI passes on that PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)