### PR TITLE
chore: add Bandit security SAST to CI

### DIFF
--- a/.github/workflows/ci-dev-pr.yml
+++ b/.github/workflows/ci-dev-pr.yml
@@ -29,6 +29,17 @@ jobs:
       - run: ruff check backend/
       - run: ruff format --check backend/
 
+  backend-security:
+    name: Backend security scan (bandit)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: pip install bandit[toml]==1.8.3
+      - run: cd backend && bandit -c pyproject.toml -r app/ --severity-level medium
+
   frontend-lint:
     name: Frontend lint (eslint)
     runs-on: ubuntu-latest
@@ -55,7 +66,7 @@ jobs:
   backend-tests:
     name: Backend tests (pytest)
     runs-on: ubuntu-latest
-    needs: [backend-lint]
+    needs: [backend-lint, backend-security]
     services:
       postgres:
         image: postgres:17

--- a/.github/workflows/ci-feature.yml
+++ b/.github/workflows/ci-feature.yml
@@ -27,6 +27,17 @@ jobs:
       - run: ruff check backend/
       - run: ruff format --check backend/
 
+  backend-security:
+    name: Backend security scan (bandit)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: pip install bandit[toml]==1.8.3
+      - run: cd backend && bandit -c pyproject.toml -r app/ --severity-level medium
+
   frontend-lint:
     name: Frontend lint (eslint)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-hotfix.yml
+++ b/.github/workflows/ci-hotfix.yml
@@ -26,6 +26,17 @@ jobs:
       - run: ruff check backend/
       - run: ruff format --check backend/
 
+  backend-security:
+    name: Backend security scan (bandit)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: pip install bandit[toml]==1.8.3
+      - run: cd backend && bandit -c pyproject.toml -r app/ --severity-level medium
+
   frontend-lint:
     name: Frontend lint (eslint)
     runs-on: ubuntu-latest
@@ -52,7 +63,7 @@ jobs:
   backend-tests:
     name: Backend tests (pytest)
     runs-on: ubuntu-latest
-    needs: [backend-lint]
+    needs: [backend-lint, backend-security]
     services:
       postgres:
         image: postgres:17

--- a/backend/app/services/loom_seed.py
+++ b/backend/app/services/loom_seed.py
@@ -168,7 +168,7 @@ async def seed() -> dict:
                     if set_clauses:
                         await session.execute(
                             text(
-                                f"UPDATE loom_references SET {set_clauses}, updated_at = now() "
+                                f"UPDATE loom_references SET {set_clauses}, updated_at = now() "  # nosec B608 — set_clauses built from internal seed data keys, not user input
                                 f"WHERE lower(brand) = lower(:brand) AND lower(model_name) = lower(:model)"
                             ),
                             {**params, "brand": brand, "model": model},
@@ -180,7 +180,7 @@ async def seed() -> dict:
                     cols = ", ".join(row.keys())
                     vals = ", ".join(f"cast(:{k} as jsonb)" if k in _ARRAY_FIELDS else f":{k}" for k in row.keys())
                     await session.execute(
-                        text(f"INSERT INTO loom_references ({cols}) VALUES ({vals})"),
+                        text(f"INSERT INTO loom_references ({cols}) VALUES ({vals})"),  # nosec B608 — cols/vals from internal seed data keys
                         params,
                     )
                     inserted += 1

--- a/backend/app/tasks/geo.py
+++ b/backend/app/tasks/geo.py
@@ -52,7 +52,7 @@ def refresh_geoip_database(self) -> dict:
     with tempfile.TemporaryDirectory(dir=dest_dir) as tmpdir:
         archive_path = os.path.join(tmpdir, "GeoLite2-City.tar.gz")
         log.info("Downloading GeoLite2-City database")
-        urllib.request.urlretrieve(url, archive_path)  # noqa: S310
+        urllib.request.urlretrieve(url, archive_path)  # noqa: S310  # nosec B310 — URL is MaxMind's known HTTPS endpoint
 
         extracted_mmdb = None
         with tarfile.open(archive_path, "r:gz") as tar:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.bandit]
+targets = ["app"]
+exclude_dirs = ["alembic"]
+severity = "medium"
+confidence = "medium"

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest-asyncio==1.3.0
 pytest-cov==7.1.0
 ruff==0.15.14
 fakeredis[aioredis]==2.35.1
+bandit[toml]==1.8.3


### PR DESCRIPTION
## Summary

- Adds `bandit[toml]==1.8.3` to `requirements-dev.txt`
- Adds `backend/pyproject.toml` with `[tool.bandit]` config (medium+ severity, `alembic/` excluded)
- Adds `backend-security` job to `ci-feature.yml`, `ci-dev-pr.yml`, and `ci-hotfix.yml`
- Gates `backend-tests` on `backend-security` in the PR and hotfix workflows

Closes #852.

## First-run triage

Scanned 17,386 lines — 0 high, 3 medium, 47 low findings. All 3 medium were false positives, suppressed with inline `# nosec`:

| Location | Rule | Reason |
|---|---|---|
| `loom_seed.py:171` | B608 (SQL injection) | `set_clauses` built from internal seed data column names, not user input |
| `loom_seed.py:183` | B608 (SQL injection) | `cols`/`vals` built from internal seed data keys |
| `geo.py:55` | B310 (url open) | MaxMind HTTPS endpoint; already had `# noqa: S310` |

47 low-severity findings (mostly `B101` assert usage in weaving engine, `B110` try/except/pass in Celery signal handlers) are intentional patterns — not suppressed, just below the medium threshold.

## Test plan

- [ ] CI passes on this branch (`ci-feature.yml` → `backend-security` job green)
- [ ] `backend-tests` correctly waits for `backend-security` in the job graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)