### PR TITLE
chore: add Codecov coverage reporting to ci-dev-pr.yml

### DIFF
--- a/.github/workflows/ci-dev-pr.yml
+++ b/.github/workflows/ci-dev-pr.yml
@@ -95,6 +95,12 @@ jobs:
           POSTGRES_USER: weaving_user
           POSTGRES_PASSWORD: ci_test_password
       - run: cd backend && python -m coverage report --fail-under=65
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: backend/coverage.xml
+          fail_ci_if_error: false
 
   migration-smoke-test:
     name: Alembic migration smoke test

--- a/.github/workflows/ci-dev-pr.yml
+++ b/.github/workflows/ci-dev-pr.yml
@@ -99,6 +99,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          slug: weftmark/weftmark
           files: backend/coverage.xml
           fail_ci_if_error: false
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # WeftMark
 
+[![codecov](https://codecov.io/gh/weftmark/weftmark/graph/badge.svg?token=GRAPH_TOKEN)](https://codecov.io/gh/weftmark/weftmark)
+
 **Weaving project management — from design file to finished cloth.**
 
 WeftMark is a web platform for handweavers. Upload your WIF drafts, track picks at the loom, manage your equipment and yarn, and document your work from warp to finishing.

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -3,5 +3,5 @@ testpaths = tests app/weaving/tests
 pythonpath = .
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
-addopts = --cov=app --cov-report=term-missing --cov-fail-under=65
+addopts = --cov=app --cov-report=term-missing --cov-report=xml --cov-fail-under=65
 


### PR DESCRIPTION
## Summary

- Adds `--cov-report=xml` to `pytest.ini` addopts — generates `backend/coverage.xml` on every test run
- Adds `codecov/codecov-action@v5` upload step after the 65% coverage gate in `ci-dev-pr.yml`
- `fail_ci_if_error: false` — Codecov outages do not block merges
- Adds Codecov badge to `README.md`

Closes #847.

## Setup required after merge

The CI step and badge are wired up but inactive until the repo is connected on Codecov:

1. Sign in at [codecov.io](https://codecov.io) with the `weftmark` GitHub org
2. Add `weftmark/weftmark` repo
3. Copy the **upload token** → add to repo Settings → Secrets → Actions as `CODECOV_TOKEN`
4. Copy the **graph token** from Codecov repo settings → replace `GRAPH_TOKEN` in the README badge URL (one-line edit, can be done in GitHub UI)

Once the first PR runs after setup, Codecov will begin posting coverage delta comments on PRs.

## Test plan

- [ ] CI passes on this branch (xml report generated, upload step runs — will show "no token" warning until secret is set, but `fail_ci_if_error: false` means it doesn't block)
- [ ] After secret is set: Codecov posts a PR comment on next dev PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)