### PR TITLE
chore: add Codecov JUnit XML test results to CI

### DIFF
--- a/.github/workflows/ci-dev-pr.yml
+++ b/.github/workflows/ci-dev-pr.yml
@@ -128,7 +128,7 @@ jobs:
           python-version: "3.12"
       - run: pip install -r backend/requirements-dev.txt
       - run: sudo apt-get install -y --no-install-recommends fonts-dejavu-core
-      - run: cd backend && python -m pytest tests/ -v
+      - run: cd backend && python -m pytest tests/ -v --junitxml=junit.xml
         env:
           POSTGRES_HOST: localhost
           POSTGRES_PORT: 5432
@@ -142,6 +142,13 @@ jobs:
           slug: weftmark/weftmark
           files: backend/coverage.xml
           fail_ci_if_error: false
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: backend/junit.xml
+          slug: weftmark/weftmark
 
   migration-smoke-test:
     name: Alembic migration smoke test

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ MANIFEST
 .coverage.*
 htmlcov/
 coverage.xml
+junit.xml
 *.coveragerc
 
 # Type checking

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,3 +1,6 @@
+[tool.pytest.ini_options]
+junit_family = "legacy"
+
 [tool.bandit]
 targets = ["app"]
 exclude_dirs = ["alembic"]


### PR DESCRIPTION
## Summary

- Adds `--junitxml=junit.xml` to the pytest step in `ci-dev-pr.yml`
- Adds `codecov/test-results-action@v1` upload step after coverage upload, with `if: ${{ !cancelled() }}` so results are sent even when tests fail
- Adds `junit_family = "legacy"` to `[tool.pytest.ini_options]` in `pyproject.toml` for XML format compatibility
- Adds `junit.xml` to `.gitignore`

Closes #863.

**Issue #864** (Codecov Vite bundle analysis plugin) is blocked: `@codecov/vite-plugin@2.0.1` only supports Vite `4.x || 5.x || 6.x`; this project is on Vite 8.x. Commented on the issue and left it open to revisit when Codecov ships Vite 8 support.

## Test plan

- [ ] CI `backend-tests` job runs and `junit.xml` is generated at `backend/junit.xml`
- [ ] "Upload test results to Codecov" step runs and Codecov Test Analytics dashboard shows test history
- [ ] If tests fail, the results step still runs (verified by `if: ${{ !cancelled() }}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)