### PR TITLE
chore: add SonarCloud quality gate to CI

### DIFF
--- a/.github/workflows/ci-dev-pr.yml
+++ b/.github/workflows/ci-dev-pr.yml
@@ -149,6 +149,32 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: backend/junit.xml
           slug: weftmark/weftmark
+      - name: Upload coverage report for SonarCloud
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: backend/coverage.xml
+          retention-days: 1
+
+  sonarcloud:
+    name: SonarCloud quality gate
+    runs-on: ubuntu-latest
+    needs: [backend-tests]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+          path: backend/
+      - name: SonarCloud scan
+        uses: SonarSource/sonarcloud-github-action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   migration-smoke-test:
     name: Alembic migration smoke test

--- a/.github/workflows/ci-dev-pr.yml
+++ b/.github/workflows/ci-dev-pr.yml
@@ -171,7 +171,7 @@ jobs:
           name: coverage-report
           path: backend/
       - name: SonarCloud scan
-        uses: SonarSource/sonarcloud-github-action@v4
+        uses: SonarSource/sonarcloud-github-action@v5.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,21 @@
+sonar.projectKey=weftmark_weftmark
+sonar.organization=weftmark
+sonar.projectName=weftmark
+
+# Source roots — Python backend and TypeScript frontend
+sonar.sources=backend/app,frontend/src
+sonar.tests=backend/tests
+sonar.test.inclusions=backend/tests/**/*.py
+
+sonar.python.version=3.12
+sonar.python.coverage.reportPaths=backend/coverage.xml
+
+# Exclude generated/vendored code and build artifacts
+sonar.exclusions=\
+  **/node_modules/**,\
+  frontend/dist/**,\
+  frontend/build/**,\
+  backend/alembic/**
+
+# Skip duplication check on the PyWeaving engine (algorithmic, not application logic)
+sonar.cpd.exclusions=backend/app/weaving/**


### PR DESCRIPTION
## Summary

- Adds `sonar-project.properties` configuring SonarCloud for both Python backend (`backend/app`) and TypeScript frontend (`frontend/src`)
- Python coverage from `backend/coverage.xml` piped through via artifact upload/download
- PyWeaving rendering engine excluded from CPD (algorithmic code — not application duplication)
- New `sonarcloud` job in `ci-dev-pr.yml` runs after `backend-tests`, posts quality gate check on every PR
- Uses `SonarSource/sonarcloud-github-action@v4` with `fetch-depth: 0` for accurate blame/history

Closes #853.

## Required before this PR can pass CI

Add `SONAR_TOKEN` to repo secrets:

1. Go to [sonarcloud.io](https://sonarcloud.io) → log in with GitHub
2. Import the `weftmark` organization
3. Set up project for `weftmark/weftmark` (auto-detected via `sonar-project.properties`)
4. Copy the token from **My Account → Security**
5. Add to repo: `gh secret set SONAR_TOKEN --repo weftmark/weftmark`

The `SONAR_TOKEN` warning in the VS Code GitHub Actions extension is a false positive — it only validates built-in secrets.

## Test plan

- [ ] `SONAR_TOKEN` added to repo secrets
- [ ] SonarCloud job passes on this PR
- [ ] SonarCloud dashboard shows duplication %, complexity, and coverage for `weftmark_weftmark`
- [ ] PR quality gate check appears alongside existing CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)