### PR TITLE
fix: WIF parser crash on missing COLOR TABLE — preview NoneType (#848 catch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 # .env.example and .env.*.example are intentionally tracked
 .remotehost
 # .remotehost.example is intentionally tracked
+.sentry-token
 
 # Seed config (contains credentials — seed.example.json is tracked)
 backend/seed.json

--- a/backend/app/weaving/_wif.py
+++ b/backend/app/weaving/_wif.py
@@ -54,7 +54,7 @@ class WIFReader:
         for thread_no in range(1, warp_thread_count + 1):
             if thread_no not in threading_map:
                 continue
-            color = wif_palette[warp_color_map[thread_no] if has_warp_colors else warp_color]
+            color = wif_palette.get(warp_color_map[thread_no] if has_warp_colors else warp_color, [0, 0, 0])
             shaft = None
             if has_threading:
                 shafts = {draft.shafts[sn - 1] for sn in threading_map[thread_no]}
@@ -97,7 +97,7 @@ class WIFReader:
         for thread_no in range(1, weft_thread_count + 1):
             if not ((has_liftplan and thread_no in liftplan_map) or (has_treadling and thread_no in treadling_map)):
                 continue
-            color = wif_palette[weft_color_map[thread_no] if has_weft_colors else weft_color]
+            color = wif_palette.get(weft_color_map[thread_no] if has_weft_colors else weft_color, [0, 0, 0])
             shafts = {draft.shafts[sn - 1] for sn in liftplan_map[thread_no]} if has_liftplan else set()
             treadles = {draft.treadles[tn - 1] for tn in treadling_map[thread_no]} if has_treadling else set()
             draft.add_weft_thread(color=color, shafts=shafts, treadles=treadles)
@@ -127,9 +127,8 @@ class WIFReader:
         else:
             palette_range = 0, 255
 
-        wif_palette: dict[int, list[int]] | None = None
+        wif_palette: dict[int, list[int]] = {}
         if self.getbool("CONTENTS", "COLOR TABLE"):
-            wif_palette = {}
             for color_no, value in self.config.items("COLOR TABLE"):
                 channels = [int(ch) for ch in value.split(",")]
                 channels = [int(round(ch * (255.0 / palette_range[1]))) for ch in channels]

--- a/backend/tests/weaving/test_wif_io.py
+++ b/backend/tests/weaving/test_wif_io.py
@@ -197,6 +197,47 @@ Color=2
 2=2,4
 """
 
+_WIF_NO_COLOR_TABLE = """\
+[WIF]
+Version=1.1
+Date=Jan 01, 2024
+
+[CONTENTS]
+WARP=1
+WEFT=1
+THREADING=1
+TREADLING=1
+TIEUP=1
+WEAVING=1
+
+[WEAVING]
+Rising Shed=true
+Shafts=2
+Treadles=2
+
+[WARP]
+Threads=2
+Units=Inches
+Color=1
+
+[WEFT]
+Threads=2
+Units=Inches
+Color=2
+
+[THREADING]
+1=1
+2=2
+
+[TREADLING]
+1=1
+2=2
+
+[TIEUP]
+1=1
+2=2
+"""
+
 _WIF_NO_COLOR_PALETTE = """\
 [WIF]
 Version=1.1
@@ -261,6 +302,26 @@ class TestWIFReaderEdgeCases:
             assert draft.liftplan is True
             assert len(draft.weft) == 2
             assert len(draft.weft[0].shafts) > 0
+        finally:
+            os.unlink(path)
+
+    def test_reads_without_color_table_section(self):
+        # Regression: WIF with no COLOR TABLE caused TypeError: 'NoneType' object
+        # is not subscriptable in put_warp / put_weft (Sentry WEFTMARK-BACKEND-FASTAPI-1)
+        path = _write_temp_wif(_WIF_NO_COLOR_TABLE)
+        try:
+            draft = WIFReader(path).read()
+            assert len(draft.warp) == 2
+            assert len(draft.weft) == 2
+        finally:
+            os.unlink(path)
+
+    def test_black_fallback_color_without_color_table(self):
+        path = _write_temp_wif(_WIF_NO_COLOR_TABLE)
+        try:
+            draft = WIFReader(path).read()
+            assert draft.warp[0].color is not None
+            assert draft.weft[0].color is not None
         finally:
             os.unlink(path)
 


### PR DESCRIPTION
## Summary

- WIF files without a `COLOR TABLE` section passed `None` as `wif_palette` to `put_warp`/`put_weft`
- Any thread color lookup then did `None[key]` → `TypeError: 'NoneType' object is not subscriptable`
- Fix: initialize palette as `{}` and use `.get(key, [0, 0, 0])` so drafts without a palette render in black instead of crashing

Caught via Sentry issue **WEFTMARK-BACKEND-FASTAPI-1**, first seen 2026-05-25.

## Test plan

- [ ] Upload a WIF file with no `[COLOR TABLE]` section — preview generates without error
- [ ] Upload a WIF file with a normal `[COLOR TABLE]` — rendering unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)