### PR TITLE
fix: validate config file path against trusted root to prevent traversal (S2083)

### DIFF
--- a/backend/app/services/config_file.py
+++ b/backend/app/services/config_file.py
@@ -84,9 +84,29 @@ def decrypt(token: str, key: str) -> str:
     return _fernet(key).decrypt(token.encode()).decode()  # type: ignore[no-any-return]
 
 
+def _get_allowed_root() -> Path:
+    """Return the trusted directory for config file I/O.
+
+    Derived from CONFIG_FILE_PATH env var (same source as settings.config_file_path)
+    so the root is always stable and independent of any argument passed at call time.
+    Falls back to /data, the standard container mount point.
+    """
+    configured = os.environ.get("CONFIG_FILE_PATH", "")
+    return Path(configured).resolve().parent if configured else Path("/data")
+
+
+def _assert_safe_path(path: str) -> Path:
+    """Resolve *path* and raise ValueError if it escapes the allowed root."""
+    resolved = Path(path).resolve()
+    allowed_root = _get_allowed_root()
+    if not resolved.is_relative_to(allowed_root):
+        raise ValueError(f"Config path outside allowed root '{allowed_root}': {resolved}")
+    return resolved
+
+
 def load(path: str, encryption_key: str) -> dict[str, Any]:
     """Load config file, decrypting secret fields. Returns {} if file absent/corrupt."""
-    p = Path(path)
+    p = _assert_safe_path(path)
     if not p.exists():
         return {}
     try:
@@ -109,7 +129,7 @@ def load(path: str, encryption_key: str) -> dict[str, Any]:
 
 def save(path: str, encryption_key: str, values: dict[str, Any]) -> None:
     """Merge values into the config file, encrypting secret fields."""
-    p = Path(path)
+    p = _assert_safe_path(path)
     p.parent.mkdir(parents=True, exist_ok=True)
 
     # Load existing to merge (don't wipe fields we're not touching)

--- a/backend/tests/services/test_config_file.py
+++ b/backend/tests/services/test_config_file.py
@@ -1,0 +1,61 @@
+"""Tests for config_file path-traversal guard (S2083)."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from app.services.config_file import load, save
+
+_KEY = "any-non-secret-key"  # only used for non-SECRET_FIELDS values; no Fernet needed
+
+
+class TestAssertSafePath:
+    def test_save_valid_path_succeeds(self, tmp_path):
+        config_path = str(tmp_path / "weftmark_config.json")
+        with patch.dict(os.environ, {"CONFIG_FILE_PATH": config_path}):
+            save(config_path, _KEY, {"smtp_host": "smtp.example.com"})
+        assert (tmp_path / "weftmark_config.json").exists()
+
+    def test_load_valid_path_returns_empty_when_absent(self, tmp_path):
+        config_path = str(tmp_path / "weftmark_config.json")
+        with patch.dict(os.environ, {"CONFIG_FILE_PATH": config_path}):
+            result = load(config_path, _KEY)
+        assert result == {}
+
+    def test_save_rejects_traversal_path(self, tmp_path):
+        config_path = str(tmp_path / "weftmark_config.json")
+        traversal = str(tmp_path / ".." / "evil.json")
+        with patch.dict(os.environ, {"CONFIG_FILE_PATH": config_path}):
+            with pytest.raises(ValueError, match="outside allowed root"):
+                save(traversal, _KEY, {"smtp_host": "x"})
+
+    def test_load_rejects_traversal_path(self, tmp_path):
+        config_path = str(tmp_path / "weftmark_config.json")
+        traversal = str(tmp_path / ".." / "evil.json")
+        with patch.dict(os.environ, {"CONFIG_FILE_PATH": config_path}):
+            with pytest.raises(ValueError, match="outside allowed root"):
+                load(traversal, _KEY)
+
+    def test_save_rejects_path_outside_configured_root(self, tmp_path):
+        config_root = tmp_path / "config"
+        config_path = str(config_root / "weftmark_config.json")
+        other_path = str(tmp_path / "other" / "config.json")
+        with patch.dict(os.environ, {"CONFIG_FILE_PATH": config_path}):
+            with pytest.raises(ValueError, match="outside allowed root"):
+                save(other_path, _KEY, {})
+
+    def test_save_roundtrip_preserves_plain_field(self, tmp_path):
+        config_path = str(tmp_path / "weftmark_config.json")
+        with patch.dict(os.environ, {"CONFIG_FILE_PATH": config_path}):
+            save(config_path, _KEY, {"smtp_host": "mail.example.com"})
+            result = load(config_path, _KEY)
+        assert result["smtp_host"] == "mail.example.com"
+
+    def test_save_removes_field_on_empty_string(self, tmp_path):
+        config_path = str(tmp_path / "weftmark_config.json")
+        with patch.dict(os.environ, {"CONFIG_FILE_PATH": config_path}):
+            save(config_path, _KEY, {"smtp_host": "mail.example.com"})
+            save(config_path, _KEY, {"smtp_host": ""})
+            result = load(config_path, _KEY)
+        assert "smtp_host" not in result


### PR DESCRIPTION
## Summary

Resolves SonarCloud BLOCKER `pythonsecurity:S2083` — path traversal risk in `config_file.save()`.

- `_get_allowed_root()` derives the trusted directory from the `CONFIG_FILE_PATH` env var (same source as `settings.config_file_path`), falling back to `/data`
- `_assert_safe_path()` resolves the incoming path and calls `Path.is_relative_to(allowed_root)` — raises `ValueError` if the path escapes the root
- Applied to both `save()` and `load()` for consistent enforcement
- 7 new tests in `TestAssertSafePath` covering valid paths, `../` traversal, and paths landing outside the configured root directory

## Test plan

- [ ] `pytest tests/services/test_config_file.py` — all 7 tests pass
- [ ] Full CI suite passes
- [ ] SonarCloud `pythonsecurity:S2083` finding resolves on next scan

Closes #880

🤖 Generated with [Claude Code](https://claude.com/claude-code)