### PR TITLE
chore: upgrade deprecated CI actions and add PR path filtering

### DIFF
--- a/.github/workflows/ci-dev-pr.yml
+++ b/.github/workflows/ci-dev-pr.yml
@@ -10,6 +10,10 @@ name: Dev PR
 on:
   pull_request:
     branches: [dev]
+    paths:
+      - "backend/**"
+      - "frontend/**"
+      - ".github/workflows/ci-dev-pr.yml"
 
 concurrency:
   group: dev-pr-${{ github.head_ref }}
@@ -144,14 +148,15 @@ jobs:
           fail_ci_if_error: false
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: backend/junit.xml
           slug: weftmark/weftmark
+          report_type: test_results
       - name: Upload coverage report for SonarCloud
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-report
           path: backend/coverage.xml
@@ -166,15 +171,16 @@ jobs:
         with:
           fetch-depth: 0
       - name: Download coverage report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: coverage-report
           path: backend/
       - name: SonarCloud scan
-        uses: SonarSource/sonarcloud-github-action@v5.0.0
+        uses: SonarSource/sonarqube-scan-action@v5.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io
 
   migration-smoke-test:
     name: Alembic migration smoke test


### PR DESCRIPTION
## Summary

Four CI maintenance issues resolved in a single workflow-only commit.

- **Path filtering** (#886) — `ci-dev-pr.yml` now only fires when `backend/**`, `frontend/**`, or the workflow file itself changes. Docs-only, SBOM, and config-only PRs skip the full ~9-min test suite entirely.
- **Node.js 20 action upgrades** (#883) — `actions/upload-artifact@v4` → `v6` and `actions/download-artifact@v4` → `v6`, consistent with `ci-dev-push.yml` and `ci-main-push.yml`.
- **Codecov test results** (#884) — Replaced deprecated `codecov/test-results-action@v1` with a second `codecov/codecov-action@v5` call using `report_type: test_results`.
- **SonarCloud action** (#872) — Replaced deprecated `SonarSource/sonarcloud-github-action@v5.0.0` with `SonarSource/sonarqube-scan-action@v5.0.0` (drop-in replacement); added required `SONAR_HOST_URL: https://sonarcloud.io`.

## Test plan

- [ ] CI passes on this PR (exercises the new action versions)
- [ ] SonarCloud quality gate result appears as a PR status check
- [ ] Codecov test results appear on the PR
- [ ] No Node.js 20 deprecation annotations in the run

Closes #883, #884, #886, #872

🤖 Generated with [Claude Code](https://claude.com/claude-code)