### PR TITLE
fix: remove false-positive warnings on superuser credentials page

### DIFF
--- a/frontend/src/pages/SuperuserPage.tsx
+++ b/frontend/src/pages/SuperuserPage.tsx
@@ -1753,10 +1753,19 @@ function ConfigSection() {
   if (isLoading) return <p className="text-sm text-muted-foreground">Loading configuration…</p>;
   if (!configState) return null;
 
+  const isZeroTrustEnabled =
+    (fieldMap["cf_zero_trust_enabled"]?.value ?? "").toLowerCase() === "true";
+
   const unpopulatedGroups = Object.entries(GROUP_CONFIG)
     .map(([, { label, fields }]) => ({
       label,
       missing: fields.filter((f) => {
+        // Boolean toggle — false is a valid complete state, never "missing"
+        if (f === "cf_zero_trust_enabled") return false;
+        // Zero Trust credentials only matter when Zero Trust is enabled
+        if ((f === "cf_access_client_id" || f === "cf_access_client_secret") && !isZeroTrustEnabled) return false;
+        // webhook_base_url always falls back to api_url — no warning needed
+        if (f === "webhook_base_url") return false;
         const s = fieldMap[f];
         return s && (CONFIG_SECRET_FIELDS.has(f) ? !s.secret_set : !s.value);
       }),
@@ -1775,7 +1784,7 @@ function ConfigSection() {
 
       {unpopulatedGroups.length > 0 && (
         <div className="rounded-md border border-border bg-muted/40 px-4 py-3 space-y-1.5">
-          <p className="text-xs font-medium">Optional services not fully configured:</p>
+          <p className="text-xs font-medium">Configuration incomplete:</p>
           {unpopulatedGroups.map(({ label, missing }) => (
             <p key={label} className="text-xs text-muted-foreground">
               <span className="font-medium text-foreground">{label}</span>


### PR DESCRIPTION
## Summary

Fixes three misleading entries in the "not fully configured" banner on the Superuser credentials page.

- **`cf_zero_trust_enabled`** — excluded from missing-field check entirely. `false` is a valid complete state — a disabled toggle is not a configuration gap.
- **`cf_access_client_id` / `cf_access_client_secret`** — only flagged as missing when `cf_zero_trust_enabled` is explicitly `true`. If Zero Trust is off, these credentials are intentionally absent.
- **`webhook_base_url`** — excluded from missing-field check. The backend always falls back to `api_url`, so the service is fully operational without it.
- Renamed banner label from "Optional services not fully configured:" → "Configuration incomplete:" — the banner now only appears for genuinely actionable gaps.

## Test plan

- [ ] Superuser credentials page: Zero Trust disabled → no mention of Zero Trust in banner
- [ ] Zero Trust enabled + `cf_access_client_id` / `cf_access_client_secret` missing → banner shows Cloudflare row
- [ ] Zero Trust enabled + both credentials present → no Cloudflare row in banner
- [ ] `webhook_base_url` empty → no banner entry for Clerk Webhook Base URL
- [ ] SMTP / S3 / GitHub with missing fields still appear in banner as before

Closes #876

🤖 Generated with [Claude Code](https://claude.com/claude-code)