### PR TITLE
fix: Ravelry colorways use Basic auth, no OAuth required (#873)

### DIFF
--- a/backend/app/routers/ravelry.py
+++ b/backend/app/routers/ravelry.py
@@ -146,15 +146,11 @@ async def disconnect(
 @router.get("/yarn-detail/{ravelry_yarn_id}")
 async def yarn_detail(
     ravelry_yarn_id: int,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    _current_user: User = Depends(get_current_user),
 ) -> dict:
-    """Proxy a single yarn's full detail from the Ravelry API."""
-    cred = await svc.get_credential(current_user.id, db)
-    if cred is None:
-        raise HTTPException(status_code=404, detail="Not connected to Ravelry")
+    """Proxy a single yarn's full detail from the Ravelry API (no OAuth required)."""
     try:
-        data = await svc.fetch_yarn_detail(ravelry_yarn_id, cred, db)
+        data = await svc.fetch_yarn_detail(ravelry_yarn_id)
     except Exception as exc:
         logger.exception("Ravelry yarn detail fetch failed for yarn %s", ravelry_yarn_id)
         raise HTTPException(status_code=502, detail="Ravelry yarn detail fetch failed") from exc

--- a/backend/app/services/ravelry.py
+++ b/backend/app/services/ravelry.py
@@ -183,19 +183,13 @@ async def save_credential(user_id: uuid.UUID, token_data: dict, db: AsyncSession
 # ---------------------------------------------------------------------------
 
 
-async def fetch_yarn_detail(ravelry_yarn_id: int, cred: RavelryCredential, db: AsyncSession) -> dict:
-    """Fetch full yarn detail from Ravelry including colorways."""
-    token = await _get_valid_token(cred, db)
-    # Use direct HTTP call — the ravelpy model strips the top-level `colorways` key
-    async with httpx.AsyncClient() as client:
-        resp = await client.get(
-            f"{_RAVELRY_API}/yarns/{ravelry_yarn_id}.json",
-            params={"include": "colorways"},
-            headers={"Authorization": f"Bearer {token}"},
-            timeout=15,
-        )
-        resp.raise_for_status()
-        return resp.json()  # type: ignore[no-any-return]
+async def fetch_yarn_detail(ravelry_yarn_id: int) -> dict:
+    """Fetch full yarn detail from Ravelry including colorways.
+
+    Colorways are public product data — Basic auth is sufficient; OAuth is not required.
+    Direct HTTP call used because the ravelpy model strips the top-level `colorways` key.
+    """
+    return await _basic_auth_get(f"/yarns/{ravelry_yarn_id}.json", {"include": "colorways"})
 
 
 async def get_popular_yarn_companies(limit: int = 10) -> list[dict]:

--- a/backend/tests/routers/test_ravelry.py
+++ b/backend/tests/routers/test_ravelry.py
@@ -1,0 +1,62 @@
+"""Tests for the Ravelry router — yarn-detail endpoint and auth guards."""
+
+from unittest.mock import AsyncMock, patch
+
+from httpx import AsyncClient
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_YARN_DETAIL_RESPONSE = {
+    "yarn": {"id": 42, "name": "Cascade 220"},
+    "colorways": [
+        {"id": 1, "name": "Cobalt", "current_status": "active", "photos": []},
+        {"id": 2, "name": "Ruby", "current_status": "active", "photos": []},
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# TestYarnDetail
+# ---------------------------------------------------------------------------
+
+
+class TestYarnDetail:
+    async def test_returns_yarn_data_without_ravelry_credential(self, auth_client: AsyncClient):
+        """Colorway fetch uses Basic auth — no user OAuth credential required."""
+        with patch(
+            "app.services.ravelry.fetch_yarn_detail",
+            new=AsyncMock(return_value=_YARN_DETAIL_RESPONSE),
+        ):
+            resp = await auth_client.get("/api/ravelry/yarn-detail/42")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["yarn"]["id"] == 42
+        assert len(data["colorways"]) == 2
+
+    async def test_returns_colorways_in_response(self, auth_client: AsyncClient):
+        with patch(
+            "app.services.ravelry.fetch_yarn_detail",
+            new=AsyncMock(return_value=_YARN_DETAIL_RESPONSE),
+        ):
+            resp = await auth_client.get("/api/ravelry/yarn-detail/42")
+
+        assert resp.status_code == 200
+        colorways = resp.json()["colorways"]
+        assert colorways[0]["name"] == "Cobalt"
+        assert colorways[1]["name"] == "Ruby"
+
+    async def test_requires_authentication(self, client: AsyncClient):
+        resp = await client.get("/api/ravelry/yarn-detail/42")
+        assert resp.status_code in (401, 403)
+
+    async def test_returns_502_on_ravelry_error(self, auth_client: AsyncClient):
+        with patch(
+            "app.services.ravelry.fetch_yarn_detail",
+            new=AsyncMock(side_effect=RuntimeError("Ravelry down")),
+        ):
+            resp = await auth_client.get("/api/ravelry/yarn-detail/42")
+
+        assert resp.status_code == 502

--- a/backend/tests/routers/test_ravelry.py
+++ b/backend/tests/routers/test_ravelry.py
@@ -1,8 +1,11 @@
-"""Tests for the Ravelry router — yarn-detail endpoint and auth guards."""
+"""Tests for the Ravelry router and service — yarn-detail endpoint and auth guards."""
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from httpx import AsyncClient
+
+from app.services.ravelry import fetch_yarn_detail
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -60,3 +63,38 @@ class TestYarnDetail:
             resp = await auth_client.get("/api/ravelry/yarn-detail/42")
 
         assert resp.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# TestFetchYarnDetailService — service function uses Basic auth
+# ---------------------------------------------------------------------------
+
+
+class TestFetchYarnDetailService:
+    async def test_calls_basic_auth_get_with_colorways_param(self):
+        with patch(
+            "app.services.ravelry._basic_auth_get",
+            new=AsyncMock(return_value=_YARN_DETAIL_RESPONSE),
+        ) as mock_get:
+            result = await fetch_yarn_detail(42)
+
+        mock_get.assert_called_once_with("/yarns/42.json", {"include": "colorways"})
+        assert result == _YARN_DETAIL_RESPONSE
+
+    async def test_returns_response_from_basic_auth_get(self):
+        with patch(
+            "app.services.ravelry._basic_auth_get",
+            new=AsyncMock(return_value=_YARN_DETAIL_RESPONSE),
+        ):
+            result = await fetch_yarn_detail(99)
+
+        assert result["yarn"]["id"] == 42
+        assert len(result["colorways"]) == 2
+
+    async def test_propagates_exception_from_basic_auth_get(self):
+        with patch(
+            "app.services.ravelry._basic_auth_get",
+            new=AsyncMock(side_effect=ValueError("API key not configured")),
+        ):
+            with pytest.raises(ValueError, match="API key not configured"):
+                await fetch_yarn_detail(42)


### PR DESCRIPTION
## Summary

- `fetch_yarn_detail` was using a user OAuth Bearer token to call `/yarns/{id}.json?include=colorways`, which meant colorways only loaded for users with a Ravelry OAuth connection
- Colorway data is public product catalog data — the Ravelry dev read-only key (Basic auth) is sufficient, OAuth is not required
- Switched `fetch_yarn_detail` to use `_basic_auth_get` (same as all other public Ravelry endpoints), removed `cred`/`db` parameters, and removed the credential guard in the router
- Added `tests/routers/test_ravelry.py` covering the happy path, colorway presence, auth guard, and 502 error handling

Closes #873

## Test plan

- [ ] Add a yarn via the Ravelry modal **without** connecting a Ravelry OAuth account — colorway picker should now populate
- [ ] Add a yarn via the Ravelry modal **with** a connected Ravelry account — colorway picker still populates
- [ ] `pytest tests/routers/test_ravelry.py` — 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)