### PR TITLE
feat: link yarn inventory to project color slots (#843)

### DIFF
--- a/backend/alembic/versions/0047_project_yarn_colors.py
+++ b/backend/alembic/versions/0047_project_yarn_colors.py
@@ -42,6 +42,13 @@ def upgrade() -> None:
             server_default=sa.func.now(),
             nullable=False,
         ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
         sa.UniqueConstraint("project_id", "color_hex", name="uq_project_yarn_color"),
     )
 

--- a/backend/alembic/versions/0047_project_yarn_colors.py
+++ b/backend/alembic/versions/0047_project_yarn_colors.py
@@ -1,0 +1,50 @@
+"""Add project_yarn_colors junction table
+
+Revision ID: 0047_project_yarn_colors
+Revises: 0046_yarn_attribute_ids
+Create Date: 2026-05-25
+
+Links yarn inventory entries to project color slots by hex key.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0047_project_yarn_colors"
+down_revision = "0046_yarn_attribute_ids"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "project_yarn_colors",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column(
+            "project_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "yarn_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("yarns.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("color_hex", sa.String(7), nullable=False),
+        sa.Column("use_yarn_photo", sa.Boolean, nullable=False, server_default="false"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("project_id", "color_hex", name="uq_project_yarn_color"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("project_yarn_colors")

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from decimal import Decimal
 
-from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Integer, Numeric, String, Text
+from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Integer, Numeric, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -80,6 +80,9 @@ class Project(Base, TimestampMixin, SoftDeleteMixin):
     photos: Mapped[list["ProjectPhoto"]] = relationship(
         "ProjectPhoto", back_populates="project", order_by="ProjectPhoto.display_order"
     )
+    yarn_colors: Mapped[list["ProjectYarnColor"]] = relationship(
+        "ProjectYarnColor", back_populates="project", order_by="ProjectYarnColor.color_hex"
+    )
 
 
 class ProjectStep(Base, TimestampMixin):
@@ -108,3 +111,21 @@ class WeaveSession(Base, TimestampMixin):
     ended_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     project: Mapped["Project"] = relationship("Project", back_populates="sessions")
+
+
+class ProjectYarnColor(Base, TimestampMixin):
+    __tablename__ = "project_yarn_colors"
+    __table_args__ = (UniqueConstraint("project_id", "color_hex", name="uq_project_yarn_color"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    yarn_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("yarns.id", ondelete="SET NULL"), nullable=True
+    )
+    color_hex: Mapped[str] = mapped_column(String(7), nullable=False)
+    use_yarn_photo: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+
+    project: Mapped["Project"] = relationship("Project", back_populates="yarn_colors")
+    yarn: Mapped["Yarn"] = relationship("Yarn", back_populates="project_yarn_colors")  # type: ignore[name-defined]

--- a/backend/app/models/yarn.py
+++ b/backend/app/models/yarn.py
@@ -73,6 +73,7 @@ class Yarn(Base, TimestampMixin, SoftDeleteMixin):
 
     skeins: Mapped[list["Skein"]] = relationship("Skein", back_populates="yarn", order_by="Skein.created_at")
     owner: Mapped["User"] = relationship("User", foreign_keys=[owner_id])  # type: ignore[name-defined]
+    project_yarn_colors: Mapped[list["ProjectYarnColor"]] = relationship("ProjectYarnColor", back_populates="yarn")  # type: ignore[name-defined]
 
 
 class Skein(Base, TimestampMixin):

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -16,8 +16,9 @@ from sqlalchemy.orm import selectinload
 from app.deps import get_current_user, get_db
 from app.models.draft import Draft
 from app.models.loom import PROJECT_SUPPORTED_LOOM_TYPES, Loom, LoomVersion
-from app.models.project import Project, ProjectPhoto, ProjectStep, WeaveSession
+from app.models.project import Project, ProjectPhoto, ProjectStep, ProjectYarnColor, WeaveSession
 from app.models.user import User
+from app.models.yarn import Yarn
 from app.services import storage, wif_parser
 from app.services.images import resize_to_jpeg, validate_image_format
 from app.services.storage_quota import check_storage_quota
@@ -47,6 +48,21 @@ class ProjectPhotoSchema(BaseModel):
     filename: str
     display_order: int
     created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class ProjectYarnColorSchema(BaseModel):
+    id: uuid.UUID
+    project_id: uuid.UUID
+    yarn_id: uuid.UUID | None
+    color_hex: str
+    use_yarn_photo: bool
+    yarn_brand: str | None = None
+    yarn_name: str | None = None
+    yarn_color_name: str | None = None
+    yarn_color_hex: str | None = None
+    yarn_has_photo: bool = False
 
     model_config = {"from_attributes": True}
 
@@ -110,6 +126,7 @@ class ProjectDetail(ProjectSummary):
     loom_reeds: list[dict] = []
     reed_dents_per_inch: float | None = None
     photos: list[ProjectPhotoSchema] = []
+    yarn_colors: list[ProjectYarnColorSchema] = []
 
 
 class CreateProjectRequest(BaseModel):
@@ -374,6 +391,22 @@ async def _resolve_loom_version(project: Project, db: AsyncSession) -> LoomVersi
     return None
 
 
+def _yarn_color_schema(pyc: ProjectYarnColor) -> ProjectYarnColorSchema:
+    yarn = pyc.yarn
+    return ProjectYarnColorSchema(
+        id=pyc.id,
+        project_id=pyc.project_id,
+        yarn_id=pyc.yarn_id,
+        color_hex=pyc.color_hex,
+        use_yarn_photo=pyc.use_yarn_photo,
+        yarn_brand=yarn.brand if yarn else None,
+        yarn_name=yarn.name if yarn else None,
+        yarn_color_name=yarn.color_name if yarn else None,
+        yarn_color_hex=yarn.color_hex if yarn else None,
+        yarn_has_photo=yarn.photo_path is not None if yarn else False,
+    )
+
+
 def _to_detail(
     project: Project,
     draft: Draft,
@@ -381,6 +414,7 @@ def _to_detail(
     photos: list[ProjectPhoto] | None = None,
     loom_version: LoomVersion | None = None,
     loom_reeds: list[dict] | None = None,
+    yarn_colors: list[ProjectYarnColor] | None = None,
 ) -> ProjectDetail:
     return ProjectDetail(
         id=project.id,
@@ -435,6 +469,7 @@ def _to_detail(
         tags=project.tags or [],
         loom_reeds=loom_reeds or [],
         photos=[ProjectPhotoSchema.model_validate(p) for p in (photos or [])],
+        yarn_colors=[_yarn_color_schema(yc) for yc in (yarn_colors or [])],
     )
 
 
@@ -873,7 +908,10 @@ async def get_project(
     stmt = (
         select(Project)
         .where(Project.id == project_id, Project.deleted_at.is_(None))
-        .options(selectinload(Project.photos))
+        .options(
+            selectinload(Project.photos),
+            selectinload(Project.yarn_colors).selectinload(ProjectYarnColor.yarn),
+        )
     )
     if not current_user.is_superuser:
         stmt = stmt.where(Project.owner_id == current_user.id)
@@ -900,6 +938,7 @@ async def get_project(
         photos=list(project.photos),
         loom_version=loom_version,
         loom_reeds=loom_reeds,
+        yarn_colors=list(project.yarn_colors),
     )
 
 
@@ -1756,6 +1795,120 @@ async def get_shared_project_preview(
         raise HTTPException(status_code=404, detail="Preview not yet generated")
     data = await storage.aread_project_drawdown_preview(project.drawdown_preview_path)
     return Response(content=data, media_type="image/png", headers={"Cache-Control": "public, max-age=300"})
+
+
+# ---------------------------------------------------------------------------
+# Yarn-color linking endpoints
+# ---------------------------------------------------------------------------
+
+
+class LinkYarnColorRequest(BaseModel):
+    yarn_id: uuid.UUID
+    color_hex: str
+    use_yarn_photo: bool = False
+
+
+class PatchYarnColorRequest(BaseModel):
+    use_yarn_photo: bool
+
+
+@router.get("/{project_id}/yarn-colors", response_model=list[ProjectYarnColorSchema])
+async def list_project_yarn_colors(
+    project_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[ProjectYarnColorSchema]:
+    await _get_owned_project(project_id, current_user, db)
+    stmt = (
+        select(ProjectYarnColor)
+        .where(ProjectYarnColor.project_id == project_id)
+        .options(selectinload(ProjectYarnColor.yarn))
+        .order_by(ProjectYarnColor.color_hex)
+    )
+    rows = (await db.scalars(stmt)).all()
+    return [_yarn_color_schema(r) for r in rows]
+
+
+@router.put("/{project_id}/yarn-colors/{color_hex}", response_model=ProjectYarnColorSchema, status_code=200)
+async def link_yarn_color(
+    project_id: uuid.UUID,
+    color_hex: str,
+    body: LinkYarnColorRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ProjectYarnColorSchema:
+    await _get_owned_project(project_id, current_user, db)
+    yarn = await db.scalar(
+        select(Yarn).where(Yarn.id == body.yarn_id, Yarn.owner_id == current_user.id, Yarn.deleted_at.is_(None))
+    )
+    if yarn is None:
+        raise HTTPException(status_code=404, detail="Yarn not found")
+    existing = await db.scalar(
+        select(ProjectYarnColor).where(
+            ProjectYarnColor.project_id == project_id,
+            ProjectYarnColor.color_hex == color_hex,
+        )
+    )
+    if existing is not None:
+        existing.yarn_id = body.yarn_id
+        existing.use_yarn_photo = body.use_yarn_photo
+        await db.commit()
+        await db.refresh(existing)
+        existing.yarn = yarn
+        return _yarn_color_schema(existing)
+    row = ProjectYarnColor(
+        project_id=project_id,
+        yarn_id=body.yarn_id,
+        color_hex=color_hex,
+        use_yarn_photo=body.use_yarn_photo,
+    )
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+    row.yarn = yarn
+    return _yarn_color_schema(row)
+
+
+@router.patch("/{project_id}/yarn-colors/{color_hex}", response_model=ProjectYarnColorSchema)
+async def patch_yarn_color(
+    project_id: uuid.UUID,
+    color_hex: str,
+    body: PatchYarnColorRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ProjectYarnColorSchema:
+    await _get_owned_project(project_id, current_user, db)
+    row = await db.scalar(
+        select(ProjectYarnColor)
+        .where(ProjectYarnColor.project_id == project_id, ProjectYarnColor.color_hex == color_hex)
+        .options(selectinload(ProjectYarnColor.yarn))
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Yarn color assignment not found")
+    row.use_yarn_photo = body.use_yarn_photo
+    await db.commit()
+    await db.refresh(row)
+    return _yarn_color_schema(row)
+
+
+@router.delete("/{project_id}/yarn-colors/{color_hex}", status_code=204)
+async def unlink_yarn_color(
+    project_id: uuid.UUID,
+    color_hex: str,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    await _get_owned_project(project_id, current_user, db)
+    row = await db.scalar(
+        select(ProjectYarnColor).where(
+            ProjectYarnColor.project_id == project_id,
+            ProjectYarnColor.color_hex == color_hex,
+        )
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Yarn color assignment not found")
+    await db.delete(row)
+    await db.commit()
 
 
 @share_router.get("/projects/{slug}/svg")

--- a/backend/app/routers/yarn.py
+++ b/backend/app/routers/yarn.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.deps import get_current_user, get_db
+from app.models.project import ProjectYarnColor
 from app.models.user import User
 from app.models.yarn import Skein, Yarn
 from app.services import storage
@@ -605,3 +606,43 @@ async def clone_yarn(
     await db.commit()
     clone = await _get_owned_yarn(clone.id, current_user, db)
     return YarnDetail.from_yarn(clone)
+
+
+# ---------------------------------------------------------------------------
+# Cross-reference: projects using this yarn
+# ---------------------------------------------------------------------------
+
+
+class YarnProjectRef(BaseModel):
+    project_id: uuid.UUID
+    project_name: str
+    project_status: str
+    color_hex: str
+
+    model_config = {"from_attributes": True}
+
+
+@router.get("/{yarn_id}/projects", response_model=list[YarnProjectRef])
+async def get_yarn_projects(
+    yarn_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[YarnProjectRef]:
+    yarn = await _get_owned_yarn(yarn_id, current_user, db)
+    stmt = (
+        select(ProjectYarnColor)
+        .where(ProjectYarnColor.yarn_id == yarn.id)
+        .options(selectinload(ProjectYarnColor.project))
+        .order_by(ProjectYarnColor.color_hex)
+    )
+    rows = (await db.scalars(stmt)).all()
+    return [
+        YarnProjectRef(
+            project_id=r.project_id,
+            project_name=r.project.name,
+            project_status=r.project.status,
+            color_hex=r.color_hex,
+        )
+        for r in rows
+        if r.project is not None and r.project.deleted_at is None
+    ]

--- a/backend/tests/routers/test_project_yarn_colors.py
+++ b/backend/tests/routers/test_project_yarn_colors.py
@@ -21,6 +21,7 @@ async def _make_draft(db: AsyncSession, owner_id: uuid.UUID) -> Draft:
         name="Test Draft",
         wif_filename="test.wif",
         wif_path="drafts/test/original.wif",
+        drawdown_preview_path="fake/preview.png",
     )
     db.add(draft)
     await db.flush()

--- a/backend/tests/routers/test_project_yarn_colors.py
+++ b/backend/tests/routers/test_project_yarn_colors.py
@@ -1,0 +1,280 @@
+"""Tests for project yarn-color linking endpoints."""
+
+import uuid
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.draft import Draft
+from app.models.project import Project, ProjectYarnColor
+from app.models.user import User
+from app.models.yarn import Yarn
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_draft(db: AsyncSession, owner_id: uuid.UUID) -> Draft:
+    draft = Draft(
+        owner_id=owner_id,
+        name="Test Draft",
+        wif_filename="test.wif",
+        wif_path="drafts/test/original.wif",
+    )
+    db.add(draft)
+    await db.flush()
+    return draft
+
+
+async def _make_project(db: AsyncSession, owner_id: uuid.UUID, draft_id: uuid.UUID) -> Project:
+    project = Project(
+        owner_id=owner_id,
+        draft_id=draft_id,
+        name="Test Project",
+        project_type="treadle",
+        status="created",
+        total_picks=10,
+    )
+    db.add(project)
+    await db.flush()
+    return project
+
+
+async def _make_yarn(db: AsyncSession, owner_id: uuid.UUID, color_hex: str = "#aa3322") -> Yarn:
+    yarn = Yarn(
+        owner_id=owner_id,
+        brand="TestBrand",
+        name="TestYarn",
+        color_hex=color_hex,
+        color_name="rust",
+    )
+    db.add(yarn)
+    await db.flush()
+    return yarn
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/projects/{id}/yarn-colors/{color_hex}
+# ---------------------------------------------------------------------------
+
+
+class TestLinkYarnColor:
+    async def test_link_creates_record(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _make_draft(db_session, test_user.id)
+        project = await _make_project(db_session, test_user.id, draft.id)
+        yarn = await _make_yarn(db_session, test_user.id)
+        await db_session.commit()
+
+        resp = await auth_client.put(
+            f"/api/projects/{project.id}/yarn-colors/%23aa3322",
+            json={"yarn_id": str(yarn.id), "color_hex": "#aa3322"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["yarn_id"] == str(yarn.id)
+        assert data["color_hex"] == "#aa3322"
+        assert data["yarn_name"] == "TestYarn"
+        assert data["yarn_brand"] == "TestBrand"
+
+    async def test_link_updates_existing(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _make_draft(db_session, test_user.id)
+        project = await _make_project(db_session, test_user.id, draft.id)
+        yarn1 = await _make_yarn(db_session, test_user.id, "#111111")
+        yarn2 = await _make_yarn(db_session, test_user.id, "#222222")
+        await db_session.commit()
+
+        await auth_client.put(
+            f"/api/projects/{project.id}/yarn-colors/%23111111",
+            json={"yarn_id": str(yarn1.id), "color_hex": "#111111"},
+        )
+        resp = await auth_client.put(
+            f"/api/projects/{project.id}/yarn-colors/%23111111",
+            json={"yarn_id": str(yarn2.id), "color_hex": "#111111"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["yarn_id"] == str(yarn2.id)
+
+    async def test_link_404_yarn_not_found(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _make_draft(db_session, test_user.id)
+        project = await _make_project(db_session, test_user.id, draft.id)
+        await db_session.commit()
+
+        resp = await auth_client.put(
+            f"/api/projects/{project.id}/yarn-colors/%23ffffff",
+            json={"yarn_id": str(uuid.uuid4()), "color_hex": "#ffffff"},
+        )
+        assert resp.status_code == 404
+
+    async def test_link_404_project_not_found(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        yarn = await _make_yarn(db_session, test_user.id)
+        await db_session.commit()
+
+        resp = await auth_client.put(
+            f"/api/projects/{uuid.uuid4()}/yarn-colors/%23ffffff",
+            json={"yarn_id": str(yarn.id), "color_hex": "#ffffff"},
+        )
+        assert resp.status_code == 404
+
+    async def test_link_rejects_other_users_project(
+        self,
+        auth_client: AsyncClient,
+        db_session: AsyncSession,
+        test_user: User,
+        admin_user: User,
+    ):
+        draft = await _make_draft(db_session, admin_user.id)
+        project = await _make_project(db_session, admin_user.id, draft.id)
+        yarn = await _make_yarn(db_session, test_user.id)
+        await db_session.commit()
+
+        resp = await auth_client.put(
+            f"/api/projects/{project.id}/yarn-colors/%23aa3322",
+            json={"yarn_id": str(yarn.id), "color_hex": "#aa3322"},
+        )
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/projects/{id}/yarn-colors/{color_hex}
+# ---------------------------------------------------------------------------
+
+
+class TestUnlinkYarnColor:
+    async def test_unlink_removes_record(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _make_draft(db_session, test_user.id)
+        project = await _make_project(db_session, test_user.id, draft.id)
+        yarn = await _make_yarn(db_session, test_user.id)
+        pyc = ProjectYarnColor(project_id=project.id, yarn_id=yarn.id, color_hex="#aa3322")
+        db_session.add(pyc)
+        await db_session.commit()
+
+        resp = await auth_client.delete(f"/api/projects/{project.id}/yarn-colors/%23aa3322")
+        assert resp.status_code == 204
+
+        row = await db_session.get(ProjectYarnColor, pyc.id)
+        assert row is None
+
+    async def test_unlink_404_when_not_linked(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _make_draft(db_session, test_user.id)
+        project = await _make_project(db_session, test_user.id, draft.id)
+        await db_session.commit()
+
+        resp = await auth_client.delete(f"/api/projects/{project.id}/yarn-colors/%23ffffff")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /api/projects/{id}/yarn-colors
+# ---------------------------------------------------------------------------
+
+
+class TestListProjectYarnColors:
+    async def test_list_returns_linked_yarn(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _make_draft(db_session, test_user.id)
+        project = await _make_project(db_session, test_user.id, draft.id)
+        yarn = await _make_yarn(db_session, test_user.id)
+        db_session.add(ProjectYarnColor(project_id=project.id, yarn_id=yarn.id, color_hex="#aa3322"))
+        await db_session.commit()
+
+        resp = await auth_client.get(f"/api/projects/{project.id}/yarn-colors")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["color_hex"] == "#aa3322"
+        assert data[0]["yarn_name"] == "TestYarn"
+
+    async def test_list_empty_when_none_linked(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _make_draft(db_session, test_user.id)
+        project = await _make_project(db_session, test_user.id, draft.id)
+        await db_session.commit()
+
+        resp = await auth_client.get(f"/api/projects/{project.id}/yarn-colors")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# GET /api/projects/{id} — yarn_colors inline in ProjectDetail
+# ---------------------------------------------------------------------------
+
+
+class TestProjectDetailIncludesYarnColors:
+    async def test_project_detail_has_yarn_colors_field(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _make_draft(db_session, test_user.id)
+        project = await _make_project(db_session, test_user.id, draft.id)
+        await db_session.commit()
+
+        resp = await auth_client.get(f"/api/projects/{project.id}")
+        assert resp.status_code == 200
+        assert "yarn_colors" in resp.json()
+        assert resp.json()["yarn_colors"] == []
+
+    async def test_project_detail_includes_linked_yarn(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _make_draft(db_session, test_user.id)
+        project = await _make_project(db_session, test_user.id, draft.id)
+        yarn = await _make_yarn(db_session, test_user.id)
+        db_session.add(ProjectYarnColor(project_id=project.id, yarn_id=yarn.id, color_hex="#aa3322"))
+        await db_session.commit()
+
+        resp = await auth_client.get(f"/api/projects/{project.id}")
+        assert resp.status_code == 200
+        yc = resp.json()["yarn_colors"]
+        assert len(yc) == 1
+        assert yc[0]["yarn_brand"] == "TestBrand"
+        assert yc[0]["color_hex"] == "#aa3322"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/yarn/{id}/projects
+# ---------------------------------------------------------------------------
+
+
+class TestGetYarnProjects:
+    async def test_returns_projects_using_yarn(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _make_draft(db_session, test_user.id)
+        project = await _make_project(db_session, test_user.id, draft.id)
+        yarn = await _make_yarn(db_session, test_user.id)
+        db_session.add(ProjectYarnColor(project_id=project.id, yarn_id=yarn.id, color_hex="#aa3322"))
+        await db_session.commit()
+
+        resp = await auth_client.get(f"/api/yarn/{yarn.id}/projects")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["project_name"] == "Test Project"
+        assert data[0]["color_hex"] == "#aa3322"
+
+    async def test_returns_empty_when_not_used(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        yarn = await _make_yarn(db_session, test_user.id)
+        await db_session.commit()
+
+        resp = await auth_client.get(f"/api/yarn/{yarn.id}/projects")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    async def test_404_for_other_users_yarn(
+        self,
+        auth_client: AsyncClient,
+        db_session: AsyncSession,
+        admin_user: User,
+    ):
+        yarn = await _make_yarn(db_session, admin_user.id)
+        await db_session.commit()
+
+        resp = await auth_client.get(f"/api/yarn/{yarn.id}/projects")
+        assert resp.status_code == 404

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -87,6 +87,19 @@ export interface ProjectPhoto {
   created_at: string;
 }
 
+export interface ProjectYarnColor {
+  id: string;
+  project_id: string;
+  yarn_id: string | null;
+  color_hex: string;
+  use_yarn_photo: boolean;
+  yarn_brand: string | null;
+  yarn_name: string | null;
+  yarn_color_name: string | null;
+  yarn_color_hex: string | null;
+  yarn_has_photo: boolean;
+}
+
 export interface WifColor {
   index: number;
   r: number;
@@ -147,6 +160,7 @@ export interface ProjectDetail extends ProjectSummary {
   loom_reeds: { id: string; dents_per_inch: number }[];
   reed_dents_per_inch: number | null;
   photos: ProjectPhoto[];
+  yarn_colors: ProjectYarnColor[];
 }
 
 export interface CreateProjectPayload {
@@ -500,4 +514,23 @@ export function sharedProjectPreviewUrl(slug: string): string {
 
 export function sharedProjectSvgUrl(slug: string): string {
   return `/api/share/projects/${slug}/svg`;
+}
+
+export function linkYarnColor(
+  projectId: string,
+  colorHex: string,
+  yarnId: string,
+  useYarnPhoto = false,
+): Promise<ProjectYarnColor> {
+  return req(`/api/projects/${projectId}/yarn-colors/${encodeURIComponent(colorHex)}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ yarn_id: yarnId, color_hex: colorHex, use_yarn_photo: useYarnPhoto }),
+  });
+}
+
+export function unlinkYarnColor(projectId: string, colorHex: string): Promise<void> {
+  return req(`/api/projects/${projectId}/yarn-colors/${encodeURIComponent(colorHex)}`, {
+    method: "DELETE",
+  });
 }

--- a/frontend/src/api/yarn.ts
+++ b/frontend/src/api/yarn.ts
@@ -258,3 +258,14 @@ export interface YarnAttributeGroup {
 export function getYarnProperties(): Promise<YarnAttributeGroup[]> {
   return req("/api/yarn/properties");
 }
+
+export interface YarnProjectRef {
+  project_id: string;
+  project_name: string;
+  project_status: string;
+  color_hex: string;
+}
+
+export function getYarnProjects(yarnId: string): Promise<YarnProjectRef[]> {
+  return req(`/api/yarn/${yarnId}/projects`);
+}

--- a/frontend/src/components/projects/YarnPickerModal.tsx
+++ b/frontend/src/components/projects/YarnPickerModal.tsx
@@ -1,0 +1,154 @@
+import { useState, useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { listYarn, yarnPhotoUrl, type YarnSummary } from "@/api/yarn";
+import { AppIcons } from "@/lib/icons";
+import { Button } from "@/components/ui/button";
+import { AuthedImage } from "@/components/ui/AuthedImage";
+
+interface Props {
+  colorHex: string;
+  currentYarnId: string | null;
+  onSelect: (yarnId: string) => void;
+  onUnlink: () => void;
+  onClose: () => void;
+  isSaving: boolean;
+}
+
+export function YarnPickerModal({ colorHex, currentYarnId, onSelect, onUnlink, onClose, isSaving }: Props) {
+  const { t } = useTranslation();
+  const [search, setSearch] = useState("");
+
+  const { data: yarns = [], isLoading } = useQuery({
+    queryKey: ["yarn"],
+    queryFn: () => listYarn(false),
+  });
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const q = search.trim().toLowerCase();
+  const filtered: YarnSummary[] = q
+    ? yarns.filter(
+        (y) =>
+          y.brand.toLowerCase().includes(q) ||
+          y.name.toLowerCase().includes(q) ||
+          (y.color_name ?? "").toLowerCase().includes(q) ||
+          (y.color_hex ?? "").toLowerCase().includes(q),
+      )
+    : yarns;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-md rounded-lg border border-border bg-card shadow-lg flex flex-col max-h-[80vh]">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 pt-5 pb-3 border-b border-border">
+          <div className="flex items-center gap-2">
+            <span
+              className="inline-block h-5 w-5 rounded border border-border flex-shrink-0"
+              style={{ background: colorHex }}
+            />
+            <h2 className="text-base font-semibold">{t("yarnPicker.title")}</h2>
+          </div>
+          <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
+            <AppIcons.close className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Search */}
+        <div className="px-4 pt-3 pb-2">
+          <input
+            type="search"
+            className="w-full rounded border border-input bg-background px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+            placeholder={t("yarnPicker.searchPlaceholder")}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            autoFocus
+          />
+        </div>
+
+        {/* List */}
+        <div className="flex-1 overflow-y-auto px-2 pb-2 space-y-0.5">
+          {isLoading && (
+            <p className="text-sm text-muted-foreground text-center py-6">{t("yarnPicker.loading")}</p>
+          )}
+          {!isLoading && filtered.length === 0 && (
+            <p className="text-sm text-muted-foreground text-center py-6">{t("yarnPicker.noResults")}</p>
+          )}
+          {filtered.map((yarn) => {
+            const isCurrent = yarn.id === currentYarnId;
+            return (
+              <button
+                key={yarn.id}
+                className={`w-full flex items-center gap-3 rounded-md px-3 py-2 text-sm text-left transition-colors ${
+                  isCurrent
+                    ? "bg-copper-subtle text-copper-on-subtle"
+                    : "hover:bg-muted"
+                }`}
+                onClick={() => onSelect(yarn.id)}
+                disabled={isSaving}
+              >
+                {/* Yarn photo / color swatch */}
+                <div className="h-8 w-8 rounded border border-border flex-shrink-0 overflow-hidden">
+                  {yarn.has_photo ? (
+                    <AuthedImage
+                      src={yarnPhotoUrl(yarn.id)}
+                      alt=""
+                      className="h-full w-full object-cover"
+                    />
+                  ) : yarn.ravelry_colorway_thumbnail_url ? (
+                    <img
+                      src={yarn.ravelry_colorway_thumbnail_url}
+                      alt=""
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <span
+                      className="block h-full w-full"
+                      style={{ background: yarn.color_hex ?? "#e5e7eb" }}
+                    />
+                  )}
+                </div>
+
+                {/* Name + color */}
+                <div className="flex-1 min-w-0">
+                  <p className="font-medium truncate">
+                    {yarn.brand} — {yarn.name}
+                  </p>
+                  {yarn.color_name && (
+                    <p className="text-xs text-muted-foreground truncate">{yarn.color_name}</p>
+                  )}
+                </div>
+
+                {/* Current badge */}
+                {isCurrent && (
+                  <AppIcons.check className="h-4 w-4 flex-shrink-0 text-accent" />
+                )}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Footer */}
+        {currentYarnId && (
+          <div className="px-4 py-3 border-t border-border">
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full text-muted-foreground"
+              onClick={onUnlink}
+              disabled={isSaving}
+            >
+              {t("yarnPicker.unlink")}
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/projects/YarnPickerModal.tsx
+++ b/frontend/src/components/projects/YarnPickerModal.tsx
@@ -9,7 +9,7 @@ import { AuthedImage } from "@/components/ui/AuthedImage";
 interface Props {
   colorHex: string;
   currentYarnId: string | null;
-  onSelect: (yarnId: string) => void;
+  onSelect: (yarnId: string, yarn: YarnSummary) => void;
   onUnlink: () => void;
   onClose: () => void;
   isSaving: boolean;
@@ -90,7 +90,7 @@ export function YarnPickerModal({ colorHex, currentYarnId, onSelect, onUnlink, o
                     ? "bg-copper-subtle text-copper-on-subtle"
                     : "hover:bg-muted"
                 }`}
-                onClick={() => onSelect(yarn.id)}
+                onClick={() => onSelect(yarn.id, yarn)}
                 disabled={isSaving}
               >
                 {/* Yarn photo / color swatch */}

--- a/frontend/src/lib/icons.ts
+++ b/frontend/src/lib/icons.ts
@@ -5,6 +5,7 @@
 import {
   Activity,
   BookOpen,
+  Check,
   CheckSquare,
   ChevronDown,
   ListChecks,
@@ -96,4 +97,7 @@ export const AppIcons = {
   designLibrary: Layers,
   pickTracking: CheckSquare,
   toolManagement: Wrench,
+
+  // ── Generic ───────────────────────────────────────────────────────────────
+  check: Check,
 } as const;

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -628,7 +628,8 @@
     "linkYarn": "Garn verknüpfen",
     "updateColorFromYarn": "Farbe aus Garn übernehmen?",
     "updateColor": "Übernehmen",
-    "keepColor": "Behalten"
+    "keepColor": "Behalten",
+    "undo": "Rückgängig"
   },
   "projectDetailPage": {
     "loading": "Laden…",

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -618,7 +618,9 @@
     "tieUpNotAvailable": "Tie-up-Daten nicht verfügbar – diese WIF-Datei enthält keinen [TIEUP]-Abschnitt.",
     "tieUpDesc": "Spalten = Tritte · Zeilen = Schäfte · Ausgefüllt = verbunden",
     "viewWeavePlan": "Webplan ansehen",
-    "printSavePdf": "Drucken / Als PDF speichern"
+    "printSavePdf": "Drucken / Als PDF speichern",
+    "yarnCol": "Garn",
+    "linkYarn": "Garn verknüpfen"
   },
   "projectDetailPage": {
     "loading": "Laden…",
@@ -881,7 +883,8 @@
     "colorNamePlaceholder": "z. B. Kaki",
     "colorwayFilter": "Farbvarianten filtern…",
     "noColorways": "Keine Farbvarianten für dieses Garn gefunden.",
-    "colorwayLoadError": "Farbvarianten konnten nicht geladen werden."
+    "colorwayLoadError": "Farbvarianten konnten nicht geladen werden.",
+    "usedInProjects": "Verwendet in Projekten"
   },
   "loomDetailPage": {
     "loading": "Laden…",
@@ -1176,5 +1179,12 @@
     "modeName": "Name",
     "namePlaceholder": "z.B. sage, kobalt...",
     "nameUnknown": "Unbekannter Farbname"
+  },
+  "yarnPicker": {
+    "title": "Garn mit Farbplatz verknüpfen",
+    "searchPlaceholder": "Nach Name, Marke oder Farbe suchen…",
+    "loading": "Wird geladen…",
+    "noResults": "Kein Garn gefunden.",
+    "unlink": "Garnverknüpfung entfernen"
   }
 }

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -625,7 +625,10 @@
     "viewWeavePlan": "Webplan ansehen",
     "printSavePdf": "Drucken / Als PDF speichern",
     "yarnCol": "Garn",
-    "linkYarn": "Garn verknüpfen"
+    "linkYarn": "Garn verknüpfen",
+    "updateColorFromYarn": "Farbe aus Garn übernehmen?",
+    "updateColor": "Übernehmen",
+    "keepColor": "Behalten"
   },
   "projectDetailPage": {
     "loading": "Laden…",

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -476,7 +476,12 @@
     "colWeight": "Gewicht",
     "colFiber": "Faser",
     "colSkeins": "Knäuel",
-    "colAdded": "Hinzugefügt"
+    "colAdded": "Hinzugefügt",
+    "inStash": "Im Stash",
+    "sourceRavelry": "ravelry",
+    "sourceWeftmark": "weftmark",
+    "colSource": "Quelle",
+    "filterInStash": "Im Stash"
   },
   "addYarnModal": {
     "title": "Garn hinzufügen",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -618,7 +618,9 @@
     "tieUpNotAvailable": "Tie-up data not available — this WIF file does not contain a [TIEUP] section.",
     "tieUpDesc": "Columns = treadles · Rows = shafts · Filled = connected",
     "viewWeavePlan": "View Weave Plan",
-    "printSavePdf": "Print / Save PDF"
+    "printSavePdf": "Print / Save PDF",
+    "yarnCol": "Yarn",
+    "linkYarn": "Link yarn"
   },
   "projectDetailPage": {
     "loading": "Loading…",
@@ -881,7 +883,8 @@
     "colorNamePlaceholder": "e.g. Kaki",
     "colorwayFilter": "Filter colorways…",
     "noColorways": "No colorways found for this yarn.",
-    "colorwayLoadError": "Failed to load colorways."
+    "colorwayLoadError": "Failed to load colorways.",
+    "usedInProjects": "Used in projects"
   },
   "loomDetailPage": {
     "loading": "Loading…",
@@ -1176,5 +1179,12 @@
     "modeName": "Name",
     "namePlaceholder": "e.g. sage, cobalt...",
     "nameUnknown": "Unknown color name"
+  },
+  "yarnPicker": {
+    "title": "Link yarn to color slot",
+    "searchPlaceholder": "Search by name, brand, or color…",
+    "loading": "Loading…",
+    "noResults": "No yarn found.",
+    "unlink": "Remove yarn link"
   }
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -628,7 +628,8 @@
     "linkYarn": "Link yarn",
     "updateColorFromYarn": "Update color from yarn?",
     "updateColor": "Update",
-    "keepColor": "Keep"
+    "keepColor": "Keep",
+    "undo": "Undo"
   },
   "projectDetailPage": {
     "loading": "Loading…",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -625,7 +625,10 @@
     "viewWeavePlan": "View Weave Plan",
     "printSavePdf": "Print / Save PDF",
     "yarnCol": "Yarn",
-    "linkYarn": "Link yarn"
+    "linkYarn": "Link yarn",
+    "updateColorFromYarn": "Update color from yarn?",
+    "updateColor": "Update",
+    "keepColor": "Keep"
   },
   "projectDetailPage": {
     "loading": "Loading…",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -476,7 +476,12 @@
     "colWeight": "Weight",
     "colFiber": "Fiber",
     "colSkeins": "Skeins",
-    "colAdded": "Added"
+    "colAdded": "Added",
+    "inStash": "In Stash",
+    "sourceRavelry": "ravelry",
+    "sourceWeftmark": "weftmark",
+    "colSource": "Source",
+    "filterInStash": "In stash"
   },
   "addYarnModal": {
     "title": "Add yarn",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -475,7 +475,12 @@
     "colWeight": "Peso",
     "colFiber": "Fibra",
     "colSkeins": "Madejas",
-    "colAdded": "Añadido"
+    "colAdded": "Añadido",
+    "inStash": "En stash",
+    "sourceRavelry": "ravelry",
+    "sourceWeftmark": "weftmark",
+    "colSource": "Origen",
+    "filterInStash": "En stash"
   },
   "addYarnModal": {
     "title": "Añadir hilo",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -624,7 +624,10 @@
     "viewWeavePlan": "Ver plan de tejido",
     "printSavePdf": "Imprimir / Guardar PDF",
     "yarnCol": "Hilo",
-    "linkYarn": "Vincular hilo"
+    "linkYarn": "Vincular hilo",
+    "updateColorFromYarn": "¿Actualizar color del hilo?",
+    "updateColor": "Actualizar",
+    "keepColor": "Conservar"
   },
   "projectDetailPage": {
     "loading": "Cargando…",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -617,7 +617,9 @@
     "tieUpNotAvailable": "Datos de ligamento no disponibles — este archivo WIF no contiene una sección [TIEUP].",
     "tieUpDesc": "Columnas = pedales · Filas = marcos · Relleno = conectado",
     "viewWeavePlan": "Ver plan de tejido",
-    "printSavePdf": "Imprimir / Guardar PDF"
+    "printSavePdf": "Imprimir / Guardar PDF",
+    "yarnCol": "Hilo",
+    "linkYarn": "Vincular hilo"
   },
   "projectDetailPage": {
     "loading": "Cargando…",
@@ -880,7 +882,8 @@
     "colorNamePlaceholder": "ej. Kaki",
     "colorwayFilter": "Filtrar colorways…",
     "noColorways": "No se encontraron colorways para este hilo.",
-    "colorwayLoadError": "Error al cargar los colorways."
+    "colorwayLoadError": "Error al cargar los colorways.",
+    "usedInProjects": "Usado en proyectos"
   },
   "loomDetailPage": {
     "loading": "Cargando…",
@@ -1175,5 +1178,12 @@
     "modeName": "Nombre",
     "namePlaceholder": "p.ej. salvia, cobalto...",
     "nameUnknown": "Nombre de color desconocido"
+  },
+  "yarnPicker": {
+    "title": "Vincular hilo al color",
+    "searchPlaceholder": "Buscar por nombre, marca o color…",
+    "loading": "Cargando…",
+    "noResults": "No se encontró hilo.",
+    "unlink": "Eliminar vínculo de hilo"
   }
 }

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -627,7 +627,8 @@
     "linkYarn": "Vincular hilo",
     "updateColorFromYarn": "¿Actualizar color del hilo?",
     "updateColor": "Actualizar",
-    "keepColor": "Conservar"
+    "keepColor": "Conservar",
+    "undo": "Deshacer"
   },
   "projectDetailPage": {
     "loading": "Cargando…",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -624,7 +624,10 @@
     "viewWeavePlan": "Voir le plan de tissage",
     "printSavePdf": "Imprimer / Enregistrer en PDF",
     "yarnCol": "Fil",
-    "linkYarn": "Lier un fil"
+    "linkYarn": "Lier un fil",
+    "updateColorFromYarn": "Mettre à jour la couleur depuis le fil ?",
+    "updateColor": "Mettre à jour",
+    "keepColor": "Garder"
   },
   "projectDetailPage": {
     "loading": "Chargement…",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -475,7 +475,12 @@
     "colWeight": "Poids",
     "colFiber": "Fibre",
     "colSkeins": "Écheveaux",
-    "colAdded": "Ajouté"
+    "colAdded": "Ajouté",
+    "inStash": "En stash",
+    "sourceRavelry": "ravelry",
+    "sourceWeftmark": "weftmark",
+    "colSource": "Source",
+    "filterInStash": "En stash"
   },
   "addYarnModal": {
     "title": "Ajouter du fil",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -627,7 +627,8 @@
     "linkYarn": "Lier un fil",
     "updateColorFromYarn": "Mettre à jour la couleur depuis le fil ?",
     "updateColor": "Mettre à jour",
-    "keepColor": "Garder"
+    "keepColor": "Garder",
+    "undo": "Annuler"
   },
   "projectDetailPage": {
     "loading": "Chargement…",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -617,7 +617,9 @@
     "tieUpNotAvailable": "Données d'armure non disponibles — ce fichier WIF ne contient pas de section [TIEUP].",
     "tieUpDesc": "Colonnes = lames · Lignes = cadres · Rempli = connecté",
     "viewWeavePlan": "Voir le plan de tissage",
-    "printSavePdf": "Imprimer / Enregistrer en PDF"
+    "printSavePdf": "Imprimer / Enregistrer en PDF",
+    "yarnCol": "Fil",
+    "linkYarn": "Lier un fil"
   },
   "projectDetailPage": {
     "loading": "Chargement…",
@@ -880,7 +882,8 @@
     "colorNamePlaceholder": "ex. Kaki",
     "colorwayFilter": "Filtrer les coloris…",
     "noColorways": "Aucun coloris trouvé pour ce fil.",
-    "colorwayLoadError": "Impossible de charger les coloris."
+    "colorwayLoadError": "Impossible de charger les coloris.",
+    "usedInProjects": "Utilisé dans des projets"
   },
   "loomDetailPage": {
     "loading": "Chargement…",
@@ -1175,5 +1178,12 @@
     "modeName": "Nom",
     "namePlaceholder": "ex. sauge, cobalt...",
     "nameUnknown": "Nom de couleur inconnu"
+  },
+  "yarnPicker": {
+    "title": "Lier un fil à la couleur",
+    "searchPlaceholder": "Rechercher par nom, marque ou couleur…",
+    "loading": "Chargement…",
+    "noResults": "Aucun fil trouvé.",
+    "unlink": "Supprimer le lien de fil"
   }
 }

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -617,7 +617,9 @@
     "tieUpNotAvailable": "Koppelingsgegevens niet beschikbaar — dit WIF-bestand bevat geen [TIEUP]-sectie.",
     "tieUpDesc": "Kolommen = treden · Rijen = schachten · Gevuld = verbonden",
     "viewWeavePlan": "Weefplan bekijken",
-    "printSavePdf": "Afdrukken / Opslaan als PDF"
+    "printSavePdf": "Afdrukken / Opslaan als PDF",
+    "yarnCol": "Garen",
+    "linkYarn": "Garen koppelen"
   },
   "projectDetailPage": {
     "loading": "Laden…",
@@ -880,7 +882,8 @@
     "colorNamePlaceholder": "bijv. Kaki",
     "colorwayFilter": "Kleurwegen filteren…",
     "noColorways": "Geen kleurwegen gevonden voor dit garen.",
-    "colorwayLoadError": "Kleurwegen konden niet worden geladen."
+    "colorwayLoadError": "Kleurwegen konden niet worden geladen.",
+    "usedInProjects": "Gebruikt in projecten"
   },
   "loomDetailPage": {
     "loading": "Laden…",
@@ -1175,5 +1178,12 @@
     "modeName": "Naam",
     "namePlaceholder": "bijv. salie, kobalt...",
     "nameUnknown": "Onbekende kleurnaam"
+  },
+  "yarnPicker": {
+    "title": "Garen koppelen aan kleurslot",
+    "searchPlaceholder": "Zoek op naam, merk of kleur…",
+    "loading": "Laden…",
+    "noResults": "Geen garen gevonden.",
+    "unlink": "Garenlink verwijderen"
   }
 }

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -475,7 +475,12 @@
     "colWeight": "Gewicht",
     "colFiber": "Vezel",
     "colSkeins": "Strengen",
-    "colAdded": "Toegevoegd"
+    "colAdded": "Toegevoegd",
+    "inStash": "In stash",
+    "sourceRavelry": "ravelry",
+    "sourceWeftmark": "weftmark",
+    "colSource": "Bron",
+    "filterInStash": "In stash"
   },
   "addYarnModal": {
     "title": "Garen toevoegen",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -624,7 +624,10 @@
     "viewWeavePlan": "Weefplan bekijken",
     "printSavePdf": "Afdrukken / Opslaan als PDF",
     "yarnCol": "Garen",
-    "linkYarn": "Garen koppelen"
+    "linkYarn": "Garen koppelen",
+    "updateColorFromYarn": "Kleur overnemen van garen?",
+    "updateColor": "Overnemen",
+    "keepColor": "Behouden"
   },
   "projectDetailPage": {
     "loading": "Laden…",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -627,7 +627,8 @@
     "linkYarn": "Garen koppelen",
     "updateColorFromYarn": "Kleur overnemen van garen?",
     "updateColor": "Overnemen",
-    "keepColor": "Behouden"
+    "keepColor": "Behouden",
+    "undo": "Ongedaan maken"
   },
   "projectDetailPage": {
     "loading": "Laden…",

--- a/frontend/src/pages/ProjectLandingPage.tsx
+++ b/frontend/src/pages/ProjectLandingPage.tsx
@@ -488,6 +488,8 @@ function ColorPaletteSection({
   const [previewOpen, setPreviewOpen] = useState(false);
   const [previewModalOpen, setPreviewModalOpen] = useState(false);
   const [yarnPickerHex, setYarnPickerHex] = useState<string | null>(null);
+  // { slotHex, suggestedHex } — offered after a yarn with a color is linked
+  const [colorOffer, setColorOffer] = useState<{ slotHex: string; suggestedHex: string } | null>(null);
 
   function setReplacement(hex: string, replacement: string) {
     const next = { ...pending };
@@ -565,7 +567,7 @@ function ColorPaletteSection({
               return (
                 <tr key={c.hex} className="border-b border-border last:border-0">
                   <td className="px-3 py-2">
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 flex-wrap">
                       <span
                         className="inline-block h-5 w-5 rounded border border-border flex-shrink-0"
                         style={{ background: displayHex }}
@@ -576,6 +578,31 @@ function ColorPaletteSection({
                           <span className="ml-1 text-accent"> → {pending[c.hex]}</span>
                         )}
                       </span>
+                      {colorOffer?.slotHex === c.hex && (
+                        <div className="flex items-center gap-1.5 rounded border border-border bg-muted/40 px-2 py-1 text-xs">
+                          <span className="text-muted-foreground">{t("projectLandingPage.updateColorFromYarn")}</span>
+                          <span
+                            className="inline-block h-3.5 w-3.5 rounded-sm border border-border flex-shrink-0"
+                            style={{ background: colorOffer.suggestedHex }}
+                          />
+                          <span className="font-mono text-muted-foreground">{colorOffer.suggestedHex}</span>
+                          <button
+                            className="ml-1 rounded px-1.5 py-0.5 bg-accent text-primary-foreground text-[10px] font-medium hover:opacity-90"
+                            onClick={() => {
+                              setReplacement(c.hex, colorOffer.suggestedHex);
+                              setColorOffer(null);
+                            }}
+                          >
+                            {t("projectLandingPage.updateColor")}
+                          </button>
+                          <button
+                            className="rounded px-1.5 py-0.5 text-[10px] text-muted-foreground hover:text-foreground"
+                            onClick={() => setColorOffer(null)}
+                          >
+                            {t("projectLandingPage.keepColor")}
+                          </button>
+                        </div>
+                      )}
                     </div>
                   </td>
                   <td className="px-3 py-2 text-right tabular-nums">
@@ -672,13 +699,20 @@ function ColorPaletteSection({
         <YarnPickerModal
           colorHex={yarnPickerHex}
           currentYarnId={yarnColors.find((yc) => yc.color_hex === yarnPickerHex)?.yarn_id ?? null}
-          onSelect={(yarnId) => {
+          onSelect={(yarnId, yarn) => {
             onYarnLink(yarnPickerHex, yarnId);
             setYarnPickerHex(null);
+            if (
+              yarn.color_hex &&
+              yarn.color_hex.toLowerCase() !== (pending[yarnPickerHex] ?? yarnPickerHex).toLowerCase()
+            ) {
+              setColorOffer({ slotHex: yarnPickerHex, suggestedHex: yarn.color_hex });
+            }
           }}
           onUnlink={() => {
             onYarnUnlink(yarnPickerHex);
             setYarnPickerHex(null);
+            if (colorOffer?.slotHex === yarnPickerHex) setColorOffer(null);
           }}
           onClose={() => setYarnPickerHex(null)}
           isSaving={isYarnSaving}

--- a/frontend/src/pages/ProjectLandingPage.tsx
+++ b/frontend/src/pages/ProjectLandingPage.tsx
@@ -13,6 +13,7 @@ import {
   PROJECT_TYPE_LABELS, PROJECT_STATUS_LABELS,
   type ProjectDetail, type ProjectYarnColor,
 } from "@/api/projects";
+import type { YarnSummary } from "@/api/yarn";
 import { YarnPickerModal } from "@/components/projects/YarnPickerModal";
 import { TagInput } from "@/components/ui/TagInput";
 import { TagChips } from "@/components/ui/TagChips";
@@ -450,9 +451,6 @@ function ColorPaletteSection({
   isSaving,
   locked,
   yarnColors,
-  onYarnLink,
-  onYarnUnlink,
-  isYarnSaving,
 }: {
   projectId: string;
   wifColors: { index: number; hex: string }[];
@@ -460,13 +458,10 @@ function ColorPaletteSection({
   weftStats: { hex: string; count: number; percentage: number }[] | null;
   colorReplacements: Record<string, string> | null;
   warpLengthCm: number | null;
-  onSave: (replacements: Record<string, string>) => void;
+  onSave: (replacements: Record<string, string>, yarnLinks: Record<string, string | null>) => void;
   isSaving: boolean;
   locked?: boolean;
   yarnColors: ProjectYarnColor[];
-  onYarnLink: (colorHex: string, yarnId: string) => void;
-  onYarnUnlink: (colorHex: string) => void;
-  isYarnSaving: boolean;
 }) {
   const { t } = useTranslation();
   const { user } = useAuthContext();
@@ -490,6 +485,8 @@ function ColorPaletteSection({
   const [yarnPickerHex, setYarnPickerHex] = useState<string | null>(null);
   // { slotHex, suggestedHex } — offered after a yarn with a color is linked
   const [colorOffer, setColorOffer] = useState<{ slotHex: string; suggestedHex: string } | null>(null);
+  // Staged yarn link changes — key: colorHex, value: { yarnId, yarn } to link, or null to unlink
+  const [pendingYarnLinks, setPendingYarnLinks] = useState<Record<string, { yarnId: string; yarn: YarnSummary } | null>>({});
 
   function setReplacement(hex: string, replacement: string) {
     const next = { ...pending };
@@ -500,6 +497,13 @@ function ColorPaletteSection({
     }
     setPending(next);
     setDirty(true);
+  }
+
+  function handleUndo() {
+    setPending(colorReplacements ?? {});
+    setPendingYarnLinks({});
+    setDirty(false);
+    setColorOffer(null);
   }
 
   if (visibleColors.length === 0) return null;
@@ -528,14 +532,32 @@ function ColorPaletteSection({
               {t("projectLandingPage.preview")}
             </Button>
           )}
-          {!locked && dirty && (
-            <Button
-              size="sm"
-              onClick={() => { onSave(pending); setDirty(false); }}
-              disabled={isSaving}
-            >
-              {isSaving ? t("projectLandingPage.saving") : t("projectLandingPage.saveColors")}
-            </Button>
+          {!locked && (dirty || Object.keys(pendingYarnLinks).length > 0) && (
+            <>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleUndo}
+                disabled={isSaving}
+              >
+                {t("projectLandingPage.undo")}
+              </Button>
+              <Button
+                size="sm"
+                onClick={() => {
+                  const links: Record<string, string | null> = {};
+                  for (const [hex, entry] of Object.entries(pendingYarnLinks)) {
+                    links[hex] = entry ? entry.yarnId : null;
+                  }
+                  onSave(pending, links);
+                  setDirty(false);
+                  setPendingYarnLinks({});
+                }}
+                disabled={isSaving}
+              >
+                {isSaving ? t("projectLandingPage.saving") : t("projectLandingPage.saveColors")}
+              </Button>
+            </>
           )}
         </div>
       </div>
@@ -633,20 +655,33 @@ function ColorPaletteSection({
                     </td>
                   )}
                   {!locked && (() => {
-                    const linked = yarnColors.find((yc) => yc.color_hex === c.hex);
+                    const hasPending = c.hex in pendingYarnLinks;
+                    const pendingEntry = pendingYarnLinks[c.hex];
+                    const serverLinked = yarnColors.find((yc) => yc.color_hex === c.hex);
+                    const isUnlinkPending = hasPending && pendingEntry === null;
+                    const displayName = hasPending
+                      ? (pendingEntry?.yarn.name ?? null)
+                      : (serverLinked?.yarn_name ?? null);
                     return (
                       <td className="px-3 py-2">
                         <button
-                          className="flex items-center gap-1.5 text-xs rounded px-2 py-1 border border-border hover:bg-muted transition-colors"
+                          className={`flex items-center gap-1.5 text-xs rounded px-2 py-1 border transition-colors ${
+                            hasPending ? "border-accent/60 bg-accent/10 hover:bg-accent/20" : "border-border hover:bg-muted"
+                          }`}
                           onClick={() => setYarnPickerHex(c.hex)}
-                          title={linked ? `${linked.yarn_brand} ${linked.yarn_name}` : t("projectLandingPage.linkYarn")}
+                          title={displayName ?? t("projectLandingPage.linkYarn")}
                         >
                           <AppIcons.yarn className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
-                          {linked ? (
-                            <span className="truncate max-w-[100px] text-card-foreground">{linked.yarn_name}</span>
+                          {isUnlinkPending && serverLinked ? (
+                            <span className="truncate max-w-[100px] text-muted-foreground line-through">{serverLinked.yarn_name}</span>
+                          ) : displayName ? (
+                            <span className={`truncate max-w-[100px] ${hasPending ? "text-accent" : "text-card-foreground"}`}>
+                              {displayName}
+                            </span>
                           ) : (
                             <span className="text-muted-foreground">{t("projectLandingPage.linkYarn")}</span>
                           )}
+                          {hasPending && <span className="text-[10px] text-accent">•</span>}
                         </button>
                       </td>
                     );
@@ -698,24 +733,30 @@ function ColorPaletteSection({
       {yarnPickerHex && (
         <YarnPickerModal
           colorHex={yarnPickerHex}
-          currentYarnId={yarnColors.find((yc) => yc.color_hex === yarnPickerHex)?.yarn_id ?? null}
+          currentYarnId={
+            yarnPickerHex in pendingYarnLinks
+              ? (pendingYarnLinks[yarnPickerHex]?.yarnId ?? null)
+              : (yarnColors.find((yc) => yc.color_hex === yarnPickerHex)?.yarn_id ?? null)
+          }
           onSelect={(yarnId, yarn) => {
-            onYarnLink(yarnPickerHex, yarnId);
+            const slotHex = yarnPickerHex;
+            setPendingYarnLinks((prev) => ({ ...prev, [slotHex]: { yarnId, yarn } }));
             setYarnPickerHex(null);
-            if (
-              yarn.color_hex &&
-              yarn.color_hex.toLowerCase() !== (pending[yarnPickerHex] ?? yarnPickerHex).toLowerCase()
-            ) {
-              setColorOffer({ slotHex: yarnPickerHex, suggestedHex: yarn.color_hex });
+            if (yarn.color_hex && yarn.color_hex.toLowerCase() !== (pending[slotHex] ?? slotHex).toLowerCase()) {
+              setColorOffer({ slotHex, suggestedHex: yarn.color_hex });
+            } else if (colorOffer?.slotHex === slotHex) {
+              setColorOffer(null);
             }
           }}
           onUnlink={() => {
-            onYarnUnlink(yarnPickerHex);
+            const slotHex = yarnPickerHex;
+            setPendingYarnLinks((prev) => ({ ...prev, [slotHex]: null }));
+            setReplacement(slotHex, slotHex);
             setYarnPickerHex(null);
-            if (colorOffer?.slotHex === yarnPickerHex) setColorOffer(null);
+            if (colorOffer?.slotHex === slotHex) setColorOffer(null);
           }}
           onClose={() => setYarnPickerHex(null)}
-          isSaving={isYarnSaving}
+          isSaving={isSaving}
         />
       )}
     </section>
@@ -1268,20 +1309,20 @@ export function ProjectLandingPage() {
     enabled: !!id,
   });
 
-  const colorMutation = useMutation({
-    mutationFn: (replacements: Record<string, string>) =>
-      setProjectColorReplacements(id!, replacements),
-    onSuccess: (updated) => qc.setQueryData(["project", id], updated),
-  });
-
-  const yarnLinkMutation = useMutation({
-    mutationFn: ({ colorHex, yarnId }: { colorHex: string; yarnId: string }) =>
-      linkYarnColor(id!, colorHex, yarnId),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["project", id] }),
-  });
-
-  const yarnUnlinkMutation = useMutation({
-    mutationFn: (colorHex: string) => unlinkYarnColor(id!, colorHex),
+  const saveMutation = useMutation({
+    mutationFn: async ({
+      replacements,
+      yarnLinks,
+    }: {
+      replacements: Record<string, string>;
+      yarnLinks: Record<string, string | null>;
+    }) => {
+      const calls: Promise<unknown>[] = [setProjectColorReplacements(id!, replacements)];
+      for (const [colorHex, yarnId] of Object.entries(yarnLinks)) {
+        calls.push(yarnId !== null ? linkYarnColor(id!, colorHex, yarnId) : unlinkYarnColor(id!, colorHex));
+      }
+      await Promise.all(calls);
+    },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["project", id] }),
   });
 
@@ -1583,13 +1624,10 @@ export function ProjectLandingPage() {
           weftStats={project.draft_weft_color_stats}
           colorReplacements={project.color_replacements}
           warpLengthCm={warpLengthCm}
-          onSave={(r) => colorMutation.mutate(r)}
-          isSaving={colorMutation.isPending}
+          onSave={(r, links) => saveMutation.mutate({ replacements: r, yarnLinks: links })}
+          isSaving={saveMutation.isPending}
           locked={project.status !== "created"}
           yarnColors={project.yarn_colors ?? []}
-          onYarnLink={(colorHex, yarnId) => yarnLinkMutation.mutate({ colorHex, yarnId })}
-          onYarnUnlink={(colorHex) => yarnUnlinkMutation.mutate(colorHex)}
-          isYarnSaving={yarnLinkMutation.isPending || yarnUnlinkMutation.isPending}
         />
       )}
 

--- a/frontend/src/pages/ProjectLandingPage.tsx
+++ b/frontend/src/pages/ProjectLandingPage.tsx
@@ -9,9 +9,11 @@ import {
   getProject, setProjectColorReplacements, deleteProject, updateProjectNotes,
   updateProjectWarpSetup, drawdownSvgUrl, drawdownPreviewUrl, projectDrawdownSvgUrl,
   getWarpingPlan, completeProject, abandonProject, setProjectReed, updateProjectTags,
+  linkYarnColor, unlinkYarnColor,
   PROJECT_TYPE_LABELS, PROJECT_STATUS_LABELS,
-  type ProjectDetail,
+  type ProjectDetail, type ProjectYarnColor,
 } from "@/api/projects";
+import { YarnPickerModal } from "@/components/projects/YarnPickerModal";
 import { TagInput } from "@/components/ui/TagInput";
 import { TagChips } from "@/components/ui/TagChips";
 import { getReedRecommendation, buildDentPattern, nearestCleanDent } from "@/lib/reedRecommendation";
@@ -447,6 +449,10 @@ function ColorPaletteSection({
   onSave,
   isSaving,
   locked,
+  yarnColors,
+  onYarnLink,
+  onYarnUnlink,
+  isYarnSaving,
 }: {
   projectId: string;
   wifColors: { index: number; hex: string }[];
@@ -457,6 +463,10 @@ function ColorPaletteSection({
   onSave: (replacements: Record<string, string>) => void;
   isSaving: boolean;
   locked?: boolean;
+  yarnColors: ProjectYarnColor[];
+  onYarnLink: (colorHex: string, yarnId: string) => void;
+  onYarnUnlink: (colorHex: string) => void;
+  isYarnSaving: boolean;
 }) {
   const { t } = useTranslation();
   const { user } = useAuthContext();
@@ -477,6 +487,7 @@ function ColorPaletteSection({
   const [dirty, setDirty] = useState(false);
   const [previewOpen, setPreviewOpen] = useState(false);
   const [previewModalOpen, setPreviewModalOpen] = useState(false);
+  const [yarnPickerHex, setYarnPickerHex] = useState<string | null>(null);
 
   function setReplacement(hex: string, replacement: string) {
     const next = { ...pending };
@@ -538,6 +549,7 @@ function ColorPaletteSection({
                 <th className="px-3 py-2 text-right">{t("projectLandingPage.estWeftLength")}</th>
               )}
               {!locked && <th className="px-3 py-2 text-left">{t("projectLandingPage.replaceWith")}</th>}
+              {!locked && <th className="px-3 py-2 text-left">{t("projectLandingPage.yarnCol")}</th>}
             </tr>
           </thead>
           <tbody>
@@ -593,6 +605,25 @@ function ColorPaletteSection({
                       </div>
                     </td>
                   )}
+                  {!locked && (() => {
+                    const linked = yarnColors.find((yc) => yc.color_hex === c.hex);
+                    return (
+                      <td className="px-3 py-2">
+                        <button
+                          className="flex items-center gap-1.5 text-xs rounded px-2 py-1 border border-border hover:bg-muted transition-colors"
+                          onClick={() => setYarnPickerHex(c.hex)}
+                          title={linked ? `${linked.yarn_brand} ${linked.yarn_name}` : t("projectLandingPage.linkYarn")}
+                        >
+                          <AppIcons.yarn className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+                          {linked ? (
+                            <span className="truncate max-w-[100px] text-card-foreground">{linked.yarn_name}</span>
+                          ) : (
+                            <span className="text-muted-foreground">{t("projectLandingPage.linkYarn")}</span>
+                          )}
+                        </button>
+                      </td>
+                    );
+                  })()}
                 </tr>
               );
             })}
@@ -634,6 +665,23 @@ function ColorPaletteSection({
         <DrawdownModal
           svgUrl={drawdownSvgUrl(projectId, 8, pending)}
           onClose={() => setPreviewModalOpen(false)}
+        />
+      )}
+
+      {yarnPickerHex && (
+        <YarnPickerModal
+          colorHex={yarnPickerHex}
+          currentYarnId={yarnColors.find((yc) => yc.color_hex === yarnPickerHex)?.yarn_id ?? null}
+          onSelect={(yarnId) => {
+            onYarnLink(yarnPickerHex, yarnId);
+            setYarnPickerHex(null);
+          }}
+          onUnlink={() => {
+            onYarnUnlink(yarnPickerHex);
+            setYarnPickerHex(null);
+          }}
+          onClose={() => setYarnPickerHex(null)}
+          isSaving={isYarnSaving}
         />
       )}
     </section>
@@ -1192,6 +1240,17 @@ export function ProjectLandingPage() {
     onSuccess: (updated) => qc.setQueryData(["project", id], updated),
   });
 
+  const yarnLinkMutation = useMutation({
+    mutationFn: ({ colorHex, yarnId }: { colorHex: string; yarnId: string }) =>
+      linkYarnColor(id!, colorHex, yarnId),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["project", id] }),
+  });
+
+  const yarnUnlinkMutation = useMutation({
+    mutationFn: (colorHex: string) => unlinkYarnColor(id!, colorHex),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["project", id] }),
+  });
+
   const tagsMutation = useMutation({
     mutationFn: (tags: string[]) => updateProjectTags(id!, tags),
     onSuccess: (updated) => {
@@ -1493,6 +1552,10 @@ export function ProjectLandingPage() {
           onSave={(r) => colorMutation.mutate(r)}
           isSaving={colorMutation.isPending}
           locked={project.status !== "created"}
+          yarnColors={project.yarn_colors ?? []}
+          onYarnLink={(colorHex, yarnId) => yarnLinkMutation.mutate({ colorHex, yarnId })}
+          onYarnUnlink={(colorHex) => yarnUnlinkMutation.mutate(colorHex)}
+          isYarnSaving={yarnLinkMutation.isPending || yarnUnlinkMutation.isPending}
         />
       )}
 

--- a/frontend/src/pages/YarnDetailPage.tsx
+++ b/frontend/src/pages/YarnDetailPage.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams, Link } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { getYarn, updateYarn, patchYarnColorway } from "@/api/yarn";
+import { getYarn, updateYarn, patchYarnColorway, getYarnProjects, type YarnProjectRef } from "@/api/yarn";
 import { getRavelryYarnDetail, type RavelryColorway, type RavelryYarnApiDetail } from "@/api/ravelry";
 import { Button } from "@/components/ui/button";
 import { ColorPicker } from "@/components/ui/ColorPicker";
@@ -375,6 +375,12 @@ export function YarnDetailPage() {
     enabled: !!id,
   });
 
+  const { data: yarnProjects = [] } = useQuery<YarnProjectRef[]>({
+    queryKey: ["yarn-projects", id],
+    queryFn: () => getYarnProjects(id!),
+    enabled: !!id,
+  });
+
   const { data: ravelryYarnResp } = useQuery({
     queryKey: ["ravelry-yarn-detail", yarn?.ravelry_yarn_id],
     queryFn: async () => {
@@ -579,6 +585,30 @@ export function YarnDetailPage() {
         <section className="rounded-lg border border-border bg-card p-4 space-y-2">
           <h2 className="text-sm font-medium text-card-foreground">{t("yarnDetailPage.notes")}</h2>
           <p className="text-sm text-muted-foreground whitespace-pre-wrap">{yarn.notes}</p>
+        </section>
+      )}
+
+      {/* Used in projects */}
+      {yarnProjects.length > 0 && (
+        <section className="rounded-lg border border-border bg-card p-4 space-y-3">
+          <h2 className="text-sm font-medium text-card-foreground">{t("yarnDetailPage.usedInProjects")}</h2>
+          <ul className="space-y-1.5">
+            {yarnProjects.map((ref) => (
+              <li key={`${ref.project_id}-${ref.color_hex}`}>
+                <Link
+                  to={`/projects/${ref.project_id}`}
+                  className="flex items-center gap-2 text-sm hover:underline text-card-foreground"
+                >
+                  <span
+                    className="inline-block h-4 w-4 rounded border border-border flex-shrink-0"
+                    style={{ background: ref.color_hex }}
+                  />
+                  <span>{ref.project_name}</span>
+                  <span className="text-xs text-muted-foreground">({ref.project_status})</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
         </section>
       )}
 

--- a/frontend/src/pages/YarnPage.tsx
+++ b/frontend/src/pages/YarnPage.tsx
@@ -188,11 +188,16 @@ function YarnCard({ yarn }: { yarn: YarnSummary }) {
           <p className="text-xs text-muted-foreground">{yarn.unit_yardage} {t("yarnPage.yardsPerUnit")}</p>
         )}
       </div>
-      {yarn.ravelry_stash_id !== null && !yarn.out_of_stash && (
-        <span className="absolute bottom-2 right-3 rounded px-1.5 py-0.5 text-[10px] bg-accent/10 text-accent">
-          {t("yarnPage.inRavelryStash")}
+      <div className="absolute bottom-2 right-2 flex gap-1">
+        {yarn.ravelry_stash_id !== null && !yarn.out_of_stash && (
+          <span className="rounded px-1.5 py-0.5 text-[10px] bg-accent/10 text-accent">
+            {t("yarnPage.inStash")}
+          </span>
+        )}
+        <span className="rounded px-1.5 py-0.5 text-[10px] bg-muted text-muted-foreground">
+          {yarn.ravelry_yarn_id ? t("yarnPage.sourceRavelry") : t("yarnPage.sourceWeftmark")}
         </span>
-      )}
+      </div>
     </Link>
   );
 }
@@ -217,9 +222,19 @@ function YarnGridTile({ yarn }: { yarn: YarnSummary }) {
           {skeinLabel}
         </span>
       </div>
-      <div className="p-2">
+      <div className="p-2 space-y-1">
         <p className="text-xs font-medium truncate">{yarn.brand}</p>
         <p className="text-xs text-muted-foreground truncate">{yarn.name}</p>
+        <div className="flex flex-wrap gap-1">
+          {yarn.ravelry_stash_id !== null && !yarn.out_of_stash && (
+            <span className="rounded px-1 py-0.5 text-[9px] bg-accent/10 text-accent leading-none">
+              {t("yarnPage.inStash")}
+            </span>
+          )}
+          <span className="rounded px-1 py-0.5 text-[9px] bg-muted text-muted-foreground leading-none">
+            {yarn.ravelry_yarn_id ? t("yarnPage.sourceRavelry") : t("yarnPage.sourceWeftmark")}
+          </span>
+        </div>
       </div>
     </Link>
   );
@@ -282,6 +297,9 @@ function YarnTable({
             <th className="px-3 py-2 text-left hidden lg:table-cell text-xs font-medium text-muted-foreground">
               {t("yarnPage.colFiber")}
             </th>
+            <th className="px-3 py-2 text-left hidden sm:table-cell text-xs font-medium text-muted-foreground">
+              {t("yarnPage.colSource")}
+            </th>
             <th className="px-3 py-2 text-right text-xs font-medium text-muted-foreground">
               {t("yarnPage.colSkeins")}
             </th>
@@ -321,6 +339,18 @@ function YarnTable({
               </td>
               <td className="px-3 py-2 text-muted-foreground text-xs hidden lg:table-cell max-w-[120px]">
                 <span className="truncate block">{yarn.fiber_content ?? "—"}</span>
+              </td>
+              <td className="px-3 py-2 hidden sm:table-cell">
+                <div className="flex flex-wrap gap-1">
+                  {yarn.ravelry_stash_id !== null && !yarn.out_of_stash && (
+                    <span className="rounded px-1.5 py-0.5 text-[10px] bg-accent/10 text-accent leading-none whitespace-nowrap">
+                      {t("yarnPage.inStash")}
+                    </span>
+                  )}
+                  <span className="rounded px-1.5 py-0.5 text-[10px] bg-muted text-muted-foreground leading-none whitespace-nowrap">
+                    {yarn.ravelry_yarn_id ? t("yarnPage.sourceRavelry") : t("yarnPage.sourceWeftmark")}
+                  </span>
+                </div>
               </td>
               <td className="px-3 py-2 text-right text-xs">{yarn.skein_count}</td>
               <td className="px-3 py-2 text-muted-foreground text-xs hidden md:table-cell whitespace-nowrap">
@@ -429,7 +459,7 @@ function FilterPopover({
                 onChange={(e) => onChange({ ...filters, inRavelryStash: e.target.checked })}
                 className="rounded accent-accent"
               />
-              {t("yarnPage.filterInRavelryStash")}
+              {t("yarnPage.filterInStash")}
             </label>
             <label className="flex items-center gap-2 text-xs cursor-pointer">
               <input


### PR DESCRIPTION
## Summary

- Adds `project_yarn_colors` junction table linking yarn entries to project color slots (by original hex key)
- Per-slot "Link yarn" button appears in the color palette editor for each WIF color; clicking opens `YarnPickerModal` with search by name/brand/color
- `YarnDetailPage` shows a "Used in projects" section listing all projects that have linked this yarn to a color slot
- `ProjectDetail` response now includes inline `yarn_colors` list (no extra fetch needed)
- `frontend/.dockerignore` added to fix a build context symlink crash from `@codecov/bundler-plugin-core` (was blocking Docker builds)
- Rendering integration (`use_yarn_photo` flag acting on tile pipeline) deferred to a follow-up issue

## Key decisions

- **Hex string keys** (not integer indices) to match the existing `color_replacements` JSONB architecture
- `UNIQUE(project_id, color_hex)` — one yarn per color slot; PUT is upsert
- `ON DELETE SET NULL` on yarn FK — yarn deletion unlinks the slot but doesn't remove the row
- `ON DELETE CASCADE` on project FK — deleting a project removes all its yarn-color rows
- **No proximity filtering** in the yarn picker — show all yarn with free-text search
- `use_yarn_photo` stored but not acted on in rendering (flag is ready for the follow-up)

## Test plan

- [ ] Open a project with a WIF that has colors — verify "Yarn" column appears in color palette table
- [ ] Click a "Link yarn" button — verify `YarnPickerModal` opens showing inventory
- [ ] Search by name/brand/color — verify results filter correctly
- [ ] Select a yarn — verify button updates to show yarn name, modal closes
- [ ] Click the linked yarn button again — verify current yarn is highlighted with checkmark
- [ ] Click "Remove yarn link" — verify slot reverts to unlinked state
- [ ] Navigate to a linked yarn's detail page — verify "Used in projects" section appears with the project listed
- [ ] Click the project link — verify navigation to the correct project landing page
- [ ] Run `pytest backend/tests/routers/test_project_yarn_colors.py` — all 16 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)