### PR TITLE
fix: add feat/* to ci-feature.yml branch trigger pattern

### DIFF
--- a/.github/workflows/ci-feature.yml
+++ b/.github/workflows/ci-feature.yml
@@ -1,13 +1,13 @@
 name: Feature CI
 
-# Runs on every push to feature/* and fix/* branches.
+# Runs on every push to feature/*, feat/*, and fix/* branches.
 # Provides fast lint/typecheck feedback before a PR is opened.
 # Full test suite runs when the PR is opened (ci-dev-pr.yml).
 # Hotfix branches use ci-hotfix.yml (full suite) because they target main directly.
 
 on:
   push:
-    branches: ["feature/*", "fix/*"]
+    branches: ["feature/*", "feat/*", "fix/*"]
 
 concurrency:
   group: feature-${{ github.ref }}


### PR DESCRIPTION
## Summary

- `feat/*` branches were silently skipped by CI — only `feature/*` and `fix/*` were matched
- Discovered when PR #918 (`feat/publish-error-container`) received no CI runs at all
- Adds `feat/*` to the push trigger alongside the existing patterns

## Test plan

- [ ] CI fires on the next push to any `feat/*` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)