### PR TITLE
fix: error container workflow — tag input clarity and bare :latest for prod

### DIFF
--- a/.github/workflows/publish-error-container.yml
+++ b/.github/workflows/publish-error-container.yml
@@ -92,6 +92,16 @@ jobs:
           severity: CRITICAL
           ignore-unfixed: false
 
+      - name: Compute image tags
+        id: tags
+        run: |
+          TAGS="ghcr.io/weftmark/weftmark-errors:${{ inputs.environment }}-${{ inputs.tag }}"
+          TAGS="${TAGS},ghcr.io/weftmark/weftmark-errors:${{ inputs.environment }}-latest"
+          if [[ "${{ inputs.environment }}" == "prod" ]]; then
+            TAGS="${TAGS},ghcr.io/weftmark/weftmark-errors:latest"
+          fi
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push (multi-platform)
         id: push
         uses: docker/build-push-action@v6
@@ -100,9 +110,7 @@ jobs:
           file: errors/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ghcr.io/weftmark/weftmark-errors:${{ inputs.environment }}-${{ inputs.tag }}
-            ghcr.io/weftmark/weftmark-errors:${{ inputs.environment }}-latest
+          tags: ${{ steps.tags.outputs.tags }}
 
   summary:
     name: Job summary
@@ -120,5 +128,8 @@ jobs:
           echo "| **Tag** | \`${{ inputs.tag }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **Images pushed** | \`ghcr.io/weftmark/weftmark-errors:${{ inputs.environment }}-${{ inputs.tag }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| | \`ghcr.io/weftmark/weftmark-errors:${{ inputs.environment }}-latest\` |" >> "$GITHUB_STEP_SUMMARY"
+          if [[ "${{ inputs.environment }}" == "prod" ]]; then
+            echo "| | \`ghcr.io/weftmark/weftmark-errors:latest\` |" >> "$GITHUB_STEP_SUMMARY"
+          fi
           echo "| **Digest** | \`${{ needs.build-scan-push.outputs.digest }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **Trivy scan** | ✅ No critical CVEs found |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-error-container.yml
+++ b/.github/workflows/publish-error-container.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Image tag to publish (e.g. 1.2.0, latest)"
+        description: "Version tag for this image (e.g. 1.2.0). The <env>-latest tag is always pushed automatically alongside this."
         type: string
         required: true
       environment:


### PR DESCRIPTION
## Summary

Two fixes to the publish-error-container workflow merged in #920:

- **Tag input description** — previous wording `e.g. 1.2.0, latest` implied comma-separated values were accepted; clarified that `tag` is a single version string and `<env>-latest` is always pushed automatically
- **Bare `:latest` for prod publishes** — the compose file pulls `weftmark-errors:latest` (no env prefix); the workflow was only pushing `prod-latest`, so a manual prod publish never updated the tag the server actually uses; now computes the tag list in a shell step and adds `ghcr.io/weftmark/weftmark-errors:latest` when `environment=prod`

## Test plan

- [ ] CI passes
- [ ] Workflow input field reads the updated description
- [ ] `dev` publish pushes `dev-<tag>` and `dev-latest` only
- [ ] `prod` publish pushes `prod-<tag>`, `prod-latest`, and `latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)