### PR TITLE
fix: replace deprecated Clerk afterSignInUrl/afterSignUpUrl props

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -86,7 +86,7 @@ export default function App() {
   }
 
   return (
-    <ClerkProvider publishableKey={clerkPublishableKey} afterSignInUrl="/home" afterSignUpUrl="/pending" afterSignOutUrl="/sign-out">
+    <ClerkProvider publishableKey={clerkPublishableKey} signInFallbackRedirectUrl="/home" signUpFallbackRedirectUrl="/pending" afterSignOutUrl="/sign-out">
       <VersionGate>
         <SystemGate>
         <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## Summary

Closes #922

Replaces two deprecated Clerk v5 props on `ClerkProvider` in [App.tsx](frontend/src/App.tsx):

| Old | New |
|---|---|
| `afterSignInUrl="/home"` | `signInFallbackRedirectUrl="/home"` |
| `afterSignUpUrl="/pending"` | `signUpFallbackRedirectUrl="/pending"` |

`afterSignOutUrl` is unchanged — not deprecated in Clerk v5.

Both replacements use the `fallbackRedirectUrl` variant (not `forceRedirectUrl`) since the intent is "go here after sign-in/sign-up unless Clerk already has another redirect target."

## Test plan

- [ ] CI passes (ESLint + tsc already clean locally)
- [ ] Sign in on dev → redirects to `/home`
- [ ] Sign up on dev → redirects to `/pending`
- [ ] No Clerk deprecation warning in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)