### PR TITLE
feat: add eyedropper tool to color picker

### DIFF
--- a/frontend/src/components/ui/ColorPicker.tsx
+++ b/frontend/src/components/ui/ColorPicker.tsx
@@ -2,6 +2,13 @@ import { useState, useRef, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { HexColorPicker } from "react-colorful";
 import { useTranslation } from "react-i18next";
+import { Pipette } from "lucide-react";
+
+declare global {
+  interface Window {
+    EyeDropper?: new () => { open: () => Promise<{ sRGBHex: string }> };
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Conversion utilities
@@ -270,6 +277,21 @@ export function ColorPicker({ value, onChange, size = "md", className }: ColorPi
     }
   }
 
+  const eyedropperSupported = "EyeDropper" in window;
+
+  async function handleEyedropper() {
+    try {
+      const result = await new window.EyeDropper!().open();
+      const hex = result.sRGBHex.toLowerCase();
+      syncAllInputs(hex);
+      onChange(hex);
+      setNameInput("");
+      setNameError(false);
+    } catch {
+      // User cancelled or browser error — ignore
+    }
+  }
+
   const swatchClass =
     size === "sm"
       ? "h-6 w-10 rounded border border-input cursor-pointer p-0.5"
@@ -322,22 +344,35 @@ export function ColorPicker({ value, onChange, size = "md", className }: ColorPi
         >
           <HexColorPicker color={value} onChange={handleWheelChange} />
 
-          {/* Mode tab strip */}
-          <div className="flex gap-0.5">
-            {modes.map(({ key, label }) => (
+          {/* Mode tab strip + eyedropper */}
+          <div className="flex items-center gap-1">
+            <div className="flex gap-0.5 flex-1">
+              {modes.map(({ key, label }) => (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => setMode(key)}
+                  className={`flex-1 rounded px-1 py-0.5 text-xs font-medium transition-colors ${
+                    mode === key
+                      ? "bg-muted text-card-foreground"
+                      : "text-muted-foreground hover:text-card-foreground"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+            {eyedropperSupported && (
               <button
-                key={key}
                 type="button"
-                onClick={() => setMode(key)}
-                className={`flex-1 rounded px-1 py-0.5 text-xs font-medium transition-colors ${
-                  mode === key
-                    ? "bg-muted text-card-foreground"
-                    : "text-muted-foreground hover:text-card-foreground"
-                }`}
+                title={t("colorPicker.eyedropperTooltip")}
+                aria-label={t("colorPicker.eyedropperTooltip")}
+                onClick={handleEyedropper}
+                className="rounded p-0.5 text-muted-foreground hover:text-card-foreground hover:bg-muted transition-colors"
               >
-                {label}
+                <Pipette size={12} />
               </button>
-            ))}
+            )}
           </div>
 
           {/* Hex input */}

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -1187,7 +1187,8 @@
     "modeHsl": "HSL",
     "modeName": "Name",
     "namePlaceholder": "z.B. sage, kobalt...",
-    "nameUnknown": "Unbekannter Farbname"
+    "nameUnknown": "Unbekannter Farbname",
+    "eyedropperTooltip": "Farbe vom Bildschirm aufnehmen"
   },
   "yarnPicker": {
     "title": "Garn mit Farbplatz verknüpfen",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1187,7 +1187,8 @@
     "modeHsl": "HSL",
     "modeName": "Name",
     "namePlaceholder": "e.g. sage, cobalt...",
-    "nameUnknown": "Unknown color name"
+    "nameUnknown": "Unknown color name",
+    "eyedropperTooltip": "Pick color from screen"
   },
   "yarnPicker": {
     "title": "Link yarn to color slot",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -1186,7 +1186,8 @@
     "modeHsl": "HSL",
     "modeName": "Nombre",
     "namePlaceholder": "p.ej. salvia, cobalto...",
-    "nameUnknown": "Nombre de color desconocido"
+    "nameUnknown": "Nombre de color desconocido",
+    "eyedropperTooltip": "Seleccionar color de la pantalla"
   },
   "yarnPicker": {
     "title": "Vincular hilo al color",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -1186,7 +1186,8 @@
     "modeHsl": "HSL",
     "modeName": "Nom",
     "namePlaceholder": "ex. sauge, cobalt...",
-    "nameUnknown": "Nom de couleur inconnu"
+    "nameUnknown": "Nom de couleur inconnu",
+    "eyedropperTooltip": "Choisir une couleur à l'écran"
   },
   "yarnPicker": {
     "title": "Lier un fil à la couleur",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -1186,7 +1186,8 @@
     "modeHsl": "HSL",
     "modeName": "Naam",
     "namePlaceholder": "bijv. salie, kobalt...",
-    "nameUnknown": "Onbekende kleurnaam"
+    "nameUnknown": "Onbekende kleurnaam",
+    "eyedropperTooltip": "Kleur van scherm kiezen"
   },
   "yarnPicker": {
     "title": "Garen koppelen aan kleurslot",


### PR DESCRIPTION
## Summary
- Adds a `Pipette` icon button to the right of the mode tab strip inside the `ColorPicker` popover
- Uses the native `EyeDropper` API (`await new EyeDropper().open()`) to sample any pixel on screen
- Feature-detected at render time — button is hidden entirely on unsupported browsers (Firefox, Safari); no degraded state to manage
- Closes #914

## Notes
- Requires a secure context (HTTPS or localhost); plain HTTP on a custom hostname will hide the button
- Firefox support is blocked on browser implementation, not something fixable in app code
- i18n: `colorPicker.eyedropperTooltip` added to all 5 locales (en, de, fr, es, nl)

## Test plan
- [ ] Open color picker on yarn or draft thread palette in Chrome — eyedropper icon appears to the right of Hex/RGB/HSL/Name tabs
- [ ] Click eyedropper — native color picker cursor activates; selecting a color updates the picker and calls `onChange`
- [ ] Cancel (Esc) — picker closes cleanly, no error
- [ ] Open same picker in Firefox — eyedropper button is not rendered
- [ ] Dark mode — icon uses `text-muted-foreground` / `hover:text-card-foreground` tokens, renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)