### PR TITLE
fix: inline error page CSS to prevent MIME mismatch on /api/* paths (#924)

### DIFF
--- a/errors/Dockerfile
+++ b/errors/Dockerfile
@@ -10,8 +10,22 @@ COPY frontend/src/theme.css ./frontend/src/theme.css
 RUN npm install @tailwindcss/cli@^4.3.0 tailwindcss@^4.3.0
 RUN node_modules/.bin/tailwindcss -i ./errors/input.css -o ./errors/styles.css
 
+# Inline the generated CSS into both HTML files so the pages have no external
+# asset dependencies. A root-relative /styles.css href causes a MIME mismatch
+# when Traefik serves the error HTML and the browser fetches the stylesheet
+# from the frontend nginx, which doesn't host that file.
+RUN node -e " \
+  const fs = require('fs'); \
+  const css = fs.readFileSync('./errors/styles.css', 'utf8'); \
+  const tag = '<link rel=\"stylesheet\" href=\"/styles.css\" />'; \
+  const inline = '<style>' + css + '</style>'; \
+  for (const f of ['404.html', '500.html']) { \
+    const p = './errors/' + f; \
+    fs.writeFileSync(p, fs.readFileSync(p, 'utf8').replace(tag, inline)); \
+  } \
+"
+
 FROM nginx:alpine
 COPY --from=build /build/errors/404.html /usr/share/nginx/html/
 COPY --from=build /build/errors/500.html /usr/share/nginx/html/
-COPY --from=build /build/errors/styles.css /usr/share/nginx/html/
 COPY errors/nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
## Summary
- Closes #924
- Error pages (`404.html`, `500.html`) referenced `/styles.css` via a root-relative href
- When Traefik served the error HTML, the browser fetched `/styles.css` from the frontend nginx, which doesn't host that file — `try_files` served `index.html` instead, and `X-Content-Type-Options: nosniff` caused the browser to reject it as a MIME mismatch
- Fix: inline the generated Tailwind CSS into both HTML files during the Docker build step, making the pages fully self-contained with no external asset dependencies

## How it works
A `node` one-liner runs after the Tailwind build in the `errors/Dockerfile` build stage. It reads `styles.css`, replaces the `<link>` tag in both HTML files with an inline `<style>` block, and the final nginx image no longer needs to serve `styles.css` at all.

## Test plan
- [ ] Build `errors/Dockerfile` locally — confirm no `styles.css` reference in output HTML
- [ ] Deploy updated error container to dev; navigate to `https://dev.weftmark.com/api/hellowrld`
- [ ] Confirm error page renders with styles applied, no MIME type errors in DevTools Network tab
- [ ] Confirm valid `/api/*` endpoints still work normally
- [ ] Close QA #913 once verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)