### PR TITLE
fix: show in-app 404 page for unknown routes (#923)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,6 +35,7 @@ import { SuperuserPage } from "@/pages/SuperuserPage";
 import { SettingsPage } from "@/pages/SettingsPage";
 import { SignOutPage } from "@/pages/SignOutPage";
 import { UnauthorizedPage } from "@/pages/UnauthorizedPage";
+import { NotFoundPage } from "@/pages/NotFoundPage";
 import { PendingPage } from "@/pages/PendingPage";
 import { DevBanner } from "@/components/DevBanner";
 import { ServiceHealthBanner } from "@/components/ServiceHealthBanner";
@@ -127,7 +128,7 @@ export default function App() {
                   <Route path="/superuser/:section" element={<AuthRoute requireSuperuser><SuperuserPage /></AuthRoute>} />
                   <Route path="/settings" element={<Navigate to="/settings/appearance" replace />} />
                   <Route path="/settings/:section" element={<AuthRoute><SettingsPage /></AuthRoute>} />
-                  <Route path="*" element={<Navigate to="/" replace />} />
+                  <Route path="*" element={<NotFoundPage />} />
                 </SentryRoutes>
               </EulaGate>
             </BrowserRouter>

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -1122,6 +1122,11 @@
     "signedOut": "Sie wurden abgemeldet",
     "redirecting": "Sie werden zur Startseite weitergeleitet…"
   },
+  "notFoundPage": {
+    "title": "Seite nicht gefunden",
+    "description": "Die gesuchte Seite existiert nicht oder wurde verschoben.",
+    "backToHome": "Zurück zur Startseite"
+  },
   "unauthorizedPage": {
     "accessDenied": "Zugriff verweigert",
     "noPermission": "Sie haben keine Berechtigung, diese Seite anzuzeigen.",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1122,6 +1122,11 @@
     "signedOut": "You've been signed out",
     "redirecting": "Redirecting you to the home page…"
   },
+  "notFoundPage": {
+    "title": "Page not found",
+    "description": "The page you're looking for doesn't exist or may have been moved.",
+    "backToHome": "Back to home"
+  },
   "unauthorizedPage": {
     "accessDenied": "Access denied",
     "noPermission": "You don't have permission to view this page.",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -1121,6 +1121,11 @@
     "signedOut": "Has cerrado sesión",
     "redirecting": "Redirigiendo a la página de inicio…"
   },
+  "notFoundPage": {
+    "title": "Página no encontrada",
+    "description": "La página que buscas no existe o ha sido movida.",
+    "backToHome": "Volver al inicio"
+  },
   "unauthorizedPage": {
     "accessDenied": "Acceso denegado",
     "noPermission": "No tienes permiso para ver esta página.",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -1121,6 +1121,11 @@
     "signedOut": "Vous avez été déconnecté",
     "redirecting": "Redirection vers la page d'accueil…"
   },
+  "notFoundPage": {
+    "title": "Page introuvable",
+    "description": "La page que vous recherchez n'existe pas ou a été déplacée.",
+    "backToHome": "Retour à l'accueil"
+  },
   "unauthorizedPage": {
     "accessDenied": "Accès refusé",
     "noPermission": "Vous n'avez pas la permission de consulter cette page.",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -1121,6 +1121,11 @@
     "signedOut": "U bent afgemeld",
     "redirecting": "U wordt doorgestuurd naar de startpagina…"
   },
+  "notFoundPage": {
+    "title": "Pagina niet gevonden",
+    "description": "De pagina die u zoekt bestaat niet of is verplaatst.",
+    "backToHome": "Terug naar home"
+  },
   "unauthorizedPage": {
     "accessDenied": "Toegang geweigerd",
     "noPermission": "U heeft geen toestemming om deze pagina te bekijken.",

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,0 +1,25 @@
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { useAuth } from "@/hooks/useAuth";
+import { AuthCard } from "@/components/auth/AuthCard";
+
+export function NotFoundPage() {
+  const { isAuthenticated } = useAuth();
+  const { t } = useTranslation();
+
+  return (
+    <AuthCard>
+      <div className="text-center">
+        <p className="text-5xl font-bold tracking-tight text-zinc-800">404</p>
+        <h1 className="mt-3 text-lg font-semibold text-zinc-800">{t("notFoundPage.title")}</h1>
+        <p className="mt-2 text-sm text-stone-600">{t("notFoundPage.description")}</p>
+        <Link
+          to={isAuthenticated ? "/home" : "/"}
+          className="mt-6 inline-block text-sm text-amber-700 underline underline-offset-2 hover:text-amber-800"
+        >
+          {t("notFoundPage.backToHome")}
+        </Link>
+      </div>
+    </AuthCard>
+  );
+}


### PR DESCRIPTION
## Summary
- Closes #923
- Replaces the `<Route path="*">` catch-all `<Navigate to="/" />` redirect with a `NotFoundPage` component
- Authenticated users see a 404 page with a link to `/home`; unauthenticated users get a link to `/`
- i18n keys added for all 5 locales (en, de, fr, es, nl)

## Why not fix nginx to return 404?

`try_files $uri /index.html` returning HTTP 200 for all paths is **correct** for a CSR SPA — it's what allows client-side routing to work. Making nginx return 404 for unknown paths would break every deep-link into the app. Traefik's errors middleware is designed for server-rendered apps where the origin knows whether a route exists. For SPAs, the app handles 404s in the React layer.

## Test plan
- [ ] Navigate to `https://dev.weftmark.com/does-not-exist` while authenticated — 404 page with "Back to home" link to `/home`
- [ ] Navigate to same URL while logged out — 404 page with link to `/`
- [ ] All existing valid routes still work normally (no regression)
- [ ] Verify in all supported languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)