### PR TITLE
fix: use h-dvh in AppLayout to fix tablet layout overflow (#917)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,10 @@ updates:
       # redis 7.x cannot be used until Celery ships a compatible kombu version.
       - dependency-name: redis
         versions: [">=7.0"]
+      # fastapi 0.136.3 is malicious (MAL-2026-4750) — hidden fastar typosquat dep.
+      # Remove this ignore once PyPI yanks the release or a clean 0.136.4+ ships.
+      - dependency-name: fastapi
+        versions: ["0.136.3"]
     groups:
       backend-deps:
         patterns:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.136.3
+fastapi==0.136.2
 uvicorn[standard]==0.48.0
 sqlalchemy[asyncio]==2.0.50
 alembic==1.18.4

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.136.2
+fastapi==0.136.1
 uvicorn[standard]==0.48.0
 sqlalchemy[asyncio]==2.0.50
 alembic==1.18.4

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -27,7 +27,7 @@ export function AppLayout({ children }: Props) {
   const desktopCollapsed = isDetailPage && expandedOnPath !== location.pathname;
 
   return (
-    <div className="flex h-screen overflow-hidden bg-background">
+    <div className="flex h-dvh overflow-hidden bg-background">
       <Sidebar
         open={sidebarOpen}
         onClose={() => setSidebarOpen(false)}


### PR DESCRIPTION
## Summary

- Replace `h-screen` (`100vh`) with `h-dvh` in `AppLayout.tsx` root container
- On mobile Chrome (Android), `100vh` can resolve to the *large viewport* (full physical screen height) even when the browser address/tab bar is visible, causing the layout to be taller than the visible area and clipping bottom-pinned controls (step arrows, pick counter, keyboard hint)
- `h-dvh` uses the *dynamic viewport* which tracks the actual visible area as browser chrome appears and disappears

## Test plan

- [ ] Verify on real Android tablet (Samsung Galaxy Tab landscape) that the project tracker `/:id/track` no longer overflows with browser chrome visible
- [ ] Smoke-test desktop browser — layout unchanged at full-height viewports (dvh = vh when no mobile chrome)
- [ ] Smoke-test other authenticated pages — sidebar, home, drafts list still fill the viewport correctly

Closes #917

🤖 Generated with [Claude Code](https://claude.com/claude-code)