### PR TITLE
ci: bump GitHub Actions to Node.js 24 compatible versions (#939)

### DIFF
--- a/.github/workflows/ci-dev-pr.yml
+++ b/.github/workflows/ci-dev-pr.yml
@@ -171,12 +171,12 @@ jobs:
         with:
           fetch-depth: 0
       - name: Download coverage report
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: coverage-report
           path: backend/
       - name: SonarCloud scan
-        uses: SonarSource/sonarqube-scan-action@v5.0.0
+        uses: SonarSource/sonarqube-scan-action@v8.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/publish-error-container.yml
+++ b/.github/workflows/publish-error-container.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Validate Dockerfile (syntax check)
         run: docker buildx build --check -f errors/Dockerfile .
@@ -74,7 +74,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build image (amd64) for scanning
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: errors/Dockerfile
@@ -84,7 +84,7 @@ jobs:
           tags: ghcr.io/weftmark/weftmark-errors:scan-target
 
       - name: Scan for critical CVEs (Trivy)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ghcr.io/weftmark/weftmark-errors:scan-target
           format: table
@@ -104,7 +104,7 @@ jobs:
 
       - name: Build and push (multi-platform)
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: errors/Dockerfile

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           script: |
             const { payload } = context;


### PR DESCRIPTION
## Summary

- Bumps 5 actions from node20 to node24 before the GitHub-enforced June 2, 2026 deadline
- Also pins `aquasecurity/trivy-action` from `@master` to `@v0.36.0` (security hygiene)

| Workflow | Action | Before | After |
|---|---|---|---|
| `ci-dev-pr.yml` | `actions/download-artifact` | `@v6` (node20) | `@v8` (node24) |
| `ci-dev-pr.yml` | `SonarSource/sonarqube-scan-action` | `@v5.0.0` (node20) | `@v8.1.0` (node24) |
| `triage.yml` | `actions/github-script` | `@v7` (node20) | `@v9` (node24) |
| `publish-error-container.yml` | `docker/setup-buildx-action` | `@v3` (node20) | `@v4` (node24) |
| `publish-error-container.yml` | `docker/build-push-action` | `@v6` (node20) | `@v7` (node24) |
| `publish-error-container.yml` | `aquasecurity/trivy-action` | `@master` | `@v0.36.0` |

Actions already on node24 (no change): `checkout@v6`, `setup-node@v6`, `setup-python@v6`, `upload-artifact@v6`, `create-github-app-token@v3`, `login-action@v4`.

## Test plan

- [ ] `ci-feature.yml` lint/typecheck passes on push
- [ ] `ci-dev-pr.yml` SonarCloud job passes — no deprecation warnings for download-artifact or sonarqube-scan-action
- [ ] `triage.yml` fires correctly on next issue open/label (no node20 warning)

Closes #939

🤖 Generated with [Claude Code](https://claude.com/claude-code)