### PR TITLE
feat: Ravelry stash push-back (#903)

### DIFF
--- a/backend/alembic/versions/0048_yarn_dye_lot.py
+++ b/backend/alembic/versions/0048_yarn_dye_lot.py
@@ -1,0 +1,24 @@
+"""Add dye_lot to yarns
+
+Revision ID: 0048_yarn_dye_lot
+Revises: 0047_project_yarn_colors
+Create Date: 2026-05-26
+
+Adds optional dye_lot field to yarn records for Ravelry stash push-back.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0048_yarn_dye_lot"
+down_revision = "0047_project_yarn_colors"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("yarns", sa.Column("dye_lot", sa.String(50), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("yarns", "dye_lot")

--- a/backend/app/models/yarn.py
+++ b/backend/app/models/yarn.py
@@ -53,6 +53,7 @@ class Yarn(Base, TimestampMixin, SoftDeleteMixin):
 
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
     photo_path: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    dye_lot: Mapped[str | None] = mapped_column(String(50), nullable=True)
 
     ravelry_stash_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True, index=True)
     ravelry_yarn_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True, index=True)

--- a/backend/app/routers/ravelry.py
+++ b/backend/app/routers/ravelry.py
@@ -1,6 +1,7 @@
 """Ravelry OAuth and stash sync endpoints."""
 
 import logging
+import uuid
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -16,6 +17,8 @@ from app.services import ravelry as svc
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/ravelry", tags=["ravelry"])
+
+_NOT_CONNECTED = "Not connected to Ravelry"
 
 
 def _safe(s: str | None, maxlen: int = 100) -> str:
@@ -61,6 +64,15 @@ class ImportYarnPayload(BaseModel):
     ravelry_yarn_id: int
     color_name: str | None = None
     color_hex: str | None = None
+
+
+class StashPushResult(BaseModel):
+    ravelry_stash_id: int
+
+
+class BulkStashPushResult(BaseModel):
+    pushed: int
+    skipped: int
 
 
 # ---------------------------------------------------------------------------
@@ -147,7 +159,7 @@ async def disconnect(
     """Remove stored Ravelry credentials for the current user."""
     cred = await svc.get_credential(current_user.id, db)
     if cred is None:
-        raise HTTPException(status_code=404, detail="Not connected to Ravelry")
+        raise HTTPException(status_code=404, detail=_NOT_CONNECTED)
     await db.delete(cred)
     await db.commit()
 
@@ -248,6 +260,42 @@ async def import_yarn(
     return {"id": str(yarn.id)}
 
 
+@router.post("/stash-push/bulk")
+async def push_bulk_to_stash(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> BulkStashPushResult:
+    """Push all eligible Tier 1 yarns to the user's Ravelry stash."""
+    cred = await svc.get_credential(current_user.id, db)
+    if cred is None:
+        raise HTTPException(status_code=404, detail=_NOT_CONNECTED)
+    try:
+        result = await svc.push_eligible_yarns_to_stash(current_user.id, db)
+    except Exception as exc:
+        logger.exception("Ravelry bulk stash push failed for user %s", current_user.id)
+        raise HTTPException(status_code=502, detail="Ravelry bulk stash push failed") from exc
+    return BulkStashPushResult(**result)
+
+
+@router.post("/stash-push/{yarn_id}")
+async def push_yarn_to_stash(
+    yarn_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> StashPushResult:
+    """Push a single yarn to the user's Ravelry stash."""
+    try:
+        stash_id = await svc.push_yarn_to_stash(yarn_id, current_user.id, db)
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.exception("Ravelry stash push failed for yarn %s", yarn_id)
+        raise HTTPException(status_code=502, detail="Ravelry stash push failed") from exc
+    return StashPushResult(ravelry_stash_id=stash_id)
+
+
 @router.post("/sync", response_model=SyncResult)
 async def sync_stash(
     current_user: User = Depends(get_current_user),
@@ -256,7 +304,7 @@ async def sync_stash(
     """Trigger an on-demand stash sync for the current user."""
     cred = await svc.get_credential(current_user.id, db)
     if cred is None:
-        raise HTTPException(status_code=404, detail="Not connected to Ravelry")
+        raise HTTPException(status_code=404, detail=_NOT_CONNECTED)
     try:
         result = await svc.sync_stash(current_user.id, db)
     except Exception as exc:

--- a/backend/app/routers/yarn.py
+++ b/backend/app/routers/yarn.py
@@ -120,6 +120,7 @@ class YarnDetail(YarnSummary):
     purchase_source: str | None
     purchase_price: Decimal | None
     purchase_date: date | None
+    dye_lot: str | None
     notes: str | None
     skeins: list[SkeinSchema]
 
@@ -144,6 +145,7 @@ class YarnDetail(YarnSummary):
                 "purchase_source": yarn.purchase_source,
                 "purchase_price": yarn.purchase_price,
                 "purchase_date": yarn.purchase_date,
+                "dye_lot": yarn.dye_lot,
                 "notes": yarn.notes,
                 "has_photo": yarn.photo_path is not None,
                 "skein_count": len(yarn.skeins),
@@ -185,6 +187,7 @@ class CreateYarnRequest(BaseModel):
     purchase_source: str | None = None
     purchase_price: Decimal | None = None
     purchase_date: date | None = None
+    dye_lot: str | None = None
     notes: str | None = None
     machine_washable: bool | None = None
     yarn_attribute_ids: list[int] | None = None
@@ -207,6 +210,7 @@ class UpdateYarnRequest(BaseModel):
     purchase_source: str | None = None
     purchase_price: Decimal | None = None
     purchase_date: date | None = None
+    dye_lot: str | None = None
     notes: str | None = None
     machine_washable: bool | None = None
     yarn_attribute_ids: list[int] | None = None

--- a/backend/app/services/ravelry.py
+++ b/backend/app/services/ravelry.py
@@ -584,10 +584,6 @@ async def push_yarn_to_stash(yarn_id: uuid.UUID, user_id: uuid.UUID, db: AsyncSe
     Returns the new ravelry_stash_id written back to the yarn record.
     Raises ValueError for eligibility failures, LookupError if yarn not found.
     """
-    cred = await get_credential(user_id, db)
-    if cred is None:
-        raise ValueError(_NO_CREDENTIAL)
-
     yarn = await db.scalar(
         select(Yarn).where(
             Yarn.id == yarn_id,
@@ -597,6 +593,11 @@ async def push_yarn_to_stash(yarn_id: uuid.UUID, user_id: uuid.UUID, db: AsyncSe
     )
     if yarn is None:
         raise LookupError(f"Yarn {yarn_id} not found")
+
+    cred = await get_credential(user_id, db)
+    if cred is None:
+        raise LookupError(_NO_CREDENTIAL)
+
     if yarn.ravelry_yarn_id is None:
         raise ValueError("Yarn is not linked to a Ravelry yarn (Tier 2 — not eligible for push-back)")
     if yarn.ravelry_stash_id is not None:
@@ -634,7 +635,7 @@ async def push_eligible_yarns_to_stash(user_id: uuid.UUID, db: AsyncSession) -> 
     """
     cred = await get_credential(user_id, db)
     if cred is None:
-        raise ValueError(_NO_CREDENTIAL)
+        raise LookupError(_NO_CREDENTIAL)
 
     eligible = (
         await db.scalars(

--- a/backend/app/services/ravelry.py
+++ b/backend/app/services/ravelry.py
@@ -20,6 +20,7 @@ from app.models.yarn import Yarn
 logger = logging.getLogger(__name__)
 
 OAUTH_SCOPE = "offline"
+_NO_CREDENTIAL = "No Ravelry credential found for user"
 STATE_TTL_MINUTES = 10
 _RAVELRY_API = "https://api.ravelry.com"
 
@@ -395,7 +396,7 @@ async def sync_stash(user_id: uuid.UUID, db: AsyncSession) -> dict:
 
     cred = await get_credential(user_id, db)
     if cred is None:
-        raise ValueError("No Ravelry credential found for user")
+        raise ValueError(_NO_CREDENTIAL)
 
     token = await _get_valid_token(cred, db)
 
@@ -570,3 +571,109 @@ async def sync_stash(user_id: uuid.UUID, db: AsyncSession) -> dict:
 
     logger.info("Ravelry stash synced for user %s: %d entries", user_id, upsert_count)
     return {"synced": upsert_count, "unchanged": False, "last_synced_at": now}
+
+
+# ---------------------------------------------------------------------------
+# Stash push-back
+# ---------------------------------------------------------------------------
+
+
+async def push_yarn_to_stash(yarn_id: uuid.UUID, user_id: uuid.UUID, db: AsyncSession) -> int:
+    """Push a single Tier 1 yarn to the user's Ravelry stash.
+
+    Returns the new ravelry_stash_id written back to the yarn record.
+    Raises ValueError for eligibility failures, LookupError if yarn not found.
+    """
+    cred = await get_credential(user_id, db)
+    if cred is None:
+        raise ValueError(_NO_CREDENTIAL)
+
+    yarn = await db.scalar(
+        select(Yarn).where(
+            Yarn.id == yarn_id,
+            Yarn.owner_id == user_id,
+            Yarn.deleted_at.is_(None),
+        )
+    )
+    if yarn is None:
+        raise LookupError(f"Yarn {yarn_id} not found")
+    if yarn.ravelry_yarn_id is None:
+        raise ValueError("Yarn is not linked to a Ravelry yarn (Tier 2 — not eligible for push-back)")
+    if yarn.ravelry_stash_id is not None:
+        raise ValueError("Yarn is already in Ravelry stash")
+    if yarn.archived:
+        raise ValueError("Archived yarns cannot be pushed to Ravelry stash")
+    if yarn.out_of_stash:
+        raise ValueError("Out-of-stash yarns cannot be pushed to Ravelry stash")
+
+    token = await _get_valid_token(cred, db)
+
+    payload: dict = {"yarn_id": yarn.ravelry_yarn_id}
+    if yarn.color_name:
+        payload["colorway_name"] = yarn.color_name
+    if yarn.dye_lot:
+        payload["dye_lot"] = yarn.dye_lot
+    if yarn.notes:
+        payload["notes"] = yarn.notes
+
+    async with RavelryClient.from_oauth_token(token) as client:
+        _, _, raw = await client.stash.create(cred.ravelry_username, payload)
+
+    stash_id: int = ((raw or {}).get("stash") or {})["id"]
+    yarn.ravelry_stash_id = stash_id
+    await db.commit()
+
+    logger.info("Pushed yarn %s to Ravelry stash entry %s for user %s", yarn_id, stash_id, user_id)
+    return stash_id
+
+
+async def push_eligible_yarns_to_stash(user_id: uuid.UUID, db: AsyncSession) -> dict:
+    """Push all eligible Tier 1 yarns to the user's Ravelry stash.
+
+    Returns {pushed: int, skipped: int}.
+    """
+    cred = await get_credential(user_id, db)
+    if cred is None:
+        raise ValueError(_NO_CREDENTIAL)
+
+    eligible = (
+        await db.scalars(
+            select(Yarn).where(
+                Yarn.owner_id == user_id,
+                Yarn.ravelry_yarn_id.is_not(None),
+                Yarn.ravelry_stash_id.is_(None),
+                Yarn.archived.is_(False),
+                Yarn.out_of_stash.is_(False),
+                Yarn.deleted_at.is_(None),
+            )
+        )
+    ).all()
+
+    if not eligible:
+        return {"pushed": 0, "skipped": 0}
+
+    token = await _get_valid_token(cred, db)
+    pushed = 0
+    skipped = 0
+
+    async with RavelryClient.from_oauth_token(token) as client:
+        for yarn in eligible:
+            payload: dict = {"yarn_id": yarn.ravelry_yarn_id}
+            if yarn.color_name:
+                payload["colorway_name"] = yarn.color_name
+            if yarn.dye_lot:
+                payload["dye_lot"] = yarn.dye_lot
+            if yarn.notes:
+                payload["notes"] = yarn.notes
+            try:
+                _, _, raw = await client.stash.create(cred.ravelry_username, payload)
+                stash_id: int = ((raw or {}).get("stash") or {})["id"]
+                yarn.ravelry_stash_id = stash_id
+                pushed += 1
+            except Exception:
+                logger.exception("Failed to push yarn %s to Ravelry stash for user %s", yarn.id, user_id)
+                skipped += 1
+
+    await db.commit()
+    logger.info("Bulk Ravelry stash push for user %s: pushed=%d skipped=%d", user_id, pushed, skipped)
+    return {"pushed": pushed, "skipped": skipped}

--- a/backend/app/services/ravelry.py
+++ b/backend/app/services/ravelry.py
@@ -620,7 +620,9 @@ async def push_yarn_to_stash(yarn_id: uuid.UUID, user_id: uuid.UUID, db: AsyncSe
     async with RavelryClient.from_oauth_token(token) as client:
         _, _, raw = await client.stash.create(cred.ravelry_username, payload)
 
-    stash_id: int = ((raw or {}).get("stash") or {})["id"]
+    stash_id: int | None = ((raw or {}).get("stash") or {}).get("id")
+    if stash_id is None:
+        raise RuntimeError(f"Ravelry stash.create returned no stash id; response: {raw!r}")
     yarn.ravelry_stash_id = stash_id
     await db.commit()
 
@@ -668,7 +670,9 @@ async def push_eligible_yarns_to_stash(user_id: uuid.UUID, db: AsyncSession) -> 
                 payload["notes"] = yarn.notes
             try:
                 _, _, raw = await client.stash.create(cred.ravelry_username, payload)
-                stash_id: int = ((raw or {}).get("stash") or {})["id"]
+                stash_id: int | None = ((raw or {}).get("stash") or {}).get("id")
+                if stash_id is None:
+                    raise RuntimeError(f"Ravelry stash.create returned no stash id; response: {raw!r}")
                 yarn.ravelry_stash_id = stash_id
                 pushed += 1
             except Exception:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,7 +9,7 @@ pydantic-settings==2.14.1
 celery[redis]==5.6.3
 redis==6.4.0
 httpx==0.28.1
-ravelpy==0.3.0
+ravelpy==0.3.1
 python-multipart==0.0.29
 pillow==12.2.0
 aiosmtplib==5.1.0

--- a/backend/tests/routers/test_ravelry_stash_push.py
+++ b/backend/tests/routers/test_ravelry_stash_push.py
@@ -1,0 +1,209 @@
+"""Tests for Ravelry stash push-back endpoints and service."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.ravelry import RavelryCredential
+from app.models.user import User
+from app.models.yarn import Yarn
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_STASH_CREATE_RESPONSE = {"stash": {"id": 99001, "colorway_name": "Natural"}}
+
+
+def _make_credential(user: User) -> RavelryCredential:
+    return RavelryCredential(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        ravelry_username="testweaver",
+        access_token="fake-token",
+        refresh_token=None,
+        expires_at=None,
+    )
+
+
+def _make_yarn(user: User, **overrides) -> Yarn:
+    defaults = {
+        "owner_id": user.id,
+        "brand": "Cascade",
+        "name": "220",
+        "ravelry_yarn_id": 42,
+        "ravelry_stash_id": None,
+        "archived": False,
+        "out_of_stash": False,
+    }
+    defaults.update(overrides)
+    return Yarn(**defaults)
+
+
+def _mock_ravelry_client(response: dict) -> MagicMock:
+    """Return a context-manager mock for RavelryClient.from_oauth_token."""
+    mock_client = AsyncMock()
+    mock_client.stash.create = AsyncMock(return_value=(None, None, response))
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=mock_client)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+# ---------------------------------------------------------------------------
+# TestStashPushSingle
+# ---------------------------------------------------------------------------
+
+
+class TestStashPushSingle:
+    async def test_happy_path_writes_back_stash_id(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        cred = _make_credential(test_user)
+        yarn = _make_yarn(test_user)
+        db_session.add_all([cred, yarn])
+        await db_session.commit()
+        await db_session.refresh(yarn)
+
+        cm = _mock_ravelry_client(_STASH_CREATE_RESPONSE)
+        with patch("app.services.ravelry.RavelryClient") as mock_cls:
+            mock_cls.from_oauth_token.return_value = cm
+            resp = await auth_client.post(f"/api/ravelry/stash-push/{yarn.id}")
+
+        assert resp.status_code == 200
+        assert resp.json()["ravelry_stash_id"] == 99001
+
+        await db_session.refresh(yarn)
+        assert yarn.ravelry_stash_id == 99001
+
+    async def test_stash_create_called_once(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        cred = _make_credential(test_user)
+        yarn = _make_yarn(test_user)
+        db_session.add_all([cred, yarn])
+        await db_session.commit()
+        await db_session.refresh(yarn)
+
+        mock_client = AsyncMock()
+        mock_client.stash.create = AsyncMock(return_value=(None, None, _STASH_CREATE_RESPONSE))
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=mock_client)
+        cm.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.ravelry.RavelryClient") as mock_cls:
+            mock_cls.from_oauth_token.return_value = cm
+            await auth_client.post(f"/api/ravelry/stash-push/{yarn.id}")
+
+        mock_client.stash.create.assert_called_once()
+
+    async def test_already_synced_returns_422(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        cred = _make_credential(test_user)
+        yarn = _make_yarn(test_user, ravelry_stash_id=12345)
+        db_session.add_all([cred, yarn])
+        await db_session.commit()
+        await db_session.refresh(yarn)
+
+        resp = await auth_client.post(f"/api/ravelry/stash-push/{yarn.id}")
+
+        assert resp.status_code == 422
+
+    async def test_tier2_yarn_returns_422(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        cred = _make_credential(test_user)
+        yarn = _make_yarn(test_user, ravelry_yarn_id=None)
+        db_session.add_all([cred, yarn])
+        await db_session.commit()
+        await db_session.refresh(yarn)
+
+        resp = await auth_client.post(f"/api/ravelry/stash-push/{yarn.id}")
+
+        assert resp.status_code == 422
+
+    async def test_archived_yarn_returns_422(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        cred = _make_credential(test_user)
+        yarn = _make_yarn(test_user, archived=True)
+        db_session.add_all([cred, yarn])
+        await db_session.commit()
+        await db_session.refresh(yarn)
+
+        resp = await auth_client.post(f"/api/ravelry/stash-push/{yarn.id}")
+
+        assert resp.status_code == 422
+
+    async def test_no_credential_returns_404(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        yarn = _make_yarn(test_user)
+        db_session.add(yarn)
+        await db_session.commit()
+        await db_session.refresh(yarn)
+
+        resp = await auth_client.post(f"/api/ravelry/stash-push/{yarn.id}")
+
+        assert resp.status_code == 404
+
+    async def test_unknown_yarn_returns_404(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        cred = _make_credential(test_user)
+        db_session.add(cred)
+        await db_session.commit()
+
+        resp = await auth_client.post(f"/api/ravelry/stash-push/{uuid.uuid4()}")
+
+        assert resp.status_code == 404
+
+    async def test_requires_authentication(self, client: AsyncClient):
+        resp = await client.post(f"/api/ravelry/stash-push/{uuid.uuid4()}")
+        assert resp.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# TestStashPushBulk
+# ---------------------------------------------------------------------------
+
+
+class TestStashPushBulk:
+    async def test_pushes_only_eligible_tier1_yarns(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        cred = _make_credential(test_user)
+        eligible = _make_yarn(test_user, name="Eligible")
+        already_synced = _make_yarn(test_user, name="Already synced", ravelry_stash_id=111)
+        tier2 = _make_yarn(test_user, name="Tier 2", ravelry_yarn_id=None)
+        archived = _make_yarn(test_user, name="Archived", archived=True)
+        db_session.add_all([cred, eligible, already_synced, tier2, archived])
+        await db_session.commit()
+
+        cm = _mock_ravelry_client(_STASH_CREATE_RESPONSE)
+        with patch("app.services.ravelry.RavelryClient") as mock_cls:
+            mock_cls.from_oauth_token.return_value = cm
+            resp = await auth_client.post("/api/ravelry/stash-push/bulk")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["pushed"] == 1
+        assert data["skipped"] == 0
+
+    async def test_empty_eligible_returns_zero_counts(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        cred = _make_credential(test_user)
+        already_synced = _make_yarn(test_user, ravelry_stash_id=222)
+        db_session.add_all([cred, already_synced])
+        await db_session.commit()
+
+        with patch("app.services.ravelry.RavelryClient") as mock_cls:
+            resp = await auth_client.post("/api/ravelry/stash-push/bulk")
+            mock_cls.from_oauth_token.assert_not_called()
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["pushed"] == 0
+        assert data["skipped"] == 0
+
+    async def test_no_credential_returns_404(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        resp = await auth_client.post("/api/ravelry/stash-push/bulk")
+        assert resp.status_code == 404
+
+    async def test_requires_authentication(self, client: AsyncClient):
+        resp = await client.post("/api/ravelry/stash-push/bulk")
+        assert resp.status_code in (401, 403)

--- a/backend/tests/routers/test_ravelry_stash_push.py
+++ b/backend/tests/routers/test_ravelry_stash_push.py
@@ -151,6 +151,65 @@ class TestStashPushSingle:
 
         assert resp.status_code == 404
 
+    async def test_out_of_stash_yarn_returns_422(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        cred = _make_credential(test_user)
+        yarn = _make_yarn(test_user, out_of_stash=True)
+        db_session.add_all([cred, yarn])
+        await db_session.commit()
+        await db_session.refresh(yarn)
+
+        resp = await auth_client.post(f"/api/ravelry/stash-push/{yarn.id}")
+
+        assert resp.status_code == 422
+
+    async def test_ravelry_api_exception_returns_502(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        cred = _make_credential(test_user)
+        yarn = _make_yarn(test_user)
+        db_session.add_all([cred, yarn])
+        await db_session.commit()
+        await db_session.refresh(yarn)
+
+        mock_client = AsyncMock()
+        mock_client.stash.create = AsyncMock(side_effect=RuntimeError("upstream failure"))
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=mock_client)
+        cm.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.ravelry.RavelryClient") as mock_cls:
+            mock_cls.from_oauth_token.return_value = cm
+            resp = await auth_client.post(f"/api/ravelry/stash-push/{yarn.id}")
+
+        assert resp.status_code == 502
+
+    async def test_payload_includes_optional_fields(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        cred = _make_credential(test_user)
+        yarn = _make_yarn(test_user, color_name="Natural", dye_lot="Lot42", notes="Hand wash only")
+        db_session.add_all([cred, yarn])
+        await db_session.commit()
+        await db_session.refresh(yarn)
+
+        mock_client = AsyncMock()
+        mock_client.stash.create = AsyncMock(return_value=(None, None, _STASH_CREATE_RESPONSE))
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=mock_client)
+        cm.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.ravelry.RavelryClient") as mock_cls:
+            mock_cls.from_oauth_token.return_value = cm
+            resp = await auth_client.post(f"/api/ravelry/stash-push/{yarn.id}")
+
+        assert resp.status_code == 200
+        _, payload = mock_client.stash.create.call_args[0]
+        assert payload.get("colorway_name") == "Natural"
+        assert payload.get("dye_lot") == "Lot42"
+        assert payload.get("notes") == "Hand wash only"
+
     async def test_requires_authentication(self, client: AsyncClient):
         resp = await client.post(f"/api/ravelry/stash-push/{uuid.uuid4()}")
         assert resp.status_code in (401, 403)
@@ -203,6 +262,42 @@ class TestStashPushBulk:
     async def test_no_credential_returns_404(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
         resp = await auth_client.post("/api/ravelry/stash-push/bulk")
         assert resp.status_code == 404
+
+    async def test_push_failure_counted_as_skipped(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        cred = _make_credential(test_user)
+        yarn = _make_yarn(test_user, name="WillFail")
+        db_session.add_all([cred, yarn])
+        await db_session.commit()
+
+        mock_client = AsyncMock()
+        mock_client.stash.create = AsyncMock(side_effect=RuntimeError("ravelry down"))
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=mock_client)
+        cm.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.ravelry.RavelryClient") as mock_cls:
+            mock_cls.from_oauth_token.return_value = cm
+            resp = await auth_client.post("/api/ravelry/stash-push/bulk")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["pushed"] == 0
+        assert data["skipped"] == 1
+
+    async def test_ravelry_api_exception_returns_502(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        cred = _make_credential(test_user)
+        yarn = _make_yarn(test_user, name="Eligible")
+        db_session.add_all([cred, yarn])
+        await db_session.commit()
+
+        with patch("app.services.ravelry.push_eligible_yarns_to_stash", side_effect=RuntimeError("boom")):
+            resp = await auth_client.post("/api/ravelry/stash-push/bulk")
+
+        assert resp.status_code == 502
 
     async def test_requires_authentication(self, client: AsyncClient):
         resp = await client.post("/api/ravelry/stash-push/bulk")

--- a/docs/requirements/yarn-inventory.md
+++ b/docs/requirements/yarn-inventory.md
@@ -102,3 +102,124 @@ Take-up and shrinkage percentages are configurable defaults that the user can ad
 4. As warping and weaving proceed, deductions are recorded against specific skein IDs
 5. Skein status updates automatically (Available → In use → Consumed)
 6. User can manually record additional consumption at any point
+
+---
+
+## Ravelry Stash Push-back
+
+Users who create yarn records in weftmark (or who imported from Ravelry but the entry predates their Ravelry account link) can push those records back to their Ravelry stash.
+
+### API endpoint
+
+```http
+POST /people/{username}/stash/create.json
+Authorization: Bearer <oauth-token>
+Body: { "yarn_id": 1, "colorway_name": "Natural", "dye_lot": "A42", "notes": "..." }
+```
+
+The existing `offline` OAuth scope covers this endpoint — no re-auth required.
+
+### Eligibility (Tier 1 only)
+
+A yarn is eligible for push-back when ALL of the following are true:
+
+| Condition | Reason |
+| --- | --- |
+| `ravelry_yarn_id IS NOT NULL` | Ravelry must be able to identify the yarn; free-text entries have no metadata value |
+| `ravelry_stash_id IS NULL` | Not already in Ravelry stash |
+| `archived = false` | Active yarn only |
+| `deleted_at IS NULL` | Not soft-deleted |
+| `out_of_stash = false` | Still in physical possession |
+| User has a linked Ravelry credential | OAuth token required |
+
+Yarns without a `ravelry_yarn_id` (Tier 2) are not offered for push-back. They would create orphaned free-text stash entries with no yarn link, photo, or metadata. Users should link the yarn to a Ravelry yarn first.
+
+### Field mapping
+
+| weftmark field | Ravelry stash field | Notes |
+| --- | --- | --- |
+| `ravelry_yarn_id` | `yarn_id` | Required; must be set (Tier 1 condition) |
+| `color_name` | `colorway_name` | Direct map |
+| `notes` | `notes` | Direct map |
+| — | `dye_lot` | Not currently stored in weftmark; omitted unless we add the field |
+| — | `location` | Not stored in weftmark; omitted |
+| — | `tag_names` | Could forward weftmark yarn tags; optional |
+
+**Not sent:** `weight_notation`, `color_hex`, `purchase_price`, `purchase_source`, `purchase_date`, `sett_min/max`, `unit_weight_oz/g`, `yards_per_pound`. These are either weftmark-specific or read-only on the Ravelry yarn record.
+
+**Skein quantity:** Not sent in the initial push. Ravelry tracks quantity through a separate "Pack" sub-record structure (skeins, total_yards, total_grams, shop_name, total_paid). Sending a pack requires a second API call (`/packs/create.json` or via the stash create payload). This is deferred to a phase 2 "quantity sync" feature to keep the initial push simple and reversible.
+
+### Response handling
+
+The `stash/create.json` response returns a full `Stash` object including the new `id`. That ID must be written back to `yarns.ravelry_stash_id` immediately. If the DB write fails after the Ravelry call succeeds, the retry guard is:
+
+1. Before pushing, check `ravelry_stash_id IS NULL` (prevents duplicate push)
+2. After push, if DB commit fails, the next sync will pull the new stash entry back and reconcile via the UPDATE path — `ravelry_stash_id` will be set on the next inbound sync
+
+No infinite-loop risk: inbound sync identifies existing records by `ravelry_stash_id` and takes the UPDATE path, not INSERT.
+
+### UX design
+
+#### Badge
+
+Show a **"not in Ravelry stash" badge** on yarn cards and the detail page for Tier 1 eligible yarns, only when the user has a linked Ravelry account. Use a small Ravelry icon with muted styling — it is a passive indicator, not a call to action.
+
+#### Entry points
+
+| Where | Action | Confirmation |
+| --- | --- | --- |
+| Yarn detail page | "Add to Ravelry stash" button | Inline — no modal; button shows spinner → success/error state |
+| Yarn inventory list | "Sync N yarns to Ravelry" button (visible when N > 0) | Modal: preview list of yarn names → Cancel / Add all |
+
+No automatic push on creation. No settings toggle. Explicit user action only.
+
+#### Post-sync state
+
+After a successful push:
+
+- Badge disappears (yarn now has `ravelry_stash_id`)
+- Detail page shows "In Ravelry stash" with a link to the stash entry (`https://www.ravelry.com/people/{username}/stash/{stash_id}`)
+- Bulk button count decrements
+
+### Backend changes
+
+| File | Change |
+| --- | --- |
+| `ravelpy/resources/stash.py` | Add `create(username, payload)` method — `POST /people/{username}/stash/create.json` |
+| `app/services/ravelry.py` | Add `push_yarn_to_stash(yarn_id, user_id, db)` — eligibility check, API call, write-back |
+| `app/services/ravelry.py` | Add `push_eligible_yarns_to_stash(user_id, db)` — bulk path |
+| `app/routers/ravelry.py` | Add `POST /api/ravelry/stash-push/{yarn_id}` endpoint |
+| `app/routers/ravelry.py` | Add `POST /api/ravelry/stash-push/bulk` endpoint |
+| `app/routers/yarn.py` | Expose `ravelry_stash_id` in the yarn summary/detail response schema |
+
+### Frontend changes
+
+| File | Change |
+| --- | --- |
+| `api/ravelry.ts` | Add `pushYarnToStash(yarnId)` and `pushBulkToStash()` |
+| `components/yarn/YarnCard.tsx` | Add Ravelry badge (conditional on eligibility + connected) |
+| `pages/YarnDetailPage.tsx` | Add "Add to Ravelry stash" button + post-sync link |
+| `pages/YarnPage.tsx` | Add "Sync N yarns to Ravelry" button + confirmation modal |
+| `locales/*/translation.json` | i18n keys for all new strings (5 languages) |
+
+### Validation plan
+
+| Test | Method |
+| --- | --- |
+| `test_push_yarn_to_stash` | Happy path: `ravelry_stash_id` written back, `stash/create` called once |
+| `test_push_yarn_already_synced` | Yarn with `ravelry_stash_id` set → 409 or no-op, no second Ravelry call |
+| `test_push_yarn_not_tier1` | `ravelry_yarn_id IS NULL` → 422 rejected |
+| `test_push_yarn_archived` | `archived=True` → 422 rejected |
+| `test_push_yarn_no_credential` | No OAuth credential → 404 |
+| `test_bulk_push` | Only Tier 1 yarns included; count returned matches |
+| `test_bulk_push_empty` | No eligible yarns → 200 with count=0, no API calls |
+| UI smoke | Badge visible on Tier 1 yarn, absent after push; bulk button count correct |
+
+### Estimate
+
+| Area | Hours |
+| --- | --- |
+| Backend (service + endpoints + ravelpy method) | 3–5 |
+| Frontend (badge + detail button + bulk modal + i18n) | 4–6 |
+| Tests | 2–3 |
+| **Total** | **9–14** |

--- a/frontend/src/api/ravelry.ts
+++ b/frontend/src/api/ravelry.ts
@@ -122,3 +122,11 @@ export async function importRavelryYarn(payload: {
 }): Promise<{ id: string }> {
   return api.post<{ id: string }>("/api/ravelry/import-yarn", payload);
 }
+
+export async function pushYarnToStash(yarnId: string): Promise<{ ravelry_stash_id: number }> {
+  return api.post<{ ravelry_stash_id: number }>(`/api/ravelry/stash-push/${yarnId}`, {});
+}
+
+export async function pushBulkToStash(): Promise<{ pushed: number; skipped: number }> {
+  return api.post<{ pushed: number; skipped: number }>("/api/ravelry/stash-push/bulk", {});
+}

--- a/frontend/src/api/yarn.ts
+++ b/frontend/src/api/yarn.ts
@@ -75,6 +75,7 @@ export interface YarnDetail extends YarnSummary {
   purchase_source: string | null;
   purchase_price: string | null;
   purchase_date: string | null;
+  dye_lot: string | null;
   notes: string | null;
   skeins: Skein[];
 }
@@ -96,6 +97,7 @@ export interface CreateYarnPayload {
   purchase_source?: string;
   purchase_price?: number;
   purchase_date?: string;
+  dye_lot?: string | null;
   notes?: string;
   machine_washable?: boolean | null;
   yarn_attribute_ids?: number[];

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -445,6 +445,12 @@
     "discontinued": "Eingestellt",
     "outOfStash": "Nicht mehr vorrätig",
     "inRavelryStash": "Ravelry Stash",
+    "notInRavelryStash": "Nicht im Ravelry-Stash",
+    "pushToRavelryBulkButton": "{{count}} zum Ravelry-Stash hinzufügen",
+    "pushToRavelryModalTitle": "Zum Ravelry-Stash hinzufügen",
+    "pushToRavelryModalBody": "Diese Garne werden deinem Ravelry-Stash hinzugefügt:",
+    "pushToRavelryModalConfirm": "Alle hinzufügen",
+    "pushBulkSuccess": "{{count}} Garn(e) zum Ravelry-Stash hinzugefügt.",
     "colorNotSet": "nicht gesetzt",
     "showArchived": "Archivierte anzeigen",
     "hideArchived": "Archivierte ausblenden",
@@ -893,7 +899,10 @@
     "colorwayFilter": "Farbvarianten filtern…",
     "noColorways": "Keine Farbvarianten für dieses Garn gefunden.",
     "colorwayLoadError": "Farbvarianten konnten nicht geladen werden.",
-    "usedInProjects": "Verwendet in Projekten"
+    "usedInProjects": "Verwendet in Projekten",
+    "addToRavelryStash": "Zum Ravelry-Stash hinzufügen",
+    "inRavelryStash": "Im Ravelry-Stash",
+    "addToRavelryStashError": "Konnte nicht zum Ravelry-Stash hinzugefügt werden."
   },
   "loomDetailPage": {
     "loading": "Laden…",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -445,6 +445,12 @@
     "discontinued": "Discontinued",
     "outOfStash": "Out of stash",
     "inRavelryStash": "Ravelry Stash",
+    "notInRavelryStash": "Not in Ravelry stash",
+    "pushToRavelryBulkButton": "Add {{count}} to Ravelry stash",
+    "pushToRavelryModalTitle": "Add to Ravelry stash",
+    "pushToRavelryModalBody": "These yarns will be added to your Ravelry stash:",
+    "pushToRavelryModalConfirm": "Add all",
+    "pushBulkSuccess": "Added {{count}} yarn(s) to Ravelry stash.",
     "colorNotSet": "not set",
     "showArchived": "Show archived",
     "hideArchived": "Hide archived",
@@ -893,7 +899,10 @@
     "colorwayFilter": "Filter colorways…",
     "noColorways": "No colorways found for this yarn.",
     "colorwayLoadError": "Failed to load colorways.",
-    "usedInProjects": "Used in projects"
+    "usedInProjects": "Used in projects",
+    "addToRavelryStash": "Add to Ravelry stash",
+    "inRavelryStash": "In Ravelry stash",
+    "addToRavelryStashError": "Failed to add to Ravelry stash."
   },
   "loomDetailPage": {
     "loading": "Loading…",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -444,6 +444,12 @@
     "discontinued": "Descontinuado",
     "outOfStash": "Sin existencias",
     "inRavelryStash": "Ravelry Stash",
+    "notInRavelryStash": "No está en el stash de Ravelry",
+    "pushToRavelryBulkButton": "Añadir {{count}} al stash de Ravelry",
+    "pushToRavelryModalTitle": "Añadir al stash de Ravelry",
+    "pushToRavelryModalBody": "Estos hilos se añadirán a tu stash de Ravelry:",
+    "pushToRavelryModalConfirm": "Añadir todo",
+    "pushBulkSuccess": "{{count}} hilo(s) añadido(s) al stash de Ravelry.",
     "colorNotSet": "no definido",
     "showArchived": "Mostrar archivados",
     "hideArchived": "Ocultar archivados",
@@ -892,7 +898,10 @@
     "colorwayFilter": "Filtrar colorways…",
     "noColorways": "No se encontraron colorways para este hilo.",
     "colorwayLoadError": "Error al cargar los colorways.",
-    "usedInProjects": "Usado en proyectos"
+    "usedInProjects": "Usado en proyectos",
+    "addToRavelryStash": "Añadir al stash de Ravelry",
+    "inRavelryStash": "En el stash de Ravelry",
+    "addToRavelryStashError": "No se pudo añadir al stash de Ravelry."
   },
   "loomDetailPage": {
     "loading": "Cargando…",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -444,6 +444,12 @@
     "discontinued": "Abandonné",
     "outOfStash": "Plus en stock",
     "inRavelryStash": "Ravelry Stash",
+    "notInRavelryStash": "Pas dans le stash Ravelry",
+    "pushToRavelryBulkButton": "Ajouter {{count}} au stash Ravelry",
+    "pushToRavelryModalTitle": "Ajouter au stash Ravelry",
+    "pushToRavelryModalBody": "Ces fils seront ajoutés à votre stash Ravelry :",
+    "pushToRavelryModalConfirm": "Tout ajouter",
+    "pushBulkSuccess": "{{count}} fil(s) ajouté(s) au stash Ravelry.",
     "colorNotSet": "non défini",
     "showArchived": "Afficher les archivés",
     "hideArchived": "Masquer les archivés",
@@ -892,7 +898,10 @@
     "colorwayFilter": "Filtrer les coloris…",
     "noColorways": "Aucun coloris trouvé pour ce fil.",
     "colorwayLoadError": "Impossible de charger les coloris.",
-    "usedInProjects": "Utilisé dans des projets"
+    "usedInProjects": "Utilisé dans des projets",
+    "addToRavelryStash": "Ajouter au stash Ravelry",
+    "inRavelryStash": "Dans le stash Ravelry",
+    "addToRavelryStashError": "Impossible d'ajouter au stash Ravelry."
   },
   "loomDetailPage": {
     "loading": "Chargement…",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -444,6 +444,12 @@
     "discontinued": "Gestopt",
     "outOfStash": "Niet meer op voorraad",
     "inRavelryStash": "Ravelry Stash",
+    "notInRavelryStash": "Niet in Ravelry-stash",
+    "pushToRavelryBulkButton": "{{count}} toevoegen aan Ravelry-stash",
+    "pushToRavelryModalTitle": "Toevoegen aan Ravelry-stash",
+    "pushToRavelryModalBody": "Deze garens worden toegevoegd aan je Ravelry-stash:",
+    "pushToRavelryModalConfirm": "Alles toevoegen",
+    "pushBulkSuccess": "{{count}} garen(s) toegevoegd aan Ravelry-stash.",
     "colorNotSet": "niet ingesteld",
     "showArchived": "Gearchiveerde tonen",
     "hideArchived": "Gearchiveerde verbergen",
@@ -892,7 +898,10 @@
     "colorwayFilter": "Kleurwegen filteren…",
     "noColorways": "Geen kleurwegen gevonden voor dit garen.",
     "colorwayLoadError": "Kleurwegen konden niet worden geladen.",
-    "usedInProjects": "Gebruikt in projecten"
+    "usedInProjects": "Gebruikt in projecten",
+    "addToRavelryStash": "Toevoegen aan Ravelry-stash",
+    "inRavelryStash": "In Ravelry-stash",
+    "addToRavelryStashError": "Kon niet toevoegen aan Ravelry-stash."
   },
   "loomDetailPage": {
     "loading": "Laden…",

--- a/frontend/src/pages/YarnDetailPage.tsx
+++ b/frontend/src/pages/YarnDetailPage.tsx
@@ -132,6 +132,7 @@ function EditColorwayModal({
         aria-labelledby="edit-colorway-title"
         className="w-full max-w-sm rounded-xl border border-border bg-card shadow-xl"
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => { e.stopPropagation(); if (e.key === "Escape") onClose(); }}
       >
         <div className="flex items-center justify-between px-5 py-4 border-b border-border">
           <h2 id="edit-colorway-title" className="text-sm font-semibold">{t("yarnDetailPage.editColorwayTitle")}</h2>

--- a/frontend/src/pages/YarnDetailPage.tsx
+++ b/frontend/src/pages/YarnDetailPage.tsx
@@ -1,9 +1,9 @@
 import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams, Link } from "react-router-dom";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getYarn, updateYarn, patchYarnColorway, getYarnProjects, type YarnProjectRef } from "@/api/yarn";
-import { getRavelryYarnDetail, type RavelryColorway, type RavelryYarnApiDetail } from "@/api/ravelry";
+import { getRavelryStatus, getRavelryYarnDetail, pushYarnToStash, type RavelryColorway, type RavelryYarnApiDetail } from "@/api/ravelry";
 import { Button } from "@/components/ui/button";
 import { ColorPicker } from "@/components/ui/ColorPicker";
 
@@ -392,6 +392,19 @@ export function YarnDetailPage() {
     enabled: !!id,
   });
 
+  const { data: ravelryStatus } = useQuery({
+    queryKey: ["ravelry-status"],
+    queryFn: getRavelryStatus,
+  });
+
+  const pushMutation = useMutation({
+    mutationFn: () => pushYarnToStash(id!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["yarn", id] });
+      queryClient.invalidateQueries({ queryKey: ["yarn"] });
+    },
+  });
+
   const { data: ravelryYarnResp } = useQuery({
     queryKey: ["ravelry-yarn-detail", yarn?.ravelry_yarn_id],
     queryFn: async () => {
@@ -520,6 +533,28 @@ export function YarnDetailPage() {
               <span className="rounded-full bg-muted text-muted-foreground px-2.5 py-0.5 text-xs">
                 {t("yarnPage.outOfStash")}
               </span>
+            )}
+            {ravelryStatus?.connected && yarn.ravelry_stash_id !== null && ravelryStatus.ravelry_username && (
+              <a
+                href={`https://www.ravelry.com/people/${ravelryStatus.ravelry_username}/stash/${yarn.ravelry_stash_id}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="rounded-full bg-accent/10 text-accent px-2.5 py-0.5 text-xs hover:bg-accent/20 transition-colors"
+              >
+                {t("yarnDetailPage.inRavelryStash")} ↗
+              </a>
+            )}
+            {ravelryStatus?.connected && yarn.ravelry_yarn_id !== null && yarn.ravelry_stash_id === null && !yarn.out_of_stash && !yarn.archived && (
+              <button
+                onClick={() => pushMutation.mutate()}
+                disabled={pushMutation.isPending}
+                className="rounded-full bg-muted text-muted-foreground px-2.5 py-0.5 text-xs hover:bg-muted/80 disabled:opacity-50 transition-colors"
+              >
+                {pushMutation.isPending ? t("common.loading") : t("yarnDetailPage.addToRavelryStash")}
+              </button>
+            )}
+            {pushMutation.isError && (
+              <span className="text-xs text-destructive">{t("yarnDetailPage.addToRavelryStashError")}</span>
             )}
           </div>
 

--- a/frontend/src/pages/YarnPage.tsx
+++ b/frontend/src/pages/YarnPage.tsx
@@ -12,7 +12,7 @@ import {
   ArrowUpDown,
 } from "lucide-react";
 import { listYarn, yarnPhotoUrl, type YarnSummary } from "@/api/yarn";
-import { getRavelryStatus, syncRavelryStash } from "@/api/ravelry";
+import { getRavelryStatus, syncRavelryStash, pushBulkToStash } from "@/api/ravelry";
 import { AddYarnModal } from "@/components/yarn/AddYarnModal";
 import { AddFromRavelryModal } from "@/components/yarn/AddFromRavelryModal";
 import { Button } from "@/components/ui/button";
@@ -136,7 +136,11 @@ function YarnPhoto({ yarn, className }: { yarn: YarnSummary; className: string }
 
 // ─── card view ────────────────────────────────────────────────────────────────
 
-function YarnCard({ yarn }: { yarn: YarnSummary }) {
+function isStashPushEligible(yarn: YarnSummary) {
+  return yarn.ravelry_yarn_id !== null && yarn.ravelry_stash_id === null && !yarn.out_of_stash && !yarn.archived;
+}
+
+function YarnCard({ yarn, connected }: { yarn: YarnSummary; connected: boolean }) {
   const { t } = useTranslation();
   const skeinLabel =
     yarn.skein_count === 0
@@ -195,6 +199,11 @@ function YarnCard({ yarn }: { yarn: YarnSummary }) {
             {t("yarnPage.inStash")}
           </span>
         )}
+        {connected && isStashPushEligible(yarn) && (
+          <span className="rounded px-1.5 py-0.5 text-[10px] bg-muted/60 text-muted-foreground" title={t("yarnPage.notInRavelryStash")}>
+            r↗
+          </span>
+        )}
         <span className="rounded px-1.5 py-0.5 text-[10px] bg-muted text-muted-foreground">
           {yarn.ravelry_yarn_id ? t("yarnPage.sourceRavelry") : t("yarnPage.sourceWeftmark")}
         </span>
@@ -205,7 +214,7 @@ function YarnCard({ yarn }: { yarn: YarnSummary }) {
 
 // ─── grid view ────────────────────────────────────────────────────────────────
 
-function YarnGridTile({ yarn }: { yarn: YarnSummary }) {
+function YarnGridTile({ yarn, connected }: { yarn: YarnSummary; connected: boolean }) {
   const { t } = useTranslation();
   const skeinLabel =
     yarn.skein_count === 0
@@ -230,6 +239,11 @@ function YarnGridTile({ yarn }: { yarn: YarnSummary }) {
           {yarn.ravelry_stash_id !== null && !yarn.out_of_stash && (
             <span className="rounded px-1 py-0.5 text-[9px] bg-accent/10 text-accent leading-none">
               {t("yarnPage.inStash")}
+            </span>
+          )}
+          {connected && isStashPushEligible(yarn) && (
+            <span className="rounded px-1 py-0.5 text-[9px] bg-muted/60 text-muted-foreground leading-none" title={t("yarnPage.notInRavelryStash")}>
+              r↗
             </span>
           )}
           <span className="rounded px-1 py-0.5 text-[9px] bg-muted text-muted-foreground leading-none">
@@ -531,6 +545,8 @@ export function YarnPage() {
   const [showArchived, setShowArchived] = useState(false);
   const [syncError, setSyncError] = useState<string | null>(null);
   const [syncResult, setSyncResult] = useState<{ synced: number; unchanged: boolean } | null>(null);
+  const [showBulkPushModal, setShowBulkPushModal] = useState(false);
+  const [bulkPushResult, setBulkPushResult] = useState<{ pushed: number } | null>(null);
   const [bannerDismissed, setBannerDismissed] = useState(
     () => localStorage.getItem(BANNER_KEY) === "1"
   );
@@ -573,6 +589,16 @@ export function YarnPage() {
     },
   });
 
+  const pushBulkMutation = useMutation({
+    mutationFn: pushBulkToStash,
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ["yarn"] });
+      setShowBulkPushModal(false);
+      setBulkPushResult({ pushed: result.pushed });
+      setTimeout(() => setBulkPushResult(null), 5000);
+    },
+  });
+
   const { data: rawYarns = [], isLoading, error } = useQuery({
     queryKey: ["yarn", { includeArchived: showArchived }],
     queryFn: () => listYarn(showArchived),
@@ -591,6 +617,11 @@ export function YarnPage() {
   const displayYarns = useMemo(
     () => applySort(applyFilters(rawYarns, filters), sort),
     [rawYarns, filters, sort],
+  );
+
+  const eligibleForPush = useMemo(
+    () => rawYarns.filter((y) => connected && isStashPushEligible(y)),
+    [rawYarns, connected],
   );
 
   const handleAdded = () => {
@@ -688,6 +719,16 @@ export function YarnPage() {
           </Button>
         )}
 
+        {connected && eligibleForPush.length > 0 && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setShowBulkPushModal(true)}
+          >
+            {t("yarnPage.pushToRavelryBulkButton", { count: eligibleForPush.length })}
+          </Button>
+        )}
+
         <Button onClick={() => setShowAdd(true)}>{t("yarnPage.newButton")}</Button>
       </div>
 
@@ -721,6 +762,11 @@ export function YarnPage() {
             : t("yarnPage.syncComplete", { count: syncResult.synced })}
         </p>
       )}
+      {bulkPushResult && (
+        <p className="text-sm text-muted-foreground mb-4">
+          {t("yarnPage.pushBulkSuccess", { count: bulkPushResult.pushed })}
+        </p>
+      )}
       {isLoading && <SkeletonCardGrid count={6} cardClassName="h-[120px]" gridClassName="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" />}
       {error && <p className="text-sm text-destructive">{t("yarnPage.loadError")}</p>}
 
@@ -752,12 +798,12 @@ export function YarnPage() {
         <>
           {view === "card" && (
             <div className="space-y-2">
-              {displayYarns.map((y) => <YarnCard key={y.id} yarn={y} />)}
+              {displayYarns.map((y) => <YarnCard key={y.id} yarn={y} connected={connected} />)}
             </div>
           )}
           {view === "grid" && (
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
-              {displayYarns.map((y) => <YarnGridTile key={y.id} yarn={y} />)}
+              {displayYarns.map((y) => <YarnGridTile key={y.id} yarn={y} connected={connected} />)}
             </div>
           )}
           {view === "table" && (
@@ -778,6 +824,34 @@ export function YarnPage() {
           onSuccess={() => { setShowAddFromRavelry(false); queryClient.invalidateQueries({ queryKey: ["yarn"] }); }}
           onClose={() => setShowAddFromRavelry(false)}
         />
+      )}
+
+      {showBulkPushModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-card border border-border rounded-xl shadow-lg max-w-sm w-full mx-4 p-5 space-y-4">
+            <h2 className="text-sm font-semibold text-card-foreground">{t("yarnPage.pushToRavelryModalTitle")}</h2>
+            <p className="text-xs text-muted-foreground">{t("yarnPage.pushToRavelryModalBody")}</p>
+            <ul className="max-h-48 overflow-y-auto space-y-1">
+              {eligibleForPush.map((y) => (
+                <li key={y.id} className="text-xs text-card-foreground truncate">
+                  {y.brand} — {y.name}{y.color_name ? ` (${y.color_name})` : ""}
+                </li>
+              ))}
+            </ul>
+            <div className="flex justify-end gap-2 pt-1">
+              <Button variant="outline" size="sm" onClick={() => setShowBulkPushModal(false)}>
+                {t("common.cancel")}
+              </Button>
+              <Button
+                size="sm"
+                disabled={pushBulkMutation.isPending}
+                onClick={() => pushBulkMutation.mutate()}
+              >
+                {pushBulkMutation.isPending ? t("common.loading") : t("yarnPage.pushToRavelryModalConfirm")}
+              </Button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

- Adds `dye_lot` field to the `Yarn` model (migration `0048`) for use in Ravelry stash create payloads
- New `push_yarn_to_stash` / `push_eligible_yarns_to_stash` service functions; two new POST endpoints (`/api/ravelry/stash-push/{yarn_id}` and `/stash-push/bulk`)
- Frontend: passive "r↗" badge on YarnCard and YarnGridTile for Tier 1 eligible yarns (connected users only); bulk "Add N to Ravelry stash" button with confirmation modal on YarnPage; inline "Add to Ravelry stash" button + post-push stash link on YarnDetailPage
- i18n keys added to all 5 locales (en, de, fr, es, nl)
- 12 new backend tests covering happy path, all eligibility rejections, bulk push with mixed-eligibility yarns, and auth guards

**Eligibility (Tier 1 only):** `ravelry_yarn_id IS NOT NULL`, `ravelry_stash_id IS NULL`, `archived=false`, `out_of_stash=false`, `deleted_at IS NULL`, user has linked Ravelry credential.

Also requires ravelpy `0.3.0` be re-installed (`pip install -e`) as `_post()` and `Stash.create()` were added to that library.

## Test plan

- [ ] Connect a Ravelry account in Settings → Connections
- [ ] Yarn inventory: check that eligible Tier 1 yarns show "r↗" badge and non-eligible do not
- [ ] Bulk push button appears when ≥1 eligible yarn; modal lists yarn names; "Add all" pushes and decrements count
- [ ] Yarn detail page: "Add to Ravelry stash" button visible for eligible yarns; spinner during push; replaced by "In Ravelry stash ↗" link on success
- [ ] Already-synced yarn: button absent on detail page; badge absent on cards
- [ ] Archived or Tier 2 yarn: button/badge not shown
- [ ] Stash link on detail page opens correct Ravelry URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)