### PR TITLE
feat: yarn list — invert color swatch filter to missing (#943)

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -471,7 +471,7 @@
     "sortWeightLight": "Gewicht leicht→schwer",
     "filterLabel": "Filter",
     "filterClearAll": "Alle löschen",
-    "filterHasColor": "Hat Farbmuster",
+    "filterMissingColor": "Ohne Farbmuster",
     "filterInRavelryStash": "Im Ravelry-Vorrat",
     "filterMachineWashable": "Maschinenwaschbar",
     "filterWeight": "Gewicht",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -471,7 +471,7 @@
     "sortWeightLight": "Weight light→heavy",
     "filterLabel": "Filters",
     "filterClearAll": "Clear all",
-    "filterHasColor": "Has color swatch",
+    "filterMissingColor": "Missing color swatch",
     "filterInRavelryStash": "In Ravelry stash",
     "filterMachineWashable": "Machine washable",
     "filterWeight": "Weight",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -470,7 +470,7 @@
     "sortWeightLight": "Peso ligero→pesado",
     "filterLabel": "Filtros",
     "filterClearAll": "Borrar todo",
-    "filterHasColor": "Tiene muestra de color",
+    "filterMissingColor": "Sin muestra de color",
     "filterInRavelryStash": "En alijo de Ravelry",
     "filterMachineWashable": "Lavable a máquina",
     "filterWeight": "Peso",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -470,7 +470,7 @@
     "sortWeightLight": "Poids léger→lourd",
     "filterLabel": "Filtres",
     "filterClearAll": "Tout effacer",
-    "filterHasColor": "A un coloris",
+    "filterMissingColor": "Sans coloris",
     "filterInRavelryStash": "Dans le stock Ravelry",
     "filterMachineWashable": "Lavable en machine",
     "filterWeight": "Poids",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -470,7 +470,7 @@
     "sortWeightLight": "Gewicht licht→zwaar",
     "filterLabel": "Filters",
     "filterClearAll": "Alles wissen",
-    "filterHasColor": "Heeft kleurmonster",
+    "filterMissingColor": "Geen kleurmonster",
     "filterInRavelryStash": "In Ravelry-voorraad",
     "filterMachineWashable": "Machinewasbaar",
     "filterWeight": "Gewicht",

--- a/frontend/src/pages/YarnPage.tsx
+++ b/frontend/src/pages/YarnPage.tsx
@@ -43,12 +43,12 @@ type SortKey =
 interface YarnFilters {
   brands: string[];
   weights: string[];
-  hasColor: boolean;
+  missingColor: boolean;
   inRavelryStash: boolean;
   machineWashable: boolean;
 }
 
-const DEFAULT_FILTERS: YarnFilters = { brands: [], weights: [], hasColor: false, inRavelryStash: false, machineWashable: false };
+const DEFAULT_FILTERS: YarnFilters = { brands: [], weights: [], missingColor: false, inRavelryStash: false, machineWashable: false };
 
 interface YarnPrefs {
   view: ViewMode;
@@ -73,7 +73,7 @@ function savePrefs(prefs: YarnPrefs) {
 // ─── filter + sort logic ──────────────────────────────────────────────────────
 
 function countActiveFilters(f: YarnFilters): number {
-  return (f.brands.length > 0 ? 1 : 0) + (f.weights.length > 0 ? 1 : 0) + (f.hasColor ? 1 : 0) + (f.inRavelryStash ? 1 : 0) + (f.machineWashable ? 1 : 0);
+  return (f.brands.length > 0 ? 1 : 0) + (f.weights.length > 0 ? 1 : 0) + (f.missingColor ? 1 : 0) + (f.inRavelryStash ? 1 : 0) + (f.machineWashable ? 1 : 0);
 }
 
 function applySort(yarns: YarnSummary[], sort: SortKey): YarnSummary[] {
@@ -103,7 +103,7 @@ function applyFilters(yarns: YarnSummary[], f: YarnFilters): YarnSummary[] {
   return yarns.filter((y) => {
     if (f.brands.length > 0 && !f.brands.includes(y.brand)) return false;
     if (f.weights.length > 0 && (!y.weight_category || !f.weights.includes(y.weight_category))) return false;
-    if (f.hasColor && !y.color_hex) return false;
+    if (f.missingColor && y.color_hex) return false;
     if (f.inRavelryStash && !(y.ravelry_stash_id !== null && !y.out_of_stash)) return false;
     if (f.machineWashable && !y.machine_washable) return false;
     return true;
@@ -461,11 +461,11 @@ function FilterPopover({
             <label className="flex items-center gap-2 text-xs cursor-pointer">
               <input
                 type="checkbox"
-                checked={filters.hasColor}
-                onChange={(e) => onChange({ ...filters, hasColor: e.target.checked })}
+                checked={filters.missingColor}
+                onChange={(e) => onChange({ ...filters, missingColor: e.target.checked })}
                 className="rounded accent-accent"
               />
-              {t("yarnPage.filterHasColor")}
+              {t("yarnPage.filterMissingColor")}
             </label>
             <label className="flex items-center gap-2 text-xs cursor-pointer">
               <input


### PR DESCRIPTION
## Summary

- Inverts the yarn list color swatch filter from **has color swatch** → **missing color swatch**
- Enables the filter to act as a task list: yarns that still need a swatch added
- Renames \`hasColor\` → \`missingColor\` in the filter interface, default state, counter, predicate, and checkbox binding
- Filter predicate inverted: \`f.hasColor && !y.color_hex\` → \`f.missingColor && y.color_hex\`
- All 5 locale files updated (en, de, fr, es, nl)
- Existing color swatch display badges in card/grid/table views are untouched

## Test plan

- [ ] Open yarn list; enable "Missing color swatch" filter — confirm only yarns without a color hex are shown
- [ ] Disable filter — confirm all yarns return
- [ ] Confirm filter count badge increments when filter is active
- [ ] Confirm no regressions to brand, weight, Ravelry stash, and machine-washable filters
- [ ] Spot-check DE/FR/ES/NL locale labels in the filter panel

Closes #943

🤖 Generated with [Claude Code](https://claude.com/claude-code)