### PR TITLE
feat: allow force-completing a project with incomplete pick tracker (#976)

### DIFF
--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -1274,16 +1274,18 @@ async def jump_item(
 @router.post("/{project_id}/complete", response_model=ProjectDetail)
 async def complete_project(
     project_id: uuid.UUID,
+    force: bool = Query(False, description="Complete even if not all picks are logged"),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> ProjectDetail:
     project = await _get_owned_project(project_id, current_user, db)
     if project.status not in ("created", "active"):
         raise HTTPException(status_code=400, detail="Project is not active")
-    if project.current_pick <= project.total_picks:
-        raise HTTPException(status_code=400, detail="Not all picks are done — advance to the last pick first")
-    if project.current_item < project.num_items:
-        raise HTTPException(status_code=400, detail="Not all items are done — advance to the last item first")
+    if not force:
+        if project.current_pick <= project.total_picks:
+            raise HTTPException(status_code=400, detail="Not all picks are done — advance to the last pick first")
+        if project.current_item < project.num_items:
+            raise HTTPException(status_code=400, detail="Not all items are done — advance to the last item first")
     project.status = "completed"
     project.completed_at = datetime.now(timezone.utc)
     await _close_open_session(project_id, db)

--- a/backend/tests/routers/test_projects.py
+++ b/backend/tests/routers/test_projects.py
@@ -1459,6 +1459,34 @@ class TestCompleteProject:
         resp = await client.post(f"/api/projects/{project.id}/complete")
         assert resp.status_code == 401
 
+    async def test_force_completes_mid_progress(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        # current_pick=1, tracker incomplete — force should succeed
+        resp = await auth_client.post(f"/api/projects/{project.id}/complete?force=true")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "completed"
+
+    async def test_force_preserves_pick_data(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        total = project.total_picks
+        resp = await auth_client.post(f"/api/projects/{project.id}/complete?force=true")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total_picks"] == total
+        assert body["current_pick"] == 1  # unchanged
+
+    async def test_force_false_still_blocks_incomplete(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        resp = await auth_client.post(f"/api/projects/{project.id}/complete?force=false")
+        assert resp.status_code == 400
+
 
 # ---------------------------------------------------------------------------
 # TestAbandonProject

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -344,8 +344,9 @@ export function stepProject(id: string, direction: "advance" | "reverse"): Promi
   });
 }
 
-export function completeProject(id: string): Promise<ProjectDetail> {
-  return req(`/api/projects/${id}/complete`, { method: "POST" });
+export function completeProject(id: string, force = false): Promise<ProjectDetail> {
+  const qs = force ? "?force=true" : "";
+  return req(`/api/projects/${id}/complete${qs}`, { method: "POST" });
 }
 
 export function abandonProject(id: string): Promise<ProjectDetail> {

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -710,6 +710,7 @@
     "markComplete": "Als abgeschlossen markieren",
     "abandon": "Aufgeben",
     "confirmComplete": "Dieses Projekt als abgeschlossen markieren?",
+    "confirmIncomplete": "Du hast erst {{current}} von {{total}} Reihen gewebt. Projekt trotzdem als abgeschlossen markieren?",
     "confirmAbandon": "Dieses Projekt aufgeben?",
     "confirm": "Bestätigen",
     "restartProject": "Projekt neu starten",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -710,6 +710,7 @@
     "markComplete": "Mark complete",
     "abandon": "Abandon",
     "confirmComplete": "Mark this project as completed?",
+    "confirmIncomplete": "You've only logged {{current}} of {{total}} picks. Mark this project complete anyway?",
     "confirmAbandon": "Abandon this project?",
     "confirm": "Confirm",
     "restartProject": "Restart project",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -709,6 +709,7 @@
     "markComplete": "Marcar como completado",
     "abandon": "Abandonar",
     "confirmComplete": "¿Marcar este proyecto como completado?",
+    "confirmIncomplete": "Solo has tejido {{current}} de {{total}} pasadas. ¿Marcar este proyecto como completado de todas formas?",
     "confirmAbandon": "¿Abandonar este proyecto?",
     "confirm": "Confirmar",
     "restartProject": "Reiniciar proyecto",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -709,6 +709,7 @@
     "markComplete": "Marquer comme terminé",
     "abandon": "Abandonner",
     "confirmComplete": "Marquer ce projet comme terminé ?",
+    "confirmIncomplete": "Vous n'avez tissé que {{current}} duites sur {{total}}. Marquer ce projet comme terminé quand même ?",
     "confirmAbandon": "Abandonner ce projet ?",
     "confirm": "Confirmer",
     "restartProject": "Redémarrer le projet",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -709,6 +709,7 @@
     "markComplete": "Markeren als voltooid",
     "abandon": "Opgeven",
     "confirmComplete": "Dit project als voltooid markeren?",
+    "confirmIncomplete": "Je hebt slechts {{current}} van {{total}} inslagnaden geweven. Project toch als voltooid markeren?",
     "confirmAbandon": "Dit project opgeven?",
     "confirm": "Bevestigen",
     "restartProject": "Project herstarten",

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1058,6 +1058,7 @@ export function ProjectDetailPage() {
   const [showAssignLoom, setShowAssignLoom] = useState(false);
   const [shareModalOpen, setShareModalOpen] = useState(false);
   const [confirmComplete, setConfirmComplete] = useState(false);
+  const [confirmIncomplete, setConfirmIncomplete] = useState(false);
   const [confirmAbandon, setConfirmAbandon] = useState(false);
   const [confirmRestart, setConfirmRestart] = useState(false);
   const [confirmClone, setConfirmClone] = useState(false);
@@ -1240,6 +1241,13 @@ export function ProjectDetailPage() {
     if (!id) return;
     setActionLoading(true);
     try { await completeProject(id); invalidate(); setConfirmComplete(false); }
+    finally { setActionLoading(false); }
+  };
+
+  const handleForceComplete = async () => {
+    if (!id) return;
+    setActionLoading(true);
+    try { await completeProject(id, true); invalidate(); setConfirmIncomplete(false); }
     finally { setActionLoading(false); }
   };
 
@@ -1900,13 +1908,15 @@ export function ProjectDetailPage() {
           {!isReadOnly && isActiveTracking && (
             <CollapsibleSection title={t("projectDetailPage.actions")}>
               <div className="flex flex-wrap gap-2">
-                {!confirmComplete && !confirmAbandon && (
+                {!confirmComplete && !confirmIncomplete && !confirmAbandon && (
                   <>
-                    {isFinished && (
-                      <Button variant="success" size="sm" onClick={() => setConfirmComplete(true)}>
-                        {t("projectDetailPage.markComplete")}
-                      </Button>
-                    )}
+                    <Button
+                      variant="success"
+                      size="sm"
+                      onClick={() => isFinished ? setConfirmComplete(true) : setConfirmIncomplete(true)}
+                    >
+                      {t("projectDetailPage.markComplete")}
+                    </Button>
                     <Button variant="outline" size="sm" onClick={() => setConfirmAbandon(true)}>
                       {t("projectDetailPage.abandon")}
                     </Button>
@@ -1917,6 +1927,20 @@ export function ProjectDetailPage() {
                     <span className="text-sm">{t("projectDetailPage.confirmComplete")}</span>
                     <Button size="sm" variant="success" onClick={handleComplete} disabled={actionLoading}>{t("projectDetailPage.confirm")}</Button>
                     <Button size="sm" variant="outline" onClick={() => setConfirmComplete(false)} disabled={actionLoading}>{t("common.cancel")}</Button>
+                  </div>
+                )}
+                {confirmIncomplete && (
+                  <div className="space-y-2 w-full">
+                    <p className="text-sm text-muted-foreground">
+                      {t("projectDetailPage.confirmIncomplete", {
+                        current: Math.min(project.current_pick - 1, project.total_picks),
+                        total: project.total_picks,
+                      })}
+                    </p>
+                    <div className="flex items-center gap-2">
+                      <Button size="sm" variant="success" onClick={handleForceComplete} disabled={actionLoading}>{t("projectDetailPage.confirm")}</Button>
+                      <Button size="sm" variant="outline" onClick={() => setConfirmIncomplete(false)} disabled={actionLoading}>{t("common.cancel")}</Button>
+                    </div>
                   </div>
                 )}
                 {confirmAbandon && (

--- a/frontend/src/pages/ProjectLandingPage.tsx
+++ b/frontend/src/pages/ProjectLandingPage.tsx
@@ -1344,15 +1344,17 @@ export function ProjectLandingPage() {
   });
 
   const [confirmComplete, setConfirmComplete] = useState(false);
+  const [confirmIncomplete, setConfirmIncomplete] = useState(false);
   const [confirmAbandon, setConfirmAbandon] = useState(false);
   const [statusActionError, setStatusActionError] = useState<string | null>(null);
 
   const completeMutation = useMutation({
-    mutationFn: () => completeProject(id!),
+    mutationFn: (force: boolean) => completeProject(id!, force),
     onSuccess: (updated) => {
       qc.setQueryData(["project", id], updated);
       qc.invalidateQueries({ queryKey: ["projects"] });
       setConfirmComplete(false);
+      setConfirmIncomplete(false);
       setStatusActionError(null);
     },
     onError: (err: Error) => {
@@ -1659,10 +1661,23 @@ export function ProjectLandingPage() {
         {confirmComplete && (
           <div className="flex flex-wrap items-center gap-2 rounded-md bg-muted px-3 py-2 text-sm">
             <span className="flex-1 text-muted-foreground">{t("projectLandingPage.confirmComplete")}</span>
-            <Button size="sm" variant="success" onClick={() => completeMutation.mutate()} disabled={completeMutation.isPending}>
+            <Button size="sm" variant="success" onClick={() => completeMutation.mutate(false)} disabled={completeMutation.isPending}>
               {t("projectLandingPage.confirm")}
             </Button>
             <Button size="sm" variant="outline" onClick={() => { setConfirmComplete(false); setStatusActionError(null); }} disabled={completeMutation.isPending}>
+              {t("common.cancel")}
+            </Button>
+          </div>
+        )}
+        {confirmIncomplete && progress && (
+          <div className="flex flex-wrap items-center gap-2 rounded-md bg-muted px-3 py-2 text-sm">
+            <span className="flex-1 text-muted-foreground">
+              {t("projectDetailPage.confirmIncomplete", { current: progress.done, total: progress.total })}
+            </span>
+            <Button size="sm" variant="success" onClick={() => completeMutation.mutate(true)} disabled={completeMutation.isPending}>
+              {t("projectLandingPage.confirm")}
+            </Button>
+            <Button size="sm" variant="outline" onClick={() => { setConfirmIncomplete(false); setStatusActionError(null); }} disabled={completeMutation.isPending}>
               {t("common.cancel")}
             </Button>
           </div>
@@ -1702,11 +1717,19 @@ export function ProjectLandingPage() {
               {t("projectLandingPage.abandon")}
             </Button>
           )}
-          {project.status === "active" && !confirmComplete && (
+          {project.status === "active" && !confirmComplete && !confirmIncomplete && (
             <Button
               variant="outline"
               className="border-green-600 text-green-700 hover:bg-green-600 hover:text-white dark:text-green-400 dark:border-green-500 dark:hover:bg-green-600 dark:hover:text-white"
-              onClick={() => { setConfirmComplete(true); setConfirmAbandon(false); setStatusActionError(null); }}
+              onClick={() => {
+                setConfirmAbandon(false);
+                setStatusActionError(null);
+                if (progress && progress.pct >= 100) {
+                  setConfirmComplete(true);
+                } else {
+                  setConfirmIncomplete(true);
+                }
+              }}
             >
               {t("projectLandingPage.markComplete")}
             </Button>


### PR DESCRIPTION
## Summary

- Adds `force=true` query param to `POST /api/projects/{id}/complete` to bypass the pick-count and item-count gate
- Both the tracker screen and project landing page now show a warning confirmation dialog displaying logged vs. planned pick counts before invoking the force path
- All five locales updated with `confirmIncomplete` translation key
- Three new backend tests cover the force-complete paths

Closes #976

## Test plan

- [ ] Open an active project with a pick tracker (total_picks > 0)
- [ ] From the tracker screen: click "Mark Complete" while not at the last pick — warning dialog appears with pick counts; confirm → project marked complete
- [ ] From the project landing page: click "Mark Complete" while tracker is incomplete — same warning dialog appears; confirm → project marked complete
- [ ] Projects that ARE at 100% picks still go through the normal confirmation (no warning dialog)
- [ ] `pytest backend/tests/routers/test_projects.py` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)