### PR TITLE
fix: display colorway code alongside name in Ravelry colorway pickers (#971)

### DIFF
--- a/frontend/src/api/ravelry.ts
+++ b/frontend/src/api/ravelry.ts
@@ -92,8 +92,16 @@ export interface RavelryYarnResult {
 export interface RavelryColorway {
   id: number;
   name: string;
+  code: string | null;
   current_status: string;
   photos: { square_url: string | null; thumbnail_url: string | null }[];
+}
+
+export function formatColorwayLabel(cw: RavelryColorway): string {
+  const code = cw.code?.trim() || null;
+  const name = cw.name?.trim() || null;
+  if (code && name) return `${code} ${name}`;
+  return code ?? name ?? "";
 }
 
 export async function getPopularRavelryCompanies(limit = 10): Promise<RavelryCompany[]> {

--- a/frontend/src/components/yarn/AddFromRavelryModal.tsx
+++ b/frontend/src/components/yarn/AddFromRavelryModal.tsx
@@ -7,6 +7,7 @@ import {
   searchRavelryYarns,
   getRavelryYarnDetail,
   importRavelryYarn,
+  formatColorwayLabel,
   getPopularRavelryCompanies,
   getPopularRavelryYarns,
   type RavelryCompany,
@@ -158,7 +159,7 @@ export function AddFromRavelryModal({ onSuccess, onClose }: Props) {
   const filteredColorways = useMemo(() => {
     if (!colorwayFilter.trim()) return colorways;
     const q = colorwayFilter.toLowerCase();
-    return colorways.filter((cw) => cw.name.toLowerCase().includes(q));
+    return colorways.filter((cw) => cw.name.toLowerCase().includes(q) || (cw.code ?? "").toLowerCase().includes(q));
   }, [colorways, colorwayFilter]);
 
   // Company search
@@ -244,7 +245,7 @@ export function AddFromRavelryModal({ onSuccess, onClose }: Props) {
       setColorways(active);
       if (active.length === 1) {
         setSelectedColorway(active[0]);
-        setColorName(active[0].name);
+        setColorName(formatColorwayLabel(active[0]));
       }
     } catch {
       setColorways([]);
@@ -255,7 +256,7 @@ export function AddFromRavelryModal({ onSuccess, onClose }: Props) {
 
   function pickColorway(cw: RavelryColorway) {
     setSelectedColorway(cw);
-    setColorName(cw.name);
+    setColorName(formatColorwayLabel(cw));
   }
 
   async function handleImport() {
@@ -529,7 +530,7 @@ export function AddFromRavelryModal({ onSuccess, onClose }: Props) {
                       {cw.photos?.[0]?.square_url && (
                         <img src={cw.photos[0].square_url} alt={cw.name} className="h-10 w-full rounded object-cover mb-1" />
                       )}
-                      <span className="truncate block leading-tight">{cw.name}</span>
+                      <span className="truncate block leading-tight">{formatColorwayLabel(cw)}</span>
                     </button>
                   ))}
                 </div>

--- a/frontend/src/pages/YarnDetailPage.tsx
+++ b/frontend/src/pages/YarnDetailPage.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useParams, Link } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getYarn, updateYarn, patchYarnColorway, getYarnProjects, type YarnProjectRef } from "@/api/yarn";
-import { getRavelryStatus, getRavelryYarnDetail, pushYarnToStash, type RavelryColorway, type RavelryYarnApiDetail } from "@/api/ravelry";
+import { formatColorwayLabel, getRavelryStatus, getRavelryYarnDetail, pushYarnToStash, type RavelryColorway, type RavelryYarnApiDetail } from "@/api/ravelry";
 import { Button } from "@/components/ui/button";
 import { ColorPicker } from "@/components/ui/ColorPicker";
 
@@ -67,7 +67,7 @@ function EditColorwayModal({
   const filteredColorways = useMemo(() => {
     if (!colorwayFilter.trim()) return colorways;
     const q = colorwayFilter.toLowerCase();
-    return colorways.filter((cw) => cw.name.toLowerCase().includes(q));
+    return colorways.filter((cw) => cw.name.toLowerCase().includes(q) || (cw.code ?? "").toLowerCase().includes(q));
   }, [colorways, colorwayFilter]);
 
   async function loadColorways() {
@@ -91,7 +91,7 @@ function EditColorwayModal({
 
   function pickColorway(cw: RavelryColorway) {
     setSelectedColorway(cw);
-    setColorName(cw.name);
+    setColorName(formatColorwayLabel(cw));
   }
 
   async function handleSave() {
@@ -192,7 +192,7 @@ function EditColorwayModal({
                       {cw.photos?.[0]?.square_url && (
                         <img src={cw.photos[0].square_url} alt={cw.name} className="h-10 w-full rounded object-cover mb-1" />
                       )}
-                      <span className="truncate block leading-tight">{cw.name}</span>
+                      <span className="truncate block leading-tight">{formatColorwayLabel(cw)}</span>
                     </button>
                   ))}
                 </div>


### PR DESCRIPTION
## Summary

- Adds `code: string | null` to the `RavelryColorway` interface (the field was already in the Ravelry API response, just not typed)
- Exports a shared `formatColorwayLabel` helper implementing the precedence rules from the issue: `code + name` → `"5209 Creme"`, name-only → `"Burnt Orange"`, code-only → `"5209"`
- Both colorway pickers (`AddFromRavelryModal` and `YarnDetailPage`) now display and store the combined label
- Filter inputs in both pickers now also match on `code`, so users can search by number

Frontend-only change — backend already proxies the `code` field verbatim.

Closes #971

## Test plan

- [ ] Add a new yarn via Ravelry import — colorway grid shows `"code name"` format (e.g. `"5209 Creme"`)
- [ ] On an existing Ravelry-linked yarn, open the colorway picker and relink — stored color name updates to combined format
- [ ] Type a numeric code into the colorway filter — matching colorways appear
- [ ] Colorways with no code still display name only; colorways with no name display code only

🤖 Generated with [Claude Code](https://claude.com/claude-code)