### PR TITLE
fix: hide sidebar collapse button on non-detail pages (#986)

### DIFF
--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -33,7 +33,7 @@ export function AppLayout({ children }: Props) {
         onClose={() => setSidebarOpen(false)}
         desktopCollapsed={desktopCollapsed}
         onDesktopExpand={() => setExpandedOnPath(location.pathname)}
-        onDesktopCollapse={() => setExpandedOnPath(null)}
+        onDesktopCollapse={isDetailPage && !desktopCollapsed ? () => setExpandedOnPath(null) : undefined}
       />
 
       <div className="flex flex-1 flex-col overflow-hidden">

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -141,17 +141,19 @@ export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpa
           >
             <AppIcons.close className="h-4 w-4" />
           </button>
-          {/* Desktop sidebar toggle — hidden on mobile, always visible on lg+ */}
-          <button
-            onClick={desktopCollapsed ? onDesktopExpand : onDesktopCollapse}
-            className="hidden rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground lg:flex"
-            aria-label={desktopCollapsed ? "Expand navigation" : "Collapse navigation"}
-            title={desktopCollapsed ? "Expand navigation" : "Collapse navigation"}
-          >
-            {desktopCollapsed
-              ? <AppIcons.chevronDoubleRight className="h-3.5 w-3.5" />
-              : <AppIcons.chevronDoubleLeft className="h-3.5 w-3.5" />}
-          </button>
+          {/* Desktop sidebar toggle — only on detail pages where rail/expand applies */}
+          {(desktopCollapsed || onDesktopCollapse) && (
+            <button
+              onClick={desktopCollapsed ? onDesktopExpand : onDesktopCollapse}
+              className={`hidden lg:flex rounded-md text-muted-foreground hover:bg-muted hover:text-foreground ${desktopCollapsed ? "p-1" : "p-1.5"}`}
+              aria-label={desktopCollapsed ? "Expand navigation" : "Collapse navigation"}
+              title={desktopCollapsed ? "Expand navigation" : "Collapse navigation"}
+            >
+              {desktopCollapsed
+                ? <AppIcons.chevronDoubleRight className="h-3.5 w-3.5" />
+                : <AppIcons.chevronDoubleLeft className="h-5 w-5" />}
+            </button>
+          )}
         </div>
 
         {/* Onboarding checklist — above primary nav, hidden for superusers */}


### PR DESCRIPTION
## Summary

Regression from #982. The collapse toggle was rendered with `hidden lg:flex` unconditionally, so it appeared on every page at desktop widths.

- `AppLayout` now only passes `onDesktopCollapse` when on a detail page in the manually-expanded state (`isDetailPage && !desktopCollapsed`)
- `Sidebar` gates the entire toggle button on `desktopCollapsed || onDesktopCollapse` — invisible when neither condition applies

**Button behaviour after fix:**
- Non-detail pages (dashboard, drafts, yarn…): no button at all
- Project detail, rail mode: chevron-right expand button
- Project detail, manually expanded: chevron-left collapse button

Closes #986

## Test plan

- [ ] Dashboard / drafts / yarn pages at ≥1024px — no toggle button in sidebar header
- [ ] Project detail page — chevron-right appears in rail mode; click expands sidebar
- [ ] After expanding — chevron-left appears; click collapses back to rail

🤖 Generated with [Claude Code](https://claude.com/claude-code)