### PR TITLE
feat: multi-draft project workflow (#977)

### DIFF
--- a/backend/alembic/versions/0002_multi_draft_projects.py
+++ b/backend/alembic/versions/0002_multi_draft_projects.py
@@ -1,0 +1,130 @@
+"""Multi-draft project sequence: add project_drafts table, migrate existing data, drop old columns.
+
+Revision ID: 0002_multi_draft_projects
+Revises: 0001_squash_902
+Create Date: 2026-05-28
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0002_multi_draft_projects"
+down_revision: Union[str, None] = "0001_squash_902"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. Create project_drafts sequence table
+    op.create_table(
+        "project_drafts",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("project_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("projects.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("draft_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("drafts.id"), nullable=False),
+        sa.Column("position", sa.Integer(), nullable=False),
+        sa.Column("repeats", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("current_pick", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.UniqueConstraint("project_id", "position", name="uq_project_draft_position"),
+    )
+    op.create_index("ix_project_drafts_project_id", "project_drafts", ["project_id"])
+    op.create_index("ix_project_drafts_draft_id", "project_drafts", ["draft_id"])
+
+    # 2. Add current_position to projects (nullable initially for the data migration step)
+    op.add_column("projects", sa.Column("current_position", sa.Integer(), nullable=True))
+
+    # 3. Add sequence_id to project_steps (nullable — existing steps have no sequence context)
+    op.add_column(
+        "project_steps",
+        sa.Column("sequence_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("project_drafts.id"), nullable=True),
+    )
+    op.create_index("ix_project_steps_sequence_id", "project_steps", ["sequence_id"])
+
+    # 4. Migrate existing projects → create one project_drafts row per project
+    #    Preserve current_pick from the old column into project_drafts.current_pick
+    op.execute("""
+        INSERT INTO project_drafts (id, project_id, draft_id, position, repeats, current_pick, created_at, updated_at)
+        SELECT
+            gen_random_uuid(),
+            p.id,
+            p.draft_id,
+            1,
+            1,
+            GREATEST(p.current_pick - 1, 0),
+            NOW(),
+            NOW()
+        FROM projects p
+        WHERE p.draft_id IS NOT NULL
+          AND p.deleted_at IS NULL
+    """)
+
+    # Also handle soft-deleted projects
+    op.execute("""
+        INSERT INTO project_drafts (id, project_id, draft_id, position, repeats, current_pick, created_at, updated_at)
+        SELECT
+            gen_random_uuid(),
+            p.id,
+            p.draft_id,
+            1,
+            1,
+            GREATEST(p.current_pick - 1, 0),
+            NOW(),
+            NOW()
+        FROM projects p
+        WHERE p.draft_id IS NOT NULL
+          AND p.deleted_at IS NOT NULL
+    """)
+
+    # 5. Set current_position = 1 for all projects
+    op.execute("UPDATE projects SET current_position = 1")
+
+    # 6. Make current_position NOT NULL with default
+    op.alter_column("projects", "current_position", nullable=False, server_default="1")
+
+    # 7. Make project_type nullable (new projects won't have it until loom is assigned)
+    op.alter_column("projects", "project_type", nullable=True)
+
+    # 8. Drop old columns from projects
+    #    (draft_id, current_pick, total_picks are now in project_drafts)
+    op.drop_index("ix_projects_draft_id", table_name="projects")
+    op.drop_column("projects", "draft_id")
+    op.drop_column("projects", "current_pick")
+    op.drop_column("projects", "total_picks")
+
+
+def downgrade() -> None:
+    # Restore old columns (best-effort: populate from first sequence entry)
+    op.add_column("projects", sa.Column("draft_id", postgresql.UUID(as_uuid=True), nullable=True))
+    op.add_column("projects", sa.Column("current_pick", sa.Integer(), nullable=True))
+    op.add_column("projects", sa.Column("total_picks", sa.Integer(), nullable=True))
+
+    op.execute("""
+        UPDATE projects p
+        SET
+            draft_id = pd.draft_id,
+            current_pick = pd.current_pick + 1,
+            total_picks = COALESCE(d.weft_threads, 1)
+        FROM project_drafts pd
+        JOIN drafts d ON d.id = pd.draft_id
+        WHERE pd.project_id = p.id AND pd.position = 1
+    """)
+
+    op.alter_column("projects", "draft_id", nullable=False)
+    op.alter_column("projects", "current_pick", nullable=False, server_default="1")
+    op.alter_column("projects", "total_picks", nullable=False, server_default="1")
+    op.create_index("ix_projects_draft_id", "projects", ["draft_id"])
+
+    op.alter_column("projects", "project_type", nullable=False)
+
+    op.drop_index("ix_project_steps_sequence_id", table_name="project_steps")
+    op.drop_column("project_steps", "sequence_id")
+
+    op.drop_column("projects", "current_position")
+
+    op.drop_index("ix_project_drafts_draft_id", table_name="project_drafts")
+    op.drop_index("ix_project_drafts_project_id", table_name="project_drafts")
+    op.drop_table("project_drafts")

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -27,27 +27,45 @@ class ProjectPhoto(Base, TimestampMixin):
     project: Mapped["Project"] = relationship("Project", back_populates="photos")
 
 
+class ProjectDraft(Base, TimestampMixin):
+    """One entry in a project's draft sequence — a draft × repeat count at a given position."""
+
+    __tablename__ = "project_drafts"
+    __table_args__ = (UniqueConstraint("project_id", "position", name="uq_project_draft_position"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    draft_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("drafts.id"), nullable=False, index=True)
+    position: Mapped[int] = mapped_column(Integer, nullable=False)  # 1-based, dense
+    repeats: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    current_pick: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    project: Mapped["Project"] = relationship("Project", back_populates="draft_sequence")
+
+
 class Project(Base, TimestampMixin, SoftDeleteMixin):
     __tablename__ = "projects"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     owner_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, index=True)
-    draft_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("drafts.id"), nullable=False, index=True)
     loom_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("looms.id"), nullable=True)
     loom_version_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("loom_versions.id"), nullable=True
     )
 
     name: Mapped[str] = mapped_column(String(255), nullable=False)
-    project_type: Mapped[str] = mapped_column(String(10), nullable=False)  # "treadle" | "lift"
-    status: Mapped[str] = mapped_column(String(20), nullable=False, default="active")
+    # project_type is derived from loom on assignment; null until a loom is assigned
+    project_type: Mapped[str | None] = mapped_column(String(10), nullable=True)  # "treadle" | "lift"
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="created")
 
-    # Step tracking
-    current_pick: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    # Active sequence position (1-based, matches project_drafts.position)
+    current_position: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+
+    # Item tracking (multiple physical items on one warp, e.g. 5 towels)
     current_item: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
-    total_picks: Mapped[int] = mapped_column(Integer, nullable=False)
-    # Stores last known pick per item: {"1": 3, "2": 7}. Updated on item transitions so
-    # jumping back to a previously visited item restores where the weaver left off.
+    # Stores last known pick per item per sequence position: {"1:1": 3, "2:1": 7}
     item_picks: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
 
     # Warp plan inputs
@@ -71,6 +89,9 @@ class Project(Base, TimestampMixin, SoftDeleteMixin):
     drawdown_preview_path: Mapped[str | None] = mapped_column(String(500), nullable=True)
     drawdown_svg_path: Mapped[str | None] = mapped_column(String(500), nullable=True)
 
+    draft_sequence: Mapped[list["ProjectDraft"]] = relationship(
+        "ProjectDraft", back_populates="project", order_by="ProjectDraft.position", cascade="all, delete-orphan"
+    )
     steps: Mapped[list["ProjectStep"]] = relationship(
         "ProjectStep", back_populates="project", order_by="ProjectStep.created_at"
     )
@@ -91,6 +112,9 @@ class ProjectStep(Base, TimestampMixin):
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     project_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("projects.id"), nullable=False, index=True
+    )
+    sequence_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("project_drafts.id"), nullable=True, index=True
     )
     event_type: Mapped[str] = mapped_column(String(10), nullable=False)  # "advance" | "reverse"
     from_pick: Mapped[int] = mapped_column(Integer, nullable=False)

--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -552,8 +552,15 @@ async def delete_draft(
     from app.models.project import Project
 
     draft = await _get_owned_draft(draft_id, current_user, db)
+    from app.models.project import ProjectDraft
+
     active_projects = (
-        await db.scalars(select(Project).where(Project.draft_id == draft.id, Project.deleted_at.is_(None)))
+        await db.scalars(
+            select(Project)
+            .join(ProjectDraft, ProjectDraft.project_id == Project.id)
+            .where(ProjectDraft.draft_id == draft.id, Project.deleted_at.is_(None))
+            .distinct()
+        )
     ).all()
 
     if active_projects and not force:

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -9,14 +9,14 @@ from decimal import Decimal
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from fastapi.responses import Response
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.deps import get_current_user, get_db
 from app.models.draft import Draft
-from app.models.loom import PROJECT_SUPPORTED_LOOM_TYPES, Loom, LoomVersion
-from app.models.project import Project, ProjectPhoto, ProjectStep, ProjectYarnColor, WeaveSession
+from app.models.loom import PROJECT_SUPPORTED_LOOM_TYPES, Loom, LoomVersion, loom_tracking_flags
+from app.models.project import Project, ProjectDraft, ProjectPhoto, ProjectStep, ProjectYarnColor, WeaveSession
 from app.models.user import User
 from app.models.yarn import Yarn
 from app.services import storage, wif_parser
@@ -67,20 +67,43 @@ class ProjectYarnColorSchema(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class ProjectDraftSchema(BaseModel):
+    id: uuid.UUID
+    draft_id: uuid.UUID
+    position: int
+    repeats: int
+    current_pick: int
+    draft_name: str
+    draft_total_picks: int  # draft.weft_threads (picks per single pass)
+    section_total_picks: int  # draft_total_picks * repeats
+    is_active: bool  # matches project.current_position
+    has_treadling: bool
+    has_liftplan: bool
+
+    model_config = {"from_attributes": True}
+
+
 class ProjectSummary(BaseModel):
     id: uuid.UUID
     owner_id: uuid.UUID
-    draft_id: uuid.UUID
     loom_id: uuid.UUID | None
     loom_version_id: uuid.UUID | None
     name: str
-    project_type: str
+    project_type: str | None  # null until loom assigned
     status: str
-    current_pick: int
+    current_position: int
+    # Active position conveniences (mirrors tracker expectations)
+    current_pick: int  # active sequence entry's current_pick
     current_item: int
-    total_picks: int
     num_items: int
     length_unit: str
+    # Aggregate progress across the full sequence
+    total_picks: int  # sum of section_total_picks
+    aggregate_current_pick: int  # sum of current_pick across all positions
+    # List-view draft info
+    draft_id: uuid.UUID | None  # primary (position-1) draft id, for thumbnail lookup
+    draft_count: int
+    draft_sequence: list[ProjectDraftSchema] = []
     completed_at: datetime | None
     abandoned_at: datetime | None
     created_at: datetime
@@ -95,29 +118,57 @@ class ProjectSummary(BaseModel):
     model_config = {"from_attributes": True}
 
 
-class ProjectDetail(ProjectSummary):
+class ProjectDetail(BaseModel):
+    # All Summary fields
+    id: uuid.UUID
+    owner_id: uuid.UUID
+    loom_id: uuid.UUID | None
+    loom_version_id: uuid.UUID | None
+    name: str
+    project_type: str | None
+    status: str
+    current_position: int
+    current_pick: int
+    current_item: int
+    num_items: int
+    length_unit: str
+    total_picks: int
+    aggregate_current_pick: int
+    draft_id: uuid.UUID | None
+    draft_count: int
+    draft_sequence: list[ProjectDraftSchema] = []
+    completed_at: datetime | None
+    abandoned_at: datetime | None
+    created_at: datetime
+    hide_unused_shafts_treadles: bool
+    has_drawdown_preview: bool = False
+    has_drawdown_svg: bool = False
+    share_slug: str | None = None
+    share_visibility: str = "private"
+    share_expires_at: datetime | None = None
+    tags: list[str] = []
+    # Detail-only fields (from active draft)
     finished_length_per_item: Decimal | None
     waste_between_items: Decimal | None
     warp_waste_allowance: Decimal | None
-    completed_at: datetime | None
     notes: str | None
-    draft_name: str
-    draft_num_shafts: int | None
-    draft_num_treadles: int | None
-    draft_effective_num_treadles: int | None
-    draft_effective_num_shafts: int | None
-    draft_metadata_overrides: dict | None
-    draft_wif_colors: list | None
-    draft_warp_color_stats: list | None
-    draft_weft_color_stats: list | None
-    draft_wif_measurements: dict | None
-    draft_warp_threads: int | None
-    draft_weft_threads: int | None
-    draft_warp_length_cm: float | None
-    draft_weaving_width_override_cm: float | None
-    draft_epi_override: float | None
-    color_replacements: dict | None
-    loom_name: str | None
+    draft_name: str | None = None
+    draft_num_shafts: int | None = None
+    draft_num_treadles: int | None = None
+    draft_effective_num_treadles: int | None = None
+    draft_effective_num_shafts: int | None = None
+    draft_metadata_overrides: dict | None = None
+    draft_wif_colors: list | None = None
+    draft_warp_color_stats: list | None = None
+    draft_weft_color_stats: list | None = None
+    draft_wif_measurements: dict | None = None
+    draft_warp_threads: int | None = None
+    draft_weft_threads: int | None = None
+    draft_warp_length_cm: float | None = None
+    draft_weaving_width_override_cm: float | None = None
+    draft_epi_override: float | None = None
+    color_replacements: dict | None = None
+    loom_name: str | None = None
     loom_num_treadles: int | None = None
     loom_num_shafts: int | None = None
     loom_warp_waste_allowance: Decimal | None = None
@@ -128,11 +179,11 @@ class ProjectDetail(ProjectSummary):
     photos: list[ProjectPhotoSchema] = []
     yarn_colors: list[ProjectYarnColorSchema] = []
 
+    model_config = {"from_attributes": True}
+
 
 class CreateProjectRequest(BaseModel):
     name: str
-    draft_id: uuid.UUID
-    project_type: str  # "treadle" | "lift"
     loom_id: uuid.UUID | None = None
     loom_version_id: uuid.UUID | None = None
     finished_length_per_item: Decimal | None = None
@@ -184,10 +235,26 @@ class StepRequest(BaseModel):
 
 
 class StepResponse(BaseModel):
-    current_pick: int
-    total_picks: int
+    current_pick: int  # active position's current_pick
+    total_picks: int  # active position's section_total_picks
+    position: int  # which sequence position is active
+    aggregate_current_pick: int
+    aggregate_total_picks: int
     current_item: int
     num_items: int
+
+
+class AddSequenceEntryRequest(BaseModel):
+    draft_id: uuid.UUID
+    repeats: int = 1
+
+
+class UpdateSequenceEntryRequest(BaseModel):
+    repeats: int | None = None
+
+
+class ReorderSequenceRequest(BaseModel):
+    ordered_ids: list[uuid.UUID]  # project_drafts.id in desired order
 
 
 class PickRow(BaseModel):
@@ -220,7 +287,7 @@ class WarpingPlanColorRun(BaseModel):
 class WarpingPlanResponse(BaseModel):
     project_id: uuid.UUID
     draft_name: str
-    project_type: str
+    project_type: str | None
     warp_threads: int | None
     total_picks: int | None
     num_shafts: int | None
@@ -266,9 +333,9 @@ class SharedProjectResponse(BaseModel):
     slug: str
     project_name: str
     project_status: str
-    project_type: str
+    project_type: str | None
     owner_display_name: str
-    draft_name: str
+    draft_name: str | None
     draft_num_shafts: int | None
     draft_num_treadles: int | None
     num_items: int
@@ -344,17 +411,14 @@ async def _check_loom_conflict(
         raise HTTPException(status_code=409, detail="This loom already has an active project")
 
 
-async def _wif_path_for_project(draft: Draft, project_type: str) -> str:
+async def _wif_path_for_project(draft: Draft, project_type: str | None) -> str:
     """Return the correct WIF path for a project type.
 
     For lift projects, prefer the liftplan-augmented file when available so
-    that the original upload is never mutated. Falls back to wif_path (covers
-    the case where the liftplan was embedded in the original WIF by the user's
-    design software).
     """
     if project_type == "lift" and draft.wif_modified_path and await storage.afile_exists(draft.wif_modified_path):
         return draft.wif_modified_path
-    return draft.wif_path
+    return draft.wif_path  # type: ignore[return-value]
 
 
 async def _get_owned_project(
@@ -391,6 +455,61 @@ async def _resolve_loom_version(project: Project, db: AsyncSession) -> LoomVersi
     return None
 
 
+async def _load_sequence(project_id: uuid.UUID, db: AsyncSession) -> list[tuple[ProjectDraft, Draft]]:
+    """Load the ordered draft sequence for a project with each entry's Draft record."""
+    entries = (
+        await db.scalars(
+            select(ProjectDraft).where(ProjectDraft.project_id == project_id).order_by(ProjectDraft.position)
+        )
+    ).all()
+    result: list[tuple[ProjectDraft, Draft]] = []
+    for entry in entries:
+        draft = await db.get(Draft, entry.draft_id)
+        if draft is not None:
+            result.append((entry, draft))
+    return result
+
+
+def _active_pair(project: Project, sequence: list[tuple[ProjectDraft, Draft]]) -> tuple[ProjectDraft, Draft] | None:
+    """Return the (entry, draft) for project.current_position, or position 1 as fallback."""
+    for entry, draft in sequence:
+        if entry.position == project.current_position:
+            return entry, draft
+    return sequence[0] if sequence else None
+
+
+def _compute_total_picks(sequence: list[tuple[ProjectDraft, Draft]]) -> int:
+    return sum((d.weft_threads or 0) * e.repeats for e, d in sequence)
+
+
+def _compute_aggregate_current_pick(sequence: list[tuple[ProjectDraft, Draft]]) -> int:
+    return sum(e.current_pick for e, _ in sequence)
+
+
+def _build_sequence_schema(
+    sequence: list[tuple[ProjectDraft, Draft]], current_position: int
+) -> list[ProjectDraftSchema]:
+    result = []
+    for entry, draft in sequence:
+        total = draft.weft_threads or 0
+        result.append(
+            ProjectDraftSchema(
+                id=entry.id,
+                draft_id=entry.draft_id,
+                position=entry.position,
+                repeats=entry.repeats,
+                current_pick=entry.current_pick,
+                draft_name=draft.name,
+                draft_total_picks=total,
+                section_total_picks=total * entry.repeats,
+                is_active=entry.position == current_position,
+                has_treadling=draft.has_treadling,
+                has_liftplan=draft.has_liftplan,
+            )
+        )
+    return result
+
+
 def _yarn_color_schema(pyc: ProjectYarnColor) -> ProjectYarnColorSchema:
     yarn = pyc.yarn
     return ProjectYarnColorSchema(
@@ -409,51 +528,63 @@ def _yarn_color_schema(pyc: ProjectYarnColor) -> ProjectYarnColorSchema:
 
 def _to_detail(
     project: Project,
-    draft: Draft,
+    sequence: list[tuple[ProjectDraft, Draft]],
     loom: Loom | None,
     photos: list[ProjectPhoto] | None = None,
     loom_version: LoomVersion | None = None,
     loom_reeds: list[dict] | None = None,
     yarn_colors: list[ProjectYarnColor] | None = None,
 ) -> ProjectDetail:
+    active = _active_pair(project, sequence)
+    active_entry = active[0] if active else None
+    active_draft = active[1] if active else None
+
+    total_picks = _compute_total_picks(sequence)
+    agg_current = _compute_aggregate_current_pick(sequence)
+    primary_draft_id = sequence[0][0].draft_id if sequence else None
+
     return ProjectDetail(
         id=project.id,
         owner_id=project.owner_id,
-        draft_id=project.draft_id,
         loom_id=project.loom_id,
         loom_version_id=project.loom_version_id,
         name=project.name,
         project_type=project.project_type,
         status=project.status,
-        current_pick=project.current_pick,
+        current_position=project.current_position,
+        current_pick=active_entry.current_pick if active_entry else 0,
         current_item=project.current_item,
-        total_picks=project.total_picks,
-        finished_length_per_item=project.finished_length_per_item,
         num_items=project.num_items,
+        length_unit=project.length_unit,
+        total_picks=total_picks,
+        aggregate_current_pick=agg_current,
+        draft_id=primary_draft_id,
+        draft_count=len(sequence),
+        draft_sequence=_build_sequence_schema(sequence, project.current_position),
+        finished_length_per_item=project.finished_length_per_item,
         waste_between_items=project.waste_between_items,
         warp_waste_allowance=project.warp_waste_allowance,
-        length_unit=project.length_unit,
         completed_at=project.completed_at,
         abandoned_at=project.abandoned_at,
         notes=project.notes,
         created_at=project.created_at,
         hide_unused_shafts_treadles=project.hide_unused_shafts_treadles,
         color_replacements=project.color_replacements,
-        draft_name=draft.name,
-        draft_num_shafts=draft.num_shafts,
-        draft_num_treadles=draft.num_treadles,
-        draft_effective_num_treadles=draft.effective_num_treadles,
-        draft_effective_num_shafts=draft.effective_num_shafts,
-        draft_metadata_overrides=draft.metadata_overrides,
-        draft_wif_colors=draft.wif_colors,
-        draft_warp_color_stats=draft.warp_color_stats,
-        draft_weft_color_stats=draft.weft_color_stats,
-        draft_wif_measurements=draft.wif_measurements,
-        draft_warp_threads=draft.warp_threads,
-        draft_weft_threads=draft.weft_threads,
-        draft_warp_length_cm=draft.warp_length_cm,
-        draft_weaving_width_override_cm=draft.weaving_width_override_cm,
-        draft_epi_override=draft.epi_override,
+        draft_name=active_draft.name if active_draft else None,
+        draft_num_shafts=active_draft.num_shafts if active_draft else None,
+        draft_num_treadles=active_draft.num_treadles if active_draft else None,
+        draft_effective_num_treadles=active_draft.effective_num_treadles if active_draft else None,
+        draft_effective_num_shafts=active_draft.effective_num_shafts if active_draft else None,
+        draft_metadata_overrides=active_draft.metadata_overrides if active_draft else None,
+        draft_wif_colors=active_draft.wif_colors if active_draft else None,
+        draft_warp_color_stats=active_draft.warp_color_stats if active_draft else None,
+        draft_weft_color_stats=active_draft.weft_color_stats if active_draft else None,
+        draft_wif_measurements=active_draft.wif_measurements if active_draft else None,
+        draft_warp_threads=active_draft.warp_threads if active_draft else None,
+        draft_weft_threads=active_draft.weft_threads if active_draft else None,
+        draft_warp_length_cm=active_draft.warp_length_cm if active_draft else None,
+        draft_weaving_width_override_cm=active_draft.weaving_width_override_cm if active_draft else None,
+        draft_epi_override=active_draft.epi_override if active_draft else None,
         loom_name=f"{loom.manufacturer} {loom.model_name}" if loom else None,
         loom_num_treadles=loom_version.num_treadles if loom_version else None,
         loom_num_shafts=loom_version.num_shafts if loom_version else None,
@@ -473,6 +604,47 @@ def _to_detail(
     )
 
 
+def _to_summary(
+    project: Project,
+    sequence: list[tuple[ProjectDraft, Draft]],
+) -> ProjectSummary:
+    active = _active_pair(project, sequence)
+    active_entry = active[0] if active else None
+    total_picks = _compute_total_picks(sequence)
+    agg_current = _compute_aggregate_current_pick(sequence)
+    primary_draft_id = sequence[0][0].draft_id if sequence else None
+
+    return ProjectSummary(
+        id=project.id,
+        owner_id=project.owner_id,
+        loom_id=project.loom_id,
+        loom_version_id=project.loom_version_id,
+        name=project.name,
+        project_type=project.project_type,
+        status=project.status,
+        current_position=project.current_position,
+        current_pick=active_entry.current_pick if active_entry else 0,
+        current_item=project.current_item,
+        num_items=project.num_items,
+        length_unit=project.length_unit,
+        total_picks=total_picks,
+        aggregate_current_pick=agg_current,
+        draft_id=primary_draft_id,
+        draft_count=len(sequence),
+        draft_sequence=_build_sequence_schema(sequence, project.current_position),
+        completed_at=project.completed_at,
+        abandoned_at=project.abandoned_at,
+        created_at=project.created_at,
+        hide_unused_shafts_treadles=project.hide_unused_shafts_treadles,
+        has_drawdown_preview=project.drawdown_preview_path is not None,
+        has_drawdown_svg=project.drawdown_svg_path is not None,
+        share_slug=project.share_slug,
+        share_visibility=project.share_visibility,
+        share_expires_at=project.share_expires_at,
+        tags=project.tags or [],
+    )
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -484,36 +656,11 @@ async def create_project(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> ProjectDetail:
-    if body.project_type not in ("treadle", "lift"):
-        raise HTTPException(status_code=400, detail="project_type must be 'treadle' or 'lift'")
-
-    draft = await db.scalar(
-        select(Draft).where(
-            Draft.id == body.draft_id,
-            Draft.owner_id == current_user.id,
-            Draft.deleted_at.is_(None),
-        )
-    )
-    if draft is None:
-        raise HTTPException(status_code=404, detail="Draft not found")
-
-    # Validate project type is supported by the WIF
-    if body.project_type == "treadle" and not draft.has_treadling:
-        raise HTTPException(status_code=400, detail="WIF file has no [TREADLING] section")
-    if body.project_type == "lift" and not draft.has_liftplan:
-        raise HTTPException(status_code=400, detail="WIF file has no [LIFTPLAN] section")
-
-    # Parse pick count from WIF
-    wif_bytes = await storage.aread_file(await _wif_path_for_project(draft, body.project_type))
-    try:
-        pick_data = await asyncio.to_thread(wif_parser.parse_picks, wif_bytes, body.project_type)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
-
     if body.loom_version_id and not body.loom_id:
         raise HTTPException(status_code=400, detail="loom_version_id requires loom_id")
 
     loom: Loom | None = None
+    project_type: str | None = None
     if body.loom_id:
         loom = await db.scalar(
             select(Loom).where(
@@ -543,16 +690,20 @@ async def create_project(
 
         await _check_loom_conflict(body.loom_id, None, current_user.id, db)
 
+        supports_lift, supports_treadle = loom_tracking_flags(loom.loom_type)
+        if supports_lift:
+            project_type = "lift"
+        elif supports_treadle:
+            project_type = "treadle"
+
     project = Project(
         owner_id=current_user.id,
-        draft_id=body.draft_id,
         loom_id=body.loom_id,
         loom_version_id=body.loom_version_id,
         name=body.name,
-        project_type=body.project_type,
+        project_type=project_type,
         status="created",
-        current_pick=1,
-        total_picks=pick_data.total_picks,
+        current_position=1,
         finished_length_per_item=body.finished_length_per_item,
         num_items=body.num_items,
         waste_between_items=body.waste_between_items,
@@ -564,36 +715,253 @@ async def create_project(
     db.add(project)
     await db.commit()
     await db.refresh(project)
-    if draft.drawdown_preview_path is None:
-        generate_drawdown_preview.delay(str(draft.id))
-    from app.config import get_settings
-    from app.services.task_history import record_queued
 
-    tile_task = prerender_project_tiles.delay(str(project.id))
-    record_queued(get_settings(), tile_task.id, "app.tasks.tiles.prerender_project_tiles", "preview")
-    generate_project_drawdown_preview.delay(str(project.id))
-    generate_project_drawdown_svg.delay(str(project.id))
-    return _to_detail(project, draft, loom)
+    return _to_detail(project, [], loom)
 
 
 @router.get("", response_model=list[ProjectSummary])
 async def list_projects(
-    draft_id: uuid.UUID | None = Query(None),
     loom_id: uuid.UUID | None = Query(None),
     tags: list[str] | None = Query(None),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> list[ProjectSummary]:
-    q = select(Project).where(Project.owner_id == current_user.id, Project.deleted_at.is_(None))
-    if draft_id is not None:
-        q = q.where(Project.draft_id == draft_id)
+    q = (
+        select(Project)
+        .where(Project.owner_id == current_user.id, Project.deleted_at.is_(None))
+        .options(selectinload(Project.draft_sequence))
+    )
     if loom_id is not None:
         q = q.where(Project.loom_id == loom_id)
     result = await db.scalars(q.order_by(Project.created_at.desc()))
     projects = result.all()
-    if tags:
-        projects = [p for p in projects if any(t in (p.tags or []) for t in tags)]
-    return [ProjectSummary.model_validate(p) for p in projects]
+
+    summaries: list[ProjectSummary] = []
+    for p in projects:
+        # Build lightweight sequence (no draft details needed for list)
+        seq: list[tuple[ProjectDraft, Draft]] = []
+        for entry in sorted(p.draft_sequence, key=lambda e: e.position):
+            draft = await db.get(Draft, entry.draft_id)
+            if draft is not None:
+                seq.append((entry, draft))
+        summary = _to_summary(p, seq)
+        if tags and not any(t in (p.tags or []) for t in tags):
+            continue
+        summaries.append(summary)
+    return summaries
+
+
+# ---------------------------------------------------------------------------
+# Sequence management
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{project_id}/sequence", response_model=ProjectDetail, status_code=201)
+async def add_sequence_entry(
+    project_id: uuid.UUID,
+    body: AddSequenceEntryRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ProjectDetail:
+    project = await _get_owned_project(project_id, current_user, db)
+    if project.status not in ("created",):
+        raise HTTPException(status_code=400, detail="Cannot modify sequence of an active or completed project")
+
+    draft = await db.scalar(
+        select(Draft).where(
+            Draft.id == body.draft_id,
+            Draft.owner_id == current_user.id,
+            Draft.deleted_at.is_(None),
+        )
+    )
+    if draft is None:
+        raise HTTPException(status_code=404, detail="Draft not found")
+
+    if body.repeats < 1:
+        raise HTTPException(status_code=400, detail="repeats must be at least 1")
+
+    # Find next position
+    existing = (
+        await db.scalars(
+            select(ProjectDraft)
+            .where(ProjectDraft.project_id == project_id)
+            .order_by(ProjectDraft.position.desc())
+            .limit(1)
+        )
+    ).first()
+    next_position = (existing.position + 1) if existing else 1
+
+    entry = ProjectDraft(
+        project_id=project_id,
+        draft_id=body.draft_id,
+        position=next_position,
+        repeats=body.repeats,
+        current_pick=0,
+    )
+    db.add(entry)
+    await db.commit()
+    await db.refresh(project)
+
+    sequence = await _load_sequence(project_id, db)
+    loom = await db.get(Loom, project.loom_id) if project.loom_id else None
+    loom_version = await _resolve_loom_version(project, db)
+
+    if draft.drawdown_preview_path is None:
+        generate_drawdown_preview.delay(str(draft.id))
+
+    return _to_detail(project, sequence, loom, loom_version=loom_version)
+
+
+@router.patch("/{project_id}/sequence/{seq_id}", response_model=ProjectDetail)
+async def update_sequence_entry(
+    project_id: uuid.UUID,
+    seq_id: uuid.UUID,
+    body: UpdateSequenceEntryRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ProjectDetail:
+    project = await _get_owned_project(project_id, current_user, db)
+
+    entry = await db.scalar(
+        select(ProjectDraft).where(ProjectDraft.id == seq_id, ProjectDraft.project_id == project_id)
+    )
+    if entry is None:
+        raise HTTPException(status_code=404, detail="Sequence entry not found")
+
+    if body.repeats is not None:
+        if body.repeats < 1:
+            raise HTTPException(status_code=400, detail="repeats must be at least 1")
+        entry.repeats = body.repeats
+
+    await db.commit()
+    await db.refresh(project)
+
+    sequence = await _load_sequence(project_id, db)
+    loom = await db.get(Loom, project.loom_id) if project.loom_id else None
+    loom_version = await _resolve_loom_version(project, db)
+    return _to_detail(project, sequence, loom, loom_version=loom_version)
+
+
+@router.delete("/{project_id}/sequence/{seq_id}", response_model=ProjectDetail)
+async def remove_sequence_entry(
+    project_id: uuid.UUID,
+    seq_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ProjectDetail:
+    project = await _get_owned_project(project_id, current_user, db)
+    if project.status not in ("created",):
+        raise HTTPException(status_code=400, detail="Cannot modify sequence of an active or completed project")
+
+    entry = await db.scalar(
+        select(ProjectDraft).where(ProjectDraft.id == seq_id, ProjectDraft.project_id == project_id)
+    )
+    if entry is None:
+        raise HTTPException(status_code=404, detail="Sequence entry not found")
+
+    removed_position = entry.position
+    await db.delete(entry)
+    await db.flush()  # ensure DELETE is visible before renumbering
+
+    # Re-number remaining entries to keep positions dense
+    remaining = (
+        await db.scalars(
+            select(ProjectDraft)
+            .where(ProjectDraft.project_id == project_id, ProjectDraft.position > removed_position)
+            .order_by(ProjectDraft.position)
+        )
+    ).all()
+    for i, rem in enumerate(remaining):
+        rem.position = removed_position + i
+
+    # Update current_position if it pointed to the removed entry
+    if project.current_position >= removed_position:
+        project.current_position = max(1, project.current_position - 1)
+
+    await db.commit()
+    await db.refresh(project)
+
+    sequence = await _load_sequence(project_id, db)
+    loom = await db.get(Loom, project.loom_id) if project.loom_id else None
+    loom_version = await _resolve_loom_version(project, db)
+    return _to_detail(project, sequence, loom, loom_version=loom_version)
+
+
+@router.post("/{project_id}/sequence/reorder", response_model=ProjectDetail)
+async def reorder_sequence(
+    project_id: uuid.UUID,
+    body: ReorderSequenceRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ProjectDetail:
+    project = await _get_owned_project(project_id, current_user, db)
+    if project.status not in ("created",):
+        raise HTTPException(status_code=400, detail="Cannot reorder sequence of an active or completed project")
+
+    entries = (await db.scalars(select(ProjectDraft).where(ProjectDraft.project_id == project_id))).all()
+    entry_map = {e.id: e for e in entries}
+
+    if set(body.ordered_ids) != set(entry_map.keys()):
+        raise HTTPException(status_code=400, detail="ordered_ids must contain exactly all current sequence entry IDs")
+
+    # Two-phase UPDATE to avoid unique constraint violations on position swaps.
+    # Phase 1: negate all positions (no collisions since negatives ≠ positives).
+    await db.execute(
+        text("UPDATE project_drafts SET position = -position WHERE project_id = CAST(:project_id AS uuid)"),
+        {"project_id": str(project_id)},
+    )
+    # Phase 2: set final positions one-by-one (no collisions since all are still negative).
+    for new_pos, entry_id in enumerate(body.ordered_ids, start=1):
+        await db.execute(
+            text(
+                "UPDATE project_drafts SET position = :pos, updated_at = now() "
+                "WHERE id = CAST(:entry_id AS uuid) AND project_id = CAST(:project_id AS uuid)"
+            ),
+            {"pos": new_pos, "entry_id": str(entry_id), "project_id": str(project_id)},
+        )
+
+    # Expire all ORM objects so _load_sequence reads fresh DB state after raw SQL updates.
+    db.expire_all()
+    await db.commit()
+    await db.refresh(project)
+
+    sequence = await _load_sequence(project_id, db)
+    loom = await db.get(Loom, project.loom_id) if project.loom_id else None
+    loom_version = await _resolve_loom_version(project, db)
+    return _to_detail(project, sequence, loom, loom_version=loom_version)
+
+
+@router.post("/{project_id}/sequence/{seq_id}/activate", response_model=ProjectDetail)
+async def activate_sequence_entry(
+    project_id: uuid.UUID,
+    seq_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ProjectDetail:
+    """Set the active sequence position (the one the pick tracker operates on)."""
+    project = await _get_owned_project(project_id, current_user, db)
+    if project.status not in ("created", "active"):
+        raise HTTPException(status_code=400, detail="Project is not active")
+
+    entry = await db.scalar(
+        select(ProjectDraft).where(ProjectDraft.id == seq_id, ProjectDraft.project_id == project_id)
+    )
+    if entry is None:
+        raise HTTPException(status_code=404, detail="Sequence entry not found")
+
+    project.current_position = entry.position
+    await db.commit()
+    await db.refresh(project)
+
+    sequence = await _load_sequence(project_id, db)
+    loom = await db.get(Loom, project.loom_id) if project.loom_id else None
+    loom_version = await _resolve_loom_version(project, db)
+    return _to_detail(project, sequence, loom, loom_version=loom_version)
+
+
+# ---------------------------------------------------------------------------
+# Drawdown endpoints (use active sequence position's draft)
+# ---------------------------------------------------------------------------
 
 
 @router.get("/{project_id}/drawdown")
@@ -611,10 +979,11 @@ async def get_project_drawdown(
     from app.services.storage import afile_exists, aproject_tile_exists, aread_file, aread_project_tile
 
     project = await _get_owned_project(project_id, current_user, db, allow_superuser=True)
-
-    draft = await db.scalar(select(Draft).where(Draft.id == project.draft_id, Draft.deleted_at.is_(None)))
-    if draft is None:
-        raise HTTPException(status_code=404, detail="Draft not found")
+    sequence = await _load_sequence(project_id, db)
+    active = _active_pair(project, sequence)
+    if active is None:
+        raise HTTPException(status_code=404, detail="Project has no draft sequence")
+    _, draft = active
 
     wif_path = await _wif_path_for_project(draft, project.project_type)
     if not wif_path or not await afile_exists(wif_path):
@@ -632,9 +1001,6 @@ async def get_project_drawdown(
     else:
         expected_scale = rendering.DRAWDOWN_SCALE
 
-    # Check pre-rendered project tile cache on standard row-boundary alignment.
-    # Only for full-width requests (start_col=None) — column-sliced requests must
-    # go through render_drawdown_tile so they return the correct pixel slice.
     if (
         start_col is None
         and warp_count > 0
@@ -682,8 +1048,6 @@ async def get_project_drawdown(
         actual_start_col = 0
         actual_col_count = warp_count
 
-    # Trigger background tile pre-render on standard boundary miss only when t0 is absent.
-    # Only applies to full-width (non-column-sliced) requests.
     if _sc is None and _sr % tile_row_count == 0 and _rc == tile_row_count:
         if not await aproject_tile_exists(project_id, expected_scale, 0):
             from app.services.task_history import record_queued
@@ -723,9 +1087,11 @@ async def get_project_drawdown_svg(
     from app.services.storage import afile_exists, aread_file
 
     project = await _get_owned_project(project_id, current_user, db, allow_superuser=True)
-    draft = await db.scalar(select(Draft).where(Draft.id == project.draft_id, Draft.deleted_at.is_(None)))
-    if draft is None:
-        raise HTTPException(status_code=404, detail="Draft not found")
+    sequence = await _load_sequence(project_id, db)
+    active = _active_pair(project, sequence)
+    if active is None:
+        raise HTTPException(status_code=404, detail="Project has no draft sequence")
+    _, draft = active
 
     wif_path = await _wif_path_for_project(draft, project.project_type)
     if not wif_path or not await afile_exists(wif_path):
@@ -779,9 +1145,11 @@ async def get_project_drawdown_preview(
     from app.services.storage import afile_exists, aread_file
 
     project = await _get_owned_project(project_id, current_user, db, allow_superuser=True)
-    draft = await db.scalar(select(Draft).where(Draft.id == project.draft_id, Draft.deleted_at.is_(None)))
-    if draft is None:
-        raise HTTPException(status_code=404, detail="Draft not found")
+    sequence = await _load_sequence(project_id, db)
+    active = _active_pair(project, sequence)
+    if active is None:
+        raise HTTPException(status_code=404, detail="Project has no draft sequence")
+    _, draft = active
 
     wif_path = await _wif_path_for_project(draft, project.project_type)
     if not wif_path or not await afile_exists(wif_path):
@@ -863,9 +1231,11 @@ async def get_project_drawdown_data(
     from app.services.storage import afile_exists, aread_file
 
     project = await _get_owned_project(project_id, current_user, db, allow_superuser=True)
-    draft = await db.scalar(select(Draft).where(Draft.id == project.draft_id, Draft.deleted_at.is_(None)))
-    if draft is None:
-        raise HTTPException(status_code=404, detail="Draft not found")
+    sequence = await _load_sequence(project_id, db)
+    active = _active_pair(project, sequence)
+    if active is None:
+        raise HTTPException(status_code=404, detail="Project has no draft sequence")
+    _, draft = active
 
     wif_path = await _wif_path_for_project(draft, project.project_type)
     if not wif_path or not await afile_exists(wif_path):
@@ -919,7 +1289,14 @@ async def get_project(
     project = result.first()
     if project is None:
         raise HTTPException(status_code=404, detail="Project not found")
-    draft = await db.get(Draft, project.draft_id)
+
+    sequence = await _load_sequence(project_id, db)
+    active = _active_pair(project, sequence)
+    if active is not None:
+        _, active_draft = active
+        if active_draft.drawdown_preview_path is None:
+            generate_drawdown_preview.delay(str(active_draft.id))
+
     loom_reeds: list[dict] = []
     if project.loom_id:
         loom_stmt = select(Loom).where(Loom.id == project.loom_id).options(selectinload(Loom.reeds))
@@ -929,11 +1306,10 @@ async def get_project(
     else:
         loom = None
     loom_version = await _resolve_loom_version(project, db)
-    if draft is not None and draft.drawdown_preview_path is None:
-        generate_drawdown_preview.delay(str(draft.id))
+
     return _to_detail(
         project,
-        draft,  # type: ignore[arg-type]
+        sequence,
         loom,
         photos=list(project.photos),
         loom_version=loom_version,
@@ -965,10 +1341,10 @@ async def rename_project(
         project.tags = [t.strip().lower() for t in body.tags if t.strip()]
     await db.commit()
     await db.refresh(project)
-    draft = await db.get(Draft, project.draft_id)
+    sequence = await _load_sequence(project_id, db)
     loom = await db.get(Loom, project.loom_id) if project.loom_id else None
     loom_version = await _resolve_loom_version(project, db)
-    return _to_detail(project, draft, loom, loom_version=loom_version)  # type: ignore[arg-type]
+    return _to_detail(project, sequence, loom, loom_version=loom_version)
 
 
 @router.patch("/{project_id}/color-replacements", response_model=ProjectDetail)
@@ -978,9 +1354,9 @@ async def set_color_replacements(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> ProjectDetail:
-    import re
+    import re as re_mod
 
-    hex_re = re.compile(r"^#[0-9a-fA-F]{6}$")
+    hex_re = re_mod.compile(r"^#[0-9a-fA-F]{6}$")
     for k, v in body.color_replacements.items():
         if not hex_re.match(k) or not hex_re.match(v):
             raise HTTPException(status_code=422, detail="color_replacements keys and values must be 6-digit hex colors")
@@ -991,10 +1367,10 @@ async def set_color_replacements(
     prerender_project_tiles.delay(str(project_id))
     generate_project_drawdown_preview.delay(str(project_id))
     generate_project_drawdown_svg.delay(str(project_id))
-    draft = await db.get(Draft, project.draft_id)
+    sequence = await _load_sequence(project_id, db)
     loom = await db.get(Loom, project.loom_id) if project.loom_id else None
     loom_version = await _resolve_loom_version(project, db)
-    return _to_detail(project, draft, loom, loom_version=loom_version)  # type: ignore[arg-type]
+    return _to_detail(project, sequence, loom, loom_version=loom_version)
 
 
 @router.patch("/{project_id}/warp-setup", response_model=ProjectDetail)
@@ -1022,10 +1398,10 @@ async def update_warp_setup(
         project.length_unit = body.length_unit  # type: ignore[assignment]
     await db.commit()
     await db.refresh(project)
-    draft = await db.get(Draft, project.draft_id)
+    sequence = await _load_sequence(project_id, db)
     loom = await db.get(Loom, project.loom_id) if project.loom_id else None
     loom_version = await _resolve_loom_version(project, db)
-    return _to_detail(project, draft, loom, loom_version=loom_version)  # type: ignore[arg-type]
+    return _to_detail(project, sequence, loom, loom_version=loom_version)
 
 
 @router.patch("/{project_id}/reed", response_model=ProjectDetail)
@@ -1041,7 +1417,7 @@ async def set_reed(
     project.reed_dents_per_inch = body.reed_dents_per_inch
     await db.commit()
     await db.refresh(project)
-    draft = await db.get(Draft, project.draft_id)
+    sequence = await _load_sequence(project_id, db)
     loom_reeds: list[dict] = []
     if project.loom_id:
         loom_stmt = select(Loom).where(Loom.id == project.loom_id).options(selectinload(Loom.reeds))
@@ -1051,7 +1427,7 @@ async def set_reed(
     else:
         loom = None
     loom_version = await _resolve_loom_version(project, db)
-    return _to_detail(project, draft, loom, loom_version=loom_version, loom_reeds=loom_reeds)  # type: ignore[arg-type]
+    return _to_detail(project, sequence, loom, loom_version=loom_version, loom_reeds=loom_reeds)
 
 
 @router.post("/{project_id}/assign-loom", response_model=ProjectDetail)
@@ -1097,11 +1473,19 @@ async def assign_loom(
 
     project.loom_id = body.loom_id
     project.loom_version_id = body.loom_version_id
+
+    # Derive project_type from loom — table_loom → lift, floor_loom → treadle
+    supports_lift, supports_treadle = loom_tracking_flags(loom.loom_type)
+    if supports_lift:
+        project.project_type = "lift"
+    elif supports_treadle:
+        project.project_type = "treadle"
+
     await db.commit()
     await db.refresh(project)
-    draft = await db.get(Draft, project.draft_id)
+    sequence = await _load_sequence(project_id, db)
     loom_version = await _resolve_loom_version(project, db)
-    return _to_detail(project, draft, loom, loom_version=loom_version)  # type: ignore[arg-type]
+    return _to_detail(project, sequence, loom, loom_version=loom_version)
 
 
 @router.post("/{project_id}/start", response_model=ProjectDetail)
@@ -1110,18 +1494,62 @@ async def start_project(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> ProjectDetail:
-    """Transition a project from 'created' to 'active'. Idempotent if already active."""
+    """Validate all gates then transition a project from 'created' to 'active'."""
     project = await _get_owned_project(project_id, current_user, db)
     if project.status not in ("created", "active"):
         raise HTTPException(status_code=400, detail="Only projects in 'created' or 'active' status can be started")
+
     if project.status == "created":
+        sequence = await _load_sequence(project_id, db)
+
+        # Gate: at least one sequence entry
+        if not sequence:
+            raise HTTPException(status_code=400, detail="Add at least one draft to the sequence before starting")
+
+        # Gate: loom assigned
+        if project.loom_id is None:
+            raise HTTPException(status_code=400, detail="Assign a loom before starting")
+
+        # Gate: loom not in use by another project
+        loom_conflict = await db.scalar(
+            select(Project).where(
+                Project.loom_id == project.loom_id,
+                Project.owner_id == current_user.id,
+                Project.status == "active",
+                Project.deleted_at.is_(None),
+                Project.id != project.id,
+            )
+        )
+        if loom_conflict is not None:
+            raise HTTPException(status_code=409, detail=f"Loom is in use by project '{loom_conflict.name}'")
+
+        # Gate: all drafts have picks > 0 and are compatible with loom type
+        for entry, draft in sequence:
+            if not (draft.weft_threads or 0):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Draft '{draft.name}' has no picks defined — cannot start tracking",
+                )
+            if project.project_type == "treadle" and not draft.has_treadling:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Draft '{draft.name}' is missing a treadling plan required for this loom",
+                )
+            if project.project_type == "lift" and not draft.has_liftplan:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Draft '{draft.name}' is missing a lift plan required for this loom",
+                )
+
         project.status = "active"
         await db.commit()
         await db.refresh(project)
-    draft = await db.get(Draft, project.draft_id)
+    else:
+        sequence = await _load_sequence(project_id, db)
+
     loom = await db.get(Loom, project.loom_id) if project.loom_id else None
     loom_version = await _resolve_loom_version(project, db)
-    return _to_detail(project, draft, loom, loom_version=loom_version)  # type: ignore[arg-type]
+    return _to_detail(project, sequence, loom, loom_version=loom_version)
 
 
 @router.post("/{project_id}/step", response_model=StepResponse)
@@ -1134,27 +1562,40 @@ async def step_project(
     if body.direction not in ("advance", "reverse"):
         raise HTTPException(status_code=400, detail="direction must be 'advance' or 'reverse'")
 
-    # FOR UPDATE serializes concurrent step requests at the DB level, preventing
-    # two simultaneous taps from reading the same current_pick and producing a
-    # duplicate increment.
     project = await _get_owned_project(project_id, current_user, db, with_for_update=True)
     if project.status not in ("created", "active"):
         raise HTTPException(status_code=400, detail="Project is not active")
     if project.status == "created":
         project.status = "active"
 
-    from_pick = project.current_pick
+    # Load and lock the active sequence entry
+    seq_entry = await db.scalar(
+        select(ProjectDraft)
+        .where(
+            ProjectDraft.project_id == project_id,
+            ProjectDraft.position == project.current_position,
+        )
+        .with_for_update()
+    )
+    if seq_entry is None:
+        raise HTTPException(status_code=400, detail="No active sequence entry — activate a sequence position first")
+
+    draft = await db.get(Draft, seq_entry.draft_id)
+    if draft is None:
+        raise HTTPException(status_code=404, detail="Draft not found")
+
+    section_total = (draft.weft_threads or 0) * seq_entry.repeats
+    from_pick = seq_entry.current_pick
 
     if body.direction == "advance":
-        if project.current_pick > project.total_picks:
-            raise HTTPException(status_code=400, detail="Already at last pick")
-        project.current_pick += 1
+        if seq_entry.current_pick >= section_total:
+            raise HTTPException(status_code=400, detail="Already at last pick of this section")
+        seq_entry.current_pick += 1
     else:
-        if project.current_pick <= 1:
-            raise HTTPException(status_code=400, detail="Already at first pick")
-        project.current_pick -= 1
+        if seq_entry.current_pick <= 0:
+            raise HTTPException(status_code=400, detail="Already at first pick of this section")
+        seq_entry.current_pick -= 1
 
-    # Compute dwell and manage session gap-on-arrival
     now = datetime.now(timezone.utc)
     idle_timeout_ms = current_user.idle_timeout_minutes * 60 * 1_000
 
@@ -1188,16 +1629,29 @@ async def step_project(
 
     step = ProjectStep(
         project_id=project.id,
+        sequence_id=seq_entry.id,
         event_type=body.direction,
         from_pick=from_pick,
-        to_pick=project.current_pick,
+        to_pick=seq_entry.current_pick,
         dwell_ms=dwell_ms,
     )
     db.add(step)
     await db.commit()
+
+    # Compute aggregates for response
+    all_entries = (await db.scalars(select(ProjectDraft).where(ProjectDraft.project_id == project_id))).all()
+    agg_drafts: list[tuple[ProjectDraft, Draft]] = []
+    for e in all_entries:
+        d = await db.get(Draft, e.draft_id)
+        if d:
+            agg_drafts.append((e, d))
+
     return StepResponse(
-        current_pick=project.current_pick,
-        total_picks=project.total_picks,
+        current_pick=seq_entry.current_pick,
+        total_picks=section_total,
+        position=project.current_position,
+        aggregate_current_pick=_compute_aggregate_current_pick(agg_drafts),
+        aggregate_total_picks=_compute_total_picks(agg_drafts),
         current_item=project.current_item,
         num_items=project.num_items,
     )
@@ -1213,12 +1667,25 @@ async def jump_project(
     project = await _get_owned_project(project_id, current_user, db)
     if project.status not in ("created", "active"):
         raise HTTPException(status_code=400, detail="Project is not active")
-    project.current_pick = max(1, min(body.pick, project.total_picks + 1))
+
+    seq_entry = await db.scalar(
+        select(ProjectDraft).where(
+            ProjectDraft.project_id == project_id,
+            ProjectDraft.position == project.current_position,
+        )
+    )
+    if seq_entry is None:
+        raise HTTPException(status_code=400, detail="No active sequence entry")
+
+    draft = await db.get(Draft, seq_entry.draft_id)
+    section_total = (draft.weft_threads or 0) * seq_entry.repeats if draft else 0
+    seq_entry.current_pick = max(0, min(body.pick, section_total))
+
     await db.commit()
     await db.refresh(project)
-    draft = await db.get(Draft, project.draft_id)
+    sequence = await _load_sequence(project_id, db)
     loom = await db.get(Loom, project.loom_id) if project.loom_id else None
-    return _to_detail(project, draft, loom)  # type: ignore[arg-type]
+    return _to_detail(project, sequence, loom)
 
 
 @router.post("/{project_id}/advance-item", response_model=StepResponse)
@@ -1230,19 +1697,28 @@ async def advance_item(
     project = await _get_owned_project(project_id, current_user, db)
     if project.status not in ("created", "active"):
         raise HTTPException(status_code=400, detail="Project is not active")
-    if project.current_pick <= project.total_picks:
-        raise HTTPException(status_code=400, detail="Current item is not finished — advance to the last pick first")
+
+    sequence = await _load_sequence(project_id, db)
+    total_picks = _compute_total_picks(sequence)
+    agg_current = _compute_aggregate_current_pick(sequence)
+
+    if agg_current < total_picks:
+        raise HTTPException(status_code=400, detail="Current sequence is not finished — complete all picks first")
     if project.current_item >= project.num_items:
         raise HTTPException(status_code=400, detail="Already on the last item — use complete instead")
-    picks = dict(project.item_picks or {})
-    picks[str(project.current_item)] = project.current_pick
+
+    # Reset all sequence picks to 0 for the next item
+    for entry, _ in sequence:
+        entry.current_pick = 0
     project.current_item += 1
-    project.current_pick = int(picks.get(str(project.current_item), 1))
-    project.item_picks = picks
     await db.commit()
+
     return StepResponse(
-        current_pick=project.current_pick,
-        total_picks=project.total_picks,
+        current_pick=0,
+        total_picks=total_picks,
+        position=project.current_position,
+        aggregate_current_pick=0,
+        aggregate_total_picks=total_picks,
         current_item=project.current_item,
         num_items=project.num_items,
     )
@@ -1258,17 +1734,13 @@ async def jump_item(
     project = await _get_owned_project(project_id, current_user, db)
     if project.status not in ("created", "active"):
         raise HTTPException(status_code=400, detail="Project is not active")
-    picks = dict(project.item_picks or {})
-    picks[str(project.current_item)] = project.current_pick
     target = max(1, min(body.item, project.num_items))
     project.current_item = target
-    project.current_pick = int(picks.get(str(target), 1))
-    project.item_picks = picks
     await db.commit()
     await db.refresh(project)
-    draft = await db.get(Draft, project.draft_id)
+    sequence = await _load_sequence(project_id, db)
     loom = await db.get(Loom, project.loom_id) if project.loom_id else None
-    return _to_detail(project, draft, loom)  # type: ignore[arg-type]
+    return _to_detail(project, sequence, loom)
 
 
 @router.post("/{project_id}/complete", response_model=ProjectDetail)
@@ -1281,19 +1753,24 @@ async def complete_project(
     project = await _get_owned_project(project_id, current_user, db)
     if project.status not in ("created", "active"):
         raise HTTPException(status_code=400, detail="Project is not active")
+
     if not force:
-        if project.current_pick <= project.total_picks:
+        sequence = await _load_sequence(project_id, db)
+        total_picks = _compute_total_picks(sequence)
+        agg_current = _compute_aggregate_current_pick(sequence)
+        if agg_current < total_picks:
             raise HTTPException(status_code=400, detail="Not all picks are done — advance to the last pick first")
         if project.current_item < project.num_items:
             raise HTTPException(status_code=400, detail="Not all items are done — advance to the last item first")
+
     project.status = "completed"
     project.completed_at = datetime.now(timezone.utc)
     await _close_open_session(project_id, db)
     await db.commit()
     await db.refresh(project)
-    draft = await db.get(Draft, project.draft_id)
+    sequence = await _load_sequence(project_id, db)
     loom = await db.get(Loom, project.loom_id) if project.loom_id else None
-    return _to_detail(project, draft, loom)  # type: ignore[arg-type]
+    return _to_detail(project, sequence, loom)
 
 
 @router.post("/{project_id}/abandon", response_model=ProjectDetail)
@@ -1310,9 +1787,9 @@ async def abandon_project(
     await _close_open_session(project_id, db)
     await db.commit()
     await db.refresh(project)
-    draft = await db.get(Draft, project.draft_id)
+    sequence = await _load_sequence(project_id, db)
     loom = await db.get(Loom, project.loom_id) if project.loom_id else None
-    return _to_detail(project, draft, loom)  # type: ignore[arg-type]
+    return _to_detail(project, sequence, loom)
 
 
 @router.post("/{project_id}/restart", response_model=ProjectDetail)
@@ -1329,11 +1806,9 @@ async def restart_project(
     project.status = "created"
     await db.commit()
     await db.refresh(project)
-    draft = await db.get(Draft, project.draft_id)
+    sequence = await _load_sequence(project_id, db)
     loom = await db.get(Loom, project.loom_id) if project.loom_id else None
-    if draft is not None and draft.drawdown_preview_path is None:
-        generate_drawdown_preview.delay(str(draft.id))
-    return _to_detail(project, draft, loom)  # type: ignore[arg-type]
+    return _to_detail(project, sequence, loom)
 
 
 @router.get("/{project_id}/metrics", response_model=ProjectMetricsResponse)
@@ -1406,16 +1881,15 @@ async def clone_project(
     source = await _get_owned_project(project_id, current_user, db)
     if source.loom_id:
         await _check_loom_conflict(source.loom_id, None, current_user.id, db)
+
     clone = Project(
         owner_id=current_user.id,
-        draft_id=source.draft_id,
         loom_id=source.loom_id,
         loom_version_id=source.loom_version_id,
         name=source.name,
         project_type=source.project_type,
         status="created",
-        current_pick=1,
-        total_picks=source.total_picks,
+        current_position=1,
         finished_length_per_item=source.finished_length_per_item,
         num_items=source.num_items,
         waste_between_items=source.waste_between_items,
@@ -1423,13 +1897,25 @@ async def clone_project(
         length_unit=source.length_unit,
     )
     db.add(clone)
+    await db.flush()
+
+    # Clone the sequence
+    source_sequence = await _load_sequence(project_id, db)
+    for entry, draft in source_sequence:
+        cloned_entry = ProjectDraft(
+            project_id=clone.id,
+            draft_id=entry.draft_id,
+            position=entry.position,
+            repeats=entry.repeats,
+            current_pick=0,
+        )
+        db.add(cloned_entry)
+
     await db.commit()
     await db.refresh(clone)
-    draft = await db.get(Draft, clone.draft_id)
+    clone_sequence = await _load_sequence(clone.id, db)
     loom = await db.get(Loom, clone.loom_id) if clone.loom_id else None
-    if draft is not None and draft.drawdown_preview_path is None:
-        generate_drawdown_preview.delay(str(draft.id))
-    return _to_detail(clone, draft, loom)  # type: ignore[arg-type]
+    return _to_detail(clone, clone_sequence, loom)
 
 
 @router.delete("/{project_id}", status_code=204)
@@ -1543,9 +2029,14 @@ async def get_picks(
     db: AsyncSession = Depends(get_db),
 ) -> PicksResponse:
     project = await _get_owned_project(project_id, current_user, db, allow_superuser=True)
-    draft = await db.get(Draft, project.draft_id)
-    if draft is None:
-        raise HTTPException(status_code=404, detail="Draft not found")
+    if project.project_type is None:
+        raise HTTPException(status_code=400, detail="Project has no type set — assign a loom first")
+
+    sequence = await _load_sequence(project_id, db)
+    active = _active_pair(project, sequence)
+    if active is None:
+        raise HTTPException(status_code=404, detail="Project has no draft sequence")
+    _, draft = active
 
     wif_bytes = await storage.aread_file(await _wif_path_for_project(draft, project.project_type))
     try:
@@ -1658,9 +2149,12 @@ async def get_warping_plan(
     db: AsyncSession = Depends(get_db),
 ) -> WarpingPlanResponse:
     project = await _get_owned_project(project_id, current_user, db, allow_superuser=True)
-    draft = await db.get(Draft, project.draft_id)
-    if draft is None:
-        raise HTTPException(status_code=404, detail="Draft not found")
+    sequence = await _load_sequence(project_id, db)
+    # Warping plan uses position-1 draft (primary warp reference)
+    primary = sequence[0] if sequence else None
+    if primary is None:
+        raise HTTPException(status_code=404, detail="Project has no draft sequence")
+    _, draft = primary
 
     threading_entries = warp_color_runs = tieup_data = tieup_num_shafts = tieup_num_treadles = None
     wif_path = await _wif_path_for_project(draft, project.project_type)
@@ -1712,9 +2206,9 @@ async def update_project_share(
         raise HTTPException(status_code=400, detail="visibility must be 'link'")
 
     project = await _get_owned_project(project_id, current_user, db, with_for_update=True)
-    draft = await db.get(Draft, project.draft_id)
-    if draft is None:
-        raise HTTPException(status_code=404, detail="Draft not found")
+    sequence = await _load_sequence(project_id, db)
+    if not sequence:
+        raise HTTPException(status_code=400, detail="Cannot share a project with no drafts")
 
     if project.share_slug is None:
         project.share_slug = await _generate_unique_slug(project.name, db)
@@ -1732,7 +2226,7 @@ async def update_project_share(
             select(ProjectPhoto).where(ProjectPhoto.project_id == project.id).order_by(ProjectPhoto.display_order)
         )
     )
-    return _to_detail(project, draft, loom, photos, loom_version)
+    return _to_detail(project, sequence, loom, photos, loom_version)
 
 
 @router.delete("/{project_id}/share", status_code=204)
@@ -1771,14 +2265,17 @@ async def get_shared_project(
     if project.share_expires_at is not None and project.share_expires_at <= now:
         raise HTTPException(status_code=410, detail="This share link has expired")
 
-    draft = await db.get(Draft, project.draft_id)
-    if draft is None:
-        raise HTTPException(status_code=404, detail="Draft not found")
+    sequence = await _load_sequence(project.id, db)
+    active = _active_pair(project, sequence)
+    active_draft = active[1] if active else None
 
     from app.models.user import User as UserModel
 
     owner = await db.get(UserModel, project.owner_id)
     owner_display = owner.display_name if owner and owner.display_name else "Unknown"
+
+    total_picks = _compute_total_picks(sequence)
+    active_entry = active[0] if active else None
 
     return SharedProjectResponse(
         slug=slug,
@@ -1786,12 +2283,12 @@ async def get_shared_project(
         project_status=project.status,
         project_type=project.project_type,
         owner_display_name=owner_display,
-        draft_name=draft.name,
-        draft_num_shafts=draft.effective_num_shafts or draft.num_shafts,
-        draft_num_treadles=draft.effective_num_treadles or draft.num_treadles,
+        draft_name=active_draft.name if active_draft else None,
+        draft_num_shafts=active_draft.effective_num_shafts or active_draft.num_shafts if active_draft else None,
+        draft_num_treadles=active_draft.effective_num_treadles or active_draft.num_treadles if active_draft else None,
         num_items=project.num_items,
-        total_picks=project.total_picks,
-        current_pick=project.current_pick,
+        total_picks=total_picks,
+        current_pick=active_entry.current_pick if active_entry else 0,
         current_item=project.current_item,
         share_visibility=project.share_visibility,
         share_expires_at=project.share_expires_at,
@@ -1801,9 +2298,9 @@ async def get_shared_project(
         has_drawdown_preview=project.drawdown_preview_path is not None,
         has_drawdown_svg=project.drawdown_svg_path is not None,
         color_replacements=project.color_replacements,
-        draft_wif_colors=draft.wif_colors,
-        draft_warp_color_stats=draft.warp_color_stats,
-        draft_weft_color_stats=draft.weft_color_stats,
+        draft_wif_colors=active_draft.wif_colors if active_draft else None,
+        draft_warp_color_stats=active_draft.warp_color_stats if active_draft else None,
+        draft_weft_color_stats=active_draft.weft_color_stats if active_draft else None,
     )
 
 
@@ -1823,6 +2320,28 @@ async def get_shared_project_preview(
         raise HTTPException(status_code=404, detail="Preview not yet generated")
     data = await storage.aread_project_drawdown_preview(project.drawdown_preview_path)
     return Response(content=data, media_type="image/png", headers={"Cache-Control": "public, max-age=300"})
+
+
+@share_router.get("/projects/{slug}/svg")
+async def get_shared_project_svg(
+    slug: str,
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Return the pre-rendered drawdown SVG for a shared project (no auth required)."""
+    project = await db.scalar(select(Project).where(Project.share_slug == slug, Project.deleted_at.is_(None)))
+    if project is None or project.share_visibility == "private":
+        raise HTTPException(status_code=404, detail="Not found")
+    now = datetime.now(timezone.utc)
+    if project.share_expires_at is not None and project.share_expires_at <= now:
+        raise HTTPException(status_code=410, detail="Expired")
+    if not project.drawdown_svg_path:
+        raise HTTPException(status_code=404, detail="SVG not yet generated")
+    svg_text = await storage.aread_project_drawdown_svg(project.drawdown_svg_path)
+    return Response(
+        content=svg_text,
+        media_type="image/svg+xml; charset=utf-8",
+        headers={"Cache-Control": "public, max-age=300"},
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1937,25 +2456,3 @@ async def unlink_yarn_color(
         raise HTTPException(status_code=404, detail="Yarn color assignment not found")
     await db.delete(row)
     await db.commit()
-
-
-@share_router.get("/projects/{slug}/svg")
-async def get_shared_project_svg(
-    slug: str,
-    db: AsyncSession = Depends(get_db),
-) -> Response:
-    """Return the pre-rendered drawdown SVG for a shared project (no auth required)."""
-    project = await db.scalar(select(Project).where(Project.share_slug == slug, Project.deleted_at.is_(None)))
-    if project is None or project.share_visibility == "private":
-        raise HTTPException(status_code=404, detail="Not found")
-    now = datetime.now(timezone.utc)
-    if project.share_expires_at is not None and project.share_expires_at <= now:
-        raise HTTPException(status_code=410, detail="Expired")
-    if not project.drawdown_svg_path:
-        raise HTTPException(status_code=404, detail="SVG not yet generated")
-    svg_text = await storage.aread_project_drawdown_svg(project.drawdown_svg_path)
-    return Response(
-        content=svg_text,
-        media_type="image/svg+xml; charset=utf-8",
-        headers={"Cache-Control": "public, max-age=300"},
-    )

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -396,22 +396,6 @@ async def _close_open_session(project_id: uuid.UUID, db: AsyncSession) -> None:
         open_session.ended_at = datetime.now(timezone.utc)
 
 
-async def _check_loom_conflict(
-    loom_id: uuid.UUID, exclude_id: uuid.UUID | None, owner_id: uuid.UUID, db: AsyncSession
-) -> None:
-    """Raise 409 if the loom already has an active or not-yet-started project (other than exclude_id)."""
-    q = select(Project).where(
-        Project.loom_id == loom_id,
-        Project.owner_id == owner_id,
-        Project.status.in_(("created", "active")),
-        Project.deleted_at.is_(None),
-    )
-    if exclude_id is not None:
-        q = q.where(Project.id != exclude_id)
-    if await db.scalar(q) is not None:
-        raise HTTPException(status_code=409, detail="This loom already has an active project")
-
-
 async def _wif_path_for_project(draft: Draft, project_type: str | None) -> str:
     """Return the correct WIF path for a project type.
 
@@ -790,8 +774,6 @@ async def create_project(
             )
             if version_ok is None:
                 raise HTTPException(status_code=400, detail="loom_version_id does not belong to the specified loom")
-
-        await _check_loom_conflict(body.loom_id, None, current_user.id, db)
 
         supports_lift, supports_treadle = loom_tracking_flags(loom.loom_type)
         if supports_lift:
@@ -1555,8 +1537,6 @@ async def assign_loom(
         if version_ok is None:
             raise HTTPException(status_code=400, detail="loom_version_id does not belong to the specified loom")
 
-    await _check_loom_conflict(body.loom_id, None, current_user.id, db)
-
     project.loom_id = body.loom_id
     project.loom_version_id = body.loom_version_id
 
@@ -1886,8 +1866,6 @@ async def restart_project(
     project = await _get_owned_project(project_id, current_user, db)
     if project.status != "abandoned":
         raise HTTPException(status_code=400, detail="Only abandoned projects can be restarted")
-    if project.loom_id:
-        await _check_loom_conflict(project.loom_id, project.id, current_user.id, db)
     project.status = "created"
     await db.commit()
     await db.refresh(project)
@@ -1964,8 +1942,6 @@ async def clone_project(
     db: AsyncSession = Depends(get_db),
 ) -> ProjectDetail:
     source = await _get_owned_project(project_id, current_user, db)
-    if source.loom_id:
-        await _check_loom_conflict(source.loom_id, None, current_user.id, db)
 
     clone = Project(
         owner_id=current_user.id,

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -545,9 +545,6 @@ def _active_draft_kwargs(active_draft: Draft | None, active_entry: ProjectDraft 
             "draft_effective_num_treadles": None,
             "draft_effective_num_shafts": None,
             "draft_metadata_overrides": None,
-            "draft_wif_colors": None,
-            "draft_warp_color_stats": None,
-            "draft_weft_color_stats": None,
             "draft_wif_measurements": None,
             "draft_warp_threads": None,
             "draft_weft_threads": None,
@@ -563,15 +560,71 @@ def _active_draft_kwargs(active_draft: Draft | None, active_entry: ProjectDraft 
         "draft_effective_num_treadles": active_draft.effective_num_treadles,
         "draft_effective_num_shafts": active_draft.effective_num_shafts,
         "draft_metadata_overrides": active_draft.metadata_overrides,
-        "draft_wif_colors": active_draft.wif_colors,
-        "draft_warp_color_stats": active_draft.warp_color_stats,
-        "draft_weft_color_stats": active_draft.weft_color_stats,
         "draft_wif_measurements": active_draft.wif_measurements,
         "draft_warp_threads": active_draft.warp_threads,
         "draft_weft_threads": active_draft.weft_threads,
         "draft_warp_length_cm": active_draft.warp_length_cm,
         "draft_weaving_width_override_cm": active_draft.weaving_width_override_cm,
         "draft_epi_override": active_draft.epi_override,
+    }
+
+
+def _aggregate_sequence_colors(sequence: list[tuple[ProjectDraft, Draft]]) -> dict:
+    """Merge WIF colors and color stats from all drafts; for single-draft, pass through unchanged."""
+    if not sequence:
+        return {
+            "draft_wif_colors": None,
+            "draft_warp_color_stats": None,
+            "draft_weft_color_stats": None,
+        }
+
+    if len(sequence) == 1:
+        draft = sequence[0][1]
+        return {
+            "draft_wif_colors": draft.wif_colors,
+            "draft_warp_color_stats": draft.warp_color_stats,
+            "draft_weft_color_stats": draft.weft_color_stats,
+        }
+
+    seen: set[str] = set()
+    all_colors: list[dict] = []
+    warp_totals: dict[str, dict] = {}
+    weft_totals: dict[str, dict] = {}
+
+    for _entry, draft in sequence:
+        if draft.wif_colors:
+            for c in draft.wif_colors:
+                h = (c.get("hex") or "").lower()
+                if h and h not in seen:
+                    seen.add(h)
+                    all_colors.append({"index": len(all_colors) + 1, "hex": h})
+        if draft.warp_color_stats:
+            for s in draft.warp_color_stats:
+                h = (s.get("hex") or "").lower()
+                if h:
+                    if h not in warp_totals:
+                        warp_totals[h] = {"hex": h, "count": 0, "percentage": 0.0}
+                    warp_totals[h]["count"] += s.get("count", 0)
+        if draft.weft_color_stats:
+            for s in draft.weft_color_stats:
+                h = (s.get("hex") or "").lower()
+                if h:
+                    if h not in weft_totals:
+                        weft_totals[h] = {"hex": h, "count": 0, "percentage": 0.0}
+                    weft_totals[h]["count"] += s.get("count", 0)
+
+    total_warp = sum(v["count"] for v in warp_totals.values())
+    for v in warp_totals.values():
+        v["percentage"] = round(v["count"] / total_warp * 100, 1) if total_warp else 0.0
+
+    total_weft = sum(v["count"] for v in weft_totals.values())
+    for v in weft_totals.values():
+        v["percentage"] = round(v["count"] / total_weft * 100, 1) if total_weft else 0.0
+
+    return {
+        "draft_wif_colors": all_colors or None,
+        "draft_warp_color_stats": list(warp_totals.values()) or None,
+        "draft_weft_color_stats": list(weft_totals.values()) or None,
     }
 
 
@@ -649,6 +702,7 @@ def _to_detail(
         photos=[ProjectPhotoSchema.model_validate(p) for p in (photos or [])],
         yarn_colors=[_yarn_color_schema(yc) for yc in (yarn_colors or [])],
         **_active_draft_kwargs(active_draft, active_entry),
+        **_aggregate_sequence_colors(sequence),
         **_loom_kwargs(loom, loom_version),
     )
 
@@ -2285,18 +2339,12 @@ def _shared_draft_fields(active_draft: Draft | None, active_entry: ProjectDraft 
             "draft_num_shafts": None,
             "draft_num_treadles": None,
             "current_pick": 0,
-            "draft_wif_colors": None,
-            "draft_warp_color_stats": None,
-            "draft_weft_color_stats": None,
         }
     return {
         "draft_name": active_draft.name,
         "draft_num_shafts": active_draft.effective_num_shafts or active_draft.num_shafts,
         "draft_num_treadles": active_draft.effective_num_treadles or active_draft.num_treadles,
         "current_pick": active_entry.current_pick if active_entry else 0,
-        "draft_wif_colors": active_draft.wif_colors,
-        "draft_warp_color_stats": active_draft.warp_color_stats,
-        "draft_weft_color_stats": active_draft.weft_color_stats,
     }
 
 
@@ -2344,6 +2392,7 @@ async def get_shared_project(
         has_drawdown_svg=project.drawdown_svg_path is not None,
         color_replacements=project.color_replacements,
         **_shared_draft_fields(active[1] if active else None, active[0] if active else None),
+        **_aggregate_sequence_colors(sequence),
     )
 
 

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -470,6 +470,14 @@ async def _load_sequence(project_id: uuid.UUID, db: AsyncSession) -> list[tuple[
     return result
 
 
+async def _sequence_detail(project: Project, project_id: uuid.UUID, db: AsyncSession) -> ProjectDetail:
+    """Load sequence + loom + loom_version and return the standard detail response."""
+    sequence = await _load_sequence(project_id, db)
+    loom = await db.get(Loom, project.loom_id) if project.loom_id else None
+    loom_version = await _resolve_loom_version(project, db)
+    return _to_detail(project, sequence, loom, loom_version=loom_version)
+
+
 def _active_pair(project: Project, sequence: list[tuple[ProjectDraft, Draft]]) -> tuple[ProjectDraft, Draft] | None:
     """Return the (entry, draft) for project.current_position, or position 1 as fallback."""
     for entry, draft in sequence:
@@ -836,10 +844,7 @@ async def update_sequence_entry(
     await db.commit()
     await db.refresh(project)
 
-    sequence = await _load_sequence(project_id, db)
-    loom = await db.get(Loom, project.loom_id) if project.loom_id else None
-    loom_version = await _resolve_loom_version(project, db)
-    return _to_detail(project, sequence, loom, loom_version=loom_version)
+    return await _sequence_detail(project, project_id, db)
 
 
 @router.delete("/{project_id}/sequence/{seq_id}", response_model=ProjectDetail)
@@ -881,10 +886,7 @@ async def remove_sequence_entry(
     await db.commit()
     await db.refresh(project)
 
-    sequence = await _load_sequence(project_id, db)
-    loom = await db.get(Loom, project.loom_id) if project.loom_id else None
-    loom_version = await _resolve_loom_version(project, db)
-    return _to_detail(project, sequence, loom, loom_version=loom_version)
+    return await _sequence_detail(project, project_id, db)
 
 
 @router.post("/{project_id}/sequence/reorder", response_model=ProjectDetail)
@@ -925,10 +927,7 @@ async def reorder_sequence(
     await db.commit()
     await db.refresh(project)
 
-    sequence = await _load_sequence(project_id, db)
-    loom = await db.get(Loom, project.loom_id) if project.loom_id else None
-    loom_version = await _resolve_loom_version(project, db)
-    return _to_detail(project, sequence, loom, loom_version=loom_version)
+    return await _sequence_detail(project, project_id, db)
 
 
 @router.post("/{project_id}/sequence/{seq_id}/activate", response_model=ProjectDetail)
@@ -953,10 +952,7 @@ async def activate_sequence_entry(
     await db.commit()
     await db.refresh(project)
 
-    sequence = await _load_sequence(project_id, db)
-    loom = await db.get(Loom, project.loom_id) if project.loom_id else None
-    loom_version = await _resolve_loom_version(project, db)
-    return _to_detail(project, sequence, loom, loom_version=loom_version)
+    return await _sequence_detail(project, project_id, db)
 
 
 # ---------------------------------------------------------------------------
@@ -1341,10 +1337,7 @@ async def rename_project(
         project.tags = [t.strip().lower() for t in body.tags if t.strip()]
     await db.commit()
     await db.refresh(project)
-    sequence = await _load_sequence(project_id, db)
-    loom = await db.get(Loom, project.loom_id) if project.loom_id else None
-    loom_version = await _resolve_loom_version(project, db)
-    return _to_detail(project, sequence, loom, loom_version=loom_version)
+    return await _sequence_detail(project, project_id, db)
 
 
 @router.patch("/{project_id}/color-replacements", response_model=ProjectDetail)
@@ -1367,10 +1360,7 @@ async def set_color_replacements(
     prerender_project_tiles.delay(str(project_id))
     generate_project_drawdown_preview.delay(str(project_id))
     generate_project_drawdown_svg.delay(str(project_id))
-    sequence = await _load_sequence(project_id, db)
-    loom = await db.get(Loom, project.loom_id) if project.loom_id else None
-    loom_version = await _resolve_loom_version(project, db)
-    return _to_detail(project, sequence, loom, loom_version=loom_version)
+    return await _sequence_detail(project, project_id, db)
 
 
 @router.patch("/{project_id}/warp-setup", response_model=ProjectDetail)
@@ -1398,10 +1388,7 @@ async def update_warp_setup(
         project.length_unit = body.length_unit  # type: ignore[assignment]
     await db.commit()
     await db.refresh(project)
-    sequence = await _load_sequence(project_id, db)
-    loom = await db.get(Loom, project.loom_id) if project.loom_id else None
-    loom_version = await _resolve_loom_version(project, db)
-    return _to_detail(project, sequence, loom, loom_version=loom_version)
+    return await _sequence_detail(project, project_id, db)
 
 
 @router.patch("/{project_id}/reed", response_model=ProjectDetail)

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -5,6 +5,7 @@ import secrets
 import uuid
 from datetime import datetime, timezone
 from decimal import Decimal
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from fastapi.responses import Response
@@ -534,6 +535,66 @@ def _yarn_color_schema(pyc: ProjectYarnColor) -> ProjectYarnColorSchema:
     )
 
 
+def _active_draft_kwargs(active_draft: Draft | None, active_entry: ProjectDraft | None) -> dict:
+    if active_draft is None:
+        return {
+            "current_pick": 0,
+            "draft_name": None,
+            "draft_num_shafts": None,
+            "draft_num_treadles": None,
+            "draft_effective_num_treadles": None,
+            "draft_effective_num_shafts": None,
+            "draft_metadata_overrides": None,
+            "draft_wif_colors": None,
+            "draft_warp_color_stats": None,
+            "draft_weft_color_stats": None,
+            "draft_wif_measurements": None,
+            "draft_warp_threads": None,
+            "draft_weft_threads": None,
+            "draft_warp_length_cm": None,
+            "draft_weaving_width_override_cm": None,
+            "draft_epi_override": None,
+        }
+    return {
+        "current_pick": active_entry.current_pick if active_entry else 0,
+        "draft_name": active_draft.name,
+        "draft_num_shafts": active_draft.num_shafts,
+        "draft_num_treadles": active_draft.num_treadles,
+        "draft_effective_num_treadles": active_draft.effective_num_treadles,
+        "draft_effective_num_shafts": active_draft.effective_num_shafts,
+        "draft_metadata_overrides": active_draft.metadata_overrides,
+        "draft_wif_colors": active_draft.wif_colors,
+        "draft_warp_color_stats": active_draft.warp_color_stats,
+        "draft_weft_color_stats": active_draft.weft_color_stats,
+        "draft_wif_measurements": active_draft.wif_measurements,
+        "draft_warp_threads": active_draft.warp_threads,
+        "draft_weft_threads": active_draft.weft_threads,
+        "draft_warp_length_cm": active_draft.warp_length_cm,
+        "draft_weaving_width_override_cm": active_draft.weaving_width_override_cm,
+        "draft_epi_override": active_draft.epi_override,
+    }
+
+
+def _loom_kwargs(loom: Loom | None, loom_version: LoomVersion | None) -> dict:
+    if loom is None:
+        return {
+            "loom_name": None,
+            "loom_num_treadles": None,
+            "loom_num_shafts": None,
+            "loom_warp_waste_allowance": None,
+            "loom_warp_waste_unit": None,
+            "loom_resolved_version_id": None,
+        }
+    return {
+        "loom_name": f"{loom.manufacturer} {loom.model_name}",
+        "loom_num_treadles": loom_version.num_treadles if loom_version else None,
+        "loom_num_shafts": loom_version.num_shafts if loom_version else None,
+        "loom_warp_waste_allowance": loom_version.warp_waste_allowance if loom_version else None,
+        "loom_warp_waste_unit": loom_version.warp_waste_unit if loom_version else None,
+        "loom_resolved_version_id": loom_version.id if loom_version else None,
+    }
+
+
 def _to_detail(
     project: Project,
     sequence: list[tuple[ProjectDraft, Draft]],
@@ -560,7 +621,6 @@ def _to_detail(
         project_type=project.project_type,
         status=project.status,
         current_position=project.current_position,
-        current_pick=active_entry.current_pick if active_entry else 0,
         current_item=project.current_item,
         num_items=project.num_items,
         length_unit=project.length_unit,
@@ -578,27 +638,6 @@ def _to_detail(
         created_at=project.created_at,
         hide_unused_shafts_treadles=project.hide_unused_shafts_treadles,
         color_replacements=project.color_replacements,
-        draft_name=active_draft.name if active_draft else None,
-        draft_num_shafts=active_draft.num_shafts if active_draft else None,
-        draft_num_treadles=active_draft.num_treadles if active_draft else None,
-        draft_effective_num_treadles=active_draft.effective_num_treadles if active_draft else None,
-        draft_effective_num_shafts=active_draft.effective_num_shafts if active_draft else None,
-        draft_metadata_overrides=active_draft.metadata_overrides if active_draft else None,
-        draft_wif_colors=active_draft.wif_colors if active_draft else None,
-        draft_warp_color_stats=active_draft.warp_color_stats if active_draft else None,
-        draft_weft_color_stats=active_draft.weft_color_stats if active_draft else None,
-        draft_wif_measurements=active_draft.wif_measurements if active_draft else None,
-        draft_warp_threads=active_draft.warp_threads if active_draft else None,
-        draft_weft_threads=active_draft.weft_threads if active_draft else None,
-        draft_warp_length_cm=active_draft.warp_length_cm if active_draft else None,
-        draft_weaving_width_override_cm=active_draft.weaving_width_override_cm if active_draft else None,
-        draft_epi_override=active_draft.epi_override if active_draft else None,
-        loom_name=f"{loom.manufacturer} {loom.model_name}" if loom else None,
-        loom_num_treadles=loom_version.num_treadles if loom_version else None,
-        loom_num_shafts=loom_version.num_shafts if loom_version else None,
-        loom_warp_waste_allowance=loom_version.warp_waste_allowance if loom_version else None,
-        loom_warp_waste_unit=loom_version.warp_waste_unit if loom_version else None,
-        loom_resolved_version_id=loom_version.id if loom_version else None,
         has_drawdown_preview=project.drawdown_preview_path is not None,
         has_drawdown_svg=project.drawdown_svg_path is not None,
         share_slug=project.share_slug,
@@ -609,6 +648,8 @@ def _to_detail(
         loom_reeds=loom_reeds or [],
         photos=[ProjectPhotoSchema.model_validate(p) for p in (photos or [])],
         yarn_colors=[_yarn_color_schema(yc) for yc in (yarn_colors or [])],
+        **_active_draft_kwargs(active_draft, active_entry),
+        **_loom_kwargs(loom, loom_version),
     )
 
 
@@ -759,21 +800,25 @@ async def list_projects(
     return summaries
 
 
+_SEQ_ENTRY_NOT_FOUND = "Sequence entry not found"
+_NO_DRAFT_SEQUENCE = "Project has no draft sequence"
+_SEQ_LOCKED = "Cannot modify sequence of an active or completed project"
+
 # ---------------------------------------------------------------------------
 # Sequence management
 # ---------------------------------------------------------------------------
 
 
-@router.post("/{project_id}/sequence", response_model=ProjectDetail, status_code=201)
+@router.post("/{project_id}/sequence", status_code=201)
 async def add_sequence_entry(
     project_id: uuid.UUID,
     body: AddSequenceEntryRequest,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectDetail:
     project = await _get_owned_project(project_id, current_user, db)
     if project.status not in ("created",):
-        raise HTTPException(status_code=400, detail="Cannot modify sequence of an active or completed project")
+        raise HTTPException(status_code=400, detail=_SEQ_LOCKED)
 
     draft = await db.scalar(
         select(Draft).where(
@@ -820,13 +865,13 @@ async def add_sequence_entry(
     return _to_detail(project, sequence, loom, loom_version=loom_version)
 
 
-@router.patch("/{project_id}/sequence/{seq_id}", response_model=ProjectDetail)
+@router.patch("/{project_id}/sequence/{seq_id}")
 async def update_sequence_entry(
     project_id: uuid.UUID,
     seq_id: uuid.UUID,
     body: UpdateSequenceEntryRequest,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectDetail:
     project = await _get_owned_project(project_id, current_user, db)
 
@@ -834,7 +879,7 @@ async def update_sequence_entry(
         select(ProjectDraft).where(ProjectDraft.id == seq_id, ProjectDraft.project_id == project_id)
     )
     if entry is None:
-        raise HTTPException(status_code=404, detail="Sequence entry not found")
+        raise HTTPException(status_code=404, detail=_SEQ_ENTRY_NOT_FOUND)
 
     if body.repeats is not None:
         if body.repeats < 1:
@@ -847,22 +892,22 @@ async def update_sequence_entry(
     return await _sequence_detail(project, project_id, db)
 
 
-@router.delete("/{project_id}/sequence/{seq_id}", response_model=ProjectDetail)
+@router.delete("/{project_id}/sequence/{seq_id}")
 async def remove_sequence_entry(
     project_id: uuid.UUID,
     seq_id: uuid.UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectDetail:
     project = await _get_owned_project(project_id, current_user, db)
     if project.status not in ("created",):
-        raise HTTPException(status_code=400, detail="Cannot modify sequence of an active or completed project")
+        raise HTTPException(status_code=400, detail=_SEQ_LOCKED)
 
     entry = await db.scalar(
         select(ProjectDraft).where(ProjectDraft.id == seq_id, ProjectDraft.project_id == project_id)
     )
     if entry is None:
-        raise HTTPException(status_code=404, detail="Sequence entry not found")
+        raise HTTPException(status_code=404, detail=_SEQ_ENTRY_NOT_FOUND)
 
     removed_position = entry.position
     await db.delete(entry)
@@ -889,16 +934,16 @@ async def remove_sequence_entry(
     return await _sequence_detail(project, project_id, db)
 
 
-@router.post("/{project_id}/sequence/reorder", response_model=ProjectDetail)
+@router.post("/{project_id}/sequence/reorder")
 async def reorder_sequence(
     project_id: uuid.UUID,
     body: ReorderSequenceRequest,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectDetail:
     project = await _get_owned_project(project_id, current_user, db)
     if project.status not in ("created",):
-        raise HTTPException(status_code=400, detail="Cannot reorder sequence of an active or completed project")
+        raise HTTPException(status_code=400, detail=_SEQ_LOCKED)
 
     entries = (await db.scalars(select(ProjectDraft).where(ProjectDraft.project_id == project_id))).all()
     entry_map = {e.id: e for e in entries}
@@ -930,12 +975,12 @@ async def reorder_sequence(
     return await _sequence_detail(project, project_id, db)
 
 
-@router.post("/{project_id}/sequence/{seq_id}/activate", response_model=ProjectDetail)
+@router.post("/{project_id}/sequence/{seq_id}/activate")
 async def activate_sequence_entry(
     project_id: uuid.UUID,
     seq_id: uuid.UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectDetail:
     """Set the active sequence position (the one the pick tracker operates on)."""
     project = await _get_owned_project(project_id, current_user, db)
@@ -946,7 +991,7 @@ async def activate_sequence_entry(
         select(ProjectDraft).where(ProjectDraft.id == seq_id, ProjectDraft.project_id == project_id)
     )
     if entry is None:
-        raise HTTPException(status_code=404, detail="Sequence entry not found")
+        raise HTTPException(status_code=404, detail=_SEQ_ENTRY_NOT_FOUND)
 
     project.current_position = entry.position
     await db.commit()
@@ -978,7 +1023,7 @@ async def get_project_drawdown(
     sequence = await _load_sequence(project_id, db)
     active = _active_pair(project, sequence)
     if active is None:
-        raise HTTPException(status_code=404, detail="Project has no draft sequence")
+        raise HTTPException(status_code=404, detail=_NO_DRAFT_SEQUENCE)
     _, draft = active
 
     wif_path = await _wif_path_for_project(draft, project.project_type)
@@ -1086,7 +1131,7 @@ async def get_project_drawdown_svg(
     sequence = await _load_sequence(project_id, db)
     active = _active_pair(project, sequence)
     if active is None:
-        raise HTTPException(status_code=404, detail="Project has no draft sequence")
+        raise HTTPException(status_code=404, detail=_NO_DRAFT_SEQUENCE)
     _, draft = active
 
     wif_path = await _wif_path_for_project(draft, project.project_type)
@@ -1144,7 +1189,7 @@ async def get_project_drawdown_preview(
     sequence = await _load_sequence(project_id, db)
     active = _active_pair(project, sequence)
     if active is None:
-        raise HTTPException(status_code=404, detail="Project has no draft sequence")
+        raise HTTPException(status_code=404, detail=_NO_DRAFT_SEQUENCE)
     _, draft = active
 
     wif_path = await _wif_path_for_project(draft, project.project_type)
@@ -1230,7 +1275,7 @@ async def get_project_drawdown_data(
     sequence = await _load_sequence(project_id, db)
     active = _active_pair(project, sequence)
     if active is None:
-        raise HTTPException(status_code=404, detail="Project has no draft sequence")
+        raise HTTPException(status_code=404, detail=_NO_DRAFT_SEQUENCE)
     _, draft = active
 
     wif_path = await _wif_path_for_project(draft, project.project_type)
@@ -1475,6 +1520,25 @@ async def assign_loom(
     return _to_detail(project, sequence, loom, loom_version=loom_version)
 
 
+def _validate_sequence_for_start(sequence: list[tuple[ProjectDraft, Draft]], project_type: str | None) -> None:
+    for _entry, draft in sequence:
+        if not (draft.weft_threads or 0):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Draft '{draft.name}' has no picks defined — cannot start tracking",
+            )
+        if project_type == "treadle" and not draft.has_treadling:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Draft '{draft.name}' is missing a treadling plan required for this loom",
+            )
+        if project_type == "lift" and not draft.has_liftplan:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Draft '{draft.name}' is missing a lift plan required for this loom",
+            )
+
+
 @router.post("/{project_id}/start", response_model=ProjectDetail)
 async def start_project(
     project_id: uuid.UUID,
@@ -1489,15 +1553,11 @@ async def start_project(
     if project.status == "created":
         sequence = await _load_sequence(project_id, db)
 
-        # Gate: at least one sequence entry
         if not sequence:
             raise HTTPException(status_code=400, detail="Add at least one draft to the sequence before starting")
-
-        # Gate: loom assigned
         if project.loom_id is None:
             raise HTTPException(status_code=400, detail="Assign a loom before starting")
 
-        # Gate: loom not in use by another project
         loom_conflict = await db.scalar(
             select(Project).where(
                 Project.loom_id == project.loom_id,
@@ -1510,23 +1570,7 @@ async def start_project(
         if loom_conflict is not None:
             raise HTTPException(status_code=409, detail=f"Loom is in use by project '{loom_conflict.name}'")
 
-        # Gate: all drafts have picks > 0 and are compatible with loom type
-        for entry, draft in sequence:
-            if not (draft.weft_threads or 0):
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Draft '{draft.name}' has no picks defined — cannot start tracking",
-                )
-            if project.project_type == "treadle" and not draft.has_treadling:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Draft '{draft.name}' is missing a treadling plan required for this loom",
-                )
-            if project.project_type == "lift" and not draft.has_liftplan:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Draft '{draft.name}' is missing a lift plan required for this loom",
-                )
+        _validate_sequence_for_start(sequence, project.project_type)
 
         project.status = "active"
         await db.commit()
@@ -2022,7 +2066,7 @@ async def get_picks(
     sequence = await _load_sequence(project_id, db)
     active = _active_pair(project, sequence)
     if active is None:
-        raise HTTPException(status_code=404, detail="Project has no draft sequence")
+        raise HTTPException(status_code=404, detail=_NO_DRAFT_SEQUENCE)
     _, draft = active
 
     wif_bytes = await storage.aread_file(await _wif_path_for_project(draft, project.project_type))
@@ -2140,7 +2184,7 @@ async def get_warping_plan(
     # Warping plan uses position-1 draft (primary warp reference)
     primary = sequence[0] if sequence else None
     if primary is None:
-        raise HTTPException(status_code=404, detail="Project has no draft sequence")
+        raise HTTPException(status_code=404, detail=_NO_DRAFT_SEQUENCE)
     _, draft = primary
 
     threading_entries = warp_color_runs = tieup_data = tieup_num_shafts = tieup_num_treadles = None
@@ -2234,6 +2278,28 @@ async def revoke_project_share(
 # ---------------------------------------------------------------------------
 
 
+def _shared_draft_fields(active_draft: Draft | None, active_entry: ProjectDraft | None) -> dict:
+    if active_draft is None:
+        return {
+            "draft_name": None,
+            "draft_num_shafts": None,
+            "draft_num_treadles": None,
+            "current_pick": 0,
+            "draft_wif_colors": None,
+            "draft_warp_color_stats": None,
+            "draft_weft_color_stats": None,
+        }
+    return {
+        "draft_name": active_draft.name,
+        "draft_num_shafts": active_draft.effective_num_shafts or active_draft.num_shafts,
+        "draft_num_treadles": active_draft.effective_num_treadles or active_draft.num_treadles,
+        "current_pick": active_entry.current_pick if active_entry else 0,
+        "draft_wif_colors": active_draft.wif_colors,
+        "draft_warp_color_stats": active_draft.warp_color_stats,
+        "draft_weft_color_stats": active_draft.weft_color_stats,
+    }
+
+
 @share_router.get("/projects/{slug}", response_model=SharedProjectResponse)
 async def get_shared_project(
     slug: str,
@@ -2254,15 +2320,11 @@ async def get_shared_project(
 
     sequence = await _load_sequence(project.id, db)
     active = _active_pair(project, sequence)
-    active_draft = active[1] if active else None
 
     from app.models.user import User as UserModel
 
     owner = await db.get(UserModel, project.owner_id)
     owner_display = owner.display_name if owner and owner.display_name else "Unknown"
-
-    total_picks = _compute_total_picks(sequence)
-    active_entry = active[0] if active else None
 
     return SharedProjectResponse(
         slug=slug,
@@ -2270,12 +2332,8 @@ async def get_shared_project(
         project_status=project.status,
         project_type=project.project_type,
         owner_display_name=owner_display,
-        draft_name=active_draft.name if active_draft else None,
-        draft_num_shafts=active_draft.effective_num_shafts or active_draft.num_shafts if active_draft else None,
-        draft_num_treadles=active_draft.effective_num_treadles or active_draft.num_treadles if active_draft else None,
         num_items=project.num_items,
-        total_picks=total_picks,
-        current_pick=active_entry.current_pick if active_entry else 0,
+        total_picks=_compute_total_picks(sequence),
         current_item=project.current_item,
         share_visibility=project.share_visibility,
         share_expires_at=project.share_expires_at,
@@ -2285,9 +2343,7 @@ async def get_shared_project(
         has_drawdown_preview=project.drawdown_preview_path is not None,
         has_drawdown_svg=project.drawdown_svg_path is not None,
         color_replacements=project.color_replacements,
-        draft_wif_colors=active_draft.wif_colors if active_draft else None,
-        draft_warp_color_stats=active_draft.warp_color_stats if active_draft else None,
-        draft_weft_color_stats=active_draft.weft_color_stats if active_draft else None,
+        **_shared_draft_fields(active[1] if active else None, active[0] if active else None),
     )
 
 
@@ -2346,11 +2402,11 @@ class PatchYarnColorRequest(BaseModel):
     use_yarn_photo: bool
 
 
-@router.get("/{project_id}/yarn-colors", response_model=list[ProjectYarnColorSchema])
+@router.get("/{project_id}/yarn-colors")
 async def list_project_yarn_colors(
     project_id: uuid.UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> list[ProjectYarnColorSchema]:
     await _get_owned_project(project_id, current_user, db)
     stmt = (
@@ -2363,13 +2419,13 @@ async def list_project_yarn_colors(
     return [_yarn_color_schema(r) for r in rows]
 
 
-@router.put("/{project_id}/yarn-colors/{color_hex}", response_model=ProjectYarnColorSchema, status_code=200)
+@router.put("/{project_id}/yarn-colors/{color_hex}", status_code=200)
 async def link_yarn_color(
     project_id: uuid.UUID,
     color_hex: str,
     body: LinkYarnColorRequest,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectYarnColorSchema:
     await _get_owned_project(project_id, current_user, db)
     yarn = await db.scalar(
@@ -2403,13 +2459,13 @@ async def link_yarn_color(
     return _yarn_color_schema(row)
 
 
-@router.patch("/{project_id}/yarn-colors/{color_hex}", response_model=ProjectYarnColorSchema)
+@router.patch("/{project_id}/yarn-colors/{color_hex}")
 async def patch_yarn_color(
     project_id: uuid.UUID,
     color_hex: str,
     body: PatchYarnColorRequest,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectYarnColorSchema:
     await _get_owned_project(project_id, current_user, db)
     row = await db.scalar(
@@ -2429,8 +2485,8 @@ async def patch_yarn_color(
 async def unlink_yarn_color(
     project_id: uuid.UUID,
     color_hex: str,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     await _get_owned_project(project_id, current_user, db)
     row = await db.scalar(

--- a/backend/app/tasks/maintenance.py
+++ b/backend/app/tasks/maintenance.py
@@ -686,9 +686,12 @@ def backfill_project_drawdown_previews(self, limit: int = 50) -> dict:
     dispatched = 0
     try:
         with Session(engine) as db:
+            from app.models.project import ProjectDraft
+
             draft_ids = db.scalars(
-                select(Project.draft_id)
-                .join(Draft, Draft.id == Project.draft_id)
+                select(ProjectDraft.draft_id)
+                .join(Project, Project.id == ProjectDraft.project_id)
+                .join(Draft, Draft.id == ProjectDraft.draft_id)
                 .where(
                     Project.status == "active",
                     Project.deleted_at.is_(None),

--- a/backend/app/tasks/preview.py
+++ b/backend/app/tasks/preview.py
@@ -129,6 +129,21 @@ async def _backfill_all_previews() -> dict:
     return result
 
 
+async def _get_primary_draft(project_id: uuid.UUID, db):
+    """Return the Draft at sequence position 1, or None if absent or deleted."""
+    from sqlalchemy import select
+
+    from app.models.draft import Draft
+    from app.models.project import ProjectDraft
+
+    entry = await db.scalar(
+        select(ProjectDraft).where(ProjectDraft.project_id == project_id, ProjectDraft.position == 1)
+    )
+    if entry is None:
+        return None
+    return await db.get(Draft, entry.draft_id)
+
+
 @celery_app.task(
     bind=True,
     max_retries=2,
@@ -143,7 +158,6 @@ def generate_project_drawdown_preview(self: Task, project_id: str) -> None:
 
 async def _generate_project_preview(task: Task, project_id: uuid.UUID) -> None:
     from app.config import get_settings
-    from app.models.draft import Draft
     from app.models.project import Project
     from app.services import rendering, storage
 
@@ -153,21 +167,12 @@ async def _generate_project_preview(task: Task, project_id: uuid.UUID) -> None:
 
     try:
         async with async_session() as db:
-            from sqlalchemy import select as sa_select
-
-            from app.models.project import ProjectDraft
-
             project = await db.get(Project, project_id)
             if project is None or project.deleted_at is not None:
                 return
 
             # Use the primary (position-1) sequence entry for the preview
-            primary_entry = await db.scalar(
-                sa_select(ProjectDraft).where(ProjectDraft.project_id == project_id, ProjectDraft.position == 1)
-            )
-            if primary_entry is None:
-                return
-            draft = await db.get(Draft, primary_entry.draft_id)
+            draft = await _get_primary_draft(project_id, db)
             if draft is None or draft.deleted_at is not None:
                 return
 
@@ -231,7 +236,6 @@ async def _backfill_all_project_previews() -> dict:
     from sqlalchemy import select
 
     from app.config import get_settings
-    from app.models.draft import Draft
     from app.models.project import Project
     from app.services import storage
 
@@ -253,19 +257,9 @@ async def _backfill_all_project_previews() -> dict:
                 )
             ).all()
 
-            from sqlalchemy import select as sa_select2
-
-            from app.models.project import ProjectDraft
-
             for project in projects:
-                primary = await db.scalar(
-                    sa_select2(ProjectDraft).where(ProjectDraft.project_id == project.id, ProjectDraft.position == 1)
-                )
-                if primary is None:
-                    skipped += 1
-                    continue
-                draft = await db.get(Draft, primary.draft_id)
-                if not draft or draft.deleted_at is not None:
+                draft = await _get_primary_draft(project.id, db)
+                if draft is None or draft.deleted_at is not None:
                     skipped += 1
                     continue
                 if (
@@ -306,7 +300,6 @@ def generate_project_drawdown_svg(self: Task, project_id: str) -> None:
 
 async def _generate_project_svg(task: Task, project_id: uuid.UUID) -> None:
     from app.config import get_settings
-    from app.models.draft import Draft
     from app.models.project import Project
     from app.services import rendering, storage
 
@@ -316,20 +309,11 @@ async def _generate_project_svg(task: Task, project_id: uuid.UUID) -> None:
 
     try:
         async with async_session() as db:
-            from sqlalchemy import select as sa_select
-
-            from app.models.project import ProjectDraft
-
             project = await db.get(Project, project_id)
             if project is None or project.deleted_at is not None:
                 return
 
-            primary_entry = await db.scalar(
-                sa_select(ProjectDraft).where(ProjectDraft.project_id == project_id, ProjectDraft.position == 1)
-            )
-            if primary_entry is None:
-                return
-            draft = await db.get(Draft, primary_entry.draft_id)
+            draft = await _get_primary_draft(project_id, db)
             if draft is None or draft.deleted_at is not None:
                 return
 
@@ -391,7 +375,6 @@ async def _backfill_all_project_svgs() -> dict:
     from sqlalchemy import select
 
     from app.config import get_settings
-    from app.models.draft import Draft
     from app.models.project import Project
     from app.services import storage
 
@@ -413,19 +396,9 @@ async def _backfill_all_project_svgs() -> dict:
                 )
             ).all()
 
-            from sqlalchemy import select as sa_select3
-
-            from app.models.project import ProjectDraft
-
             for project in projects:
-                primary = await db.scalar(
-                    sa_select3(ProjectDraft).where(ProjectDraft.project_id == project.id, ProjectDraft.position == 1)
-                )
-                if primary is None:
-                    skipped += 1
-                    continue
-                draft = await db.get(Draft, primary.draft_id)
-                if not draft or draft.deleted_at is not None:
+                draft = await _get_primary_draft(project.id, db)
+                if draft is None or draft.deleted_at is not None:
                     skipped += 1
                     continue
                 if (

--- a/backend/app/tasks/preview.py
+++ b/backend/app/tasks/preview.py
@@ -153,10 +153,21 @@ async def _generate_project_preview(task: Task, project_id: uuid.UUID) -> None:
 
     try:
         async with async_session() as db:
+            from sqlalchemy import select as sa_select
+
+            from app.models.project import ProjectDraft
+
             project = await db.get(Project, project_id)
             if project is None or project.deleted_at is not None:
                 return
-            draft = await db.get(Draft, project.draft_id)
+
+            # Use the primary (position-1) sequence entry for the preview
+            primary_entry = await db.scalar(
+                sa_select(ProjectDraft).where(ProjectDraft.project_id == project_id, ProjectDraft.position == 1)
+            )
+            if primary_entry is None:
+                return
+            draft = await db.get(Draft, primary_entry.draft_id)
             if draft is None or draft.deleted_at is not None:
                 return
 
@@ -242,8 +253,18 @@ async def _backfill_all_project_previews() -> dict:
                 )
             ).all()
 
+            from sqlalchemy import select as sa_select2
+
+            from app.models.project import ProjectDraft
+
             for project in projects:
-                draft = await db.get(Draft, project.draft_id)
+                primary = await db.scalar(
+                    sa_select2(ProjectDraft).where(ProjectDraft.project_id == project.id, ProjectDraft.position == 1)
+                )
+                if primary is None:
+                    skipped += 1
+                    continue
+                draft = await db.get(Draft, primary.draft_id)
                 if not draft or draft.deleted_at is not None:
                     skipped += 1
                     continue
@@ -295,10 +316,20 @@ async def _generate_project_svg(task: Task, project_id: uuid.UUID) -> None:
 
     try:
         async with async_session() as db:
+            from sqlalchemy import select as sa_select
+
+            from app.models.project import ProjectDraft
+
             project = await db.get(Project, project_id)
             if project is None or project.deleted_at is not None:
                 return
-            draft = await db.get(Draft, project.draft_id)
+
+            primary_entry = await db.scalar(
+                sa_select(ProjectDraft).where(ProjectDraft.project_id == project_id, ProjectDraft.position == 1)
+            )
+            if primary_entry is None:
+                return
+            draft = await db.get(Draft, primary_entry.draft_id)
             if draft is None or draft.deleted_at is not None:
                 return
 
@@ -382,8 +413,18 @@ async def _backfill_all_project_svgs() -> dict:
                 )
             ).all()
 
+            from sqlalchemy import select as sa_select3
+
+            from app.models.project import ProjectDraft
+
             for project in projects:
-                draft = await db.get(Draft, project.draft_id)
+                primary = await db.scalar(
+                    sa_select3(ProjectDraft).where(ProjectDraft.project_id == project.id, ProjectDraft.position == 1)
+                )
+                if primary is None:
+                    skipped += 1
+                    continue
+                draft = await db.get(Draft, primary.draft_id)
                 if not draft or draft.deleted_at is not None:
                     skipped += 1
                     continue

--- a/backend/app/tasks/tiles.py
+++ b/backend/app/tasks/tiles.py
@@ -107,7 +107,16 @@ async def _prerender_project(task: Task, project_id: uuid.UUID) -> None:
             if project is None or project.deleted_at is not None:
                 return
 
-            draft = await db.get(Draft, project.draft_id)
+            from sqlalchemy import select as sa_select
+
+            from app.models.project import ProjectDraft
+
+            primary_entry = await db.scalar(
+                sa_select(ProjectDraft).where(ProjectDraft.project_id == project_id, ProjectDraft.position == 1)
+            )
+            if primary_entry is None:
+                return
+            draft = await db.get(Draft, primary_entry.draft_id)
             if draft is None or draft.deleted_at is not None:
                 return
 

--- a/backend/tests/routers/test_admin.py
+++ b/backend/tests/routers/test_admin.py
@@ -62,21 +62,11 @@ class TestListAdminUsers:
     async def test_storage_bytes_reflects_project_photos(
         self, admin_client: AsyncClient, db_session: AsyncSession, admin_user: User
     ):
-        draft = Draft(
-            owner_id=admin_user.id,
-            name="Storage Test Draft",
-            wif_filename="s.wif",
-            wif_path="s.wif",
-        )
-        db_session.add(draft)
-        await db_session.flush()
         project = Project(
             owner_id=admin_user.id,
-            draft_id=draft.id,
             name="Storage Test Project",
             project_type="treadle",
             status="active",
-            total_picks=100,
         )
         db_session.add(project)
         await db_session.flush()
@@ -231,21 +221,11 @@ class TestAdminStats:
         self, admin_client: AsyncClient, db_session: AsyncSession, admin_user: User
     ):
         before = (await admin_client.get("/api/admin/stats")).json()["total_storage_bytes"]
-        draft = Draft(
-            owner_id=admin_user.id,
-            name="Stats Storage Draft",
-            wif_filename="s.wif",
-            wif_path="s.wif",
-        )
-        db_session.add(draft)
-        await db_session.flush()
         project = Project(
             owner_id=admin_user.id,
-            draft_id=draft.id,
             name="Stats Storage Project",
             project_type="treadle",
             status="active",
-            total_picks=100,
         )
         db_session.add(project)
         await db_session.flush()
@@ -1407,31 +1387,11 @@ class TestPatchScheduledTask:
 
 class TestAdminProjectSteps:
     async def _insert_project(self, db: AsyncSession, owner: User) -> Project:
-        import uuid as _uuid
-
-        from app.models.draft import Draft as _Draft
-
-        draft = _Draft(
-            id=_uuid.uuid4(),
-            owner_id=owner.id,
-            name="Step Log Test Draft",
-            wif_filename="t.wif",
-            wif_path="drafts/t.wif",
-            has_treadling=True,
-            has_liftplan=True,
-            num_shafts=4,
-            num_treadles=4,
-            weft_threads=2,
-        )
-        db.add(draft)
         project = Project(
             owner_id=owner.id,
-            draft_id=draft.id,
             name="Step Log Test Project",
             project_type="treadle",
             status="active",
-            current_pick=3,
-            total_picks=10,
         )
         db.add(project)
         await db.commit()
@@ -1685,22 +1645,10 @@ class TestCredentials:
 
 class TestProjectSlugs:
     async def _create_shared_project(self, db: AsyncSession, owner: User) -> "Project":
-        from app.models.draft import Draft
-
-        draft = Draft(
-            owner_id=owner.id,
-            name="Slug Test Draft",
-            wif_filename="slug.wif",
-            wif_path="drafts/slug.wif",
-        )
-        db.add(draft)
-        await db.flush()
         proj = Project(
             owner_id=owner.id,
-            draft_id=draft.id,
             name="Slug Test Project",
             project_type="treadle",
-            total_picks=10,
             share_slug=f"slug-{uuid.uuid4().hex[:8]}",
             share_visibility="public",
         )

--- a/backend/tests/routers/test_collections.py
+++ b/backend/tests/routers/test_collections.py
@@ -54,11 +54,9 @@ async def _insert_draft(db: AsyncSession, owner: User) -> Draft:
 async def _insert_project(db: AsyncSession, owner: User, draft: Draft) -> Project:
     p = Project(
         owner_id=owner.id,
-        draft_id=draft.id,
         name="Test Project",
         project_type="treadle",
         status="active",
-        total_picks=10,
     )
     db.add(p)
     await db.commit()

--- a/backend/tests/routers/test_drafts.py
+++ b/backend/tests/routers/test_drafts.py
@@ -1192,15 +1192,17 @@ async def _insert_project_for_draft(
     *,
     status: str = "active",
 ) -> Project:
+    from app.models.project import ProjectDraft
+
     project = Project(
         owner_id=owner.id,
-        draft_id=draft.id,
         name="Test Project",
         project_type="treadle",
-        total_picks=10,
         status=status,
     )
     db_session.add(project)
+    await db_session.flush()
+    db_session.add(ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=0))
     await db_session.commit()
     return project
 

--- a/backend/tests/routers/test_looms.py
+++ b/backend/tests/routers/test_looms.py
@@ -825,11 +825,9 @@ async def _insert_project_for_loom(
 ) -> Project:
     project = Project(
         owner_id=owner.id,
-        draft_id=draft.id,
         loom_id=loom.id,
         name="Test Project",
         project_type="treadle",
-        total_picks=10,
         status=status,
     )
     db_session.add(project)

--- a/backend/tests/routers/test_project_sequence.py
+++ b/backend/tests/routers/test_project_sequence.py
@@ -1,0 +1,404 @@
+"""Tests for project sequence management endpoints.
+
+Covers:
+  POST   /{project_id}/sequence          — add_sequence_entry
+  PATCH  /{project_id}/sequence/{seq_id} — update_sequence_entry
+  DELETE /{project_id}/sequence/{seq_id} — remove_sequence_entry
+  POST   /{project_id}/sequence/reorder  — reorder_sequence
+  POST   /{project_id}/sequence/{seq_id}/activate — activate_sequence_entry
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.draft import Draft
+from app.models.project import Project, ProjectDraft
+from app.models.user import User
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _insert_draft(db_session: AsyncSession, owner: User) -> Draft:
+    import app.services.storage as storage
+
+    draft_id = uuid.uuid4()
+    wif_key = storage.save_wif(draft_id, "test.wif", b"[WIF]\nVersion=1.1\n")
+    draft = Draft(
+        id=draft_id,
+        owner_id=owner.id,
+        name="Seq Test Draft",
+        wif_filename="test.wif",
+        wif_path=wif_key,
+        has_treadling=True,
+        has_liftplan=True,
+        num_shafts=4,
+        num_treadles=2,
+        weft_threads=4,
+    )
+    db_session.add(draft)
+    await db_session.commit()
+    return draft
+
+
+async def _insert_project(
+    db_session: AsyncSession,
+    owner: User,
+    *,
+    status: str = "created",
+) -> Project:
+    project = Project(
+        owner_id=owner.id,
+        name="Seq Test Project",
+        status=status,
+    )
+    db_session.add(project)
+    await db_session.commit()
+    return project
+
+
+async def _add_entry(
+    db_session: AsyncSession,
+    project: Project,
+    draft: Draft,
+    *,
+    position: int | None = None,
+    repeats: int = 1,
+) -> ProjectDraft:
+    if position is None:
+        existing = (
+            await db_session.scalars(
+                select(ProjectDraft)
+                .where(ProjectDraft.project_id == project.id)
+                .order_by(ProjectDraft.position.desc())
+                .limit(1)
+            )
+        ).first()
+        position = (existing.position + 1) if existing else 1
+
+    entry = ProjectDraft(
+        project_id=project.id,
+        draft_id=draft.id,
+        position=position,
+        repeats=repeats,
+        current_pick=0,
+    )
+    db_session.add(entry)
+    await db_session.commit()
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# TestAddSequenceEntry — POST /{project_id}/sequence
+# ---------------------------------------------------------------------------
+
+
+class TestAddSequenceEntry:
+    async def test_returns_201(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user)
+        resp = await auth_client.post(f"/api/projects/{project.id}/sequence", json={"draft_id": str(draft.id)})
+        assert resp.status_code == 201
+
+    async def test_entry_appears_in_sequence(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user)
+        body = (await auth_client.post(f"/api/projects/{project.id}/sequence", json={"draft_id": str(draft.id)})).json()
+        assert len(body["draft_sequence"]) == 1
+        assert body["draft_sequence"][0]["draft_id"] == str(draft.id)
+
+    async def test_position_starts_at_1(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user)
+        body = (await auth_client.post(f"/api/projects/{project.id}/sequence", json={"draft_id": str(draft.id)})).json()
+        assert body["draft_sequence"][0]["position"] == 1
+
+    async def test_second_entry_gets_position_2(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user)
+        await auth_client.post(f"/api/projects/{project.id}/sequence", json={"draft_id": str(draft.id)})
+        body = (await auth_client.post(f"/api/projects/{project.id}/sequence", json={"draft_id": str(draft.id)})).json()
+        positions = [e["position"] for e in body["draft_sequence"]]
+        assert positions == [1, 2]
+
+    async def test_repeats_stored(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user)
+        body = (
+            await auth_client.post(
+                f"/api/projects/{project.id}/sequence", json={"draft_id": str(draft.id), "repeats": 3}
+            )
+        ).json()
+        assert body["draft_sequence"][0]["repeats"] == 3
+
+    async def test_repeats_defaults_to_1(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user)
+        body = (await auth_client.post(f"/api/projects/{project.id}/sequence", json={"draft_id": str(draft.id)})).json()
+        assert body["draft_sequence"][0]["repeats"] == 1
+
+    async def test_zero_repeats_returns_400(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user)
+        resp = await auth_client.post(
+            f"/api/projects/{project.id}/sequence", json={"draft_id": str(draft.id), "repeats": 0}
+        )
+        assert resp.status_code == 400
+
+    async def test_active_project_returns_400(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user, status="active")
+        resp = await auth_client.post(f"/api/projects/{project.id}/sequence", json={"draft_id": str(draft.id)})
+        assert resp.status_code == 400
+
+    async def test_unknown_draft_returns_404(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        project = await _insert_project(db_session, test_user)
+        resp = await auth_client.post(f"/api/projects/{project.id}/sequence", json={"draft_id": str(uuid.uuid4())})
+        assert resp.status_code == 404
+
+    async def test_unknown_project_returns_404(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        resp = await auth_client.post(f"/api/projects/{uuid.uuid4()}/sequence", json={"draft_id": str(draft.id)})
+        assert resp.status_code == 404
+
+    async def test_unauthenticated_returns_401(self, client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user)
+        resp = await client.post(f"/api/projects/{project.id}/sequence", json={"draft_id": str(draft.id)})
+        assert resp.status_code == 401
+
+    async def test_dispatches_preview_when_no_preview(
+        self,
+        auth_client: AsyncClient,
+        db_session: AsyncSession,
+        test_user: User,
+    ):
+        from unittest.mock import patch
+
+        draft = await _insert_draft(db_session, test_user)
+        assert draft.drawdown_preview_path is None
+        project = await _insert_project(db_session, test_user)
+
+        with patch("app.tasks.preview.generate_drawdown_preview.delay") as mock_delay:
+            await auth_client.post(f"/api/projects/{project.id}/sequence", json={"draft_id": str(draft.id)})
+            mock_delay.assert_called_once_with(str(draft.id))
+
+    async def test_skips_preview_when_already_exists(
+        self,
+        auth_client: AsyncClient,
+        db_session: AsyncSession,
+        test_user: User,
+    ):
+        from unittest.mock import patch
+
+        draft = await _insert_draft(db_session, test_user)
+        draft.drawdown_preview_path = "project-previews/existing.png"
+        await db_session.commit()
+        project = await _insert_project(db_session, test_user)
+
+        with patch("app.tasks.preview.generate_drawdown_preview.delay") as mock_delay:
+            await auth_client.post(f"/api/projects/{project.id}/sequence", json={"draft_id": str(draft.id)})
+            mock_delay.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestUpdateSequenceEntry — PATCH /{project_id}/sequence/{seq_id}
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateSequenceEntry:
+    async def test_updates_repeats(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user)
+        entry = await _add_entry(db_session, project, draft, repeats=1)
+        body = (await auth_client.patch(f"/api/projects/{project.id}/sequence/{entry.id}", json={"repeats": 5})).json()
+        seq = next(e for e in body["draft_sequence"] if e["id"] == str(entry.id))
+        assert seq["repeats"] == 5
+
+    async def test_zero_repeats_returns_400(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user)
+        entry = await _add_entry(db_session, project, draft)
+        resp = await auth_client.patch(f"/api/projects/{project.id}/sequence/{entry.id}", json={"repeats": 0})
+        assert resp.status_code == 400
+
+    async def test_unknown_entry_returns_404(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        project = await _insert_project(db_session, test_user)
+        resp = await auth_client.patch(f"/api/projects/{project.id}/sequence/{uuid.uuid4()}", json={"repeats": 2})
+        assert resp.status_code == 404
+
+    async def test_unauthenticated_returns_401(self, client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user)
+        entry = await _add_entry(db_session, project, draft)
+        resp = await client.patch(f"/api/projects/{project.id}/sequence/{entry.id}", json={"repeats": 2})
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# TestRemoveSequenceEntry — DELETE /{project_id}/sequence/{seq_id}
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveSequenceEntry:
+    async def test_returns_200(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user)
+        entry = await _add_entry(db_session, project, draft)
+        resp = await auth_client.delete(f"/api/projects/{project.id}/sequence/{entry.id}")
+        assert resp.status_code == 200
+
+    async def test_entry_removed_from_sequence(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user)
+        entry = await _add_entry(db_session, project, draft)
+        body = (await auth_client.delete(f"/api/projects/{project.id}/sequence/{entry.id}")).json()
+        assert len(body["draft_sequence"]) == 0
+
+    async def test_positions_renumbered_after_remove(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user)
+        _e1 = await _add_entry(db_session, project, draft)
+        e2 = await _add_entry(db_session, project, draft)
+        _e3 = await _add_entry(db_session, project, draft)
+
+        # Remove the middle entry — remaining should be 1, 2
+        body = (await auth_client.delete(f"/api/projects/{project.id}/sequence/{e2.id}")).json()
+        positions = sorted(e["position"] for e in body["draft_sequence"])
+        assert positions == [1, 2]
+
+    async def test_active_project_returns_400(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user, status="active")
+        entry = await _add_entry(db_session, project, draft)
+        resp = await auth_client.delete(f"/api/projects/{project.id}/sequence/{entry.id}")
+        assert resp.status_code == 400
+
+    async def test_unknown_entry_returns_404(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        project = await _insert_project(db_session, test_user)
+        resp = await auth_client.delete(f"/api/projects/{project.id}/sequence/{uuid.uuid4()}")
+        assert resp.status_code == 404
+
+    async def test_unauthenticated_returns_401(self, client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user)
+        entry = await _add_entry(db_session, project, draft)
+        resp = await client.delete(f"/api/projects/{project.id}/sequence/{entry.id}")
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# TestReorderSequence — POST /{project_id}/sequence/reorder
+# ---------------------------------------------------------------------------
+
+
+class TestReorderSequence:
+    async def test_reorders_entries(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user)
+        e1 = await _add_entry(db_session, project, draft)
+        e2 = await _add_entry(db_session, project, draft)
+        e3 = await _add_entry(db_session, project, draft)
+
+        # Reverse order: 3, 2, 1
+        body = (
+            await auth_client.post(
+                f"/api/projects/{project.id}/sequence/reorder",
+                json={"ordered_ids": [str(e3.id), str(e2.id), str(e1.id)]},
+            )
+        ).json()
+        seq = {e["id"]: e["position"] for e in body["draft_sequence"]}
+        assert seq[str(e3.id)] == 1
+        assert seq[str(e2.id)] == 2
+        assert seq[str(e1.id)] == 3
+
+    async def test_missing_entry_in_order_returns_400(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user)
+        e1 = await _add_entry(db_session, project, draft)
+        await _add_entry(db_session, project, draft)
+
+        # Only include one of the two entries
+        resp = await auth_client.post(
+            f"/api/projects/{project.id}/sequence/reorder",
+            json={"ordered_ids": [str(e1.id)]},
+        )
+        assert resp.status_code == 400
+
+    async def test_active_project_returns_400(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user, status="active")
+        entry = await _add_entry(db_session, project, draft)
+        resp = await auth_client.post(
+            f"/api/projects/{project.id}/sequence/reorder",
+            json={"ordered_ids": [str(entry.id)]},
+        )
+        assert resp.status_code == 400
+
+    async def test_unauthenticated_returns_401(self, client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user)
+        entry = await _add_entry(db_session, project, draft)
+        resp = await client.post(f"/api/projects/{project.id}/sequence/reorder", json={"ordered_ids": [str(entry.id)]})
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# TestActivateSequenceEntry — POST /{project_id}/sequence/{seq_id}/activate
+# ---------------------------------------------------------------------------
+
+
+class TestActivateSequenceEntry:
+    async def test_sets_current_position(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user, status="active")
+        _e1 = await _add_entry(db_session, project, draft)
+        e2 = await _add_entry(db_session, project, draft)
+
+        body = (await auth_client.post(f"/api/projects/{project.id}/sequence/{e2.id}/activate")).json()
+        assert body["current_position"] == 2
+
+    async def test_activate_unknown_entry_returns_404(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        project = await _insert_project(db_session, test_user, status="active")
+        resp = await auth_client.post(f"/api/projects/{project.id}/sequence/{uuid.uuid4()}/activate")
+        assert resp.status_code == 404
+
+    async def test_inactive_project_returns_400(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user, status="completed")
+        entry = await _add_entry(db_session, project, draft)
+        resp = await auth_client.post(f"/api/projects/{project.id}/sequence/{entry.id}/activate")
+        assert resp.status_code == 400
+
+    async def test_unauthenticated_returns_401(self, client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project(db_session, test_user, status="active")
+        entry = await _add_entry(db_session, project, draft)
+        resp = await client.post(f"/api/projects/{project.id}/sequence/{entry.id}/activate")
+        assert resp.status_code == 401

--- a/backend/tests/routers/test_project_sequence.py
+++ b/backend/tests/routers/test_project_sequence.py
@@ -11,7 +11,9 @@ Covers:
 from __future__ import annotations
 
 import uuid
+from unittest.mock import MagicMock
 
+import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -19,6 +21,18 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.draft import Draft
 from app.models.project import Project, ProjectDraft
 from app.models.user import User
+
+
+@pytest.fixture(autouse=True)
+def _mock_preview_tasks(monkeypatch):
+    for attr in (
+        "generate_drawdown_preview",
+        "generate_project_drawdown_preview",
+        "generate_project_drawdown_svg",
+        "prerender_project_tiles",
+    ):
+        monkeypatch.setattr(f"app.routers.projects.{attr}", MagicMock())
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -191,9 +205,9 @@ class TestAddSequenceEntry:
         assert draft.drawdown_preview_path is None
         project = await _insert_project(db_session, test_user)
 
-        with patch("app.tasks.preview.generate_drawdown_preview.delay") as mock_delay:
+        with patch("app.routers.projects.generate_drawdown_preview") as mock_task:
             await auth_client.post(f"/api/projects/{project.id}/sequence", json={"draft_id": str(draft.id)})
-            mock_delay.assert_called_once_with(str(draft.id))
+            mock_task.delay.assert_called_once_with(str(draft.id))
 
     async def test_skips_preview_when_already_exists(
         self,

--- a/backend/tests/routers/test_project_sharing.py
+++ b/backend/tests/routers/test_project_sharing.py
@@ -79,19 +79,20 @@ async def _insert_draft(db: AsyncSession, owner: User) -> Draft:
 
 
 async def _insert_project(db: AsyncSession, owner: User, draft: Draft, **kwargs) -> Project:
+    from app.models.project import ProjectDraft
+
     project = Project(
         owner_id=owner.id,
-        draft_id=draft.id,
         name=kwargs.get("name", "My Weave"),
         project_type="treadle",
         status=kwargs.get("status", "active"),
-        current_pick=1,
-        total_picks=2,
         share_slug=kwargs.get("share_slug"),
         share_visibility=kwargs.get("share_visibility", "private"),
         share_expires_at=kwargs.get("share_expires_at"),
     )
     db.add(project)
+    await db.flush()
+    db.add(ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=0))
     await db.commit()
     return project
 

--- a/backend/tests/routers/test_project_yarn_colors.py
+++ b/backend/tests/routers/test_project_yarn_colors.py
@@ -5,7 +5,6 @@ import uuid
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.draft import Draft
 from app.models.project import Project, ProjectYarnColor
 from app.models.user import User
 from app.models.yarn import Yarn
@@ -15,27 +14,12 @@ from app.models.yarn import Yarn
 # ---------------------------------------------------------------------------
 
 
-async def _make_draft(db: AsyncSession, owner_id: uuid.UUID) -> Draft:
-    draft = Draft(
-        owner_id=owner_id,
-        name="Test Draft",
-        wif_filename="test.wif",
-        wif_path="drafts/test/original.wif",
-        drawdown_preview_path="fake/preview.png",
-    )
-    db.add(draft)
-    await db.flush()
-    return draft
-
-
-async def _make_project(db: AsyncSession, owner_id: uuid.UUID, draft_id: uuid.UUID) -> Project:
+async def _make_project(db: AsyncSession, owner_id: uuid.UUID) -> Project:
     project = Project(
         owner_id=owner_id,
-        draft_id=draft_id,
         name="Test Project",
         project_type="treadle",
         status="created",
-        total_picks=10,
     )
     db.add(project)
     await db.flush()
@@ -62,8 +46,7 @@ async def _make_yarn(db: AsyncSession, owner_id: uuid.UUID, color_hex: str = "#a
 
 class TestLinkYarnColor:
     async def test_link_creates_record(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
-        draft = await _make_draft(db_session, test_user.id)
-        project = await _make_project(db_session, test_user.id, draft.id)
+        project = await _make_project(db_session, test_user.id)
         yarn = await _make_yarn(db_session, test_user.id)
         await db_session.commit()
 
@@ -79,8 +62,7 @@ class TestLinkYarnColor:
         assert data["yarn_brand"] == "TestBrand"
 
     async def test_link_updates_existing(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
-        draft = await _make_draft(db_session, test_user.id)
-        project = await _make_project(db_session, test_user.id, draft.id)
+        project = await _make_project(db_session, test_user.id)
         yarn1 = await _make_yarn(db_session, test_user.id, "#111111")
         yarn2 = await _make_yarn(db_session, test_user.id, "#222222")
         await db_session.commit()
@@ -97,8 +79,7 @@ class TestLinkYarnColor:
         assert resp.json()["yarn_id"] == str(yarn2.id)
 
     async def test_link_404_yarn_not_found(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
-        draft = await _make_draft(db_session, test_user.id)
-        project = await _make_project(db_session, test_user.id, draft.id)
+        project = await _make_project(db_session, test_user.id)
         await db_session.commit()
 
         resp = await auth_client.put(
@@ -126,8 +107,7 @@ class TestLinkYarnColor:
         test_user: User,
         admin_user: User,
     ):
-        draft = await _make_draft(db_session, admin_user.id)
-        project = await _make_project(db_session, admin_user.id, draft.id)
+        project = await _make_project(db_session, admin_user.id)
         yarn = await _make_yarn(db_session, test_user.id)
         await db_session.commit()
 
@@ -145,8 +125,7 @@ class TestLinkYarnColor:
 
 class TestUnlinkYarnColor:
     async def test_unlink_removes_record(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
-        draft = await _make_draft(db_session, test_user.id)
-        project = await _make_project(db_session, test_user.id, draft.id)
+        project = await _make_project(db_session, test_user.id)
         yarn = await _make_yarn(db_session, test_user.id)
         pyc = ProjectYarnColor(project_id=project.id, yarn_id=yarn.id, color_hex="#aa3322")
         db_session.add(pyc)
@@ -161,8 +140,7 @@ class TestUnlinkYarnColor:
     async def test_unlink_404_when_not_linked(
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
     ):
-        draft = await _make_draft(db_session, test_user.id)
-        project = await _make_project(db_session, test_user.id, draft.id)
+        project = await _make_project(db_session, test_user.id)
         await db_session.commit()
 
         resp = await auth_client.delete(f"/api/projects/{project.id}/yarn-colors/%23ffffff")
@@ -176,8 +154,7 @@ class TestUnlinkYarnColor:
 
 class TestListProjectYarnColors:
     async def test_list_returns_linked_yarn(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
-        draft = await _make_draft(db_session, test_user.id)
-        project = await _make_project(db_session, test_user.id, draft.id)
+        project = await _make_project(db_session, test_user.id)
         yarn = await _make_yarn(db_session, test_user.id)
         db_session.add(ProjectYarnColor(project_id=project.id, yarn_id=yarn.id, color_hex="#aa3322"))
         await db_session.commit()
@@ -192,8 +169,7 @@ class TestListProjectYarnColors:
     async def test_list_empty_when_none_linked(
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
     ):
-        draft = await _make_draft(db_session, test_user.id)
-        project = await _make_project(db_session, test_user.id, draft.id)
+        project = await _make_project(db_session, test_user.id)
         await db_session.commit()
 
         resp = await auth_client.get(f"/api/projects/{project.id}/yarn-colors")
@@ -210,8 +186,7 @@ class TestProjectDetailIncludesYarnColors:
     async def test_project_detail_has_yarn_colors_field(
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
     ):
-        draft = await _make_draft(db_session, test_user.id)
-        project = await _make_project(db_session, test_user.id, draft.id)
+        project = await _make_project(db_session, test_user.id)
         await db_session.commit()
 
         resp = await auth_client.get(f"/api/projects/{project.id}")
@@ -222,8 +197,7 @@ class TestProjectDetailIncludesYarnColors:
     async def test_project_detail_includes_linked_yarn(
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
     ):
-        draft = await _make_draft(db_session, test_user.id)
-        project = await _make_project(db_session, test_user.id, draft.id)
+        project = await _make_project(db_session, test_user.id)
         yarn = await _make_yarn(db_session, test_user.id)
         db_session.add(ProjectYarnColor(project_id=project.id, yarn_id=yarn.id, color_hex="#aa3322"))
         await db_session.commit()
@@ -245,8 +219,7 @@ class TestGetYarnProjects:
     async def test_returns_projects_using_yarn(
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
     ):
-        draft = await _make_draft(db_session, test_user.id)
-        project = await _make_project(db_session, test_user.id, draft.id)
+        project = await _make_project(db_session, test_user.id)
         yarn = await _make_yarn(db_session, test_user.id)
         db_session.add(ProjectYarnColor(project_id=project.id, yarn_id=yarn.id, color_hex="#aa3322"))
         await db_session.commit()

--- a/backend/tests/routers/test_projects.py
+++ b/backend/tests/routers/test_projects.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.draft import Draft
 from app.models.loom import Loom, LoomVersion, loom_tracking_flags
-from app.models.project import Project
+from app.models.project import Project, ProjectDraft
 from app.models.project import ProjectPhoto as ProjectPhotoModel
 from app.models.user import User
 
@@ -228,24 +228,38 @@ async def _insert_loom(db_session: AsyncSession, owner: User, **kwargs) -> tuple
 async def _insert_active_project(db_session: AsyncSession, owner: User, draft: Draft, loom: Loom | None) -> Project:
     project = Project(
         owner_id=owner.id,
-        draft_id=draft.id,
         loom_id=loom.id if loom else None,
         name="Existing project",
         project_type="treadle",
         status="active",
-        current_pick=1,
-        total_picks=2,
     )
     db_session.add(project)
+    await db_session.flush()
+    seq = ProjectDraft(
+        project_id=project.id,
+        draft_id=draft.id,
+        position=1,
+        repeats=1,
+        current_pick=1,
+    )
+    db_session.add(seq)
     await db_session.commit()
     return project
 
 
-def _base_payload(draft_id: str, **overrides) -> dict:
+async def _get_seq_entry(db_session: AsyncSession, project: Project) -> ProjectDraft:
+    from sqlalchemy import select as _sa_select
+
+    entry = await db_session.scalar(
+        _sa_select(ProjectDraft).where(ProjectDraft.project_id == project.id, ProjectDraft.position == 1)
+    )
+    assert entry is not None
+    return entry
+
+
+def _base_payload(**overrides) -> dict:
     return {
         "name": "My project",
-        "draft_id": draft_id,
-        "project_type": "treadle",
         **overrides,
     }
 
@@ -256,52 +270,36 @@ def _base_payload(draft_id: str, **overrides) -> dict:
 
 
 class TestCreateProject:
-    async def test_returns_201(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
-        draft = await _insert_draft(db_session, test_user)
-        resp = await auth_client.post("/api/projects", json=_base_payload(str(draft.id)))
+    async def test_returns_201(self, auth_client: AsyncClient):
+        resp = await auth_client.post("/api/projects", json=_base_payload())
         assert resp.status_code == 201
 
-    async def test_returns_project_fields(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
-        draft = await _insert_draft(db_session, test_user)
-        resp = await auth_client.post("/api/projects", json=_base_payload(str(draft.id)))
+    async def test_returns_project_fields(self, auth_client: AsyncClient):
+        resp = await auth_client.post("/api/projects", json=_base_payload())
         body = resp.json()
         assert body["name"] == "My project"
-        assert body["project_type"] == "treadle"
+        assert body["project_type"] is None  # null until loom assigned
         assert body["status"] == "created"
-        assert body["current_pick"] == 1
+        assert body["current_pick"] == 0  # no sequence yet
 
-    async def test_unauthenticated_returns_401(self, client: AsyncClient, db_session: AsyncSession, test_user: User):
-        draft = await _insert_draft(db_session, test_user)
-        resp = await client.post("/api/projects", json=_base_payload(str(draft.id)))
+    async def test_unauthenticated_returns_401(self, client: AsyncClient):
+        resp = await client.post("/api/projects", json=_base_payload())
         assert resp.status_code == 401
-
-    async def test_unknown_draft_returns_404(self, auth_client: AsyncClient):
-        resp = await auth_client.post("/api/projects", json=_base_payload(str(uuid.uuid4())))
-        assert resp.status_code == 404
-
-    async def test_invalid_project_type_returns_400(
-        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
-    ):
-        draft = await _insert_draft(db_session, test_user)
-        resp = await auth_client.post("/api/projects", json=_base_payload(str(draft.id), project_type="invalid"))
-        assert resp.status_code == 400
 
     async def test_with_valid_loom_returns_201(
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
     ):
-        draft = await _insert_draft(db_session, test_user)
         loom, _ = await _insert_loom(db_session, test_user)
-        resp = await auth_client.post("/api/projects", json=_base_payload(str(draft.id), loom_id=str(loom.id)))
+        resp = await auth_client.post("/api/projects", json=_base_payload(loom_id=str(loom.id)))
         assert resp.status_code == 201
 
     async def test_with_valid_loom_version_returns_201(
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
     ):
-        draft = await _insert_draft(db_session, test_user)
         loom, version = await _insert_loom(db_session, test_user)
         resp = await auth_client.post(
             "/api/projects",
-            json=_base_payload(str(draft.id), loom_id=str(loom.id), loom_version_id=str(version.id)),
+            json=_base_payload(loom_id=str(loom.id), loom_version_id=str(version.id)),
         )
         assert resp.status_code == 201
         assert resp.json()["loom_version_id"] == str(version.id)
@@ -309,23 +307,21 @@ class TestCreateProject:
     async def test_loom_version_from_other_loom_returns_400(
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
     ):
-        draft = await _insert_draft(db_session, test_user)
         loom_a, _ = await _insert_loom(db_session, test_user)
         loom_b, version_b = await _insert_loom(db_session, test_user, model_name="Other Loom")
         resp = await auth_client.post(
             "/api/projects",
-            json=_base_payload(str(draft.id), loom_id=str(loom_a.id), loom_version_id=str(version_b.id)),
+            json=_base_payload(loom_id=str(loom_a.id), loom_version_id=str(version_b.id)),
         )
         assert resp.status_code == 400
 
     async def test_loom_version_without_loom_returns_400(
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
     ):
-        draft = await _insert_draft(db_session, test_user)
         _, version = await _insert_loom(db_session, test_user)
         resp = await auth_client.post(
             "/api/projects",
-            json=_base_payload(str(draft.id), loom_version_id=str(version.id)),
+            json=_base_payload(loom_version_id=str(version.id)),
         )
         assert resp.status_code == 400
 
@@ -335,7 +331,7 @@ class TestCreateProject:
         draft = await _insert_draft(db_session, test_user)
         loom, _ = await _insert_loom(db_session, test_user)
         await _insert_active_project(db_session, test_user, draft, loom)
-        resp = await auth_client.post("/api/projects", json=_base_payload(str(draft.id), loom_id=str(loom.id)))
+        resp = await auth_client.post("/api/projects", json=_base_payload(loom_id=str(loom.id)))
         assert resp.status_code == 409
 
     async def test_completed_project_does_not_block_new_one(
@@ -346,47 +342,15 @@ class TestCreateProject:
         existing = await _insert_active_project(db_session, test_user, draft, loom)
         existing.status = "completed"
         await db_session.commit()
-        resp = await auth_client.post("/api/projects", json=_base_payload(str(draft.id), loom_id=str(loom.id)))
+        resp = await auth_client.post("/api/projects", json=_base_payload(loom_id=str(loom.id)))
         assert resp.status_code == 201
 
     async def test_other_users_loom_returns_404(
-        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User, admin_user: User
+        self, auth_client: AsyncClient, db_session: AsyncSession, admin_user: User
     ):
-        draft = await _insert_draft(db_session, test_user)
         loom, _ = await _insert_loom(db_session, admin_user)
-        resp = await auth_client.post("/api/projects", json=_base_payload(str(draft.id), loom_id=str(loom.id)))
+        resp = await auth_client.post("/api/projects", json=_base_payload(loom_id=str(loom.id)))
         assert resp.status_code == 404
-
-    async def test_dispatches_preview_when_draft_has_no_preview(
-        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
-    ):
-        from unittest.mock import MagicMock, patch
-
-        draft = await _insert_draft(db_session, test_user)
-        assert draft.drawdown_preview_path is None
-
-        with patch("app.routers.projects.generate_drawdown_preview") as mock_task:
-            mock_task.delay = MagicMock()
-            resp = await auth_client.post("/api/projects", json=_base_payload(str(draft.id)))
-
-        assert resp.status_code == 201
-        mock_task.delay.assert_called_once_with(str(draft.id))
-
-    async def test_skips_preview_dispatch_when_draft_already_has_preview(
-        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
-    ):
-        from unittest.mock import MagicMock, patch
-
-        draft = await _insert_draft(db_session, test_user)
-        draft.drawdown_preview_path = "drawdown-previews/existing.png"
-        await db_session.commit()
-
-        with patch("app.routers.projects.generate_drawdown_preview") as mock_task:
-            mock_task.delay = MagicMock()
-            resp = await auth_client.post("/api/projects", json=_base_payload(str(draft.id)))
-
-        assert resp.status_code == 201
-        mock_task.delay.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -418,7 +382,8 @@ class TestRestartProject:
         loom, _ = await _insert_loom(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, loom)
         project.status = "abandoned"
-        project.current_pick = 2
+        seq = await _get_seq_entry(db_session, project)
+        seq.current_pick = 2
         await db_session.commit()
         resp = await auth_client.post(f"/api/projects/{project.id}/restart")
         assert resp.json()["current_pick"] == 2
@@ -457,38 +422,6 @@ class TestRestartProject:
         resp = await client.post(f"/api/projects/{project.id}/restart")
         assert resp.status_code == 401
 
-    async def test_dispatches_preview_when_draft_has_no_preview(
-        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
-    ):
-        from unittest.mock import MagicMock, patch
-
-        draft = await _insert_draft(db_session, test_user)
-        project = await _insert_active_project(db_session, test_user, draft, None)
-        project.status = "abandoned"
-        await db_session.commit()
-        with patch("app.routers.projects.generate_drawdown_preview") as mock_task:
-            mock_task.delay = MagicMock()
-            resp = await auth_client.post(f"/api/projects/{project.id}/restart")
-        assert resp.status_code == 200
-        mock_task.delay.assert_called_once_with(str(draft.id))
-
-    async def test_skips_preview_dispatch_when_draft_already_has_preview(
-        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
-    ):
-        from unittest.mock import MagicMock, patch
-
-        draft = await _insert_draft(db_session, test_user)
-        draft.drawdown_preview_path = "drawdown-previews/existing.png"
-        await db_session.commit()
-        project = await _insert_active_project(db_session, test_user, draft, None)
-        project.status = "abandoned"
-        await db_session.commit()
-        with patch("app.routers.projects.generate_drawdown_preview") as mock_task:
-            mock_task.delay = MagicMock()
-            resp = await auth_client.post(f"/api/projects/{project.id}/restart")
-        assert resp.status_code == 200
-        mock_task.delay.assert_not_called()
-
 
 # ---------------------------------------------------------------------------
 # TestCloneProject
@@ -500,15 +433,21 @@ async def _insert_project_with_status(
 ) -> Project:
     project = Project(
         owner_id=owner.id,
-        draft_id=draft.id,
         loom_id=loom.id if loom else None,
         name="Original project",
         project_type="treadle",
         status=status,
-        current_pick=3,
-        total_picks=10,
     )
     db_session.add(project)
+    await db_session.flush()
+    seq = ProjectDraft(
+        project_id=project.id,
+        draft_id=draft.id,
+        position=1,
+        repeats=1,
+        current_pick=1,
+    )
+    db_session.add(seq)
     await db_session.commit()
     return project
 
@@ -520,11 +459,11 @@ class TestCloneProject:
         resp = await auth_client.post(f"/api/projects/{project.id}/clone")
         assert resp.status_code == 201
 
-    async def test_clone_starts_at_pick_1(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+    async def test_clone_starts_at_pick_0(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_project_with_status(db_session, test_user, draft, None, "completed")
         resp = await auth_client.post(f"/api/projects/{project.id}/clone")
-        assert resp.json()["current_pick"] == 1
+        assert resp.json()["current_pick"] == 0  # clone resets all picks to 0
 
     async def test_clone_is_created(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
         draft = await _insert_draft(db_session, test_user)
@@ -539,7 +478,7 @@ class TestCloneProject:
         body = resp.json()
         assert body["name"] == project.name
         assert body["project_type"] == project.project_type
-        assert body["draft_id"] == str(project.draft_id)
+        assert body["draft_id"] == str(draft.id)
 
     async def test_can_clone_active_project(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
         draft = await _insert_draft(db_session, test_user)
@@ -564,34 +503,6 @@ class TestCloneProject:
         project = await _insert_project_with_status(db_session, test_user, draft, None, "completed")
         resp = await client.post(f"/api/projects/{project.id}/clone")
         assert resp.status_code == 401
-
-    async def test_dispatches_preview_when_draft_has_no_preview(
-        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
-    ):
-        from unittest.mock import MagicMock, patch
-
-        draft = await _insert_draft(db_session, test_user)
-        project = await _insert_project_with_status(db_session, test_user, draft, None, "completed")
-        with patch("app.routers.projects.generate_drawdown_preview") as mock_task:
-            mock_task.delay = MagicMock()
-            resp = await auth_client.post(f"/api/projects/{project.id}/clone")
-        assert resp.status_code == 201
-        mock_task.delay.assert_called_once_with(str(draft.id))
-
-    async def test_skips_preview_dispatch_when_draft_already_has_preview(
-        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
-    ):
-        from unittest.mock import MagicMock, patch
-
-        draft = await _insert_draft(db_session, test_user)
-        draft.drawdown_preview_path = "drawdown-previews/existing.png"
-        await db_session.commit()
-        project = await _insert_project_with_status(db_session, test_user, draft, None, "completed")
-        with patch("app.routers.projects.generate_drawdown_preview") as mock_task:
-            mock_task.delay = MagicMock()
-            resp = await auth_client.post(f"/api/projects/{project.id}/clone")
-        assert resp.status_code == 201
-        mock_task.delay.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -975,24 +886,14 @@ class TestGetProject:
     ):
         draft = await _insert_draft(db_session, test_user)
         loom, version = await _insert_loom(db_session, test_user)
-        project = Project(
-            owner_id=test_user.id,
-            draft_id=draft.id,
-            loom_id=loom.id,
-            loom_version_id=version.id,
-            name="Test project",
-            project_type="treadle",
-            status="active",
-            current_pick=1,
-            total_picks=2,
-        )
-        db_session.add(project)
+        project = await _insert_active_project(db_session, test_user, draft, loom)
+        project.loom_version_id = version.id
         await db_session.commit()
         body = (await auth_client.get(f"/api/projects/{project.id}")).json()
         assert body["loom_num_treadles"] == version.num_treadles
         assert body["loom_num_shafts"] == version.num_shafts
 
-    async def test_dispatches_preview_when_draft_has_no_preview(
+    async def test_dispatches_preview_when_active_draft_has_no_preview(
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
     ):
         from unittest.mock import MagicMock, patch
@@ -1005,7 +906,7 @@ class TestGetProject:
         assert resp.status_code == 200
         mock_task.delay.assert_called_once_with(str(draft.id))
 
-    async def test_skips_preview_dispatch_when_draft_already_has_preview(
+    async def test_skips_preview_dispatch_when_active_draft_has_preview(
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
     ):
         from unittest.mock import MagicMock, patch
@@ -1163,10 +1064,7 @@ class TestHideUnusedShaftsTreadlesInheritance:
         db_session.add(draft)
         await db_session.commit()
 
-        resp = await auth_client.post(
-            "/api/projects",
-            json={"name": "P", "draft_id": str(draft_id), "project_type": "treadle"},
-        )
+        resp = await auth_client.post("/api/projects", json={"name": "P"})
         assert resp.status_code == 201
         assert resp.json()["hide_unused_shafts_treadles"] is False
 
@@ -1174,32 +1072,10 @@ class TestHideUnusedShaftsTreadlesInheritance:
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
     ):
         """New project inherits hide_unused_shafts_treadles=True when user default is on."""
-        import app.services.storage as storage
-
         test_user.hide_unused_shafts_treadles = True
         await db_session.commit()
 
-        draft_id = uuid.uuid4()
-        wif_key = storage.save_wif(draft_id, "test.wif", _WIF)
-        draft = Draft(
-            id=draft_id,
-            owner_id=test_user.id,
-            name="Draft",
-            wif_filename="test.wif",
-            wif_path=wif_key,
-            has_treadling=True,
-            num_shafts=4,
-            num_treadles=4,
-            warp_threads=4,
-            weft_threads=4,
-        )
-        db_session.add(draft)
-        await db_session.commit()
-
-        resp = await auth_client.post(
-            "/api/projects",
-            json={"name": "P", "draft_id": str(draft_id), "project_type": "treadle"},
-        )
+        resp = await auth_client.post("/api/projects", json={"name": "P"})
         assert resp.status_code == 201
         assert resp.json()["hide_unused_shafts_treadles"] is True
 
@@ -1249,7 +1125,8 @@ class TestStepProject:
     async def test_reverse_decrements_pick(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
-        project.current_pick = 2
+        seq = await _get_seq_entry(db_session, project)
+        seq.current_pick = 2
         await db_session.commit()
         body = (await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "reverse"})).json()
         assert body["current_pick"] == 1
@@ -1259,6 +1136,9 @@ class TestStepProject:
     ):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
+        seq = await _get_seq_entry(db_session, project)
+        seq.current_pick = 0
+        await db_session.commit()
         resp = await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "reverse"})
         assert resp.status_code == 400
 
@@ -1267,7 +1147,8 @@ class TestStepProject:
     ):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
-        project.current_pick = project.total_picks + 1
+        seq = await _get_seq_entry(db_session, project)
+        seq.current_pick = 2  # == section_total (weft_threads=2, repeats=1)
         await db_session.commit()
         resp = await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
         assert resp.status_code == 400
@@ -1300,11 +1181,21 @@ class TestStepProject:
         resp = await client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
         assert resp.status_code == 401
 
-    async def test_response_is_lightweight(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+    async def test_response_has_expected_keys(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
         body = (await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})).json()
-        assert set(body.keys()) == {"current_pick", "total_picks", "current_item", "num_items"}
+        assert set(body.keys()) == {
+            "current_pick",
+            "total_picks",
+            "position",
+            "aggregate_current_pick",
+            "aggregate_total_picks",
+            "current_item",
+            "num_items",
+        }
 
     async def test_logs_step_to_database(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
         from sqlalchemy import select
@@ -1329,14 +1220,20 @@ class TestStepProject:
         draft = await _insert_draft(db_session, test_user)
         project = Project(
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Rapid tap project",
             project_type="treadle",
             status="active",
-            current_pick=1,
-            total_picks=10,
         )
         db_session.add(project)
+        await db_session.flush()
+        seq = ProjectDraft(
+            project_id=project.id,
+            draft_id=draft.id,
+            position=1,
+            repeats=5,  # section_total = 2 * 5 = 10
+            current_pick=0,
+        )
+        db_session.add(seq)
         await db_session.commit()
         picks = []
         for _ in range(4):
@@ -1358,19 +1255,19 @@ class TestJumpProject:
         body = (await auth_client.post(f"/api/projects/{project.id}/jump", json={"pick": 2})).json()
         assert body["current_pick"] == 2
 
-    async def test_clamps_above_total_plus_one(
+    async def test_clamps_above_section_total(
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
     ):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
         body = (await auth_client.post(f"/api/projects/{project.id}/jump", json={"pick": 999})).json()
-        assert body["current_pick"] == project.total_picks + 1
+        assert body["current_pick"] == 2  # clamped to section_total (weft=2, repeats=1)
 
-    async def test_clamps_below_one(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+    async def test_clamps_below_zero(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
-        body = (await auth_client.post(f"/api/projects/{project.id}/jump", json={"pick": 0})).json()
-        assert body["current_pick"] == 1
+        body = (await auth_client.post(f"/api/projects/{project.id}/jump", json={"pick": -5})).json()
+        assert body["current_pick"] == 0  # clamped to 0
 
     async def test_completed_project_returns_400(
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
@@ -1396,7 +1293,8 @@ class TestCompleteProject:
     async def test_returns_200(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
-        project.current_pick = project.total_picks + 1
+        seq = await _get_seq_entry(db_session, project)
+        seq.current_pick = 2  # section_total (weft=2, repeats=1) → all done
         await db_session.commit()
         resp = await auth_client.post(f"/api/projects/{project.id}/complete")
         assert resp.status_code == 200
@@ -1404,7 +1302,8 @@ class TestCompleteProject:
     async def test_status_becomes_completed(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
-        project.current_pick = project.total_picks + 1
+        seq = await _get_seq_entry(db_session, project)
+        seq.current_pick = 2
         await db_session.commit()
         body = (await auth_client.post(f"/api/projects/{project.id}/complete")).json()
         assert body["status"] == "completed"
@@ -1412,7 +1311,8 @@ class TestCompleteProject:
     async def test_sets_completed_at(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
-        project.current_pick = project.total_picks + 1
+        seq = await _get_seq_entry(db_session, project)
+        seq.current_pick = 2
         await db_session.commit()
         await auth_client.post(f"/api/projects/{project.id}/complete")
         await db_session.refresh(project)
@@ -1423,7 +1323,7 @@ class TestCompleteProject:
     ):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
-        # current_pick=1, not at end
+        # seq.current_pick=1, section_total=2 → agg_current(1) < total_picks(2)
         resp = await auth_client.post(f"/api/projects/{project.id}/complete")
         assert resp.status_code == 400
 
@@ -1434,7 +1334,8 @@ class TestCompleteProject:
         project = await _insert_active_project(db_session, test_user, draft, None)
         project.num_items = 3
         project.current_item = 1
-        project.current_pick = project.total_picks + 1
+        seq = await _get_seq_entry(db_session, project)
+        seq.current_pick = 2  # all sequence picks done
         await db_session.commit()
         resp = await auth_client.post(f"/api/projects/{project.id}/complete")
         assert resp.status_code == 400
@@ -1472,11 +1373,10 @@ class TestCompleteProject:
     async def test_force_preserves_pick_data(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
-        total = project.total_picks
         resp = await auth_client.post(f"/api/projects/{project.id}/complete?force=true")
         assert resp.status_code == 200
         body = resp.json()
-        assert body["total_picks"] == total
+        assert body["total_picks"] == 2  # weft=2 * repeats=1
         assert body["current_pick"] == 1  # unchanged
 
     async def test_force_false_still_blocks_incomplete(
@@ -1547,50 +1447,12 @@ class TestAdvanceItem:
         project = await _insert_active_project(db_session, test_user, draft, None)
         project.num_items = 3
         project.current_item = 1
-        project.current_pick = project.total_picks + 1
+        seq = await _get_seq_entry(db_session, project)
+        seq.current_pick = 2  # section_total (weft=2, repeats=1) → all done
         await db_session.commit()
         body = (await auth_client.post(f"/api/projects/{project.id}/advance-item")).json()
         assert body["current_item"] == 2
-        assert body["current_pick"] == 1
-
-    async def test_saves_departing_item_pick_and_restores_on_return(
-        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
-    ):
-        draft = await _insert_draft(db_session, test_user)
-        project = await _insert_active_project(db_session, test_user, draft, None)
-        project.num_items = 3
-        project.current_item = 1
-        project.current_pick = project.total_picks + 1
-        await db_session.commit()
-        # Advance to item 2
-        await auth_client.post(f"/api/projects/{project.id}/advance-item")
-        # Work a bit on item 2
-        project2 = await db_session.get(type(project), project.id)
-        assert project2 is not None
-        project2.current_pick = 2
-        await db_session.commit()
-        # Jump back to item 1 — should restore to total_picks + 1 (completed state)
-        body = (await auth_client.post(f"/api/projects/{project.id}/jump-item", json={"item": 1})).json()
-        assert body["current_item"] == 1
-        assert body["current_pick"] == project.total_picks + 1
-
-    async def test_restores_previously_visited_item_pick(
-        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
-    ):
-        draft = await _insert_draft(db_session, test_user)
-        project = await _insert_active_project(db_session, test_user, draft, None)
-        project.num_items = 3
-        project.current_item = 2
-        project.current_pick = 2
-        project.item_picks = {"1": project.total_picks + 1}
-        await db_session.commit()
-        # Advance from item 2 (at end) to item 3 — item 2's pick (2) should be saved
-        project.current_pick = project.total_picks + 1
-        await db_session.commit()
-        await auth_client.post(f"/api/projects/{project.id}/advance-item")
-        # Jump back to item 2 — should restore pick 2
-        body = (await auth_client.post(f"/api/projects/{project.id}/jump-item", json={"item": 2})).json()
-        assert body["current_pick"] == project.total_picks + 1  # saved at end
+        assert body["current_pick"] == 0
 
     async def test_response_includes_num_items(
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
@@ -1599,7 +1461,8 @@ class TestAdvanceItem:
         project = await _insert_active_project(db_session, test_user, draft, None)
         project.num_items = 3
         project.current_item = 1
-        project.current_pick = project.total_picks + 1
+        seq = await _get_seq_entry(db_session, project)
+        seq.current_pick = 2  # section_total → all done
         await db_session.commit()
         body = (await auth_client.post(f"/api/projects/{project.id}/advance-item")).json()
         assert body["num_items"] == 3
@@ -1623,7 +1486,8 @@ class TestAdvanceItem:
         project = await _insert_active_project(db_session, test_user, draft, None)
         project.num_items = 3
         project.current_item = 3
-        project.current_pick = project.total_picks + 1
+        seq = await _get_seq_entry(db_session, project)
+        seq.current_pick = 2  # section_total → sequence done, but already on last item
         await db_session.commit()
         resp = await auth_client.post(f"/api/projects/{project.id}/advance-item")
         assert resp.status_code == 400
@@ -1633,7 +1497,8 @@ class TestAdvanceItem:
     ):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
-        project.current_pick = project.total_picks + 1
+        seq = await _get_seq_entry(db_session, project)
+        seq.current_pick = 2  # section_total → sequence done; num_items=1, current_item=1 → last item
         await db_session.commit()
         resp = await auth_client.post(f"/api/projects/{project.id}/advance-item")
         assert resp.status_code == 400
@@ -1665,44 +1530,15 @@ class TestAdvanceItem:
 
 
 class TestJumpItem:
-    async def test_sets_item_and_resets_pick(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+    async def test_sets_item(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
         project.num_items = 5
         project.current_item = 3
-        project.current_pick = 2
         await db_session.commit()
         body = (await auth_client.post(f"/api/projects/{project.id}/jump-item", json={"item": 2})).json()
         assert body["current_item"] == 2
-        assert body["current_pick"] == 1  # item 2 never visited → defaults to 1
-
-    async def test_restores_pick_for_previously_visited_item(
-        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
-    ):
-        draft = await _insert_draft(db_session, test_user)
-        project = await _insert_active_project(db_session, test_user, draft, None)
-        project.num_items = 3
-        project.current_item = 2
-        project.current_pick = 7
-        project.item_picks = {"1": project.total_picks + 1}  # item 1 was completed
-        await db_session.commit()
-        body = (await auth_client.post(f"/api/projects/{project.id}/jump-item", json={"item": 1})).json()
-        assert body["current_item"] == 1
-        assert body["current_pick"] == project.total_picks + 1
-
-    async def test_saves_current_pick_when_jumping(
-        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
-    ):
-
-        draft = await _insert_draft(db_session, test_user)
-        project = await _insert_active_project(db_session, test_user, draft, None)
-        project.num_items = 3
-        project.current_item = 2
-        project.current_pick = 7
-        await db_session.commit()
-        await auth_client.post(f"/api/projects/{project.id}/jump-item", json={"item": 1})
-        await db_session.refresh(project)
-        assert project.item_picks.get("2") == 7
+        assert body["current_pick"] == 1  # seq entry current_pick unchanged by jump-item
 
     async def test_clamps_above_num_items(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
         draft = await _insert_draft(db_session, test_user)
@@ -1893,14 +1729,14 @@ class TestGetPicks:
         await db_session.commit()
         project = Project(
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Lift project",
             project_type="lift",
             status="active",
-            current_pick=1,
-            total_picks=2,
         )
         db_session.add(project)
+        await db_session.flush()
+        seq = ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=1)
+        db_session.add(seq)
         await db_session.commit()
         resp = await auth_client.get(f"/api/projects/{project.id}/picks")
         assert resp.status_code == 200
@@ -1915,38 +1751,34 @@ class TestUnsupportedLoomType:
     async def test_unsupported_loom_type_blocks_create(
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
     ):
-        draft = await _insert_draft(db_session, test_user)
         loom, _ = await _insert_loom(db_session, test_user, loom_type="rigid_heddle")
         resp = await auth_client.post(
             "/api/projects",
-            json=_base_payload(str(draft.id), loom_id=str(loom.id)),
+            json=_base_payload(loom_id=str(loom.id)),
         )
         assert resp.status_code == 422
 
     async def test_dobby_loom_blocks_create(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
-        draft = await _insert_draft(db_session, test_user)
         loom, _ = await _insert_loom(db_session, test_user, loom_type="dobby")
         resp = await auth_client.post(
             "/api/projects",
-            json=_base_payload(str(draft.id), loom_id=str(loom.id)),
+            json=_base_payload(loom_id=str(loom.id)),
         )
         assert resp.status_code == 422
 
     async def test_floor_loom_allowed(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
-        draft = await _insert_draft(db_session, test_user)
         loom, _ = await _insert_loom(db_session, test_user, loom_type="floor_loom")
         resp = await auth_client.post(
             "/api/projects",
-            json=_base_payload(str(draft.id), loom_id=str(loom.id)),
+            json=_base_payload(loom_id=str(loom.id)),
         )
         assert resp.status_code == 201
 
     async def test_table_loom_allowed(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
-        draft = await _insert_draft(db_session, test_user)
         loom, _ = await _insert_loom(db_session, test_user, loom_type="table_loom")
         resp = await auth_client.post(
             "/api/projects",
-            json=_base_payload(str(draft.id), project_type="lift", loom_id=str(loom.id)),
+            json=_base_payload(loom_id=str(loom.id)),
         )
         assert resp.status_code == 201
 
@@ -1961,33 +1793,6 @@ class TestUnsupportedLoomType:
             json={"loom_id": str(loom.id)},
         )
         assert resp.status_code == 422
-
-
-# ---------------------------------------------------------------------------
-# create_project fires prerender with project.id (not draft.id)
-# ---------------------------------------------------------------------------
-
-
-class TestCreateProjectFiresProjectPrerender:
-    async def test_prerender_called_with_project_id(
-        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User, _mock_tile_task
-    ):
-        draft = await _insert_draft(db_session, test_user)
-        resp = await auth_client.post("/api/projects", json=_base_payload(str(draft.id)))
-        assert resp.status_code == 201
-        project_id = resp.json()["id"]
-
-        _mock_tile_task.delay.assert_called_once_with(project_id)
-
-    async def test_prerender_not_called_with_draft_id(
-        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User, _mock_tile_task
-    ):
-        draft = await _insert_draft(db_session, test_user)
-        await auth_client.post("/api/projects", json=_base_payload(str(draft.id)))
-
-        call_args = _mock_tile_task.delay.call_args
-        assert call_args is not None
-        assert str(draft.id) not in call_args.args
 
 
 # ---------------------------------------------------------------------------
@@ -2026,14 +1831,14 @@ async def _insert_project_with_wif(
 
     project = Project(
         owner_id=owner.id,
-        draft_id=draft.id,
         name="Tile Test Project",
         project_type="treadle",
         status="active",
-        current_pick=1,
-        total_picks=weft_threads,
     )
     db_session.add(project)
+    await db_session.flush()
+    seq = ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=1)
+    db_session.add(seq)
     await db_session.commit()
     return draft, project
 
@@ -2216,6 +2021,9 @@ class TestWeaveSessions:
 
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
+        seq = await _get_seq_entry(db_session, project)
+        seq.current_pick = 0  # reset so 2 advances are possible (section_total=2)
+        await db_session.commit()
 
         await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
         await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
@@ -2247,12 +2055,13 @@ class TestWeaveSessions:
         old_step = ProjectStep(
             project_id=project.id,
             event_type="advance",
-            from_pick=1,
-            to_pick=2,
+            from_pick=0,
+            to_pick=1,
             created_at=datetime.now(timezone.utc) - timedelta(hours=1),
         )
         db_session.add(old_step)
-        project.current_pick = 2
+        seq = await _get_seq_entry(db_session, project)
+        seq.current_pick = 1  # 1 pick still available (section_total=2)
         # Manually insert an open session
         old_session = WeaveSession(
             project_id=project.id,
@@ -2286,12 +2095,13 @@ class TestWeaveSessions:
         old_step = ProjectStep(
             project_id=project.id,
             event_type="advance",
-            from_pick=1,
-            to_pick=2,
+            from_pick=0,
+            to_pick=1,
             created_at=datetime.now(timezone.utc) - timedelta(hours=2),
         )
         db_session.add(old_step)
-        project.current_pick = 2
+        seq = await _get_seq_entry(db_session, project)
+        seq.current_pick = 1  # 1 pick still available (section_total=2)
         db_session.add(
             WeaveSession(
                 project_id=project.id,
@@ -2320,7 +2130,8 @@ class TestWeaveSessions:
 
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
-        project.current_pick = project.total_picks + 1
+        seq = await _get_seq_entry(db_session, project)
+        seq.current_pick = 2  # section_total → complete
         await db_session.commit()
 
         open_session = WeaveSession(project_id=project.id, started_at=datetime.now(timezone.utc))
@@ -2380,6 +2191,9 @@ class TestProjectMetrics:
     ):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
+        seq = await _get_seq_entry(db_session, project)
+        seq.current_pick = 0  # start from 0 so 2 advances are available (section_total=2)
+        await db_session.commit()
         await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
         await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
         await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "reverse"})
@@ -2605,14 +2419,13 @@ class TestProjectDrawdownSvg:
         await db_session.flush()
         project = Project(
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="No WIF Project",
             project_type="treadle",
             status="active",
-            current_pick=1,
-            total_picks=2,
         )
         db_session.add(project)
+        await db_session.flush()
+        db_session.add(ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=1))
         await db_session.commit()
         resp = await auth_client.get(f"/api/projects/{project.id}/drawdown/svg")
         assert resp.status_code == 404
@@ -2727,14 +2540,13 @@ class TestProjectDrawdownData:
         await db_session.flush()
         project = Project(
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="No WIF Project",
             project_type="treadle",
             status="active",
-            current_pick=1,
-            total_picks=2,
         )
         db_session.add(project)
+        await db_session.flush()
+        db_session.add(ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=1))
         await db_session.commit()
         resp = await auth_client.get(f"/api/projects/{project.id}/drawdown/data")
         assert resp.status_code == 404
@@ -2761,10 +2573,27 @@ class TestStartProject:
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
     ):
         draft = await _insert_draft(db_session, test_user)
-        project = await _insert_project_with_status(db_session, test_user, draft, None, "created")
+        loom, _ = await _insert_loom(db_session, test_user)
+        project = await _insert_project_with_status(db_session, test_user, draft, loom, "created")
         resp = await auth_client.post(f"/api/projects/{project.id}/start")
         assert resp.status_code == 200
         assert resp.json()["status"] == "active"
+
+    async def test_returns_400_when_no_sequence(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        loom, _ = await _insert_loom(db_session, test_user)
+        project = Project(owner_id=test_user.id, name="Empty seq", loom_id=loom.id, status="created")
+        db_session.add(project)
+        await db_session.commit()
+        resp = await auth_client.post(f"/api/projects/{project.id}/start")
+        assert resp.status_code == 400
+
+    async def test_returns_400_when_no_loom(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_project_with_status(db_session, test_user, draft, None, "created")
+        resp = await auth_client.post(f"/api/projects/{project.id}/start")
+        assert resp.status_code == 400
 
     async def test_idempotent_when_already_active(
         self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
@@ -2851,53 +2680,6 @@ class TestSetColorReplacements:
         body = {"color_replacements": {"#ff0000": "#0000ff"}}
         resp = await auth_client.patch(f"/api/projects/{uuid.uuid4()}/color-replacements", json=body)
         assert resp.status_code == 404
-
-
-# ---------------------------------------------------------------------------
-# TestProjectTypeValidation — error branches for treadle/lift type checks
-# ---------------------------------------------------------------------------
-
-
-class TestProjectTypeValidation:
-    async def _insert_draft_flags(
-        self, db_session: AsyncSession, owner: User, *, has_treadling: bool, has_liftplan: bool
-    ) -> Draft:
-        import app.services.storage as storage
-
-        draft_id = uuid.uuid4()
-        wif_key = storage.save_wif(draft_id, "test.wif", _WIF)
-        draft = Draft(
-            id=draft_id,
-            owner_id=owner.id,
-            name="Flag Draft",
-            wif_filename="test.wif",
-            wif_path=wif_key,
-            has_treadling=has_treadling,
-            has_liftplan=has_liftplan,
-        )
-        db_session.add(draft)
-        await db_session.commit()
-        return draft
-
-    async def test_treadle_type_rejected_when_no_treadling(
-        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
-    ):
-        draft = await self._insert_draft_flags(db_session, test_user, has_treadling=False, has_liftplan=True)
-        resp = await auth_client.post(
-            "/api/projects", json={"name": "p", "draft_id": str(draft.id), "project_type": "treadle"}
-        )
-        assert resp.status_code == 400
-        assert "TREADLING" in resp.json()["detail"]
-
-    async def test_lift_type_rejected_when_no_liftplan(
-        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
-    ):
-        draft = await self._insert_draft_flags(db_session, test_user, has_treadling=True, has_liftplan=False)
-        resp = await auth_client.post(
-            "/api/projects", json={"name": "p", "draft_id": str(draft.id), "project_type": "lift"}
-        )
-        assert resp.status_code == 400
-        assert "LIFTPLAN" in resp.json()["detail"]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/routers/test_storage_report.py
+++ b/backend/tests/routers/test_storage_report.py
@@ -36,11 +36,9 @@ async def _make_user_with_files(db_session: AsyncSession) -> User:
 
     project = Project(
         owner_id=user.id,
-        draft_id=draft.id,
         name="Report Project",
         project_type="treadle",
         status="active",
-        total_picks=10,
     )
     db_session.add(project)
     await db_session.flush()

--- a/backend/tests/routers/test_tags.py
+++ b/backend/tests/routers/test_tags.py
@@ -84,11 +84,9 @@ async def _insert_draft(db: AsyncSession, owner: User, *, tags: list[str] | None
 async def _insert_project(db: AsyncSession, owner: User, draft: Draft, *, tags: list[str] | None = None) -> Project:
     p = Project(
         owner_id=owner.id,
-        draft_id=draft.id,
         name="Test Project",
         project_type="treadle",
         status="created",
-        total_picks=100,
         tags=tags or [],
     )
     db.add(p)

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -215,12 +215,9 @@ class TestDeleteAccount:
 
         project = Project(
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Test Project",
             project_type="treadle",
             status="active",
-            current_pick=1,
-            total_picks=100,
         )
         db_session.add(project)
         await db_session.flush()
@@ -273,12 +270,9 @@ class TestDeleteAccount:
 
         project = Project(
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="P",
             project_type="treadle",
             status="active",
-            current_pick=1,
-            total_picks=10,
         )
         db_session.add(project)
         await db_session.flush()
@@ -373,12 +367,9 @@ class TestDeleteAccount:
 
         project = Project(
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="P",
             project_type="treadle",
-            status="planning",
-            current_pick=1,
-            total_picks=10,
+            status="created",
         )
         db_session.add(project)
         await db_session.flush()
@@ -540,12 +531,9 @@ class TestActivityHeatmap:
 
         project = Project(
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Heatmap Project",
             project_type="treadle",
             status="active",
-            current_pick=1,
-            total_picks=10,
         )
         db_session.add(project)
         await db_session.flush()
@@ -583,12 +571,9 @@ class TestActivityHeatmap:
 
         project = Project(
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Multi Project",
             project_type="treadle",
             status="active",
-            current_pick=1,
-            total_picks=10,
         )
         db_session.add(project)
         await db_session.flush()
@@ -626,12 +611,9 @@ class TestActivityHeatmap:
 
         project = Project(
             owner_id=admin_user.id,
-            draft_id=draft.id,
             name="Admin Project",
             project_type="treadle",
             status="active",
-            current_pick=1,
-            total_picks=10,
         )
         db_session.add(project)
         await db_session.flush()
@@ -664,12 +646,9 @@ class TestActivityHeatmap:
 
         project = Project(
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Old Project",
             project_type="treadle",
             status="active",
-            current_pick=1,
-            total_picks=10,
         )
         db_session.add(project)
         await db_session.flush()
@@ -701,12 +680,9 @@ class TestActivityHeatmap:
         await db_session.flush()
         project = Project(
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="E Project",
             project_type="treadle",
             status="active",
-            current_pick=1,
-            total_picks=10,
         )
         db_session.add(project)
         await db_session.flush()
@@ -731,12 +707,9 @@ class TestActivityHeatmap:
         await db_session.flush()
         project = Project(
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Y Project",
             project_type="treadle",
             status="active",
-            current_pick=1,
-            total_picks=10,
         )
         db_session.add(project)
         await db_session.flush()
@@ -758,12 +731,9 @@ class TestActivityHeatmap:
         await db_session.flush()
         project = Project(
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="YP Project",
             project_type="treadle",
             status="active",
-            current_pick=1,
-            total_picks=10,
         )
         db_session.add(project)
         await db_session.flush()
@@ -791,12 +761,9 @@ class TestActivityHeatmap:
         await db_session.flush()
         project = Project(
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="PL Project",
             project_type="treadle",
             status="active",
-            current_pick=1,
-            total_picks=10,
         )
         db_session.add(project)
         await db_session.flush()

--- a/backend/tests/tasks/test_deletion_helpers.py
+++ b/backend/tests/tasks/test_deletion_helpers.py
@@ -203,10 +203,8 @@ class TestPurgeStorage:
         project = Project(
             id=uuid.uuid4(),
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Photo Project",
             project_type="treadle",
-            total_picks=4,
         )
         db_session.add(project)
         await db_session.flush()
@@ -245,10 +243,8 @@ class TestPurgeStorage:
         project = Project(
             id=uuid.uuid4(),
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Tiles Project",
             project_type="treadle",
-            total_picks=4,
         )
         db_session.add(project)
         await db_session.commit()

--- a/backend/tests/tasks/test_export.py
+++ b/backend/tests/tasks/test_export.py
@@ -314,13 +314,10 @@ class TestBuildExportHappyPath:
 
     async def test_project_status_and_name_in_json(self, db_session, mock_db, mock_storage, mock_email):
         user = await _make_user(db_session)
-        draft = await _make_draft(db_session, user.id)
         project = Project(
             owner_id=user.id,
-            draft_id=draft.id,
             name="Spring Scarf",
             project_type="treadle",
-            total_picks=200,
             status="completed",
         )
         db_session.add(project)
@@ -452,13 +449,10 @@ class TestBuildExportErrorPaths:
 
     async def test_photo_storage_failure_skipped(self, db_session, mock_db, mock_email):
         user = await _make_user(db_session)
-        draft = await _make_draft(db_session, user.id)
         project = Project(
             owner_id=user.id,
-            draft_id=draft.id,
             name="Photo Project",
             project_type="treadle",
-            total_picks=10,
         )
         db_session.add(project)
         await db_session.flush()

--- a/backend/tests/tasks/test_maintenance.py
+++ b/backend/tests/tasks/test_maintenance.py
@@ -366,7 +366,7 @@ class TestBackfillProjectDrawdownPreviews:
 
         import app.services.storage as storage
         from app.models.draft import Draft
-        from app.models.project import Project
+        from app.models.project import Project, ProjectDraft
         from app.tasks.maintenance import backfill_project_drawdown_previews
 
         draft = Draft(
@@ -382,14 +382,13 @@ class TestBackfillProjectDrawdownPreviews:
 
         project = Project(
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Active Project",
             project_type="treadle",
             status="active",
-            current_pick=1,
-            total_picks=10,
         )
         db_session.add(project)
+        await db_session.flush()
+        db_session.add(ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=0))
         await db_session.commit()
 
         with patch("app.tasks.preview.generate_drawdown_preview") as mock_preview:
@@ -420,12 +419,9 @@ class TestBackfillProjectDrawdownPreviews:
         await db_session.flush()
         project = Project(
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Completed",
             project_type="treadle",
             status="completed",
-            current_pick=10,
-            total_picks=10,
         )
         db_session.add(project)
         await db_session.commit()
@@ -458,12 +454,9 @@ class TestBackfillProjectDrawdownPreviews:
         await db_session.flush()
         project = Project(
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Abandoned",
             project_type="treadle",
             status="abandoned",
-            current_pick=1,
-            total_picks=10,
         )
         db_session.add(project)
         await db_session.commit()
@@ -496,12 +489,9 @@ class TestBackfillProjectDrawdownPreviews:
         await db_session.flush()
         project = Project(
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Has Preview",
             project_type="treadle",
             status="active",
-            current_pick=1,
-            total_picks=10,
         )
         db_session.add(project)
         await db_session.commit()
@@ -519,7 +509,7 @@ class TestBackfillProjectDrawdownPreviews:
 
         import app.services.storage as storage
         from app.models.draft import Draft
-        from app.models.project import Project
+        from app.models.project import Project, ProjectDraft
         from app.tasks.maintenance import backfill_project_drawdown_previews
 
         draft = Draft(
@@ -534,16 +524,16 @@ class TestBackfillProjectDrawdownPreviews:
         await db_session.flush()
 
         for i in range(3):
+            project = Project(
+                owner_id=test_user.id,
+                name=f"Project {i}",
+                project_type="treadle",
+                status="active",
+            )
+            db_session.add(project)
+            await db_session.flush()
             db_session.add(
-                Project(
-                    owner_id=test_user.id,
-                    draft_id=draft.id,
-                    name=f"Project {i}",
-                    project_type="treadle",
-                    status="active",
-                    current_pick=1,
-                    total_picks=10,
-                )
+                ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=0)
             )
         await db_session.commit()
 
@@ -560,7 +550,7 @@ class TestBackfillProjectDrawdownPreviews:
 
         import app.services.storage as storage
         from app.models.draft import Draft
-        from app.models.project import Project
+        from app.models.project import Project, ProjectDraft
         from app.tasks.maintenance import backfill_project_drawdown_previews
 
         for i in range(5):
@@ -574,16 +564,16 @@ class TestBackfillProjectDrawdownPreviews:
             )
             db_session.add(draft)
             await db_session.flush()
+            project = Project(
+                owner_id=test_user.id,
+                name=f"Project {i}",
+                project_type="treadle",
+                status="active",
+            )
+            db_session.add(project)
+            await db_session.flush()
             db_session.add(
-                Project(
-                    owner_id=test_user.id,
-                    draft_id=draft.id,
-                    name=f"Project {i}",
-                    project_type="treadle",
-                    status="active",
-                    current_pick=1,
-                    total_picks=10,
-                )
+                ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=0)
             )
         await db_session.commit()
 
@@ -615,12 +605,9 @@ class TestBackfillProjectDrawdownPreviews:
         await db_session.flush()
         project = Project(
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Deleted",
             project_type="treadle",
             status="active",
-            current_pick=1,
-            total_picks=10,
         )
         project.deleted_at = _ago(minutes=5)
         db_session.add(project)
@@ -920,12 +907,9 @@ class TestPruneInactiveProjectTiles:
 
         project = Project(
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Stale Project",
             project_type="treadle",
             status="active",
-            current_pick=1,
-            total_picks=10,
         )
         db_session.add(project)
         await db_session.commit()
@@ -966,12 +950,9 @@ class TestPruneInactiveProjectTiles:
 
         project = Project(
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Active Project",
             project_type="treadle",
             status="active",
-            current_pick=5,
-            total_picks=10,
         )
         db_session.add(project)
         await db_session.commit()
@@ -1004,12 +985,9 @@ class TestPruneInactiveProjectTiles:
 
         project = Project(
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Deleted Project",
             project_type="treadle",
             status="active",
-            current_pick=1,
-            total_picks=10,
         )
         project.deleted_at = _ago(minutes=5)
         db_session.add(project)
@@ -1394,10 +1372,8 @@ class TestExpireProjectSlugs:
         project = Project(
             id=uuid.uuid4(),
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Shared Project",
             project_type="weave",
-            total_picks=4,
             share_slug="test-slug-expired",
             share_visibility="public",
             share_expires_at=_ago(days=1),
@@ -1432,10 +1408,8 @@ class TestExpireProjectSlugs:
         project = Project(
             id=uuid.uuid4(),
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Future Shared",
             project_type="weave",
-            total_picks=4,
             share_slug="not-yet-expired",
             share_visibility="public",
             share_expires_at=future_time,
@@ -1499,12 +1473,9 @@ class TestPruneInactiveProjectTilesExceptionHandler:
         await db_session.flush()
         project = Project(
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Tile Project",
             project_type="treadle",
             status="active",
-            current_pick=1,
-            total_picks=10,
         )
         db_session.add(project)
         await db_session.commit()

--- a/backend/tests/tasks/test_preview.py
+++ b/backend/tests/tasks/test_preview.py
@@ -375,20 +375,20 @@ class TestGenerateProjectPreview:
         return draft
 
     async def _make_project(self, db_session, test_user, draft, deleted=False, **kwargs):
-        from app.models.project import Project
+        from app.models.project import Project, ProjectDraft
 
         project = Project(
             id=uuid.uuid4(),
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Test Project",
             project_type="treadle",
-            total_picks=4,
             **kwargs,
         )
         if deleted:
             project.deleted_at = datetime.now(timezone.utc)
         db_session.add(project)
+        await db_session.flush()
+        db_session.add(ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=0))
         await db_session.commit()
         return project
 
@@ -475,12 +475,14 @@ class TestGenerateProjectPreview:
         project = Project(
             id=uuid.uuid4(),
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Lift Project",
             project_type="lift",
-            total_picks=4,
         )
         db_session.add(project)
+        await db_session.flush()
+        from app.models.project import ProjectDraft
+
+        db_session.add(ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=0))
         await db_session.commit()
         mock_storage["drafts/proj_modified.wif"] = MINIMAL_WIF
 
@@ -520,18 +522,18 @@ class TestGenerateProjectSVG:
         return draft
 
     async def _make_project(self, db_session, test_user, draft, **kwargs):
-        from app.models.project import Project
+        from app.models.project import Project, ProjectDraft
 
         project = Project(
             id=uuid.uuid4(),
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="SVG Project",
             project_type="treadle",
-            total_picks=4,
             **kwargs,
         )
         db_session.add(project)
+        await db_session.flush()
+        db_session.add(ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=0))
         await db_session.commit()
         return project
 
@@ -539,16 +541,13 @@ class TestGenerateProjectSVG:
         await _generate_project_svg(_task_mock(), uuid.uuid4())
 
     async def test_deleted_project_returns_cleanly(self, db_session, test_user, mock_engine_and_session):
-        draft = await self._make_draft(db_session, test_user)
         from app.models.project import Project
 
         project = Project(
             id=uuid.uuid4(),
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Del Project",
             project_type="treadle",
-            total_picks=4,
             deleted_at=datetime.now(timezone.utc),
         )
         db_session.add(project)
@@ -616,12 +615,14 @@ class TestGenerateProjectSVG:
         project = Project(
             id=uuid.uuid4(),
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Lift SVG Project",
             project_type="lift",
-            total_picks=4,
         )
         db_session.add(project)
+        await db_session.flush()
+        from app.models.project import ProjectDraft as _PD
+
+        db_session.add(_PD(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=0))
         await db_session.commit()
         mock_storage["drafts/svg_modified.wif"] = MINIMAL_WIF
 
@@ -656,7 +657,7 @@ class TestGenerateProjectSVG:
 class TestBackfillAllProjectPreviews:
     async def _make_draft_and_project(self, db_session, test_user, wif_path="drafts/bfp.wif", deleted_draft=False):
         from app.models.draft import Draft
-        from app.models.project import Project
+        from app.models.project import Project, ProjectDraft
 
         draft = Draft(
             id=uuid.uuid4(),
@@ -672,12 +673,12 @@ class TestBackfillAllProjectPreviews:
         project = Project(
             id=uuid.uuid4(),
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="BF Project",
             project_type="treadle",
-            total_picks=4,
         )
         db_session.add(project)
+        await db_session.flush()
+        db_session.add(ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=0))
         await db_session.commit()
         return draft, project
 
@@ -725,7 +726,7 @@ class TestBackfillAllProjectPreviews:
 class TestBackfillAllProjectSVGs:
     async def _make_draft_and_project(self, db_session, test_user, wif_path="drafts/bfs.wif", deleted_draft=False):
         from app.models.draft import Draft
-        from app.models.project import Project
+        from app.models.project import Project, ProjectDraft
 
         draft = Draft(
             id=uuid.uuid4(),
@@ -741,12 +742,12 @@ class TestBackfillAllProjectSVGs:
         project = Project(
             id=uuid.uuid4(),
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="BFS Project",
             project_type="treadle",
-            total_picks=4,
         )
         db_session.add(project)
+        await db_session.flush()
+        db_session.add(ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=0))
         await db_session.commit()
         return draft, project
 
@@ -789,7 +790,7 @@ class TestBackfillAllProjectSVGs:
 
     async def test_skips_project_with_existing_svg(self, db_session, test_user, mock_engine_and_session, mock_storage):
         from app.models.draft import Draft
-        from app.models.project import Project
+        from app.models.project import Project, ProjectDraft
 
         draft = Draft(
             id=uuid.uuid4(),
@@ -804,13 +805,13 @@ class TestBackfillAllProjectSVGs:
         project = Project(
             id=uuid.uuid4(),
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="SVG Done Project",
             project_type="treadle",
-            total_picks=4,
             drawdown_svg_path="projects/existing.svg",
         )
         db_session.add(project)
+        await db_session.flush()
+        db_session.add(ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=0))
         await db_session.commit()
         mock_storage["drafts/svgd.wif"] = MINIMAL_WIF
 

--- a/backend/tests/tasks/test_preview.py
+++ b/backend/tests/tasks/test_preview.py
@@ -137,6 +137,81 @@ def mock_rendering():
         yield mock_draft
 
 
+async def _make_draft(
+    db_session: AsyncSession,
+    test_user,
+    *,
+    name: str = "Test Draft",
+    wif_filename: str = "test.wif",
+    wif_path: str = "drafts/test.wif",
+    deleted: bool = False,
+    flush_only: bool = False,
+):
+    from app.models.draft import Draft
+
+    draft = Draft(
+        id=uuid.uuid4(),
+        owner_id=test_user.id,
+        name=name,
+        wif_filename=wif_filename,
+        wif_path=wif_path,
+        deleted_at=datetime.now(timezone.utc) if deleted else None,
+    )
+    db_session.add(draft)
+    if flush_only:
+        await db_session.flush()
+    else:
+        await db_session.commit()
+    return draft
+
+
+async def _make_project(
+    db_session: AsyncSession,
+    test_user,
+    draft,
+    *,
+    name: str = "Test Project",
+    deleted: bool = False,
+    **kwargs,
+):
+    from app.models.project import Project, ProjectDraft
+
+    project = Project(
+        id=uuid.uuid4(),
+        owner_id=test_user.id,
+        name=name,
+        project_type="treadle",
+        **kwargs,
+    )
+    if deleted:
+        project.deleted_at = datetime.now(timezone.utc)
+    db_session.add(project)
+    await db_session.flush()
+    db_session.add(ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=0))
+    await db_session.commit()
+    return project
+
+
+async def _make_draft_and_project(
+    db_session: AsyncSession,
+    test_user,
+    *,
+    wif_path: str = "drafts/test.wif",
+    wif_filename: str = "test.wif",
+    deleted_draft: bool = False,
+):
+    draft = await _make_draft(
+        db_session,
+        test_user,
+        wif_path=wif_path,
+        wif_filename=wif_filename,
+        deleted=deleted_draft,
+        flush_only=True,
+    )
+    project = await _make_project(db_session, test_user, draft)
+    return draft, project
+
+
 # ---------------------------------------------------------------------------
 # TestGeneratePreview — _generate_preview
 # ---------------------------------------------------------------------------
@@ -144,20 +219,7 @@ def mock_rendering():
 
 class TestGeneratePreview:
     async def _make_draft(self, db_session, test_user, wif_path=None, deleted=False):
-        from app.models.draft import Draft
-
-        draft = Draft(
-            id=uuid.uuid4(),
-            owner_id=test_user.id,
-            name="Preview Draft",
-            wif_filename="test.wif",
-            wif_path=wif_path or "drafts/test.wif",
-        )
-        if deleted:
-            draft.deleted_at = datetime.now(timezone.utc)
-        db_session.add(draft)
-        await db_session.commit()
-        return draft
+        return await _make_draft(db_session, test_user, wif_path=wif_path or "drafts/test.wif", deleted=deleted)
 
     async def test_draft_not_found_returns_cleanly(self, db_session, mock_engine_and_session):
         await _generate_preview(_task_mock(), uuid.uuid4())
@@ -361,36 +423,12 @@ class TestBackfillAllPreviews:
 
 class TestGenerateProjectPreview:
     async def _make_draft(self, db_session, test_user):
-        from app.models.draft import Draft
-
-        draft = Draft(
-            id=uuid.uuid4(),
-            owner_id=test_user.id,
-            name="Proj Draft",
-            wif_filename="proj.wif",
-            wif_path="drafts/proj.wif",
+        return await _make_draft(
+            db_session, test_user, wif_path="drafts/proj.wif", wif_filename="proj.wif", flush_only=True
         )
-        db_session.add(draft)
-        await db_session.flush()
-        return draft
 
     async def _make_project(self, db_session, test_user, draft, deleted=False, **kwargs):
-        from app.models.project import Project, ProjectDraft
-
-        project = Project(
-            id=uuid.uuid4(),
-            owner_id=test_user.id,
-            name="Test Project",
-            project_type="treadle",
-            **kwargs,
-        )
-        if deleted:
-            project.deleted_at = datetime.now(timezone.utc)
-        db_session.add(project)
-        await db_session.flush()
-        db_session.add(ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=0))
-        await db_session.commit()
-        return project
+        return await _make_project(db_session, test_user, draft, deleted=deleted, **kwargs)
 
     async def test_project_not_found_returns_cleanly(self, db_session, mock_engine_and_session):
         await _generate_project_preview(_task_mock(), uuid.uuid4())
@@ -508,34 +546,12 @@ class TestGenerateProjectPreview:
 
 class TestGenerateProjectSVG:
     async def _make_draft(self, db_session, test_user, wif_path="drafts/svg.wif"):
-        from app.models.draft import Draft
-
-        draft = Draft(
-            id=uuid.uuid4(),
-            owner_id=test_user.id,
-            name="SVG Draft",
-            wif_filename="svg.wif",
-            wif_path=wif_path,
+        return await _make_draft(
+            db_session, test_user, name="SVG Draft", wif_filename="svg.wif", wif_path=wif_path, flush_only=True
         )
-        db_session.add(draft)
-        await db_session.flush()
-        return draft
 
     async def _make_project(self, db_session, test_user, draft, **kwargs):
-        from app.models.project import Project, ProjectDraft
-
-        project = Project(
-            id=uuid.uuid4(),
-            owner_id=test_user.id,
-            name="SVG Project",
-            project_type="treadle",
-            **kwargs,
-        )
-        db_session.add(project)
-        await db_session.flush()
-        db_session.add(ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=0))
-        await db_session.commit()
-        return project
+        return await _make_project(db_session, test_user, draft, name="SVG Project", **kwargs)
 
     async def test_project_not_found_returns_cleanly(self, db_session, mock_engine_and_session):
         await _generate_project_svg(_task_mock(), uuid.uuid4())
@@ -656,31 +672,9 @@ class TestGenerateProjectSVG:
 
 class TestBackfillAllProjectPreviews:
     async def _make_draft_and_project(self, db_session, test_user, wif_path="drafts/bfp.wif", deleted_draft=False):
-        from app.models.draft import Draft
-        from app.models.project import Project, ProjectDraft
-
-        draft = Draft(
-            id=uuid.uuid4(),
-            owner_id=test_user.id,
-            name="BF Project Draft",
-            wif_filename="bfp.wif",
-            wif_path=wif_path,
-            deleted_at=datetime.now(timezone.utc) if deleted_draft else None,
+        return await _make_draft_and_project(
+            db_session, test_user, wif_path=wif_path, wif_filename="bfp.wif", deleted_draft=deleted_draft
         )
-        db_session.add(draft)
-        await db_session.flush()
-
-        project = Project(
-            id=uuid.uuid4(),
-            owner_id=test_user.id,
-            name="BF Project",
-            project_type="treadle",
-        )
-        db_session.add(project)
-        await db_session.flush()
-        db_session.add(ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=0))
-        await db_session.commit()
-        return draft, project
 
     async def test_returns_result_dict(self, db_session, mock_engine_and_session):
         result = await _backfill_all_project_previews()
@@ -725,31 +719,9 @@ class TestBackfillAllProjectPreviews:
 
 class TestBackfillAllProjectSVGs:
     async def _make_draft_and_project(self, db_session, test_user, wif_path="drafts/bfs.wif", deleted_draft=False):
-        from app.models.draft import Draft
-        from app.models.project import Project, ProjectDraft
-
-        draft = Draft(
-            id=uuid.uuid4(),
-            owner_id=test_user.id,
-            name="BFS Draft",
-            wif_filename="bfs.wif",
-            wif_path=wif_path,
-            deleted_at=datetime.now(timezone.utc) if deleted_draft else None,
+        return await _make_draft_and_project(
+            db_session, test_user, wif_path=wif_path, wif_filename="bfs.wif", deleted_draft=deleted_draft
         )
-        db_session.add(draft)
-        await db_session.flush()
-
-        project = Project(
-            id=uuid.uuid4(),
-            owner_id=test_user.id,
-            name="BFS Project",
-            project_type="treadle",
-        )
-        db_session.add(project)
-        await db_session.flush()
-        db_session.add(ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=0))
-        await db_session.commit()
-        return draft, project
 
     async def test_returns_result_dict(self, db_session, mock_engine_and_session):
         result = await _backfill_all_project_svgs()
@@ -789,29 +761,10 @@ class TestBackfillAllProjectSVGs:
         mock_task.delay.assert_not_called()
 
     async def test_skips_project_with_existing_svg(self, db_session, test_user, mock_engine_and_session, mock_storage):
-        from app.models.draft import Draft
-        from app.models.project import Project, ProjectDraft
-
-        draft = Draft(
-            id=uuid.uuid4(),
-            owner_id=test_user.id,
-            name="SVG Done",
-            wif_filename="svgd.wif",
-            wif_path="drafts/svgd.wif",
+        draft, project = await _make_draft_and_project(
+            db_session, test_user, wif_path="drafts/svgd.wif", wif_filename="svgd.wif"
         )
-        db_session.add(draft)
-        await db_session.flush()
-
-        project = Project(
-            id=uuid.uuid4(),
-            owner_id=test_user.id,
-            name="SVG Done Project",
-            project_type="treadle",
-            drawdown_svg_path="projects/existing.svg",
-        )
-        db_session.add(project)
-        await db_session.flush()
-        db_session.add(ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=0))
+        project.drawdown_svg_path = "projects/existing.svg"
         await db_session.commit()
         mock_storage["drafts/svgd.wif"] = MINIMAL_WIF
 

--- a/backend/tests/tasks/test_purge.py
+++ b/backend/tests/tasks/test_purge.py
@@ -340,14 +340,11 @@ class TestPurgeProjects:
 
         from app.models.project import Project
 
-        draft = await self._make_draft(db_session, test_user, suffix="-del")
         project = Project(
             id=uuid.uuid4(),
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Old Project",
             project_type="treadle",
-            total_picks=4,
             deleted_at=_ago(days=30),
         )
         db_session.add(project)
@@ -365,14 +362,11 @@ class TestPurgeProjects:
 
         from app.models.project import Project, ProjectPhoto
 
-        draft = await self._make_draft(db_session, test_user, suffix="-photo")
         project = Project(
             id=uuid.uuid4(),
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Photo Project",
             project_type="treadle",
-            total_picks=4,
             deleted_at=_ago(days=30),
         )
         db_session.add(project)
@@ -399,14 +393,11 @@ class TestPurgeProjects:
 
         from app.models.project import Project
 
-        draft = await self._make_draft(db_session, test_user, suffix="-recent")
         project = Project(
             id=uuid.uuid4(),
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Recent Project",
             project_type="treadle",
-            total_picks=4,
             deleted_at=_ago(days=1),
         )
         db_session.add(project)

--- a/backend/tests/tasks/test_s3_audit.py
+++ b/backend/tests/tasks/test_s3_audit.py
@@ -508,10 +508,8 @@ class TestDoScanS3PathWithAssets:
         project = Project(
             id=uuid.uuid4(),
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="PPProject",
             project_type="treadle",
-            total_picks=4,
         )
         db_session.add(project)
         await db_session.flush()

--- a/backend/tests/tasks/test_tiles.py
+++ b/backend/tests/tasks/test_tiles.py
@@ -421,14 +421,10 @@ class TestPrerenderProject:
         from app.models.project import Project
         from app.tasks.tiles import _prerender_project
 
-        draft = await self._make_draft(db_session, test_user)
         project = Project(
             id=uuid.uuid4(),
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Deleted Project",
-            project_type="weave",
-            total_picks=4,
             deleted_at=datetime.now(timezone.utc),
         )
         db_session.add(project)
@@ -438,7 +434,7 @@ class TestPrerenderProject:
         mock_engine_and_session.dispose.assert_called_once()
 
     async def test_project_with_deleted_draft_returns_cleanly(self, db_session, test_user, mock_engine_and_session):
-        from app.models.project import Project
+        from app.models.project import Project, ProjectDraft
         from app.tasks.tiles import _prerender_project
 
         draft = await self._make_draft(db_session, test_user)
@@ -446,31 +442,29 @@ class TestPrerenderProject:
         project = Project(
             id=uuid.uuid4(),
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Draft Deleted",
-            project_type="weave",
-            total_picks=4,
         )
         db_session.add(project)
+        await db_session.flush()
+        db_session.add(ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=0))
         await db_session.commit()
 
         await _prerender_project(_task_mock(), project.id)
         mock_engine_and_session.dispose.assert_called_once()
 
     async def test_project_with_missing_wif_returns_cleanly(self, db_session, test_user, mock_engine_and_session):
-        from app.models.project import Project
+        from app.models.project import Project, ProjectDraft
         from app.tasks.tiles import _prerender_project
 
         draft = await self._make_draft(db_session, test_user, wif_key="drafts/not-stored.wif")
         project = Project(
             id=uuid.uuid4(),
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Missing WIF",
-            project_type="weave",
-            total_picks=4,
         )
         db_session.add(project)
+        await db_session.flush()
+        db_session.add(ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=0))
         await db_session.commit()
 
         await _prerender_project(_task_mock(), project.id)
@@ -478,7 +472,7 @@ class TestPrerenderProject:
 
     async def test_valid_project_runs_to_completion(self, db_session, test_user, mock_engine_and_session):
         import app.services.storage as _storage
-        from app.models.project import Project
+        from app.models.project import Project, ProjectDraft
         from app.tasks.tiles import _prerender_project
 
         wif_key = f"drafts/proj-{uuid.uuid4().hex}.wif"
@@ -488,12 +482,11 @@ class TestPrerenderProject:
         project = Project(
             id=uuid.uuid4(),
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Valid Project",
-            project_type="weave",
-            total_picks=4,
         )
         db_session.add(project)
+        await db_session.flush()
+        db_session.add(ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=0))
         await db_session.commit()
 
         await _prerender_project(_task_mock(), project.id)
@@ -525,12 +518,14 @@ class TestPrerenderProject:
         project = Project(
             id=uuid.uuid4(),
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Lift Project",
             project_type="lift",
-            total_picks=4,
         )
         db_session.add(project)
+        await db_session.flush()
+        from app.models.project import ProjectDraft
+
+        db_session.add(ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=0))
         await db_session.commit()
 
         await _prerender_project(_task_mock(), project.id)
@@ -549,12 +544,13 @@ class TestPrerenderProject:
         project = Project(
             id=uuid.uuid4(),
             owner_id=test_user.id,
-            draft_id=draft.id,
             name="Retry Project",
-            project_type="weave",
-            total_picks=4,
         )
         db_session.add(project)
+        await db_session.flush()
+        from app.models.project import ProjectDraft
+
+        db_session.add(ProjectDraft(project_id=project.id, draft_id=draft.id, position=1, repeats=1, current_pick=0))
         await db_session.commit()
 
         task = _task_mock()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,14 +1,17 @@
 {
   "name": "weaving-site",
-  "version": "0.200.3",
+  "version": "0.204.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weaving-site",
-      "version": "0.200.3",
+      "version": "0.204.4",
       "dependencies": {
         "@clerk/clerk-react": "^5.61.7",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@sentry/react": "^10.54.0",
         "@tanstack/react-query": "^5.100.14",
         "@types/dompurify": "^3.2.0",
@@ -137,6 +140,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -466,27 +470,58 @@
         "vite": "4.x || 5.x || 6.x"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "optional": true,
+      "peer": true,
       "dependencies": {
-        "tslib": "^2.4.0"
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -745,6 +780,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -1456,27 +1492,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "dev": true,
@@ -1645,6 +1660,7 @@
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -1655,6 +1671,7 @@
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1711,6 +1728,7 @@
       "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.0",
         "@typescript-eslint/types": "8.60.0",
@@ -1954,6 +1972,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2067,6 +2086,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2319,6 +2339,7 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2716,6 +2737,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6"
       },
@@ -3372,6 +3394,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3391,6 +3414,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3656,6 +3680,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3711,6 +3736,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3813,6 +3839,7 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3966,6 +3993,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -140,7 +140,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -487,7 +486,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -522,6 +520,29 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -780,7 +801,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -1492,6 +1512,27 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "dev": true,
@@ -1660,7 +1701,6 @@
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -1671,7 +1711,6 @@
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1728,7 +1767,6 @@
       "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.0",
         "@typescript-eslint/types": "8.60.0",
@@ -1972,7 +2010,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2086,7 +2123,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2339,7 +2375,6 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2737,7 +2772,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6"
       },
@@ -3394,7 +3428,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3414,7 +3447,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3680,7 +3712,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3736,7 +3767,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3839,7 +3869,6 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3993,7 +4022,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,9 @@
   },
   "dependencies": {
     "@clerk/clerk-react": "^5.61.7",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@sentry/react": "^10.54.0",
     "@tanstack/react-query": "^5.100.14",
     "@types/dompurify": "^3.2.0",

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -1,6 +1,20 @@
 export type ProjectType = "treadle" | "lift";
 export type ProjectStatus = "created" | "active" | "completed" | "abandoned";
 
+export interface ProjectDraftSchema {
+  id: string;
+  draft_id: string;
+  position: number;
+  repeats: number;
+  current_pick: number;
+  draft_name: string;
+  draft_total_picks: number;
+  section_total_picks: number;
+  is_active: boolean;
+  has_treadling: boolean;
+  has_liftplan: boolean;
+}
+
 import i18next from "i18next";
 
 export const PROJECT_TYPE_LABELS: Record<ProjectType, string> = {
@@ -20,17 +34,21 @@ export type ShareVisibility = "private" | "link" | "public";
 export interface ProjectSummary {
   id: string;
   owner_id: string;
-  draft_id: string;
+  draft_id: string | null;
   loom_id: string | null;
   loom_version_id: string | null;
   name: string;
-  project_type: ProjectType;
+  project_type: ProjectType | null;
   status: ProjectStatus;
+  current_position: number;
   current_pick: number;
   current_item: number;
   total_picks: number;
+  aggregate_current_pick: number;
   num_items: number;
   length_unit: string;
+  draft_count: number;
+  draft_sequence: ProjectDraftSchema[];
   completed_at: string | null;
   abandoned_at: string | null;
   created_at: string;
@@ -135,7 +153,7 @@ export interface ProjectDetail extends ProjectSummary {
   warp_waste_allowance: string | null;
   completed_at: string | null;
   notes: string | null;
-  draft_name: string;
+  draft_name: string | null;
   draft_num_shafts: number | null;
   draft_num_treadles: number | null;
   draft_effective_num_treadles: number | null;
@@ -165,8 +183,6 @@ export interface ProjectDetail extends ProjectSummary {
 
 export interface CreateProjectPayload {
   name: string;
-  draft_id: string;
-  project_type: ProjectType;
   loom_id?: string;
   loom_version_id?: string;
   finished_length_per_item?: number;
@@ -180,6 +196,9 @@ export interface CreateProjectPayload {
 export interface StepResponse {
   current_pick: number;
   total_picks: number;
+  position: number;
+  aggregate_current_pick: number;
+  aggregate_total_picks: number;
   current_item: number;
   num_items: number;
 }
@@ -534,4 +553,44 @@ export function unlinkYarnColor(projectId: string, colorHex: string): Promise<vo
   return req(`/api/projects/${projectId}/yarn-colors/${encodeURIComponent(colorHex)}`, {
     method: "DELETE",
   });
+}
+
+export function addSequenceEntry(
+  projectId: string,
+  draftId: string,
+  repeats = 1,
+): Promise<ProjectDetail> {
+  return req(`/api/projects/${projectId}/sequence`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ draft_id: draftId, repeats }),
+  });
+}
+
+export function updateSequenceEntry(
+  projectId: string,
+  seqId: string,
+  repeats: number,
+): Promise<ProjectDetail> {
+  return req(`/api/projects/${projectId}/sequence/${seqId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ repeats }),
+  });
+}
+
+export function removeSequenceEntry(projectId: string, seqId: string): Promise<ProjectDetail> {
+  return req(`/api/projects/${projectId}/sequence/${seqId}`, { method: "DELETE" });
+}
+
+export function reorderSequence(projectId: string, orderedIds: string[]): Promise<ProjectDetail> {
+  return req(`/api/projects/${projectId}/sequence/reorder`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ordered_ids: orderedIds }),
+  });
+}
+
+export function activateSequenceEntry(projectId: string, seqId: string): Promise<ProjectDetail> {
+  return req(`/api/projects/${projectId}/sequence/${seqId}/activate`, { method: "POST" });
 }

--- a/frontend/src/components/projects/AssignLoomModal.tsx
+++ b/frontend/src/components/projects/AssignLoomModal.tsx
@@ -1,12 +1,11 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { assignLoom, completeProject, abandonProject, ApiError, type ProjectSummary } from "@/api/projects";
+import { assignLoom } from "@/api/projects";
 import { listLooms, getLoom, SUPPORTED_LOOM_TYPES } from "@/api/looms";
 import { Button } from "@/components/ui/button";
 
 interface Props {
   projectId: string;
-  activeProjects: ProjectSummary[];
   projectType?: string;
   draftNumTreadles?: number | null;
   draftNumShafts?: number | null;
@@ -18,12 +17,11 @@ interface Props {
 
 const f = "w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
 
-export function AssignLoomModal({ projectId, activeProjects, projectType, draftNumTreadles, draftNumShafts, draftEffectiveNumTreadles, draftEffectiveNumShafts, onSuccess, onClose }: Props) {
+export function AssignLoomModal({ projectId, projectType, draftNumTreadles, draftNumShafts, draftEffectiveNumTreadles, draftEffectiveNumShafts, onSuccess, onClose }: Props) {
   const [loomId, setLoomId] = useState("");
   const [loomVersionId, setLoomVersionId] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [conflictProject, setConflictProject] = useState<ProjectSummary | null>(null);
 
   const { data: looms = [] } = useQuery({ queryKey: ["looms"], queryFn: () => listLooms() });
   const { data: loomDetail } = useQuery({
@@ -38,7 +36,6 @@ export function AssignLoomModal({ projectId, activeProjects, projectType, draftN
   const loomTreadles = selectedLoom?.current_version?.num_treadles ?? null;
   const loomShafts = selectedLoom?.current_version?.num_shafts ?? null;
 
-  // Use effective counts for compatibility; fall back to declared
   const effectiveTreadles = draftEffectiveNumTreadles ?? draftNumTreadles ?? null;
   const effectiveShafts = draftEffectiveNumShafts ?? draftNumShafts ?? null;
 
@@ -66,17 +63,6 @@ export function AssignLoomModal({ projectId, activeProjects, projectType, draftN
     draftEffectiveNumShafts != null &&
     draftNumShafts !== draftEffectiveNumShafts;
 
-  const handleLoomChange = (newLoomId: string) => {
-    setLoomId(newLoomId);
-    setLoomVersionId("");
-    setError(null);
-    setConflictProject(null);
-    if (newLoomId) {
-      const conflict = activeProjects.find((a) => a.loom_id === newLoomId && a.id !== projectId) ?? null;
-      setConflictProject(conflict);
-    }
-  };
-
   const doAssign = async () => {
     setError(null);
     setLoading(true);
@@ -84,32 +70,7 @@ export function AssignLoomModal({ projectId, activeProjects, projectType, draftN
       await assignLoom(projectId, loomId, loomVersionId || undefined);
       onSuccess();
     } catch (err) {
-      if (err instanceof ApiError && err.status === 409) {
-        const conflict = activeProjects.find((a) => a.loom_id === loomId && a.id !== projectId) ?? null;
-        setConflictProject(conflict);
-      } else {
-        setError(err instanceof Error ? err.message : "Failed to assign loom");
-      }
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleResolveAndAssign = async (resolve: "complete" | "abandon") => {
-    if (!conflictProject) return;
-    setError(null);
-    setLoading(true);
-    try {
-      if (resolve === "complete") {
-        await completeProject(conflictProject.id);
-      } else {
-        await abandonProject(conflictProject.id);
-      }
-      await assignLoom(projectId, loomId, loomVersionId || undefined);
-      onSuccess();
-    } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to assign loom");
-      setConflictProject(null);
     } finally {
       setLoading(false);
     }
@@ -125,7 +86,7 @@ export function AssignLoomModal({ projectId, activeProjects, projectType, draftN
         <div className="px-6 py-4 space-y-4">
           <div>
             <label className="mb-1 block text-sm font-medium">Loom <span className="text-destructive">*</span></label>
-            <select className={f} value={loomId} onChange={(e) => handleLoomChange(e.target.value)}>
+            <select className={f} value={loomId} onChange={(e) => { setLoomId(e.target.value); setLoomVersionId(""); setError(null); }}>
               <option value="">Select a loom…</option>
               {looms.filter((l) => SUPPORTED_LOOM_TYPES.has(l.loom_type)).map((l) => (
                 <option key={l.id} value={l.id}>{l.manufacturer} {l.model_name}</option>
@@ -172,34 +133,12 @@ export function AssignLoomModal({ projectId, activeProjects, projectType, draftN
             </div>
           )}
 
-          {conflictProject && (
-            <div className="rounded-md border border-copper-subtle bg-copper-subtle px-3 py-3 text-sm space-y-2">
-              <p className="font-medium text-copper-on-subtle">
-                This loom has an active project: <span className="font-semibold">{conflictProject.name}</span>
-              </p>
-              <p className="text-copper-on-subtle text-xs">
-                Mark it as completed or abandon it to assign this loom, or choose a different loom.
-              </p>
-              <div className="flex flex-wrap gap-2 pt-1">
-                <Button type="button" size="sm" onClick={() => handleResolveAndAssign("complete")} disabled={loading}>
-                  {loading ? "Working…" : "Mark completed & assign"}
-                </Button>
-                <Button type="button" size="sm" variant="outline" onClick={() => handleResolveAndAssign("abandon")} disabled={loading}>
-                  {loading ? "Working…" : "Abandon & assign"}
-                </Button>
-                <Button type="button" size="sm" variant="ghost" onClick={() => handleLoomChange("")} disabled={loading}>
-                  Clear loom
-                </Button>
-              </div>
-            </div>
-          )}
-
           {error && <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</p>}
         </div>
 
         <div className="flex justify-end gap-2 px-6 py-4 border-t">
           <Button type="button" variant="outline" onClick={onClose} disabled={loading}>Cancel</Button>
-          <Button onClick={doAssign} disabled={!loomId || !!conflictProject || loading}>
+          <Button onClick={doAssign} disabled={!loomId || loading}>
             {loading ? "Assigning…" : "Assign loom"}
           </Button>
         </div>

--- a/frontend/src/components/projects/CreateProjectModal.tsx
+++ b/frontend/src/components/projects/CreateProjectModal.tsx
@@ -1,17 +1,16 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { createProject, completeProject, abandonProject, listProjects, ApiError, PROJECT_TYPE_LABELS, type ProjectType, type ProjectSummary } from "@/api/projects";
-import { listDrafts } from "@/api/drafts";
+import { createProject, completeProject, abandonProject, listProjects, ApiError, type ProjectSummary } from "@/api/projects";
 import { listLooms, getLoom, SUPPORTED_LOOM_TYPES } from "@/api/looms";
 import { Button } from "@/components/ui/button";
 import { TagInput } from "@/components/ui/TagInput";
 import { useAuthContext } from "@/context/AuthContext";
-import { measurementSystemToUnit, convertLength, formatLength } from "@/lib/units";
+import { measurementSystemToUnit } from "@/lib/units";
+import { useTranslation } from "react-i18next";
 
 interface Props {
   onSuccess: (id: string) => void;
   onClose: () => void;
-  defaultDraftId?: string;
 }
 
 const CM_PER_IN = 2.54;
@@ -25,11 +24,10 @@ function convertLen(value: string, toUnit: "cm" | "in"): string {
 
 const f = "w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
 
-export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props) {
+export function CreateProjectModal({ onSuccess, onClose }: Props) {
+  const { t } = useTranslation();
   const { user } = useAuthContext();
   const [name, setName] = useState("");
-  const [draftId, setDraftId] = useState(defaultDraftId ?? "");
-  const [projectType, setProjectType] = useState<ProjectType | "">("");
   const [loomId, setLoomId] = useState("");
   const [loomVersionId, setLoomVersionId] = useState("");
   const [finishedLength, setFinishedLength] = useState("");
@@ -39,8 +37,6 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
   const [lengthUnit, setLengthUnit] = useState<"cm" | "in">(
     measurementSystemToUnit(user?.measurement_system ?? "metric")
   );
-  // Track previous draft ID to detect when draft selection changes.
-  const [prevDraftId, setPrevDraftId] = useState<string | undefined>(undefined);
 
   const handleUnitChange = (newUnit: "cm" | "in") => {
     setFinishedLength((v) => convertLen(v, newUnit));
@@ -53,7 +49,6 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
   const [error, setError] = useState<string | null>(null);
   const [conflictProject, setConflictProject] = useState<ProjectSummary | null>(null);
 
-  const { data: drafts = [] } = useQuery({ queryKey: ["drafts"], queryFn: () => listDrafts() });
   const { data: looms = [] } = useQuery({ queryKey: ["looms"], queryFn: () => listLooms() });
   const { data: loomDetail } = useQuery({
     queryKey: ["loom", loomId],
@@ -61,90 +56,9 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
     enabled: !!loomId,
   });
 
-  const selectedDraft = drafts.find((d) => d.id === draftId);
   const selectedLoom = looms.find((l) => l.id === loomId);
-
-  // Pre-populate finished length when draft selection changes (setState during render — React-approved).
-  const warpLengthDefaultCm = selectedDraft?.warp_length_cm ?? null;
-  if (selectedDraft?.id !== prevDraftId) {
-    setPrevDraftId(selectedDraft?.id);
-    if (selectedDraft?.warp_length_cm != null) {
-      const val = convertLength(selectedDraft.warp_length_cm, "cm", lengthUnit);
-      setFinishedLength(parseFloat(val.toFixed(1)).toString());
-    } else {
-      setFinishedLength("");
-    }
-  }
-
-  // Filter project types by what the WIF supports and loom supports
-  const availableTypes: ProjectType[] = [];
-  if (selectedDraft) {
-    if (selectedDraft.has_treadling) availableTypes.push("treadle");
-    if (selectedDraft.has_liftplan) availableTypes.push("lift");
-  }
-
-  // Filter to types the loom also supports (if a loom is selected)
-  const filteredTypes = selectedLoom
-    ? availableTypes.filter((t) => {
-        if (t === "treadle") return selectedLoom.supports_treadle_tracking;
-        if (t === "lift") return selectedLoom.supports_lift_tracking;
-        return true;
-      })
-    : availableTypes;
-
-  // Auto-select type when only one option
-  const effectiveType: ProjectType | "" =
-    projectType ||
-    (filteredTypes.length === 1 ? filteredTypes[0] : "");
-
   const loomVersions = loomDetail?.versions ?? [];
   const selectedVersion = loomVersions.find((v) => v.id === loomVersionId);
-
-  const loomTreadles = selectedLoom?.current_version?.num_treadles ?? null;
-  const loomShafts = selectedLoom?.current_version?.num_shafts ?? null;
-
-  // Use effective counts (from actual treadling data) for compatibility; fall back to declared
-  const effectiveTreadles = selectedDraft?.effective_num_treadles ?? selectedDraft?.num_treadles ?? null;
-  const effectiveShafts = selectedDraft?.effective_num_shafts ?? selectedDraft?.num_shafts ?? null;
-
-  const treadleMismatch =
-    !!selectedLoom &&
-    (effectiveType === "treadle" || (!effectiveType && availableTypes.includes("treadle"))) &&
-    (effectiveTreadles ?? 0) > 0 &&
-    (loomTreadles ?? 0) > 0 &&
-    (effectiveTreadles ?? 0) > (loomTreadles ?? 0);
-
-  const shaftMismatch =
-    !!selectedLoom &&
-    (effectiveType === "lift" || (!effectiveType && availableTypes.includes("lift"))) &&
-    (effectiveShafts ?? 0) > 0 &&
-    (loomShafts ?? 0) > 0 &&
-    (effectiveShafts ?? 0) > (loomShafts ?? 0);
-
-  // Informational: declared metadata doesn't match actual usage
-  const treadleMetaMismatch =
-    selectedDraft?.num_treadles != null &&
-    selectedDraft?.effective_num_treadles != null &&
-    selectedDraft.num_treadles !== selectedDraft.effective_num_treadles;
-
-  const shaftMetaMismatch =
-    selectedDraft?.num_shafts != null &&
-    selectedDraft?.effective_num_shafts != null &&
-    selectedDraft.num_shafts !== selectedDraft.effective_num_shafts;
-
-  const draftHasWarpLength = selectedDraft?.warp_length_cm != null;
-  const finishedLengthCm = finishedLength !== "" && !isNaN(parseFloat(finishedLength))
-    ? convertLength(parseFloat(finishedLength), lengthUnit, "cm")
-    : null;
-  const warpLengthDefaultLabel = warpLengthDefaultCm != null
-    ? formatLength(convertLength(warpLengthDefaultCm, "cm", lengthUnit), lengthUnit)
-    : null;
-  const finishedLengthDeviatesFromDefault = warpLengthDefaultCm != null
-    && finishedLengthCm != null
-    && Math.abs(finishedLengthCm - warpLengthDefaultCm) > 0.5;
-  const finishedLengthMatchesDefault = warpLengthDefaultCm != null
-    && finishedLengthCm != null
-    && Math.abs(finishedLengthCm - warpLengthDefaultCm) <= 0.5;
 
   const loomWasteInCurrentUnit = (allowance: string | null | undefined, wasteUnit: string): string => {
     if (!allowance) return "";
@@ -154,7 +68,6 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
   const handleLoomChange = (newLoomId: string) => {
     setLoomId(newLoomId);
     setLoomVersionId("");
-    setProjectType("");
     setWarpWaste("");
     setConflictProject(null);
     setError(null);
@@ -162,8 +75,6 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
 
   const _buildPayload = () => ({
     name: name.trim(),
-    draft_id: draftId,
-    project_type: effectiveType as ProjectType,
     loom_id: loomId || undefined,
     loom_version_id: loomVersionId || undefined,
     finished_length_per_item: finishedLength ? parseFloat(finishedLength) : undefined,
@@ -176,7 +87,6 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!effectiveType) return;
     setError(null);
     setConflictProject(null);
     setLoading(true);
@@ -189,7 +99,7 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
         const conflict = projects.find((p) => p.loom_id === loomId && p.status === "active") ?? null;
         setConflictProject(conflict);
       } else {
-        setError(err instanceof Error ? err.message : "Failed to create project");
+        setError(err instanceof Error ? err.message : t("createProject.error.failed"));
       }
     } finally {
       setLoading(false);
@@ -197,90 +107,72 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
   };
 
   const handleResolveAndCreate = async (resolve: "complete" | "abandon") => {
-    if (!conflictProject || !effectiveType) return;
+    if (!conflictProject) return;
     setError(null);
     setLoading(true);
     try {
       if (resolve === "complete") {
-        await completeProject(conflictProject.id);
+        await completeProject(conflictProject.id, true);
       } else {
         await abandonProject(conflictProject.id);
       }
       const created = await createProject(_buildPayload());
       onSuccess(created.id);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to create project");
+      setError(err instanceof Error ? err.message : t("createProject.error.failed"));
       setConflictProject(null);
     } finally {
       setLoading(false);
     }
   };
 
-  const canSubmit = name.trim() && draftId && !!effectiveType && !loading;
+  const canSubmit = name.trim() && !loading;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
       <div className="w-full max-w-lg rounded-lg border bg-background shadow-lg flex flex-col max-h-[90vh]">
         <div className="px-6 pt-6 pb-4 border-b">
-          <h2 className="text-lg font-semibold">New project</h2>
+          <h2 className="text-lg font-semibold">{t("createProject.title")}</h2>
         </div>
 
         <form onSubmit={handleSubmit} className="overflow-y-auto px-6 py-4 space-y-4 flex-1">
           <div>
-            <label className="mb-1 block text-sm font-medium">Project name <span className="text-destructive">*</span></label>
-            <input className={f} value={name} onChange={(e) => setName(e.target.value)} placeholder="Spring towels — warp 1" required />
+            <label className="mb-1 block text-sm font-medium">{t("createProject.name")} <span className="text-destructive">*</span></label>
+            <input className={f} value={name} onChange={(e) => setName(e.target.value)} placeholder={t("createProject.namePlaceholder")} required />
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium">Tags <span className="text-muted-foreground font-normal">(optional)</span></label>
-            <TagInput tags={tags} onChange={setTags} placeholder="cotton, twill…" />
+            <label className="mb-1 block text-sm font-medium">{t("createProject.tags")} <span className="text-muted-foreground font-normal">({t("common.optional")})</span></label>
+            <TagInput tags={tags} onChange={setTags} placeholder={t("createProject.tagsPlaceholder")} />
+          </div>
+
+          <div className="rounded-md border border-border bg-muted px-3 py-2.5 text-sm">
+            <p className="font-medium text-foreground">{t("createProject.sequenceHint.title")}</p>
+            <p className="mt-0.5 text-xs text-subdued">{t("createProject.sequenceHint.body")}</p>
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium">Draft <span className="text-destructive">*</span></label>
-            {defaultDraftId ? (
-              <p className="py-2 text-sm">{selectedDraft?.name ?? "—"}</p>
-            ) : (
-              <select className={f} value={draftId} onChange={(e) => { setDraftId(e.target.value); setProjectType(""); }} required>
-                <option value="">Select a draft…</option>
-                {drafts.map((d) => (
-                  <option key={d.id} value={d.id}>{d.name}</option>
-                ))}
-              </select>
-            )}
-          </div>
-
-          <div>
-            <label className="mb-1 block text-sm font-medium">Loom <span className="text-muted-foreground font-normal">(optional)</span></label>
+            <label className="mb-1 block text-sm font-medium">{t("createProject.loom")} <span className="text-muted-foreground font-normal">({t("common.optional")})</span></label>
             <select className={f} value={loomId} onChange={(e) => handleLoomChange(e.target.value)}>
-              <option value="">No loom selected</option>
+              <option value="">{t("createProject.noLoom")}</option>
               {looms.filter((l) => SUPPORTED_LOOM_TYPES.has(l.loom_type)).map((l) => (
                 <option key={l.id} value={l.id}>{l.manufacturer} {l.model_name}</option>
               ))}
             </select>
             {looms.some((l) => !SUPPORTED_LOOM_TYPES.has(l.loom_type)) && (
-              <p className="mt-1 text-xs text-muted-foreground">Looms without project tracking support are not shown.</p>
+              <p className="mt-1 text-xs text-muted-foreground">{t("createProject.unsupportedLoomsHidden")}</p>
             )}
           </div>
 
-          {!loomId && selectedDraft && (
-            <div className="rounded-md border border-border bg-muted px-3 py-2.5 text-sm">
-              <p className="font-medium text-foreground">No loom selected — preview mode</p>
-              <p className="mt-0.5 text-xs text-subdued">
-                This project will not be linked to equipment. Select a project type below to create a standalone tracking preview. You can create a separate project to preview the other type.
-              </p>
-            </div>
-          )}
-
           {selectedLoom && loomVersions.length > 1 && (
             <div>
-              <label className="mb-1 block text-sm font-medium">Loom configuration</label>
+              <label className="mb-1 block text-sm font-medium">{t("createProject.loomConfig")}</label>
               <select className={f} value={loomVersionId} onChange={(e) => {
                 setLoomVersionId(e.target.value);
                 const v = loomVersions.find((v) => v.id === e.target.value);
                 if (v?.warp_waste_allowance) setWarpWaste(loomWasteInCurrentUnit(v.warp_waste_allowance, v.warp_waste_unit));
               }}>
-                <option value="">Latest ({loomVersions.at(-1)?.name ?? `v${loomVersions.at(-1)?.version_number}`})</option>
+                <option value="">{t("createProject.loomConfigLatest", { name: loomVersions.at(-1)?.name ?? `v${loomVersions.at(-1)?.version_number}` })}</option>
                 {loomVersions.map((v) => (
                   <option key={v.id} value={v.id}>{v.name ?? `Version ${v.version_number}`}</option>
                 ))}
@@ -288,83 +180,12 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
             </div>
           )}
 
-          {(treadleMismatch || shaftMismatch) && selectedLoom && (
-            <div className="rounded-md border border-copper-subtle bg-copper-subtle px-3 py-2.5 text-sm">
-              <p className="font-medium text-copper-on-subtle">
-                {treadleMismatch ? "Treadle count mismatch" : "Shaft count mismatch"}
-              </p>
-              <p className="mt-0.5 text-xs text-copper-on-subtle">
-                {treadleMismatch
-                  ? `This design uses up to ${effectiveTreadles} treadles, but ${selectedLoom.manufacturer} ${selectedLoom.model_name} only has ${loomTreadles}. Treadle positions beyond ${loomTreadles} cannot be pressed.`
-                  : `This design uses up to ${effectiveShafts} shafts, but ${selectedLoom.manufacturer} ${selectedLoom.model_name} only has ${loomShafts}. Shaft positions beyond ${loomShafts} cannot be raised.`}
-              </p>
-            </div>
-          )}
-
-          {(treadleMetaMismatch || shaftMetaMismatch) && !treadleMismatch && !shaftMismatch && (
-            <div className="rounded-md border border-border bg-muted px-3 py-2.5 text-sm">
-              <p className="font-medium text-foreground">WIF metadata note</p>
-              <p className="mt-0.5 text-xs text-subdued">
-                {treadleMetaMismatch
-                  ? `The WIF file declares ${selectedDraft!.num_treadles} treadles in metadata, but the treadling data only uses ${selectedDraft!.effective_num_treadles}. Loom compatibility uses the actual count (${selectedDraft!.effective_num_treadles}). You can fix the declared count in your design software.`
-                  : `The WIF file declares ${selectedDraft!.num_shafts} shafts in metadata, but the lift plan only uses ${selectedDraft!.effective_num_shafts}. Loom compatibility uses the actual count (${selectedDraft!.effective_num_shafts}). You can fix the declared count in your design software.`}
-              </p>
-            </div>
-          )}
-
-          {selectedDraft && (
-            <div>
-              <label className="mb-1 block text-sm font-medium">Project type <span className="text-destructive">*</span></label>
-              {filteredTypes.length === 0 ? (
-                <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2.5 text-sm">
-                  {selectedLoom && availableTypes.length > 0 ? (
-                    <>
-                      <p className="font-medium text-destructive">Loom and draft are incompatible</p>
-                      <p className="mt-0.5 text-xs text-muted-foreground">
-                        This WIF supports {availableTypes.map(t => PROJECT_TYPE_LABELS[t]).join(" and ")}, but the selected loom does not.
-                        {availableTypes.includes("lift") && !selectedLoom.supports_lift_tracking && " The loom does not support lift tracking."}
-                        {availableTypes.includes("treadle") && !selectedLoom.supports_treadle_tracking && " The loom does not support treadle tracking."}
-                        {" "}Try a different loom or go to the draft page to generate a lift plan.
-                      </p>
-                    </>
-                  ) : (
-                    <>
-                      <p className="font-medium text-destructive">No project types available</p>
-                      <p className="mt-0.5 text-xs text-muted-foreground">
-                        This WIF has no treadling or lift plan data. Go to the draft page to generate a lift plan if the file has tieup and treadling sections.
-                      </p>
-                    </>
-                  )}
-                </div>
-              ) : filteredTypes.length === 1 ? (
-                <p className="text-sm py-2">{PROJECT_TYPE_LABELS[filteredTypes[0]]}</p>
-              ) : (
-                <select className={f} value={effectiveType} onChange={(e) => setProjectType(e.target.value as ProjectType)} required>
-                  <option value="">Select type…</option>
-                  {filteredTypes.map((t) => (
-                    <option key={t} value={t}>{PROJECT_TYPE_LABELS[t]}</option>
-                  ))}
-                </select>
-              )}
-            </div>
-          )}
-
           <div className="border-t pt-4">
-            <p className="mb-3 text-xs font-medium text-muted-foreground uppercase tracking-wide">Warp plan</p>
-            <p className="mb-3 text-xs text-muted-foreground">Warp plan tracking is not yet available. These fields are coming in a future update.</p>
-
-            {selectedDraft && !draftHasWarpLength && (
-              <div className="mb-3 rounded-md border border-border bg-muted px-3 py-2.5 text-sm">
-                <p className="font-medium text-foreground">Warp length not set</p>
-                <p className="mt-0.5 text-xs text-subdued">
-                  Set the warp length on the draft page to enable warp waste and spacing calculations.
-                </p>
-              </div>
-            )}
+            <p className="mb-3 text-xs font-medium text-muted-foreground uppercase tracking-wide">{t("createProject.warpPlan")}</p>
 
             <div className="grid grid-cols-3 gap-3">
               <div className="col-span-2">
-                <label className="mb-1 block text-sm font-medium">Finished length / item</label>
+                <label className="mb-1 block text-sm font-medium">{t("createProject.finishedLength")}</label>
                 <div className="flex gap-2">
                   <input
                     type="number"
@@ -384,60 +205,50 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
                     <option value="in">in</option>
                   </select>
                 </div>
-                {finishedLengthDeviatesFromDefault && (
-                  <p className="mt-1 text-xs text-copper-on-subtle">
-                    Changed from WIF warp length ({warpLengthDefaultLabel})
-                  </p>
-                )}
-                {finishedLengthMatchesDefault && (
-                  <p className="mt-1 text-xs text-muted-foreground">Pre-filled from WIF warp length</p>
-                )}
               </div>
               <div>
-                <label className="mb-1 block text-sm font-medium">Number of items</label>
+                <label className="mb-1 block text-sm font-medium">{t("createProject.numItems")}</label>
                 <input type="number" min={1} step="1" className={f} value={numItems} onChange={(e) => setNumItems(e.target.value)} />
               </div>
             </div>
 
-            {draftHasWarpLength && (
-              <div className="grid grid-cols-2 gap-3 mt-3">
-                {parseInt(numItems, 10) > 1 && (
-                  <div>
-                    <label className="mb-1 block text-sm font-medium">Waste between items</label>
-                    <div className="flex gap-1">
-                      <input type="number" min={0} step="0.1" className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring" value={wasteBetween} onChange={(e) => setWasteBetween(e.target.value)} placeholder="5" />
-                      <span className="flex items-center rounded-md border border-input bg-muted px-2 text-sm text-muted-foreground">{lengthUnit}</span>
-                    </div>
-                  </div>
-                )}
-                <div className={parseInt(numItems, 10) <= 1 ? "col-span-2" : ""}>
-                  <label className="mb-1 block text-sm font-medium">Loom warp waste</label>
+            <div className="grid grid-cols-2 gap-3 mt-3">
+              {parseInt(numItems, 10) > 1 && (
+                <div>
+                  <label className="mb-1 block text-sm font-medium">{t("createProject.wasteBetween")}</label>
                   <div className="flex gap-1">
-                    <input type="number" min={0} step="0.1" className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring" value={warpWaste || loomWasteInCurrentUnit(selectedVersion?.warp_waste_allowance ?? loomDetail?.versions.at(-1)?.warp_waste_allowance, selectedVersion?.warp_waste_unit ?? loomDetail?.versions.at(-1)?.warp_waste_unit ?? "cm")} onChange={(e) => setWarpWaste(e.target.value)} placeholder="30" />
+                    <input type="number" min={0} step="0.1" className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring" value={wasteBetween} onChange={(e) => setWasteBetween(e.target.value)} placeholder="5" />
                     <span className="flex items-center rounded-md border border-input bg-muted px-2 text-sm text-muted-foreground">{lengthUnit}</span>
                   </div>
                 </div>
+              )}
+              <div className={parseInt(numItems, 10) <= 1 ? "col-span-2" : ""}>
+                <label className="mb-1 block text-sm font-medium">{t("createProject.warpWaste")}</label>
+                <div className="flex gap-1">
+                  <input type="number" min={0} step="0.1" className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring" value={warpWaste || loomWasteInCurrentUnit(selectedVersion?.warp_waste_allowance ?? loomDetail?.versions.at(-1)?.warp_waste_allowance, selectedVersion?.warp_waste_unit ?? loomDetail?.versions.at(-1)?.warp_waste_unit ?? "cm")} onChange={(e) => setWarpWaste(e.target.value)} placeholder="30" />
+                  <span className="flex items-center rounded-md border border-input bg-muted px-2 text-sm text-muted-foreground">{lengthUnit}</span>
+                </div>
               </div>
-            )}
+            </div>
           </div>
 
           {conflictProject && (
             <div className="rounded-md border border-copper-subtle bg-copper-subtle px-3 py-3 text-sm space-y-2">
               <p className="font-medium text-copper-on-subtle">
-                This loom has an active project: <span className="font-semibold">{conflictProject.name}</span>
+                {t("createProject.conflict.title", { name: conflictProject.name })}
               </p>
               <p className="text-copper-on-subtle text-xs">
-                Mark it as completed or abandon it to start this new project, or choose a different loom.
+                {t("createProject.conflict.body")}
               </p>
               <div className="flex flex-wrap gap-2 pt-1">
                 <Button type="button" size="sm" onClick={() => handleResolveAndCreate("complete")} disabled={loading}>
-                  {loading ? "Working…" : "Mark completed & continue"}
+                  {loading ? t("common.working") : t("createProject.conflict.complete")}
                 </Button>
                 <Button type="button" size="sm" variant="outline" onClick={() => handleResolveAndCreate("abandon")} disabled={loading}>
-                  {loading ? "Working…" : "Abandon & continue"}
+                  {loading ? t("common.working") : t("createProject.conflict.abandon")}
                 </Button>
                 <Button type="button" size="sm" variant="ghost" onClick={() => handleLoomChange("")} disabled={loading}>
-                  Clear loom
+                  {t("createProject.conflict.clearLoom")}
                 </Button>
               </div>
             </div>
@@ -446,9 +257,9 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
         </form>
 
         <div className="flex justify-end gap-2 px-6 py-4 border-t">
-          <Button type="button" variant="outline" onClick={onClose} disabled={loading}>Cancel</Button>
+          <Button type="button" variant="outline" onClick={onClose} disabled={loading}>{t("common.cancel")}</Button>
           <Button onClick={handleSubmit} disabled={!canSubmit}>
-            {loading ? "Creating…" : "Start project"}
+            {loading ? t("common.creating") : t("createProject.submit")}
           </Button>
         </div>
       </div>

--- a/frontend/src/components/projects/CreateProjectModal.tsx
+++ b/frontend/src/components/projects/CreateProjectModal.tsx
@@ -9,8 +9,8 @@ import { measurementSystemToUnit } from "@/lib/units";
 import { useTranslation } from "react-i18next";
 
 interface Props {
-  onSuccess: (id: string) => void;
-  onClose: () => void;
+  readonly onSuccess: (id: string) => void;
+  readonly onClose: () => void;
 }
 
 const CM_PER_IN = 2.54;

--- a/frontend/src/components/projects/CreateProjectModal.tsx
+++ b/frontend/src/components/projects/CreateProjectModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { createProject, completeProject, abandonProject, listProjects, ApiError, type ProjectSummary } from "@/api/projects";
+import { createProject } from "@/api/projects";
 import { listLooms, getLoom, SUPPORTED_LOOM_TYPES } from "@/api/looms";
 import { Button } from "@/components/ui/button";
 import { TagInput } from "@/components/ui/TagInput";
@@ -21,7 +21,6 @@ export function CreateProjectModal({ onSuccess, onClose }: Props) {
   const [tags, setTags] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [conflictProject, setConflictProject] = useState<ProjectSummary | null>(null);
 
   const { data: looms = [] } = useQuery({ queryKey: ["looms"], queryFn: () => listLooms() });
   const { data: loomDetail } = useQuery({
@@ -36,53 +35,23 @@ export function CreateProjectModal({ onSuccess, onClose }: Props) {
   const handleLoomChange = (newLoomId: string) => {
     setLoomId(newLoomId);
     setLoomVersionId("");
-    setConflictProject(null);
     setError(null);
   };
-
-  const _buildPayload = () => ({
-    name: name.trim(),
-    loom_id: loomId || undefined,
-    loom_version_id: loomVersionId || undefined,
-    tags: tags.length ? tags : undefined,
-  });
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
-    setConflictProject(null);
     setLoading(true);
     try {
-      const created = await createProject(_buildPayload());
-      onSuccess(created.id);
-    } catch (err) {
-      if (err instanceof ApiError && err.status === 409 && loomId) {
-        const projects = await listProjects().catch(() => []);
-        const conflict = projects.find((p) => p.loom_id === loomId && p.status === "active") ?? null;
-        setConflictProject(conflict);
-      } else {
-        setError(err instanceof Error ? err.message : t("createProject.error.failed"));
-      }
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleResolveAndCreate = async (resolve: "complete" | "abandon") => {
-    if (!conflictProject) return;
-    setError(null);
-    setLoading(true);
-    try {
-      if (resolve === "complete") {
-        await completeProject(conflictProject.id, true);
-      } else {
-        await abandonProject(conflictProject.id);
-      }
-      const created = await createProject(_buildPayload());
+      const created = await createProject({
+        name: name.trim(),
+        loom_id: loomId || undefined,
+        loom_version_id: loomVersionId || undefined,
+        tags: tags.length ? tags : undefined,
+      });
       onSuccess(created.id);
     } catch (err) {
       setError(err instanceof Error ? err.message : t("createProject.error.failed"));
-      setConflictProject(null);
     } finally {
       setLoading(false);
     }
@@ -138,27 +107,6 @@ export function CreateProjectModal({ onSuccess, onClose }: Props) {
             </div>
           )}
 
-          {conflictProject && (
-            <div className="rounded-md border border-copper-subtle bg-copper-subtle px-3 py-3 text-sm space-y-2">
-              <p className="font-medium text-copper-on-subtle">
-                {t("createProject.conflict.title", { name: conflictProject.name })}
-              </p>
-              <p className="text-copper-on-subtle text-xs">
-                {t("createProject.conflict.body")}
-              </p>
-              <div className="flex flex-wrap gap-2 pt-1">
-                <Button type="button" size="sm" onClick={() => handleResolveAndCreate("complete")} disabled={loading}>
-                  {loading ? t("common.working") : t("createProject.conflict.complete")}
-                </Button>
-                <Button type="button" size="sm" variant="outline" onClick={() => handleResolveAndCreate("abandon")} disabled={loading}>
-                  {loading ? t("common.working") : t("createProject.conflict.abandon")}
-                </Button>
-                <Button type="button" size="sm" variant="ghost" onClick={() => handleLoomChange("")} disabled={loading}>
-                  {t("createProject.conflict.clearLoom")}
-                </Button>
-              </div>
-            </div>
-          )}
           {error && <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</p>}
         </form>
 

--- a/frontend/src/components/projects/CreateProjectModal.tsx
+++ b/frontend/src/components/projects/CreateProjectModal.tsx
@@ -4,8 +4,6 @@ import { createProject, completeProject, abandonProject, listProjects, ApiError,
 import { listLooms, getLoom, SUPPORTED_LOOM_TYPES } from "@/api/looms";
 import { Button } from "@/components/ui/button";
 import { TagInput } from "@/components/ui/TagInput";
-import { useAuthContext } from "@/context/AuthContext";
-import { measurementSystemToUnit } from "@/lib/units";
 import { useTranslation } from "react-i18next";
 
 interface Props {
@@ -13,37 +11,13 @@ interface Props {
   readonly onClose: () => void;
 }
 
-const CM_PER_IN = 2.54;
-
-function convertLen(value: string, toUnit: "cm" | "in"): string {
-  const v = parseFloat(value);
-  if (!value || isNaN(v)) return value;
-  const result = toUnit === "in" ? v / CM_PER_IN : v * CM_PER_IN;
-  return parseFloat(result.toFixed(2)).toString();
-}
-
 const f = "w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
 
 export function CreateProjectModal({ onSuccess, onClose }: Props) {
   const { t } = useTranslation();
-  const { user } = useAuthContext();
   const [name, setName] = useState("");
   const [loomId, setLoomId] = useState("");
   const [loomVersionId, setLoomVersionId] = useState("");
-  const [finishedLength, setFinishedLength] = useState("");
-  const [numItems, setNumItems] = useState("1");
-  const [wasteBetween, setWasteBetween] = useState("");
-  const [warpWaste, setWarpWaste] = useState("");
-  const [lengthUnit, setLengthUnit] = useState<"cm" | "in">(
-    measurementSystemToUnit(user?.measurement_system ?? "metric")
-  );
-
-  const handleUnitChange = (newUnit: "cm" | "in") => {
-    setFinishedLength((v) => convertLen(v, newUnit));
-    setWasteBetween((v) => convertLen(v, newUnit));
-    setWarpWaste((v) => convertLen(v, newUnit));
-    setLengthUnit(newUnit);
-  };
   const [tags, setTags] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -58,17 +32,10 @@ export function CreateProjectModal({ onSuccess, onClose }: Props) {
 
   const selectedLoom = looms.find((l) => l.id === loomId);
   const loomVersions = loomDetail?.versions ?? [];
-  const selectedVersion = loomVersions.find((v) => v.id === loomVersionId);
-
-  const loomWasteInCurrentUnit = (allowance: string | null | undefined, wasteUnit: string): string => {
-    if (!allowance) return "";
-    return wasteUnit === lengthUnit ? allowance : convertLen(allowance, lengthUnit);
-  };
 
   const handleLoomChange = (newLoomId: string) => {
     setLoomId(newLoomId);
     setLoomVersionId("");
-    setWarpWaste("");
     setConflictProject(null);
     setError(null);
   };
@@ -77,11 +44,6 @@ export function CreateProjectModal({ onSuccess, onClose }: Props) {
     name: name.trim(),
     loom_id: loomId || undefined,
     loom_version_id: loomVersionId || undefined,
-    finished_length_per_item: finishedLength ? parseFloat(finishedLength) : undefined,
-    num_items: parseInt(numItems, 10) || 1,
-    waste_between_items: wasteBetween ? parseFloat(wasteBetween) : undefined,
-    warp_waste_allowance: warpWaste ? parseFloat(warpWaste) : undefined,
-    length_unit: lengthUnit,
     tags: tags.length ? tags : undefined,
   });
 
@@ -167,11 +129,7 @@ export function CreateProjectModal({ onSuccess, onClose }: Props) {
           {selectedLoom && loomVersions.length > 1 && (
             <div>
               <label className="mb-1 block text-sm font-medium">{t("createProject.loomConfig")}</label>
-              <select className={f} value={loomVersionId} onChange={(e) => {
-                setLoomVersionId(e.target.value);
-                const v = loomVersions.find((v) => v.id === e.target.value);
-                if (v?.warp_waste_allowance) setWarpWaste(loomWasteInCurrentUnit(v.warp_waste_allowance, v.warp_waste_unit));
-              }}>
+              <select className={f} value={loomVersionId} onChange={(e) => setLoomVersionId(e.target.value)}>
                 <option value="">{t("createProject.loomConfigLatest", { name: loomVersions.at(-1)?.name ?? `v${loomVersions.at(-1)?.version_number}` })}</option>
                 {loomVersions.map((v) => (
                   <option key={v.id} value={v.id}>{v.name ?? `Version ${v.version_number}`}</option>
@@ -179,58 +137,6 @@ export function CreateProjectModal({ onSuccess, onClose }: Props) {
               </select>
             </div>
           )}
-
-          <div className="border-t pt-4">
-            <p className="mb-3 text-xs font-medium text-muted-foreground uppercase tracking-wide">{t("createProject.warpPlan")}</p>
-
-            <div className="grid grid-cols-3 gap-3">
-              <div className="col-span-2">
-                <label className="mb-1 block text-sm font-medium">{t("createProject.finishedLength")}</label>
-                <div className="flex gap-2">
-                  <input
-                    type="number"
-                    min={0}
-                    step="0.1"
-                    className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-                    value={finishedLength}
-                    onChange={(e) => setFinishedLength(e.target.value)}
-                    placeholder="50"
-                  />
-                  <select
-                    className="rounded-md border border-input bg-background px-2 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-                    value={lengthUnit}
-                    onChange={(e) => handleUnitChange(e.target.value as "cm" | "in")}
-                  >
-                    <option value="cm">cm</option>
-                    <option value="in">in</option>
-                  </select>
-                </div>
-              </div>
-              <div>
-                <label className="mb-1 block text-sm font-medium">{t("createProject.numItems")}</label>
-                <input type="number" min={1} step="1" className={f} value={numItems} onChange={(e) => setNumItems(e.target.value)} />
-              </div>
-            </div>
-
-            <div className="grid grid-cols-2 gap-3 mt-3">
-              {parseInt(numItems, 10) > 1 && (
-                <div>
-                  <label className="mb-1 block text-sm font-medium">{t("createProject.wasteBetween")}</label>
-                  <div className="flex gap-1">
-                    <input type="number" min={0} step="0.1" className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring" value={wasteBetween} onChange={(e) => setWasteBetween(e.target.value)} placeholder="5" />
-                    <span className="flex items-center rounded-md border border-input bg-muted px-2 text-sm text-muted-foreground">{lengthUnit}</span>
-                  </div>
-                </div>
-              )}
-              <div className={parseInt(numItems, 10) <= 1 ? "col-span-2" : ""}>
-                <label className="mb-1 block text-sm font-medium">{t("createProject.warpWaste")}</label>
-                <div className="flex gap-1">
-                  <input type="number" min={0} step="0.1" className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring" value={warpWaste || loomWasteInCurrentUnit(selectedVersion?.warp_waste_allowance ?? loomDetail?.versions.at(-1)?.warp_waste_allowance, selectedVersion?.warp_waste_unit ?? loomDetail?.versions.at(-1)?.warp_waste_unit ?? "cm")} onChange={(e) => setWarpWaste(e.target.value)} placeholder="30" />
-                  <span className="flex items-center rounded-md border border-input bg-muted px-2 text-sm text-muted-foreground">{lengthUnit}</span>
-                </div>
-              </div>
-            </div>
-          </div>
 
           {conflictProject && (
             <div className="rounded-md border border-copper-subtle bg-copper-subtle px-3 py-3 text-sm space-y-2">

--- a/frontend/src/components/projects/ProjectSummaryList.tsx
+++ b/frontend/src/components/projects/ProjectSummaryList.tsx
@@ -30,7 +30,7 @@ function ProjectRow({ project }: { project: ProjectSummary }) {
     >
       <div className="min-w-0">
         <p className="truncate text-sm font-medium">{project.name}</p>
-        <p className="text-xs text-muted-foreground">{PROJECT_TYPE_LABELS[project.project_type]}{endDate ? ` · ${fmtDate(endDate)}` : ""}</p>
+        <p className="text-xs text-muted-foreground">{project.project_type ? PROJECT_TYPE_LABELS[project.project_type] : ""}{endDate ? ` · ${fmtDate(endDate)}` : ""}</p>
       </div>
       <span className={`shrink-0 rounded px-1.5 py-0.5 text-xs font-medium ${STATUS_COLORS[badgeKey]}`}>
         {badgeLabel}

--- a/frontend/src/lib/icons.ts
+++ b/frontend/src/lib/icons.ts
@@ -20,6 +20,7 @@ import {
   FileDown,
   FolderOpen,
   Footprints,
+  GripVertical,
   Heart,
   LayoutDashboard,
   Layers,
@@ -73,6 +74,7 @@ export const AppIcons = {
   support: Heart,
 
   // ── UI chrome ─────────────────────────────────────────────────────────────
+  grip: GripVertical,
   edit: Pencil,
   mobileMenu: Menu,
   close: X,

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -87,6 +87,11 @@
     "clear": "Löschen",
     "loading": "Lädt …",
     "saving": "Wird gespeichert…",
+    "working": "Wird verarbeitet…",
+    "creating": "Wird erstellt…",
+    "adding": "Wird hinzugefügt…",
+    "optional": "optional",
+    "remove": "Entfernen",
     "error": "Etwas ist schiefgelaufen."
   },
   "settings": {
@@ -345,6 +350,38 @@
     "emptyState": "Noch keine Entwürfe. Lade eine WIF-Datei hoch, um loszulegen.",
     "noTagMatch": "Keine Entwürfe mit Tag \"{{tag}}\".",
     "archived": "Archiviert ({{count}})"
+  },
+  "createProject": {
+    "title": "Neues Projekt",
+    "name": "Name",
+    "namePlaceholder": "Frühlingsschals…",
+    "tags": "Tags",
+    "tagsPlaceholder": "Tag hinzufügen…",
+    "sequenceHint": {
+      "title": "Entwürfe werden auf der Projektseite hinzugefügt",
+      "body": "Nach dem Erstellen können Sie auf der Projektseite Entwürfe zur Sequenz hinzufügen."
+    },
+    "loom": "Webstuhl",
+    "noLoom": "Kein Webstuhl",
+    "loomConfig": "Webstuhlkonfiguration",
+    "loomConfigLatest": "Neueste ({{name}})",
+    "unsupportedLoomsHidden": "Einige Webstühle sind ausgeblendet (nicht unterstützter Typ).",
+    "warpPlan": "Kettenplan",
+    "finishedLength": "Fertiglänge / Stück",
+    "numItems": "Stücke",
+    "wasteBetween": "Abfall zwischen Stücken",
+    "warpWaste": "Webstuhlverlust",
+    "conflict": {
+      "title": "\"{{name}}\" verwendet diesen Webstuhl bereits",
+      "body": "Möchten Sie das vorhandene Projekt zuerst abschließen oder aufgeben?",
+      "complete": "Abschließen & neu erstellen",
+      "abandon": "Aufgeben & neu erstellen",
+      "clearLoom": "Webstuhl entfernen"
+    },
+    "error": {
+      "failed": "Projekt konnte nicht erstellt werden."
+    },
+    "submit": "Projekt erstellen"
   },
   "projectsPage": {
     "title": "Projekte",
@@ -635,7 +672,20 @@
     "updateColorFromYarn": "Farbe aus Garn übernehmen?",
     "updateColor": "Übernehmen",
     "keepColor": "Behalten",
-    "undo": "Rückgängig"
+    "undo": "Rückgängig",
+    "draftSequence": "Entwurfssequenz",
+    "noDrafts": "Noch keine Entwürfe hinzugefügt.",
+    "selectDraft": "Entwurf auswählen…",
+    "addDraft": "Hinzufügen",
+    "moveUp": "Nach oben",
+    "moveDown": "Nach unten",
+    "entryPicks": "{{count}} Schüsse",
+    "multidraft": "{{count}} Entwürfe",
+    "noDraftPreview": "Kein Entwurf",
+    "beforeStarting": "Vor dem Start:",
+    "needsDrafts": "Mindestens einen Entwurf zur Sequenz hinzufügen",
+    "needsLoom": "Webstuhl zuweisen (Abschnitt Ketteneinrichtung)",
+    "couldNotStart": "Projekt konnte nicht gestartet werden."
   },
   "projectDetailPage": {
     "loading": "Laden…",

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -679,6 +679,8 @@
     "addDraft": "Hinzufügen",
     "moveUp": "Nach oben",
     "moveDown": "Nach unten",
+    "decreaseRepeats": "Wiederholungen verringern",
+    "increaseRepeats": "Wiederholungen erhöhen",
     "entryPicks": "{{count}} Schüsse",
     "multidraft": "{{count}} Entwürfe",
     "noDraftPreview": "Kein Entwurf",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -87,6 +87,11 @@
     "clear": "Clear",
     "loading": "Loading…",
     "saving": "Saving…",
+    "working": "Working…",
+    "creating": "Creating…",
+    "adding": "Adding…",
+    "optional": "optional",
+    "remove": "Remove",
     "error": "Something went wrong."
   },
   "settings": {
@@ -345,6 +350,38 @@
     "emptyState": "No drafts yet. Upload a WIF file to get started.",
     "noTagMatch": "No drafts tagged \"{{tag}}\".",
     "archived": "Archived ({{count}})"
+  },
+  "createProject": {
+    "title": "New Project",
+    "name": "Name",
+    "namePlaceholder": "Spring scarves…",
+    "tags": "Tags",
+    "tagsPlaceholder": "Add a tag…",
+    "sequenceHint": {
+      "title": "Drafts are added on the project page",
+      "body": "After creating, open the project to add drafts to the sequence before you start weaving."
+    },
+    "loom": "Loom",
+    "noLoom": "No loom",
+    "loomConfig": "Loom configuration",
+    "loomConfigLatest": "Latest ({{name}})",
+    "unsupportedLoomsHidden": "Some looms are hidden (unsupported type).",
+    "warpPlan": "Warp Plan",
+    "finishedLength": "Finished length / item",
+    "numItems": "Items",
+    "wasteBetween": "Waste between items",
+    "warpWaste": "Loom waste",
+    "conflict": {
+      "title": "\"{{name}}\" is already using this loom",
+      "body": "Do you want to complete or abandon the existing project before creating a new one?",
+      "complete": "Complete & create new",
+      "abandon": "Abandon & create new",
+      "clearLoom": "Clear loom"
+    },
+    "error": {
+      "failed": "Failed to create project."
+    },
+    "submit": "Create project"
   },
   "projectsPage": {
     "title": "Projects",
@@ -635,7 +672,20 @@
     "updateColorFromYarn": "Update color from yarn?",
     "updateColor": "Update",
     "keepColor": "Keep",
-    "undo": "Undo"
+    "undo": "Undo",
+    "draftSequence": "Draft Sequence",
+    "noDrafts": "No drafts added yet. Add a draft below to begin.",
+    "selectDraft": "Select a draft…",
+    "addDraft": "Add",
+    "moveUp": "Move up",
+    "moveDown": "Move down",
+    "entryPicks": "{{count}} picks",
+    "multidraft": "{{count}} drafts",
+    "noDraftPreview": "No draft",
+    "beforeStarting": "Before you can start:",
+    "needsDrafts": "Add at least one draft to the sequence",
+    "needsLoom": "Assign a loom (Warp Setup section above)",
+    "couldNotStart": "Could not start project."
   },
   "projectDetailPage": {
     "loading": "Loading…",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -679,6 +679,8 @@
     "addDraft": "Add",
     "moveUp": "Move up",
     "moveDown": "Move down",
+    "decreaseRepeats": "Decrease repeats",
+    "increaseRepeats": "Increase repeats",
     "entryPicks": "{{count}} picks",
     "multidraft": "{{count}} drafts",
     "noDraftPreview": "No draft",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -86,6 +86,11 @@
     "clear": "Borrar",
     "loading": "Cargando…",
     "saving": "Guardando…",
+    "working": "Procesando…",
+    "creating": "Creando…",
+    "adding": "Añadiendo…",
+    "optional": "opcional",
+    "remove": "Eliminar",
     "error": "Algo salió mal."
   },
   "settings": {
@@ -344,6 +349,38 @@
     "emptyState": "Sin ligamentos todavía. Sube un archivo WIF para empezar.",
     "noTagMatch": "Sin ligamentos con la etiqueta \"{{tag}}\".",
     "archived": "Archivados ({{count}})"
+  },
+  "createProject": {
+    "title": "Nuevo proyecto",
+    "name": "Nombre",
+    "namePlaceholder": "Bufandas de primavera…",
+    "tags": "Etiquetas",
+    "tagsPlaceholder": "Añadir etiqueta…",
+    "sequenceHint": {
+      "title": "Los ligamentos se añaden en la página del proyecto",
+      "body": "Después de crear, abre el proyecto para añadir ligamentos a la secuencia."
+    },
+    "loom": "Telar",
+    "noLoom": "Sin telar",
+    "loomConfig": "Configuración del telar",
+    "loomConfigLatest": "Última ({{name}})",
+    "unsupportedLoomsHidden": "Algunos telares están ocultos (tipo no compatible).",
+    "warpPlan": "Plan de urdimbre",
+    "finishedLength": "Longitud terminada / pieza",
+    "numItems": "Piezas",
+    "wasteBetween": "Desperdicio entre piezas",
+    "warpWaste": "Pérdida de telar",
+    "conflict": {
+      "title": "\"{{name}}\" ya está usando este telar",
+      "body": "¿Desea completar o abandonar el proyecto existente antes de crear uno nuevo?",
+      "complete": "Completar y crear nuevo",
+      "abandon": "Abandonar y crear nuevo",
+      "clearLoom": "Quitar telar"
+    },
+    "error": {
+      "failed": "No se pudo crear el proyecto."
+    },
+    "submit": "Crear proyecto"
   },
   "projectsPage": {
     "title": "Proyectos",
@@ -634,7 +671,20 @@
     "updateColorFromYarn": "¿Actualizar color del hilo?",
     "updateColor": "Actualizar",
     "keepColor": "Conservar",
-    "undo": "Deshacer"
+    "undo": "Deshacer",
+    "draftSequence": "Secuencia de ligamentos",
+    "noDrafts": "Aún no se han añadido ligamentos.",
+    "selectDraft": "Seleccionar un ligamento…",
+    "addDraft": "Añadir",
+    "moveUp": "Subir",
+    "moveDown": "Bajar",
+    "entryPicks": "{{count}} pasadas",
+    "multidraft": "{{count}} ligamentos",
+    "noDraftPreview": "Sin ligamento",
+    "beforeStarting": "Antes de empezar:",
+    "needsDrafts": "Añadir al menos un ligamento a la secuencia",
+    "needsLoom": "Asignar un telar (sección Configuración de urdimbre)",
+    "couldNotStart": "No se pudo iniciar el proyecto."
   },
   "projectDetailPage": {
     "loading": "Cargando…",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -678,6 +678,8 @@
     "addDraft": "Añadir",
     "moveUp": "Subir",
     "moveDown": "Bajar",
+    "decreaseRepeats": "Reducir repeticiones",
+    "increaseRepeats": "Aumentar repeticiones",
     "entryPicks": "{{count}} pasadas",
     "multidraft": "{{count}} ligamentos",
     "noDraftPreview": "Sin ligamento",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -86,6 +86,11 @@
     "clear": "Effacer",
     "loading": "Chargement…",
     "saving": "Enregistrement…",
+    "working": "En cours…",
+    "creating": "Création…",
+    "adding": "Ajout…",
+    "optional": "facultatif",
+    "remove": "Supprimer",
     "error": "Une erreur est survenue."
   },
   "settings": {
@@ -344,6 +349,38 @@
     "emptyState": "Aucune armure. Téléversez un fichier WIF pour commencer.",
     "noTagMatch": "Aucune armure avec le tag \"{{tag}}\".",
     "archived": "Archivées ({{count}})"
+  },
+  "createProject": {
+    "title": "Nouveau projet",
+    "name": "Nom",
+    "namePlaceholder": "Écharpes de printemps…",
+    "tags": "Tags",
+    "tagsPlaceholder": "Ajouter un tag…",
+    "sequenceHint": {
+      "title": "Les armures sont ajoutées sur la page du projet",
+      "body": "Après la création, ouvrez le projet pour ajouter des armures à la séquence."
+    },
+    "loom": "Métier",
+    "noLoom": "Aucun métier",
+    "loomConfig": "Configuration du métier",
+    "loomConfigLatest": "Dernière ({{name}})",
+    "unsupportedLoomsHidden": "Certains métiers sont masqués (type non supporté).",
+    "warpPlan": "Plan de chaîne",
+    "finishedLength": "Longueur finie / pièce",
+    "numItems": "Pièces",
+    "wasteBetween": "Gaspillage entre les pièces",
+    "warpWaste": "Perte de chaîne",
+    "conflict": {
+      "title": "\"{{name}}\" utilise déjà ce métier",
+      "body": "Voulez-vous terminer ou abandonner le projet existant avant de créer un nouveau ?",
+      "complete": "Terminer & créer nouveau",
+      "abandon": "Abandonner & créer nouveau",
+      "clearLoom": "Effacer le métier"
+    },
+    "error": {
+      "failed": "Impossible de créer le projet."
+    },
+    "submit": "Créer le projet"
   },
   "projectsPage": {
     "title": "Projets",
@@ -634,7 +671,20 @@
     "updateColorFromYarn": "Mettre à jour la couleur depuis le fil ?",
     "updateColor": "Mettre à jour",
     "keepColor": "Garder",
-    "undo": "Annuler"
+    "undo": "Annuler",
+    "draftSequence": "Séquence d'armures",
+    "noDrafts": "Aucune armure ajoutée.",
+    "selectDraft": "Sélectionner une armure…",
+    "addDraft": "Ajouter",
+    "moveUp": "Monter",
+    "moveDown": "Descendre",
+    "entryPicks": "{{count}} duites",
+    "multidraft": "{{count}} armures",
+    "noDraftPreview": "Aucune armure",
+    "beforeStarting": "Avant de commencer :",
+    "needsDrafts": "Ajouter au moins une armure à la séquence",
+    "needsLoom": "Assigner un métier (section Préparation de chaîne)",
+    "couldNotStart": "Impossible de démarrer le projet."
   },
   "projectDetailPage": {
     "loading": "Chargement…",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -678,6 +678,8 @@
     "addDraft": "Ajouter",
     "moveUp": "Monter",
     "moveDown": "Descendre",
+    "decreaseRepeats": "Diminuer les répétitions",
+    "increaseRepeats": "Augmenter les répétitions",
     "entryPicks": "{{count}} duites",
     "multidraft": "{{count}} armures",
     "noDraftPreview": "Aucune armure",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -678,6 +678,8 @@
     "addDraft": "Toevoegen",
     "moveUp": "Omhoog",
     "moveDown": "Omlaag",
+    "decreaseRepeats": "Herhalingen verminderen",
+    "increaseRepeats": "Herhalingen verhogen",
     "entryPicks": "{{count}} inslagen",
     "multidraft": "{{count}} bindingen",
     "noDraftPreview": "Geen binding",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -86,6 +86,11 @@
     "clear": "Wissen",
     "loading": "Laden…",
     "saving": "Opslaan…",
+    "working": "Bezig…",
+    "creating": "Aanmaken…",
+    "adding": "Toevoegen…",
+    "optional": "optioneel",
+    "remove": "Verwijderen",
     "error": "Er is iets misgegaan."
   },
   "settings": {
@@ -344,6 +349,38 @@
     "emptyState": "Nog geen bindingen. Upload een WIF-bestand om te beginnen.",
     "noTagMatch": "Geen bindingen met tag \"{{tag}}\".",
     "archived": "Gearchiveerd ({{count}})"
+  },
+  "createProject": {
+    "title": "Nieuw project",
+    "name": "Naam",
+    "namePlaceholder": "Lentesjalen…",
+    "tags": "Tags",
+    "tagsPlaceholder": "Tag toevoegen…",
+    "sequenceHint": {
+      "title": "Bindingen worden op de projectpagina toegevoegd",
+      "body": "Na het aanmaken kun je bindingen aan de volgorde toevoegen op de projectpagina."
+    },
+    "loom": "Weefgetouw",
+    "noLoom": "Geen weefgetouw",
+    "loomConfig": "Weefgetouwconfiguratie",
+    "loomConfigLatest": "Nieuwste ({{name}})",
+    "unsupportedLoomsHidden": "Sommige weefgetouwen zijn verborgen (niet-ondersteund type).",
+    "warpPlan": "Scheerplan",
+    "finishedLength": "Afgewerkte lengte / stuk",
+    "numItems": "Stuks",
+    "wasteBetween": "Tussenafval",
+    "warpWaste": "Getouwafval",
+    "conflict": {
+      "title": "\"{{name}}\" gebruikt dit weefgetouw al",
+      "body": "Wil je het bestaande project voltooien of opgeven voor je een nieuw aanmaakt?",
+      "complete": "Voltooien & nieuw aanmaken",
+      "abandon": "Opgeven & nieuw aanmaken",
+      "clearLoom": "Weefgetouw verwijderen"
+    },
+    "error": {
+      "failed": "Project kon niet worden aangemaakt."
+    },
+    "submit": "Project aanmaken"
   },
   "projectsPage": {
     "title": "Projecten",
@@ -634,7 +671,20 @@
     "updateColorFromYarn": "Kleur overnemen van garen?",
     "updateColor": "Overnemen",
     "keepColor": "Behouden",
-    "undo": "Ongedaan maken"
+    "undo": "Ongedaan maken",
+    "draftSequence": "Bindingsvolgorde",
+    "noDrafts": "Nog geen bindingen toegevoegd.",
+    "selectDraft": "Selecteer een binding…",
+    "addDraft": "Toevoegen",
+    "moveUp": "Omhoog",
+    "moveDown": "Omlaag",
+    "entryPicks": "{{count}} inslagen",
+    "multidraft": "{{count}} bindingen",
+    "noDraftPreview": "Geen binding",
+    "beforeStarting": "Vereist voor de start:",
+    "needsDrafts": "Voeg minstens één binding toe aan de volgorde",
+    "needsLoom": "Wijs een weefgetouw toe (sectie Scheeropzet)",
+    "couldNotStart": "Project kon niet worden gestart."
   },
   "projectDetailPage": {
     "loading": "Laden…",

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -325,6 +325,132 @@ export function DashboardPage() {
   const planningProjects = projects.filter((a) => (a.status === "active" || a.status === "created") && !a.loom_id);
   const completedCount = projects.filter((a) => a.status === "completed").length;
 
+  let draftsContent;
+  if (draftsLoading) {
+    draftsContent = <SkeletonCardGrid count={3} cardClassName="h-[72px]" gridClassName="grid grid-cols-2 sm:grid-cols-3 gap-3" />;
+  } else if (drafts.length === 0) {
+    draftsContent = (
+      <div className="rounded-lg border border-dashed p-6 text-center">
+        <p className="text-sm text-muted-foreground">{t("dashboard.drafts.empty")}</p>
+        <Link to="/drafts" className="mt-2 inline-block text-sm text-foreground underline underline-offset-2">
+          {t("dashboard.drafts.uploadFirst")}
+        </Link>
+      </div>
+    );
+  } else {
+    draftsContent = (
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+        {drafts.slice(0, 3).map((draft) => (
+          <Link
+            key={draft.id}
+            to="/drafts"
+            className="rounded-lg border p-4 hover:border-ring transition-colors flex items-start gap-3"
+          >
+            <div className="shrink-0 mt-0.5">
+              <AppIcons.draft className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
+            </div>
+            <div className="min-w-0">
+              <p className="text-sm font-medium truncate">{draft.name}</p>
+              <p className="mt-0.5 text-xs text-muted-foreground truncate">{draft.wif_filename}</p>
+            </div>
+          </Link>
+        ))}
+        {drafts.length > 3 && (
+          <Link
+            to="/drafts"
+            className="rounded-lg border border-dashed p-4 flex items-center justify-center hover:border-ring transition-colors"
+          >
+            <span className="text-xs text-muted-foreground">{t("dashboard.moreItems", { count: drafts.length - 3 })}</span>
+          </Link>
+        )}
+      </div>
+    );
+  }
+
+  let collectionsContent;
+  if (collectionsLoading) {
+    collectionsContent = <SkeletonCardGrid count={3} cardClassName="h-[80px]" gridClassName="grid gap-3 sm:grid-cols-3" />;
+  } else if (collections.length === 0) {
+    collectionsContent = (
+      <div className="rounded-lg border border-dashed p-6 text-center">
+        <p className="text-sm text-muted-foreground">{t("dashboard.collectionSection.empty")}</p>
+        <Link to="/collections" className="mt-2 inline-block text-sm text-foreground underline underline-offset-2">{t("dashboard.collectionSection.createFirst")}</Link>
+      </div>
+    );
+  } else {
+    collectionsContent = (
+      <div className="grid gap-3 sm:grid-cols-3">
+        {collections.slice(0, 3).map((c) => (
+          <Link key={c.id} to={`/collections/${c.id}`} className="rounded-lg border p-4 hover:border-ring transition-colors">
+            <div className="flex items-start gap-2">
+              <AppIcons.collections className="h-4 w-4 shrink-0 mt-0.5 text-muted-foreground" strokeWidth={1.75} />
+              <div className="min-w-0">
+                <p className="text-sm font-medium truncate">{c.name}</p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  {t("dashboard.collectionSection.itemSummary", {
+                    drafts: t("dashboard.collectionSection.draftCount", { count: c.draft_count }),
+                    projects: t("dashboard.collectionSection.projectCount", { count: c.project_count }),
+                  })}
+                </p>
+              </div>
+            </div>
+          </Link>
+        ))}
+        {collections.length > 3 && (
+          <Link to="/collections" className="rounded-lg border border-dashed p-4 flex items-center justify-center text-xs text-muted-foreground hover:border-ring transition-colors">
+            {t("dashboard.moreItems", { count: collections.length - 3 })}
+          </Link>
+        )}
+      </div>
+    );
+  }
+
+  let loomsContent;
+  if (loomsLoading) {
+    loomsContent = <SkeletonCardGrid count={3} cardClassName="h-[72px]" gridClassName="grid grid-cols-2 sm:grid-cols-3 gap-3" />;
+  } else if (looms.length === 0) {
+    loomsContent = (
+      <div className="rounded-lg border border-dashed p-6 text-center">
+        <p className="text-sm text-muted-foreground">{t("dashboard.equipment.empty")}</p>
+        <Link to="/looms" className="mt-2 inline-block text-sm text-foreground underline underline-offset-2">
+          {t("dashboard.equipment.addFirst")}
+        </Link>
+      </div>
+    );
+  } else {
+    loomsContent = (
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+        {looms.slice(0, 3).map((loom) => (
+          <Link
+            key={loom.id}
+            to="/looms"
+            className="rounded-lg border p-4 hover:border-ring transition-colors flex items-start gap-3"
+          >
+            <div className="shrink-0 mt-0.5">
+              {loom.supports_lift_tracking
+                ? <AppIcons.lift className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
+                : loom.supports_treadle_tracking
+                  ? <AppIcons.treadle className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
+                  : <AppIcons.equipment className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />}
+            </div>
+            <div className="min-w-0">
+              <p className="text-sm font-medium truncate">{loom.model_name}</p>
+              <p className="mt-0.5 text-xs text-muted-foreground truncate">{loom.manufacturer}</p>
+            </div>
+          </Link>
+        ))}
+        {looms.length > 3 && (
+          <Link
+            to="/looms"
+            className="rounded-lg border border-dashed p-4 flex items-center justify-center hover:border-ring transition-colors"
+          >
+            <span className="text-xs text-muted-foreground">{t("dashboard.moreItems", { count: looms.length - 3 })}</span>
+          </Link>
+        )}
+      </div>
+    );
+  }
+
   return (
     <div className="p-6 max-w-3xl mx-auto w-full space-y-8">
       <div>
@@ -459,42 +585,7 @@ export function DashboardPage() {
             {t("dashboard.viewAll")}
           </Link>
         </div>
-        {draftsLoading ? (
-          <SkeletonCardGrid count={3} cardClassName="h-[72px]" gridClassName="grid grid-cols-2 sm:grid-cols-3 gap-3" />
-        ) : drafts.length === 0 ? (
-          <div className="rounded-lg border border-dashed p-6 text-center">
-            <p className="text-sm text-muted-foreground">{t("dashboard.drafts.empty")}</p>
-            <Link to="/drafts" className="mt-2 inline-block text-sm text-foreground underline underline-offset-2">
-              {t("dashboard.drafts.uploadFirst")}
-            </Link>
-          </div>
-        ) : (
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-            {drafts.slice(0, 3).map((draft) => (
-              <Link
-                key={draft.id}
-                to="/drafts"
-                className="rounded-lg border p-4 hover:border-ring transition-colors flex items-start gap-3"
-              >
-                <div className="shrink-0 mt-0.5">
-                  <AppIcons.draft className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
-                </div>
-                <div className="min-w-0">
-                  <p className="text-sm font-medium truncate">{draft.name}</p>
-                  <p className="mt-0.5 text-xs text-muted-foreground truncate">{draft.wif_filename}</p>
-                </div>
-              </Link>
-            ))}
-            {drafts.length > 3 && (
-              <Link
-                to="/drafts"
-                className="rounded-lg border border-dashed p-4 flex items-center justify-center hover:border-ring transition-colors"
-              >
-                <span className="text-xs text-muted-foreground">{t("dashboard.moreItems", { count: drafts.length - 3 })}</span>
-              </Link>
-            )}
-          </div>
-        )}
+        {draftsContent}
       </section>
 
       {/* Collections */}
@@ -503,38 +594,7 @@ export function DashboardPage() {
           <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">{t("dashboard.collectionSection.heading")}</h2>
           <Link to="/collections" className="text-xs text-muted-foreground hover:text-foreground">{t("dashboard.viewAll")}</Link>
         </div>
-        {collectionsLoading ? (
-          <SkeletonCardGrid count={3} cardClassName="h-[80px]" gridClassName="grid gap-3 sm:grid-cols-3" />
-        ) : collections.length === 0 ? (
-          <div className="rounded-lg border border-dashed p-6 text-center">
-            <p className="text-sm text-muted-foreground">{t("dashboard.collectionSection.empty")}</p>
-            <Link to="/collections" className="mt-2 inline-block text-sm text-foreground underline underline-offset-2">{t("dashboard.collectionSection.createFirst")}</Link>
-          </div>
-        ) : (
-          <div className="grid gap-3 sm:grid-cols-3">
-            {collections.slice(0, 3).map((c) => (
-              <Link key={c.id} to={`/collections/${c.id}`} className="rounded-lg border p-4 hover:border-ring transition-colors">
-                <div className="flex items-start gap-2">
-                  <AppIcons.collections className="h-4 w-4 shrink-0 mt-0.5 text-muted-foreground" strokeWidth={1.75} />
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium truncate">{c.name}</p>
-                    <p className="text-xs text-muted-foreground mt-0.5">
-                      {t("dashboard.collectionSection.itemSummary", {
-                        drafts: t("dashboard.collectionSection.draftCount", { count: c.draft_count }),
-                        projects: t("dashboard.collectionSection.projectCount", { count: c.project_count }),
-                      })}
-                    </p>
-                  </div>
-                </div>
-              </Link>
-            ))}
-            {collections.length > 3 && (
-              <Link to="/collections" className="rounded-lg border border-dashed p-4 flex items-center justify-center text-xs text-muted-foreground hover:border-ring transition-colors">
-                {t("dashboard.moreItems", { count: collections.length - 3 })}
-              </Link>
-            )}
-          </div>
-        )}
+        {collectionsContent}
       </section>
 
       {/* Equipment */}
@@ -545,46 +605,7 @@ export function DashboardPage() {
             {t("dashboard.viewAll")}
           </Link>
         </div>
-        {loomsLoading ? (
-          <SkeletonCardGrid count={3} cardClassName="h-[72px]" gridClassName="grid grid-cols-2 sm:grid-cols-3 gap-3" />
-        ) : looms.length === 0 ? (
-          <div className="rounded-lg border border-dashed p-6 text-center">
-            <p className="text-sm text-muted-foreground">{t("dashboard.equipment.empty")}</p>
-            <Link to="/looms" className="mt-2 inline-block text-sm text-foreground underline underline-offset-2">
-              {t("dashboard.equipment.addFirst")}
-            </Link>
-          </div>
-        ) : (
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-            {looms.slice(0, 3).map((loom) => (
-              <Link
-                key={loom.id}
-                to="/looms"
-                className="rounded-lg border p-4 hover:border-ring transition-colors flex items-start gap-3"
-              >
-                <div className="shrink-0 mt-0.5">
-                  {loom.supports_lift_tracking
-                    ? <AppIcons.lift className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
-                    : loom.supports_treadle_tracking
-                      ? <AppIcons.treadle className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
-                      : <AppIcons.equipment className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />}
-                </div>
-                <div className="min-w-0">
-                  <p className="text-sm font-medium truncate">{loom.model_name}</p>
-                  <p className="mt-0.5 text-xs text-muted-foreground truncate">{loom.manufacturer}</p>
-                </div>
-              </Link>
-            ))}
-            {looms.length > 3 && (
-              <Link
-                to="/looms"
-                className="rounded-lg border border-dashed p-4 flex items-center justify-center hover:border-ring transition-colors"
-              >
-                <span className="text-xs text-muted-foreground">{t("dashboard.moreItems", { count: looms.length - 3 })}</span>
-              </Link>
-            )}
-          </div>
-        )}
+        {loomsContent}
       </section>
 
       {/* Activity heatmap */}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -368,7 +368,7 @@ export function DashboardPage() {
                     <div className="flex-1 min-w-0">
                       <p className="font-medium truncate">{a.name}</p>
                       <p className="text-xs text-muted-foreground mt-0.5">
-                        {PROJECT_TYPE_LABELS[a.project_type]}
+                        {a.project_type ? PROJECT_TYPE_LABELS[a.project_type] : ""}
                       </p>
                       {a.status === "active" && (
                         <div className="mt-2">

--- a/frontend/src/pages/DraftDetailPage.tsx
+++ b/frontend/src/pages/DraftDetailPage.tsx
@@ -993,7 +993,6 @@ export function DraftDetailPage() {
 
       {showCreateProject && (
         <CreateProjectModal
-          defaultDraftId={id}
           onSuccess={(newId) => {
             setShowCreateProject(false);
             queryClient.invalidateQueries({ queryKey: ["projects", { draftId: id }] });

--- a/frontend/src/pages/DraftsPage.tsx
+++ b/frontend/src/pages/DraftsPage.tsx
@@ -29,6 +29,7 @@ export function DraftsPage() {
   const projectCountsByDraft = projects.reduce<Record<string, { active: number; planning: number; completed: number; abandoned: number }>>(
     (acc, a) => {
       const did = a.draft_id;
+      if (!did) return acc;
       if (!acc[did]) acc[did] = { active: 0, planning: 0, completed: 0, abandoned: 0 };
       if (a.status === "active" && !!a.loom_id) acc[did].active++;
       else if (a.status === "active" && !a.loom_id) acc[did].planning++;

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1494,13 +1494,15 @@ export function ProjectDetailPage() {
           >
             {t("projectDetailPage.viewDesign")}
           </button>
-          <Link
-            to={`/projects/${project.id}/warping-plan`}
-            className="rounded-md border border-primary/30 bg-primary/5 px-3 py-1.5 text-xs font-medium text-primary transition-colors hover:bg-primary/10 hidden sm:inline-flex items-center gap-1"
-            title={t("projectDetailPage.weavePlanTitle")}
-          >
-            {t("projectDetailPage.weavePlan")}
-          </Link>
+          {project.draft_count === 1 && (
+            <Link
+              to={`/projects/${project.id}/warping-plan`}
+              className="rounded-md border border-primary/30 bg-primary/5 px-3 py-1.5 text-xs font-medium text-primary transition-colors hover:bg-primary/10 hidden sm:inline-flex items-center gap-1"
+              title={t("projectDetailPage.weavePlanTitle")}
+            >
+              {t("projectDetailPage.weavePlan")}
+            </Link>
+          )}
           {!isReadOnly && (
             <button
               onClick={() => setShareModalOpen(true)}

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -953,7 +953,7 @@ function CompletedSummary({
 
       {/* Links */}
       <div className="grid gap-3 sm:grid-cols-2">
-        {project.draft_id ? (
+        {project.draft_id && (
           <Link
             to={`/drafts/${project.draft_id}`}
             className="rounded-lg border p-4 hover:border-ring transition-colors block"
@@ -961,12 +961,13 @@ function CompletedSummary({
             <p className="text-xs text-muted-foreground uppercase tracking-wide mb-1">{t("projectDetailPage.draftLink")}</p>
             <p className="font-medium text-sm">{project.draft_name}</p>
           </Link>
-        ) : project.draft_name ? (
+        )}
+        {!project.draft_id && project.draft_name && (
           <div className="rounded-lg border p-4">
             <p className="text-xs text-muted-foreground uppercase tracking-wide mb-1">{t("projectDetailPage.draftLink")}</p>
             <p className="font-medium text-sm">{project.draft_name}</p>
           </div>
-        ) : null}
+        )}
         {project.loom_id && project.loom_name && (
           <Link
             to={`/looms/${project.loom_id}`}

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -927,8 +927,10 @@ function CompletedSummary({
             <><dt className="text-muted-foreground">{t("projectDetailPage.warpWaste")}</dt>
             <dd>{displayLength(project.warp_waste_allowance, project.length_unit, displayUnit)}</dd></>
           )}
-          <dt className="text-muted-foreground">{t("projectDetailPage.type")}</dt>
-          <dd>{PROJECT_TYPE_LABELS[project.project_type]}</dd>
+          {project.project_type && (
+            <><dt className="text-muted-foreground">{t("projectDetailPage.type")}</dt>
+            <dd>{PROJECT_TYPE_LABELS[project.project_type]}</dd></>
+          )}
         </dl>
       </div>
 
@@ -951,13 +953,20 @@ function CompletedSummary({
 
       {/* Links */}
       <div className="grid gap-3 sm:grid-cols-2">
-        <Link
-          to={`/drafts/${project.draft_id}`}
-          className="rounded-lg border p-4 hover:border-ring transition-colors block"
-        >
-          <p className="text-xs text-muted-foreground uppercase tracking-wide mb-1">{t("projectDetailPage.draftLink")}</p>
-          <p className="font-medium text-sm">{project.draft_name}</p>
-        </Link>
+        {project.draft_id ? (
+          <Link
+            to={`/drafts/${project.draft_id}`}
+            className="rounded-lg border p-4 hover:border-ring transition-colors block"
+          >
+            <p className="text-xs text-muted-foreground uppercase tracking-wide mb-1">{t("projectDetailPage.draftLink")}</p>
+            <p className="font-medium text-sm">{project.draft_name}</p>
+          </Link>
+        ) : project.draft_name ? (
+          <div className="rounded-lg border p-4">
+            <p className="text-xs text-muted-foreground uppercase tracking-wide mb-1">{t("projectDetailPage.draftLink")}</p>
+            <p className="font-medium text-sm">{project.draft_name}</p>
+          </div>
+        ) : null}
         {project.loom_id && project.loom_name && (
           <Link
             to={`/looms/${project.loom_id}`}
@@ -1111,7 +1120,7 @@ export function ProjectDetailPage() {
 
   const { data: siblingProjects = [] } = useQuery({
     queryKey: ["projects", { draftId: project?.draft_id }],
-    queryFn: () => listProjects({ draftId: project!.draft_id }),
+    queryFn: () => listProjects({ draftId: project!.draft_id! }),
     enabled: isCompleted && !!project?.draft_id,
   });
 
@@ -1666,7 +1675,7 @@ export function ProjectDetailPage() {
                       <PickDisplay
                         pick={picksData.picks[currentPickIndex - 1]}
                         totalCount={displayCount}
-                        projectType={project.project_type}
+                        projectType={project.project_type ?? "treadle"}
                         colorMode={colorMode}
                         showWeftColor={false}
                         compact
@@ -1678,7 +1687,7 @@ export function ProjectDetailPage() {
                 <PickDisplay
                   pick={picksData.picks[currentPickIndex]}
                   totalCount={displayCount}
-                  projectType={project.project_type}
+                  projectType={project.project_type ?? "treadle"}
                   colorMode={colorMode}
                   showWeftColor={showWeftColor}
                 />
@@ -1690,7 +1699,7 @@ export function ProjectDetailPage() {
                       <PickDisplay
                         pick={picksData.picks[currentPickIndex + 1]}
                         totalCount={displayCount}
-                        projectType={project.project_type}
+                        projectType={project.project_type ?? "treadle"}
                         colorMode={colorMode}
                         showWeftColor={false}
                         compact
@@ -1703,7 +1712,7 @@ export function ProjectDetailPage() {
               <PickDisplay
                 pick={picksData.picks[currentPickIndex]}
                 totalCount={displayCount}
-                projectType={project.project_type}
+                projectType={project.project_type ?? "treadle"}
                 colorMode={colorMode}
                 showWeftColor={showWeftColor}
               />
@@ -1731,7 +1740,7 @@ export function ProjectDetailPage() {
           )}
 
           {/* Abandoned design preview — full drawdown with unweaved portion desaturated */}
-          {isAbandoned && (
+          {isAbandoned && project.draft_id && (
             <div className="mx-auto w-full max-w-2xl lg:max-w-5xl xl:max-w-7xl px-8 pb-4 pt-4">
               <AbandonedDrawdownView
                 draftId={project.draft_id}
@@ -1867,8 +1876,10 @@ export function ProjectDetailPage() {
 
           <CollapsibleSection title={t("projectDetailPage.details")}>
             <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
-              <dt className="text-muted-foreground">{t("projectDetailPage.type")}</dt>
-              <dd>{PROJECT_TYPE_LABELS[project.project_type]}</dd>
+              {project.project_type && (
+                <><dt className="text-muted-foreground">{t("projectDetailPage.type")}</dt>
+                <dd>{PROJECT_TYPE_LABELS[project.project_type]}</dd></>
+              )}
               {project.loom_name && (
                 <><dt className="text-muted-foreground">{t("projectDetailPage.loom")}</dt><dd>{project.loom_name}</dd></>
               )}
@@ -2063,7 +2074,7 @@ export function ProjectDetailPage() {
           projectId={project.id}
           hasDrawdownPreview={project.has_drawdown_preview}
           colorReplacements={project.color_replacements}
-          draftName={project.draft_name}
+          draftName={project.draft_name ?? ""}
           onClose={() => setShowDesignPreview(false)}
         />
       )}
@@ -2072,7 +2083,7 @@ export function ProjectDetailPage() {
         <AssignLoomModal
           projectId={project.id}
           activeProjects={allProjects.filter((a) => a.status === "active")}
-          projectType={project.project_type}
+          projectType={project.project_type ?? undefined}
           draftNumTreadles={project.draft_num_treadles}
           draftNumShafts={project.draft_num_shafts}
           draftEffectiveNumTreadles={project.draft_effective_num_treadles}

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1113,12 +1113,6 @@ export function ProjectDetailPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isCreated, id]);
 
-  const { data: allProjects = [] } = useQuery({
-    queryKey: ["projects"],
-    queryFn: () => listProjects(),
-    enabled: isPlanning || showAssignLoom,
-  });
-
   const { data: siblingProjects = [] } = useQuery({
     queryKey: ["projects", { draftId: project?.draft_id }],
     queryFn: () => listProjects({ draftId: project!.draft_id! }),
@@ -2085,7 +2079,6 @@ export function ProjectDetailPage() {
       {showAssignLoom && (
         <AssignLoomModal
           projectId={project.id}
-          activeProjects={allProjects.filter((a) => a.status === "active")}
           projectType={project.project_type ?? undefined}
           draftNumTreadles={project.draft_num_treadles}
           draftNumShafts={project.draft_num_shafts}

--- a/frontend/src/pages/ProjectLandingPage.tsx
+++ b/frontend/src/pages/ProjectLandingPage.tsx
@@ -1969,6 +1969,12 @@ export function ProjectLandingPage() {
         />
       )}
 
+      {/* Reed selector — always visible */}
+      <ReedSelector
+        project={project}
+        onUpdated={(updated) => qc.setQueryData(["project", id], updated)}
+      />
+
       {/* Color palette */}
       {project.draft_wif_colors && project.draft_wif_colors.length > 0 && (
         <ColorPaletteSection
@@ -1993,12 +1999,6 @@ export function ProjectLandingPage() {
           onUpdated={(updated) => qc.setQueryData(["project", id], updated)}
         />
       )}
-
-      {/* Reed selector — always visible */}
-      <ReedSelector
-        project={project}
-        onUpdated={(updated) => qc.setQueryData(["project", id], updated)}
-      />
 
       {/* Notes */}
       <NotesSection

--- a/frontend/src/pages/ProjectLandingPage.tsx
+++ b/frontend/src/pages/ProjectLandingPage.tsx
@@ -10,7 +10,7 @@ import {
   updateProjectWarpSetup, drawdownSvgUrl, drawdownPreviewUrl, projectDrawdownSvgUrl,
   getWarpingPlan, completeProject, abandonProject, startProject, setProjectReed, updateProjectTags,
   linkYarnColor, unlinkYarnColor,
-  addSequenceEntry, removeSequenceEntry, reorderSequence,
+  addSequenceEntry, updateSequenceEntry, removeSequenceEntry, reorderSequence,
   PROJECT_TYPE_LABELS, PROJECT_STATUS_LABELS,
   type ProjectDetail, type ProjectYarnColor, type ProjectDraftSchema,
 } from "@/api/projects";
@@ -1225,6 +1225,115 @@ function ReedSelector({
 // Draft sequence section
 // ---------------------------------------------------------------------------
 
+function SequenceRow({
+  entry,
+  idx,
+  total,
+  isEditable,
+  projectId,
+  onUpdated,
+  onRemove,
+  onMove,
+  reorderPending,
+  removePending,
+}: {
+  readonly entry: ProjectDraftSchema;
+  readonly idx: number;
+  readonly total: number;
+  readonly isEditable: boolean;
+  readonly projectId: string;
+  readonly onUpdated: (p: ProjectDetail) => void;
+  readonly onRemove: (id: string) => void;
+  readonly onMove: (idx: number, dir: -1 | 1) => void;
+  readonly reorderPending: boolean;
+  readonly removePending: boolean;
+}) {
+  const { t } = useTranslation();
+  const [repeats, setRepeats] = useState(String(entry.repeats));
+
+  const updateMutation = useMutation({
+    mutationFn: (r: number) => updateSequenceEntry(projectId, entry.id, r),
+    onSuccess: onUpdated,
+  });
+
+  function commitRepeats(raw: string) {
+    const n = Math.max(1, parseInt(raw, 10) || 1);
+    setRepeats(String(n));
+    if (n !== entry.repeats) updateMutation.mutate(n);
+  }
+
+  function step(delta: 1 | -1) {
+    const n = Math.max(1, entry.repeats + delta);
+    setRepeats(String(n));
+    if (n !== entry.repeats) updateMutation.mutate(n);
+  }
+
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2">
+      <span className="text-xs font-mono text-muted-foreground w-5 flex-shrink-0">{idx + 1}.</span>
+      <span className="flex-1 text-sm truncate">{entry.draft_name}</span>
+      <span className="text-xs text-muted-foreground flex-shrink-0">
+        {t("projectLandingPage.entryPicks", { count: entry.section_total_picks })}
+      </span>
+      {isEditable && (
+        <>
+          <div className="flex items-center flex-shrink-0">
+            <button
+              type="button"
+              onClick={() => step(-1)}
+              disabled={entry.repeats <= 1 || updateMutation.isPending}
+              className="h-6 w-6 rounded-l border border-input bg-muted text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:opacity-30 flex items-center justify-center"
+              title={t("projectLandingPage.decreaseRepeats")}
+            >−</button>
+            <input
+              type="number"
+              min={1}
+              step={1}
+              value={repeats}
+              onChange={(e) => setRepeats(e.target.value)}
+              onBlur={(e) => commitRepeats(e.target.value)}
+              className="h-6 w-10 border-y border-input bg-background text-center text-sm focus:outline-none focus:ring-1 focus:ring-ring [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+            />
+            <button
+              type="button"
+              onClick={() => step(1)}
+              disabled={updateMutation.isPending}
+              className="h-6 w-6 rounded-r border border-input bg-muted text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:opacity-30 flex items-center justify-center"
+              title={t("projectLandingPage.increaseRepeats")}
+            >+</button>
+          </div>
+          <div className="flex items-center gap-0.5 flex-shrink-0">
+            <button
+              onClick={() => onMove(idx, -1)}
+              disabled={idx === 0 || reorderPending}
+              className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30"
+              title={t("projectLandingPage.moveUp")}
+            >
+              <ChevronRightIcon className="h-3.5 w-3.5 -rotate-90" />
+            </button>
+            <button
+              onClick={() => onMove(idx, 1)}
+              disabled={idx === total - 1 || reorderPending}
+              className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30"
+              title={t("projectLandingPage.moveDown")}
+            >
+              <ChevronRightIcon className="h-3.5 w-3.5 rotate-90" />
+            </button>
+            <button
+              onClick={() => onRemove(entry.id)}
+              disabled={removePending}
+              className="p-0.5 text-destructive hover:text-destructive/70 ml-1"
+              title={t("common.remove")}
+            >
+              <CloseIcon className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
 function DraftSequenceSection({
   project,
   onUpdated,
@@ -1275,41 +1384,19 @@ function DraftSequenceSection({
         <p className="text-sm text-muted-foreground">{t("projectLandingPage.noDrafts")}</p>
       )}
       {seq.map((entry, idx) => (
-        <div key={entry.id} className="flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2">
-          <span className="text-xs font-mono text-muted-foreground w-5 flex-shrink-0">{idx + 1}.</span>
-          <span className="flex-1 text-sm truncate">{entry.draft_name}</span>
-          <span className="text-xs text-muted-foreground flex-shrink-0">
-            {t("projectLandingPage.entryPicks", { count: entry.section_total_picks })}
-          </span>
-          {isEditable && (
-            <div className="flex items-center gap-0.5 flex-shrink-0">
-              <button
-                onClick={() => moveEntry(idx, -1)}
-                disabled={idx === 0 || reorderMutation.isPending}
-                className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30"
-                title={t("projectLandingPage.moveUp")}
-              >
-                <ChevronRightIcon className="h-3.5 w-3.5 -rotate-90" />
-              </button>
-              <button
-                onClick={() => moveEntry(idx, 1)}
-                disabled={idx === seq.length - 1 || reorderMutation.isPending}
-                className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30"
-                title={t("projectLandingPage.moveDown")}
-              >
-                <ChevronRightIcon className="h-3.5 w-3.5 rotate-90" />
-              </button>
-              <button
-                onClick={() => removeMutation.mutate(entry.id)}
-                disabled={removeMutation.isPending}
-                className="p-0.5 text-destructive hover:text-destructive/70 ml-1"
-                title={t("common.remove")}
-              >
-                <CloseIcon className="h-3.5 w-3.5" />
-              </button>
-            </div>
-          )}
-        </div>
+        <SequenceRow
+          key={entry.id}
+          entry={entry}
+          idx={idx}
+          total={seq.length}
+          isEditable={isEditable}
+          projectId={project.id}
+          onUpdated={onUpdated}
+          onRemove={(id) => removeMutation.mutate(id)}
+          onMove={moveEntry}
+          reorderPending={reorderMutation.isPending}
+          removePending={removeMutation.isPending}
+        />
       ))}
       {isEditable && (
         <div className="flex gap-2">
@@ -1766,6 +1853,14 @@ export function ProjectLandingPage() {
         </section>
       )}
 
+      {/* Draft sequence — editable when created, read-only when active/done */}
+      {(project.status === "created" || project.draft_sequence.length > 0) && (
+        <DraftSequenceSection
+          project={project}
+          onUpdated={(updated) => qc.setQueryData(["project", id], updated)}
+        />
+      )}
+
       {/* Color palette */}
       {project.draft_wif_colors && project.draft_wif_colors.length > 0 && (
         <ColorPaletteSection
@@ -1787,14 +1882,6 @@ export function ProjectLandingPage() {
         <WarpSetupSection
           project={project}
           displayUnit={displayUnit}
-          onUpdated={(updated) => qc.setQueryData(["project", id], updated)}
-        />
-      )}
-
-      {/* Draft sequence — editable when created, read-only when active/done */}
-      {(project.status === "created" || project.draft_sequence.length > 0) && (
-        <DraftSequenceSection
-          project={project}
           onUpdated={(updated) => qc.setQueryData(["project", id], updated)}
         />
       )}

--- a/frontend/src/pages/ProjectLandingPage.tsx
+++ b/frontend/src/pages/ProjectLandingPage.tsx
@@ -1437,6 +1437,27 @@ function DraftSequenceSection({
       <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
         {t("projectLandingPage.draftSequence")}
       </h3>
+      {isEditable && (
+        <div className="flex gap-2">
+          <select
+            className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+            value={addDraftId}
+            onChange={(e) => setAddDraftId(e.target.value)}
+          >
+            <option value="">{t("projectLandingPage.selectDraft")}</option>
+            {drafts.map((d) => (
+              <option key={d.id} value={d.id}>{d.name}</option>
+            ))}
+          </select>
+          <Button
+            size="sm"
+            onClick={() => addDraftId && addMutation.mutate(addDraftId)}
+            disabled={!addDraftId || addMutation.isPending}
+          >
+            {addMutation.isPending ? t("common.working") : t("projectLandingPage.addDraft")}
+          </Button>
+        </div>
+      )}
       {seq.length === 0 && (
         <p className="text-sm text-muted-foreground">{t("projectLandingPage.noDrafts")}</p>
       )}
@@ -1471,27 +1492,6 @@ function DraftSequenceSection({
           )}
         </DragOverlay>
       </DndContext>
-      {isEditable && (
-        <div className="flex gap-2">
-          <select
-            className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-            value={addDraftId}
-            onChange={(e) => setAddDraftId(e.target.value)}
-          >
-            <option value="">{t("projectLandingPage.selectDraft")}</option>
-            {drafts.map((d) => (
-              <option key={d.id} value={d.id}>{d.name}</option>
-            ))}
-          </select>
-          <Button
-            size="sm"
-            onClick={() => addDraftId && addMutation.mutate(addDraftId)}
-            disabled={!addDraftId || addMutation.isPending}
-          >
-            {addMutation.isPending ? t("common.working") : t("projectLandingPage.addDraft")}
-          </Button>
-        </div>
-      )}
     </section>
   );
 }

--- a/frontend/src/pages/ProjectLandingPage.tsx
+++ b/frontend/src/pages/ProjectLandingPage.tsx
@@ -1782,8 +1782,8 @@ export function ProjectLandingPage() {
         />
       )}
 
-      {/* Warp setup — editable before weaving starts */}
-      {project.status === "created" && (
+      {/* Warp setup — editable before weaving starts, single-draft only */}
+      {project.status === "created" && project.draft_count === 1 && (
         <WarpSetupSection
           project={project}
           displayUnit={displayUnit}

--- a/frontend/src/pages/ProjectLandingPage.tsx
+++ b/frontend/src/pages/ProjectLandingPage.tsx
@@ -30,6 +30,24 @@ import { cn } from "@/lib/utils";
 import { ShareModal } from "@/components/projects/ShareModal";
 import { addProjectToCollection, removeProjectFromCollection } from "@/api/collections";
 import { AddToCollectionModal } from "@/components/collections/AddToCollectionModal";
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 
 // PascalCase aliases so they satisfy the react/jsx-pascal-case rule when used as JSX elements
 const CloseIcon = AppIcons.close;
@@ -1226,6 +1244,19 @@ function ReedSelector({
 // Draft sequence section
 // ---------------------------------------------------------------------------
 
+type SequenceRowBaseProps = {
+  entry: ProjectDraftSchema;
+  idx: number;
+  total: number;
+  isEditable: boolean;
+  projectId: string;
+  onUpdated: (p: ProjectDetail) => void;
+  onRemove: (id: string) => void;
+  onMove: (idx: number, dir: -1 | 1) => void;
+  reorderPending: boolean;
+  removePending: boolean;
+};
+
 function SequenceRow({
   entry,
   idx,
@@ -1237,29 +1268,19 @@ function SequenceRow({
   onMove,
   reorderPending,
   removePending,
+  setNodeRef,
+  dragStyle,
   isDragging,
-  isOver,
-  onDragStart,
-  onDragOver,
-  onDrop,
-  onDragEnd,
-}: {
-  readonly entry: ProjectDraftSchema;
-  readonly idx: number;
-  readonly total: number;
-  readonly isEditable: boolean;
-  readonly projectId: string;
-  readonly onUpdated: (p: ProjectDetail) => void;
-  readonly onRemove: (id: string) => void;
-  readonly onMove: (idx: number, dir: -1 | 1) => void;
-  readonly reorderPending: boolean;
-  readonly removePending: boolean;
-  readonly isDragging: boolean;
-  readonly isOver: boolean;
-  readonly onDragStart: () => void;
-  readonly onDragOver: (e: React.DragEvent) => void;
-  readonly onDrop: () => void;
-  readonly onDragEnd: () => void;
+  gripListeners,
+  gripAttributes,
+}: SequenceRowBaseProps & {
+  readonly setNodeRef?: (el: HTMLElement | null) => void;
+  readonly dragStyle?: React.CSSProperties;
+  readonly isDragging?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly gripListeners?: Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly gripAttributes?: Record<string, any>;
 }) {
   const { t } = useTranslation();
   const [repeats, setRepeats] = useState(String(entry.repeats));
@@ -1283,19 +1304,21 @@ function SequenceRow({
 
   return (
     <div
-      draggable={isEditable}
-      onDragStart={isEditable ? onDragStart : undefined}
-      onDragOver={isEditable ? onDragOver : undefined}
-      onDrop={isEditable ? onDrop : undefined}
-      onDragEnd={isEditable ? onDragEnd : undefined}
+      ref={setNodeRef}
+      style={dragStyle}
       className={cn(
-        "flex items-center gap-2 rounded-md border bg-card px-3 py-2 transition-colors",
-        isOver ? "border-ring bg-accent/20" : "border-border",
+        "flex items-center gap-2 rounded-md border bg-card px-3 py-2 transition-colors border-border",
         isDragging ? "opacity-40" : "opacity-100",
       )}
     >
       {isEditable && (
-        <GripIcon className="h-4 w-4 text-muted-foreground flex-shrink-0 cursor-grab active:cursor-grabbing" />
+        <span
+          className="flex-shrink-0 cursor-grab active:cursor-grabbing touch-none"
+          {...(gripAttributes ?? {})}
+          {...(gripListeners ?? {})}
+        >
+          <GripIcon className="h-4 w-4 text-muted-foreground" />
+        </span>
       )}
       <span className="text-xs font-mono text-muted-foreground w-5 flex-shrink-0">{idx + 1}.</span>
       <span className="flex-1 text-sm truncate">{entry.draft_name}</span>
@@ -1361,6 +1384,20 @@ function SequenceRow({
   );
 }
 
+function SortableSequenceRow(props: SequenceRowBaseProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: props.entry.id });
+  return (
+    <SequenceRow
+      {...props}
+      setNodeRef={setNodeRef}
+      dragStyle={{ transform: CSS.Transform.toString(transform), transition }}
+      isDragging={isDragging}
+      gripListeners={listeners}
+      gripAttributes={attributes}
+    />
+  );
+}
+
 function DraftSequenceSection({
   project,
   onUpdated,
@@ -1370,8 +1407,7 @@ function DraftSequenceSection({
 }) {
   const { t } = useTranslation();
   const [addDraftId, setAddDraftId] = useState("");
-  const [dragIndex, setDragIndex] = useState<number | null>(null);
-  const [overIndex, setOverIndex] = useState<number | null>(null);
+  const [activeId, setActiveId] = useState<string | null>(null);
   const isEditable = project.status === "created";
 
   const { data: drafts = [] } = useQuery({
@@ -1395,7 +1431,13 @@ function DraftSequenceSection({
     onSuccess: onUpdated,
   });
 
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
   const seq: ProjectDraftSchema[] = project.draft_sequence ?? [];
+  const activeEntry = activeId ? (seq.find((e) => e.id === activeId) ?? null) : null;
 
   function moveEntry(idx: number, direction: -1 | 1) {
     const ids = seq.map((e) => e.id);
@@ -1404,19 +1446,24 @@ function DraftSequenceSection({
     reorderMutation.mutate(ids);
   }
 
-  function handleDrop(dropIdx: number) {
-    if (dragIndex === null || dragIndex === dropIdx) {
-      setDragIndex(null);
-      setOverIndex(null);
-      return;
-    }
-    const ids = seq.map((e) => e.id);
-    const [moved] = ids.splice(dragIndex, 1);
-    ids.splice(dropIdx, 0, moved);
-    reorderMutation.mutate(ids);
-    setDragIndex(null);
-    setOverIndex(null);
+  function handleDragEnd({ active, over }: DragEndEvent) {
+    setActiveId(null);
+    if (!over || active.id === over.id) return;
+    const oldIndex = seq.findIndex((e) => e.id === active.id);
+    const newIndex = seq.findIndex((e) => e.id === over.id);
+    if (oldIndex === -1 || newIndex === -1) return;
+    reorderMutation.mutate(arrayMove(seq.map((e) => e.id), oldIndex, newIndex));
   }
+
+  const sharedRowProps: Omit<SequenceRowBaseProps, "entry" | "idx" | "total"> = {
+    isEditable,
+    projectId: project.id,
+    onUpdated,
+    onRemove: (id: string) => removeMutation.mutate(id),
+    onMove: moveEntry,
+    reorderPending: reorderMutation.isPending,
+    removePending: removeMutation.isPending,
+  };
 
   return (
     <section className="space-y-2">
@@ -1426,27 +1473,39 @@ function DraftSequenceSection({
       {seq.length === 0 && (
         <p className="text-sm text-muted-foreground">{t("projectLandingPage.noDrafts")}</p>
       )}
-      {seq.map((entry, idx) => (
-        <SequenceRow
-          key={entry.id}
-          entry={entry}
-          idx={idx}
-          total={seq.length}
-          isEditable={isEditable}
-          projectId={project.id}
-          onUpdated={onUpdated}
-          onRemove={(id) => removeMutation.mutate(id)}
-          onMove={moveEntry}
-          reorderPending={reorderMutation.isPending}
-          removePending={removeMutation.isPending}
-          isDragging={dragIndex === idx}
-          isOver={overIndex === idx && dragIndex !== idx}
-          onDragStart={() => setDragIndex(idx)}
-          onDragOver={(e) => { e.preventDefault(); setOverIndex(idx); }}
-          onDrop={() => handleDrop(idx)}
-          onDragEnd={() => { setDragIndex(null); setOverIndex(null); }}
-        />
-      ))}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={(e) => setActiveId(String(e.active.id))}
+        onDragEnd={handleDragEnd}
+        onDragCancel={() => setActiveId(null)}
+      >
+        <SortableContext items={seq.map((e) => e.id)} strategy={verticalListSortingStrategy}>
+          <div className="space-y-2">
+            {seq.map((entry, idx) => (
+              <SortableSequenceRow
+                key={entry.id}
+                entry={entry}
+                idx={idx}
+                total={seq.length}
+                {...sharedRowProps}
+              />
+            ))}
+          </div>
+        </SortableContext>
+        <DragOverlay>
+          {activeEntry && (
+            <div className="shadow-xl">
+              <SequenceRow
+                entry={activeEntry}
+                idx={seq.findIndex((e) => e.id === activeEntry.id)}
+                total={seq.length}
+                {...sharedRowProps}
+              />
+            </div>
+          )}
+        </DragOverlay>
+      </DndContext>
       {isEditable && (
         <div className="flex gap-2">
           <select

--- a/frontend/src/pages/ProjectLandingPage.tsx
+++ b/frontend/src/pages/ProjectLandingPage.tsx
@@ -8,10 +8,11 @@ import { measurementSystemToUnit, displayLength, formatApproxLength, convertLeng
 import {
   getProject, setProjectColorReplacements, deleteProject, updateProjectNotes,
   updateProjectWarpSetup, drawdownSvgUrl, drawdownPreviewUrl, projectDrawdownSvgUrl,
-  getWarpingPlan, completeProject, abandonProject, setProjectReed, updateProjectTags,
+  getWarpingPlan, completeProject, abandonProject, startProject, setProjectReed, updateProjectTags,
   linkYarnColor, unlinkYarnColor,
+  addSequenceEntry, removeSequenceEntry, reorderSequence,
   PROJECT_TYPE_LABELS, PROJECT_STATUS_LABELS,
-  type ProjectDetail, type ProjectYarnColor,
+  type ProjectDetail, type ProjectYarnColor, type ProjectDraftSchema,
 } from "@/api/projects";
 import type { YarnSummary } from "@/api/yarn";
 import { YarnPickerModal } from "@/components/projects/YarnPickerModal";
@@ -19,7 +20,7 @@ import { TagInput } from "@/components/ui/TagInput";
 import { TagChips } from "@/components/ui/TagChips";
 import { getReedRecommendation, buildDentPattern, nearestCleanDent } from "@/lib/reedRecommendation";
 import { TieUpDiagram } from "@/components/TieUpDiagram";
-import { previewUrl } from "@/api/drafts";
+import { previewUrl, listDrafts } from "@/api/drafts";
 import { getAuthToken } from "@/api/client";
 import { AuthedImage } from "@/components/ui/AuthedImage";
 import { Button, buttonVariants } from "@/components/ui/button";
@@ -1212,6 +1213,121 @@ function ReedSelector({
 // ShareModal is imported from @/components/projects/ShareModal
 
 // ---------------------------------------------------------------------------
+// Draft sequence section
+// ---------------------------------------------------------------------------
+
+function DraftSequenceSection({
+  project,
+  onUpdated,
+}: {
+  project: ProjectDetail;
+  onUpdated: (updated: ProjectDetail) => void;
+}) {
+  const { t } = useTranslation();
+  const [addDraftId, setAddDraftId] = useState("");
+  const isEditable = project.status === "created";
+
+  const { data: drafts = [] } = useQuery({
+    queryKey: ["drafts"],
+    queryFn: () => listDrafts(),
+    enabled: isEditable,
+  });
+
+  const addMutation = useMutation({
+    mutationFn: (draftId: string) => addSequenceEntry(project.id, draftId),
+    onSuccess: (updated) => { onUpdated(updated); setAddDraftId(""); },
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: (seqId: string) => removeSequenceEntry(project.id, seqId),
+    onSuccess: onUpdated,
+  });
+
+  const reorderMutation = useMutation({
+    mutationFn: (orderedIds: string[]) => reorderSequence(project.id, orderedIds),
+    onSuccess: onUpdated,
+  });
+
+  const seq: ProjectDraftSchema[] = project.draft_sequence ?? [];
+
+  function moveEntry(idx: number, direction: -1 | 1) {
+    const ids = seq.map((e) => e.id);
+    const swapIdx = idx + direction;
+    [ids[idx], ids[swapIdx]] = [ids[swapIdx], ids[idx]];
+    reorderMutation.mutate(ids);
+  }
+
+  return (
+    <section className="space-y-2">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+        {t("projectLandingPage.draftSequence")}
+      </h3>
+      {seq.length === 0 && (
+        <p className="text-sm text-muted-foreground">{t("projectLandingPage.noDrafts")}</p>
+      )}
+      {seq.map((entry, idx) => (
+        <div key={entry.id} className="flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2">
+          <span className="text-xs font-mono text-muted-foreground w-5 flex-shrink-0">{idx + 1}.</span>
+          <span className="flex-1 text-sm truncate">{entry.draft_name}</span>
+          <span className="text-xs text-muted-foreground flex-shrink-0">
+            {t("projectLandingPage.entryPicks", { count: entry.section_total_picks })}
+          </span>
+          {isEditable && (
+            <div className="flex items-center gap-0.5 flex-shrink-0">
+              <button
+                onClick={() => moveEntry(idx, -1)}
+                disabled={idx === 0 || reorderMutation.isPending}
+                className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30"
+                title={t("projectLandingPage.moveUp")}
+              >
+                <AppIcons.chevronRight className="h-3.5 w-3.5 -rotate-90" />
+              </button>
+              <button
+                onClick={() => moveEntry(idx, 1)}
+                disabled={idx === seq.length - 1 || reorderMutation.isPending}
+                className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30"
+                title={t("projectLandingPage.moveDown")}
+              >
+                <AppIcons.chevronRight className="h-3.5 w-3.5 rotate-90" />
+              </button>
+              <button
+                onClick={() => removeMutation.mutate(entry.id)}
+                disabled={removeMutation.isPending}
+                className="p-0.5 text-destructive hover:text-destructive/70 ml-1"
+                title={t("common.remove")}
+              >
+                <AppIcons.close className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          )}
+        </div>
+      ))}
+      {isEditable && (
+        <div className="flex gap-2">
+          <select
+            className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+            value={addDraftId}
+            onChange={(e) => setAddDraftId(e.target.value)}
+          >
+            <option value="">{t("projectLandingPage.selectDraft")}</option>
+            {drafts.map((d) => (
+              <option key={d.id} value={d.id}>{d.name}</option>
+            ))}
+          </select>
+          <Button
+            size="sm"
+            onClick={() => addDraftId && addMutation.mutate(addDraftId)}
+            disabled={!addDraftId || addMutation.isPending}
+          >
+            {addMutation.isPending ? t("common.working") : t("projectLandingPage.addDraft")}
+          </Button>
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Notes inline editor
 // ---------------------------------------------------------------------------
 
@@ -1375,9 +1491,21 @@ export function ProjectLandingPage() {
     },
   });
 
+  const startMutation = useMutation({
+    mutationFn: () => startProject(id!),
+    onSuccess: (updated) => {
+      qc.setQueryData(["project", id], updated);
+      qc.invalidateQueries({ queryKey: ["projects"] });
+      navigate(`/projects/${id}/track`);
+    },
+    onError: (err: Error) => {
+      setStatusActionError(err.message ?? t("projectLandingPage.couldNotStart"));
+    },
+  });
+
   const progress = useMemo(() => {
-    if (!project) return null;
-    const done = project.current_pick - 1;
+    if (!project || project.total_picks === 0) return null;
+    const done = project.aggregate_current_pick;
     const pct = Math.min(100, Math.round((done / Math.max(project.total_picks, 1)) * 100));
     return { pct, done, total: project.total_picks };
   }, [project]);
@@ -1401,7 +1529,6 @@ export function ProjectLandingPage() {
     );
   }
 
-  const isActive = project.status === "active" || project.status === "created";
   const m = project.draft_wif_measurements;
   const warpLengthCm = project.draft_warp_length_cm;
 
@@ -1425,9 +1552,11 @@ export function ProjectLandingPage() {
             >
               {PROJECT_STATUS_LABELS[project.status]}
             </span>
-            <span className="rounded-full px-2 py-0.5 text-xs font-medium bg-muted text-muted-foreground">
-              {PROJECT_TYPE_LABELS[project.project_type]}
-            </span>
+            {project.project_type && (
+              <span className="rounded-full px-2 py-0.5 text-xs font-medium bg-muted text-muted-foreground">
+                {PROJECT_TYPE_LABELS[project.project_type]}
+              </span>
+            )}
             {project.share_slug && project.share_visibility !== "private" && (
               <button
                 onClick={() => setShareModalOpen(true)}
@@ -1441,9 +1570,13 @@ export function ProjectLandingPage() {
           </div>
           <h1 className="text-xl font-semibold leading-tight truncate">{project.name}</h1>
           <p className="text-sm text-muted-foreground mt-0.5">
-            <Link to={`/drafts/${project.draft_id}`} className="hover:underline">
-              {project.draft_name}
-            </Link>
+            {project.draft_id ? (
+              <Link to={`/drafts/${project.draft_id}`} className="hover:underline">
+                {project.draft_name ?? t("projectLandingPage.multidraft", { count: project.draft_count })}
+              </Link>
+            ) : project.draft_count > 0 ? (
+              <span>{t("projectLandingPage.multidraft", { count: project.draft_count })}</span>
+            ) : null}
             {project.loom_name && <span> · {project.loom_name}</span>}
           </p>
           {!editingTags && (
@@ -1506,11 +1639,17 @@ export function ProjectLandingPage() {
             onClick={() => setDrawdownOpen(true)}
             title={t("projectLandingPage.clickForDrawdown")}
           >
-            <AuthedImage
-              src={previewUrl(project.draft_id)}
-              alt="Draft preview"
-              className="h-36 w-36 object-contain"
-            />
+            {project.draft_id ? (
+              <AuthedImage
+                src={previewUrl(project.draft_id)}
+                alt="Draft preview"
+                className="h-36 w-36 object-contain"
+              />
+            ) : (
+              <div className="h-36 w-36 flex items-center justify-center text-xs text-muted-foreground">
+                {t("projectLandingPage.noDraftPreview")}
+              </div>
+            )}
           </button>
           {project.project_type === "treadle" && (
             <button
@@ -1642,6 +1781,14 @@ export function ProjectLandingPage() {
         />
       )}
 
+      {/* Draft sequence — editable when created, read-only when active/done */}
+      {(project.status === "created" || project.draft_sequence.length > 0) && (
+        <DraftSequenceSection
+          project={project}
+          onUpdated={(updated) => qc.setQueryData(["project", id], updated)}
+        />
+      )}
+
       {/* Reed selector — always visible */}
       <ReedSelector
         project={project}
@@ -1740,13 +1887,47 @@ export function ProjectLandingPage() {
           >
             {t("projectLandingPage.weavePlan")}
           </Link>
-          {isActive && (
+          {project.status === "created" && (() => {
+            const missingDrafts = project.draft_sequence.length === 0;
+            const missingLoom = !project.loom_id;
+            const canStart = !missingDrafts && !missingLoom;
+            return (
+              <>
+                {(missingDrafts || missingLoom) && (
+                  <div className="w-full rounded-md border border-border bg-muted px-3 py-2 text-sm space-y-1 mb-1">
+                    <p className="font-medium text-muted-foreground text-xs uppercase tracking-wide">{t("projectLandingPage.beforeStarting")}</p>
+                    {missingDrafts && (
+                      <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                        <AppIcons.close className="h-3 w-3 text-destructive flex-shrink-0" />
+                        {t("projectLandingPage.needsDrafts")}
+                      </p>
+                    )}
+                    {missingLoom && (
+                      <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                        <AppIcons.close className="h-3 w-3 text-destructive flex-shrink-0" />
+                        {t("projectLandingPage.needsLoom")}
+                      </p>
+                    )}
+                  </div>
+                )}
+                <Button
+                  variant="success"
+                  disabled={!canStart || startMutation.isPending}
+                  onClick={() => startMutation.mutate()}
+                >
+                  <AppIcons.projectActive className="h-4 w-4 mr-1.5" />
+                  {startMutation.isPending ? t("common.working") : t("projectLandingPage.startWeaving")}
+                </Button>
+              </>
+            );
+          })()}
+          {project.status === "active" && (
             <Link
               to={`/projects/${project.id}/track`}
-              className={cn(buttonVariants({ variant: project.status === "created" ? "success" : "default" }))}
+              className={cn(buttonVariants({ variant: "default" }))}
             >
               <AppIcons.projectActive className="h-4 w-4 mr-1.5" />
-              {project.status === "created" ? t("projectLandingPage.startWeaving") : t("projectLandingPage.track")}
+              {t("projectLandingPage.track")}
             </Link>
           )}
         </div>
@@ -1760,7 +1941,7 @@ export function ProjectLandingPage() {
               ? projectDrawdownSvgUrl(project.id)
               : drawdownSvgUrl(project.id, 8)
           }
-          title={project.draft_name}
+          title={project.draft_name ?? project.name}
           onClose={() => setDrawdownOpen(false)}
         />
       )}
@@ -1768,7 +1949,7 @@ export function ProjectLandingPage() {
       {tieupOpen && (
         <TieUpModal
           projectId={project.id}
-          draftName={project.draft_name}
+          draftName={project.draft_name ?? ""}
           onClose={() => setTieupOpen(false)}
         />
       )}

--- a/frontend/src/pages/ProjectLandingPage.tsx
+++ b/frontend/src/pages/ProjectLandingPage.tsx
@@ -31,6 +31,12 @@ import { ShareModal } from "@/components/projects/ShareModal";
 import { addProjectToCollection, removeProjectFromCollection } from "@/api/collections";
 import { AddToCollectionModal } from "@/components/collections/AddToCollectionModal";
 
+// PascalCase aliases so they satisfy the react/jsx-pascal-case rule when used as JSX elements
+const CloseIcon = AppIcons.close;
+const ChevronRightIcon = AppIcons.chevronRight;
+const YarnIcon = AppIcons.yarn;
+const ProjectActiveIcon = AppIcons.projectActive;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -320,7 +326,7 @@ function DrawdownModal({ svgUrl, title = "Design preview", onClose }: {
             onClick={onClose}
             title="Close"
           >
-            <AppIcons.close className="h-4 w-4" />
+            <CloseIcon className="h-4 w-4" />
           </button>
         </div>
 
@@ -385,7 +391,7 @@ function TieUpModal({ projectId, draftName, onClose }: {
         <div className="flex items-center justify-between px-4 py-3 border-b border-border">
           <h2 className="font-semibold text-sm">{t("projectLandingPage.tieUpTitle", { name: draftName })}</h2>
           <button onClick={onClose} className="text-muted-foreground hover:text-foreground" aria-label="Close">
-            <AppIcons.close className="h-4 w-4" />
+            <CloseIcon className="h-4 w-4" />
           </button>
         </div>
         <div className="flex-1 overflow-auto p-5">
@@ -663,6 +669,14 @@ function ColorPaletteSection({
                     const displayName = hasPending
                       ? (pendingEntry?.yarn.name ?? null)
                       : (serverLinked?.yarn_name ?? null);
+                    let yarnLabel;
+                    if (isUnlinkPending && serverLinked) {
+                      yarnLabel = <span className="truncate max-w-[100px] text-muted-foreground line-through">{serverLinked.yarn_name}</span>;
+                    } else if (displayName) {
+                      yarnLabel = <span className={`truncate max-w-[100px] ${hasPending ? "text-accent" : "text-card-foreground"}`}>{displayName}</span>;
+                    } else {
+                      yarnLabel = <span className="text-muted-foreground">{t("projectLandingPage.linkYarn")}</span>;
+                    }
                     return (
                       <td className="px-3 py-2">
                         <button
@@ -672,16 +686,8 @@ function ColorPaletteSection({
                           onClick={() => setYarnPickerHex(c.hex)}
                           title={displayName ?? t("projectLandingPage.linkYarn")}
                         >
-                          <AppIcons.yarn className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
-                          {isUnlinkPending && serverLinked ? (
-                            <span className="truncate max-w-[100px] text-muted-foreground line-through">{serverLinked.yarn_name}</span>
-                          ) : displayName ? (
-                            <span className={`truncate max-w-[100px] ${hasPending ? "text-accent" : "text-card-foreground"}`}>
-                              {displayName}
-                            </span>
-                          ) : (
-                            <span className="text-muted-foreground">{t("projectLandingPage.linkYarn")}</span>
-                          )}
+                          <YarnIcon className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+                          {yarnLabel}
                           {hasPending && <span className="text-[10px] text-accent">•</span>}
                         </button>
                       </td>
@@ -703,7 +709,7 @@ function ColorPaletteSection({
               className="rounded p-0.5 text-muted-foreground hover:text-foreground"
               onClick={() => setPreviewOpen(false)}
             >
-              <AppIcons.close className="h-4 w-4" />
+              <CloseIcon className="h-4 w-4" />
             </button>
           </div>
           <div className="p-3">
@@ -1220,8 +1226,8 @@ function DraftSequenceSection({
   project,
   onUpdated,
 }: {
-  project: ProjectDetail;
-  onUpdated: (updated: ProjectDetail) => void;
+  readonly project: ProjectDetail;
+  readonly onUpdated: (updated: ProjectDetail) => void;
 }) {
   const { t } = useTranslation();
   const [addDraftId, setAddDraftId] = useState("");
@@ -1280,7 +1286,7 @@ function DraftSequenceSection({
                 className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30"
                 title={t("projectLandingPage.moveUp")}
               >
-                <AppIcons.chevronRight className="h-3.5 w-3.5 -rotate-90" />
+                <ChevronRightIcon className="h-3.5 w-3.5 -rotate-90" />
               </button>
               <button
                 onClick={() => moveEntry(idx, 1)}
@@ -1288,7 +1294,7 @@ function DraftSequenceSection({
                 className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30"
                 title={t("projectLandingPage.moveDown")}
               >
-                <AppIcons.chevronRight className="h-3.5 w-3.5 rotate-90" />
+                <ChevronRightIcon className="h-3.5 w-3.5 rotate-90" />
               </button>
               <button
                 onClick={() => removeMutation.mutate(entry.id)}
@@ -1296,7 +1302,7 @@ function DraftSequenceSection({
                 className="p-0.5 text-destructive hover:text-destructive/70 ml-1"
                 title={t("common.remove")}
               >
-                <AppIcons.close className="h-3.5 w-3.5" />
+                <CloseIcon className="h-3.5 w-3.5" />
               </button>
             </div>
           )}
@@ -1406,7 +1412,7 @@ function NotesSection({
 
 export function ProjectLandingPage() {
   const { t } = useTranslation();
-  const { id } = useParams<{ id: string }>();
+  const { id = "" } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { user } = useAuthContext();
   const qc = useQueryClient();
@@ -1421,7 +1427,7 @@ export function ProjectLandingPage() {
 
   const { data: project, isLoading, error } = useQuery({
     queryKey: ["project", id],
-    queryFn: () => getProject(id!),
+    queryFn: () => getProject(id),
     enabled: !!id,
   });
 
@@ -1433,9 +1439,9 @@ export function ProjectLandingPage() {
       replacements: Record<string, string>;
       yarnLinks: Record<string, string | null>;
     }) => {
-      const calls: Promise<unknown>[] = [setProjectColorReplacements(id!, replacements)];
+      const calls: Promise<unknown>[] = [setProjectColorReplacements(id, replacements)];
       for (const [colorHex, yarnId] of Object.entries(yarnLinks)) {
-        calls.push(yarnId !== null ? linkYarnColor(id!, colorHex, yarnId) : unlinkYarnColor(id!, colorHex));
+        calls.push(yarnId !== null ? linkYarnColor(id, colorHex, yarnId) : unlinkYarnColor(id, colorHex));
       }
       await Promise.all(calls);
     },
@@ -1443,7 +1449,7 @@ export function ProjectLandingPage() {
   });
 
   const tagsMutation = useMutation({
-    mutationFn: (tags: string[]) => updateProjectTags(id!, tags),
+    mutationFn: (tags: string[]) => updateProjectTags(id, tags),
     onSuccess: (updated) => {
       qc.setQueryData(["project", id], updated);
       qc.invalidateQueries({ queryKey: ["projects"] });
@@ -1452,7 +1458,7 @@ export function ProjectLandingPage() {
   });
 
   const deleteMutation = useMutation({
-    mutationFn: () => deleteProject(id!),
+    mutationFn: () => deleteProject(id),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["projects"] });
       navigate("/projects");
@@ -1465,7 +1471,7 @@ export function ProjectLandingPage() {
   const [statusActionError, setStatusActionError] = useState<string | null>(null);
 
   const completeMutation = useMutation({
-    mutationFn: (force: boolean) => completeProject(id!, force),
+    mutationFn: (force: boolean) => completeProject(id, force),
     onSuccess: (updated) => {
       qc.setQueryData(["project", id], updated);
       qc.invalidateQueries({ queryKey: ["projects"] });
@@ -1479,7 +1485,7 @@ export function ProjectLandingPage() {
   });
 
   const abandonMutation = useMutation({
-    mutationFn: () => abandonProject(id!),
+    mutationFn: () => abandonProject(id),
     onSuccess: (updated) => {
       qc.setQueryData(["project", id], updated);
       qc.invalidateQueries({ queryKey: ["projects"] });
@@ -1492,7 +1498,7 @@ export function ProjectLandingPage() {
   });
 
   const startMutation = useMutation({
-    mutationFn: () => startProject(id!),
+    mutationFn: () => startProject(id),
     onSuccess: (updated) => {
       qc.setQueryData(["project", id], updated);
       qc.invalidateQueries({ queryKey: ["projects"] });
@@ -1543,7 +1549,7 @@ export function ProjectLandingPage() {
           className="mt-0.5 flex-shrink-0"
           onClick={() => navigate("/projects")}
         >
-          <AppIcons.chevronRight className="h-4 w-4 rotate-180" />
+          <ChevronRightIcon className="h-4 w-4 rotate-180" />
         </Button>
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-2 mb-1">
@@ -1570,13 +1576,14 @@ export function ProjectLandingPage() {
           </div>
           <h1 className="text-xl font-semibold leading-tight truncate">{project.name}</h1>
           <p className="text-sm text-muted-foreground mt-0.5">
-            {project.draft_id ? (
+            {project.draft_id && (
               <Link to={`/drafts/${project.draft_id}`} className="hover:underline">
                 {project.draft_name ?? t("projectLandingPage.multidraft", { count: project.draft_count })}
               </Link>
-            ) : project.draft_count > 0 ? (
+            )}
+            {!project.draft_id && project.draft_count > 0 && (
               <span>{t("projectLandingPage.multidraft", { count: project.draft_count })}</span>
-            ) : null}
+            )}
             {project.loom_name && <span> · {project.loom_name}</span>}
           </p>
           {!editingTags && (
@@ -1898,13 +1905,13 @@ export function ProjectLandingPage() {
                     <p className="font-medium text-muted-foreground text-xs uppercase tracking-wide">{t("projectLandingPage.beforeStarting")}</p>
                     {missingDrafts && (
                       <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                        <AppIcons.close className="h-3 w-3 text-destructive flex-shrink-0" />
+                        <CloseIcon className="h-3 w-3 text-destructive flex-shrink-0" />
                         {t("projectLandingPage.needsDrafts")}
                       </p>
                     )}
                     {missingLoom && (
                       <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                        <AppIcons.close className="h-3 w-3 text-destructive flex-shrink-0" />
+                        <CloseIcon className="h-3 w-3 text-destructive flex-shrink-0" />
                         {t("projectLandingPage.needsLoom")}
                       </p>
                     )}
@@ -1915,7 +1922,7 @@ export function ProjectLandingPage() {
                   disabled={!canStart || startMutation.isPending}
                   onClick={() => startMutation.mutate()}
                 >
-                  <AppIcons.projectActive className="h-4 w-4 mr-1.5" />
+                  <ProjectActiveIcon className="h-4 w-4 mr-1.5" />
                   {startMutation.isPending ? t("common.working") : t("projectLandingPage.startWeaving")}
                 </Button>
               </>
@@ -1926,7 +1933,7 @@ export function ProjectLandingPage() {
               to={`/projects/${project.id}/track`}
               className={cn(buttonVariants({ variant: "default" }))}
             >
-              <AppIcons.projectActive className="h-4 w-4 mr-1.5" />
+              <ProjectActiveIcon className="h-4 w-4 mr-1.5" />
               {t("projectLandingPage.track")}
             </Link>
           )}

--- a/frontend/src/pages/ProjectLandingPage.tsx
+++ b/frontend/src/pages/ProjectLandingPage.tsx
@@ -1247,26 +1247,20 @@ function ReedSelector({
 type SequenceRowBaseProps = {
   entry: ProjectDraftSchema;
   idx: number;
-  total: number;
   isEditable: boolean;
   projectId: string;
   onUpdated: (p: ProjectDetail) => void;
   onRemove: (id: string) => void;
-  onMove: (idx: number, dir: -1 | 1) => void;
-  reorderPending: boolean;
   removePending: boolean;
 };
 
 function SequenceRow({
   entry,
   idx,
-  total,
   isEditable,
   projectId,
   onUpdated,
   onRemove,
-  onMove,
-  reorderPending,
   removePending,
   setNodeRef,
   dragStyle,
@@ -1352,32 +1346,14 @@ function SequenceRow({
               title={t("projectLandingPage.increaseRepeats")}
             >+</button>
           </div>
-          <div className="flex items-center gap-0.5 flex-shrink-0">
-            <button
-              onClick={() => onMove(idx, -1)}
-              disabled={idx === 0 || reorderPending}
-              className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30"
-              title={t("projectLandingPage.moveUp")}
-            >
-              <ChevronRightIcon className="h-3.5 w-3.5 -rotate-90" />
-            </button>
-            <button
-              onClick={() => onMove(idx, 1)}
-              disabled={idx === total - 1 || reorderPending}
-              className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30"
-              title={t("projectLandingPage.moveDown")}
-            >
-              <ChevronRightIcon className="h-3.5 w-3.5 rotate-90" />
-            </button>
-            <button
-              onClick={() => onRemove(entry.id)}
-              disabled={removePending}
-              className="p-0.5 text-destructive hover:text-destructive/70 ml-1"
-              title={t("common.remove")}
-            >
-              <CloseIcon className="h-3.5 w-3.5" />
-            </button>
-          </div>
+          <button
+            onClick={() => onRemove(entry.id)}
+            disabled={removePending}
+            className="p-1.5 ml-3 rounded text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors flex-shrink-0"
+            title={t("common.remove")}
+          >
+            <CloseIcon className="h-3.5 w-3.5" />
+          </button>
         </>
       )}
     </div>
@@ -1439,13 +1415,6 @@ function DraftSequenceSection({
   const seq: ProjectDraftSchema[] = project.draft_sequence ?? [];
   const activeEntry = activeId ? (seq.find((e) => e.id === activeId) ?? null) : null;
 
-  function moveEntry(idx: number, direction: -1 | 1) {
-    const ids = seq.map((e) => e.id);
-    const swapIdx = idx + direction;
-    [ids[idx], ids[swapIdx]] = [ids[swapIdx], ids[idx]];
-    reorderMutation.mutate(ids);
-  }
-
   function handleDragEnd({ active, over }: DragEndEvent) {
     setActiveId(null);
     if (!over || active.id === over.id) return;
@@ -1455,13 +1424,11 @@ function DraftSequenceSection({
     reorderMutation.mutate(arrayMove(seq.map((e) => e.id), oldIndex, newIndex));
   }
 
-  const sharedRowProps: Omit<SequenceRowBaseProps, "entry" | "idx" | "total"> = {
+  const sharedRowProps: Omit<SequenceRowBaseProps, "entry" | "idx"> = {
     isEditable,
     projectId: project.id,
     onUpdated,
     onRemove: (id: string) => removeMutation.mutate(id),
-    onMove: moveEntry,
-    reorderPending: reorderMutation.isPending,
     removePending: removeMutation.isPending,
   };
 
@@ -1487,7 +1454,6 @@ function DraftSequenceSection({
                 key={entry.id}
                 entry={entry}
                 idx={idx}
-                total={seq.length}
                 {...sharedRowProps}
               />
             ))}
@@ -1499,7 +1465,6 @@ function DraftSequenceSection({
               <SequenceRow
                 entry={activeEntry}
                 idx={seq.findIndex((e) => e.id === activeEntry.id)}
-                total={seq.length}
                 {...sharedRowProps}
               />
             </div>

--- a/frontend/src/pages/ProjectLandingPage.tsx
+++ b/frontend/src/pages/ProjectLandingPage.tsx
@@ -34,6 +34,7 @@ import { AddToCollectionModal } from "@/components/collections/AddToCollectionMo
 // PascalCase aliases so they satisfy the react/jsx-pascal-case rule when used as JSX elements
 const CloseIcon = AppIcons.close;
 const ChevronRightIcon = AppIcons.chevronRight;
+const GripIcon = AppIcons.grip;
 const YarnIcon = AppIcons.yarn;
 const ProjectActiveIcon = AppIcons.projectActive;
 
@@ -1236,6 +1237,12 @@ function SequenceRow({
   onMove,
   reorderPending,
   removePending,
+  isDragging,
+  isOver,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd,
 }: {
   readonly entry: ProjectDraftSchema;
   readonly idx: number;
@@ -1247,6 +1254,12 @@ function SequenceRow({
   readonly onMove: (idx: number, dir: -1 | 1) => void;
   readonly reorderPending: boolean;
   readonly removePending: boolean;
+  readonly isDragging: boolean;
+  readonly isOver: boolean;
+  readonly onDragStart: () => void;
+  readonly onDragOver: (e: React.DragEvent) => void;
+  readonly onDrop: () => void;
+  readonly onDragEnd: () => void;
 }) {
   const { t } = useTranslation();
   const [repeats, setRepeats] = useState(String(entry.repeats));
@@ -1269,7 +1282,21 @@ function SequenceRow({
   }
 
   return (
-    <div className="flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2">
+    <div
+      draggable={isEditable}
+      onDragStart={isEditable ? onDragStart : undefined}
+      onDragOver={isEditable ? onDragOver : undefined}
+      onDrop={isEditable ? onDrop : undefined}
+      onDragEnd={isEditable ? onDragEnd : undefined}
+      className={cn(
+        "flex items-center gap-2 rounded-md border bg-card px-3 py-2 transition-colors",
+        isOver ? "border-ring bg-accent/20" : "border-border",
+        isDragging ? "opacity-40" : "opacity-100",
+      )}
+    >
+      {isEditable && (
+        <GripIcon className="h-4 w-4 text-muted-foreground flex-shrink-0 cursor-grab active:cursor-grabbing" />
+      )}
       <span className="text-xs font-mono text-muted-foreground w-5 flex-shrink-0">{idx + 1}.</span>
       <span className="flex-1 text-sm truncate">{entry.draft_name}</span>
       <span className="text-xs text-muted-foreground flex-shrink-0">
@@ -1343,6 +1370,8 @@ function DraftSequenceSection({
 }) {
   const { t } = useTranslation();
   const [addDraftId, setAddDraftId] = useState("");
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [overIndex, setOverIndex] = useState<number | null>(null);
   const isEditable = project.status === "created";
 
   const { data: drafts = [] } = useQuery({
@@ -1375,6 +1404,20 @@ function DraftSequenceSection({
     reorderMutation.mutate(ids);
   }
 
+  function handleDrop(dropIdx: number) {
+    if (dragIndex === null || dragIndex === dropIdx) {
+      setDragIndex(null);
+      setOverIndex(null);
+      return;
+    }
+    const ids = seq.map((e) => e.id);
+    const [moved] = ids.splice(dragIndex, 1);
+    ids.splice(dropIdx, 0, moved);
+    reorderMutation.mutate(ids);
+    setDragIndex(null);
+    setOverIndex(null);
+  }
+
   return (
     <section className="space-y-2">
       <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
@@ -1396,6 +1439,12 @@ function DraftSequenceSection({
           onMove={moveEntry}
           reorderPending={reorderMutation.isPending}
           removePending={removeMutation.isPending}
+          isDragging={dragIndex === idx}
+          isOver={overIndex === idx && dragIndex !== idx}
+          onDragStart={() => setDragIndex(idx)}
+          onDragOver={(e) => { e.preventDefault(); setOverIndex(idx); }}
+          onDrop={() => handleDrop(idx)}
+          onDragEnd={() => { setDragIndex(null); setOverIndex(null); }}
         />
       ))}
       {isEditable && (

--- a/frontend/src/pages/ProjectLandingPage.tsx
+++ b/frontend/src/pages/ProjectLandingPage.tsx
@@ -365,10 +365,11 @@ function DrawdownModal({ svgUrl, title = "Design preview", onClose }: {
 // Tie-up modal
 // ---------------------------------------------------------------------------
 
-function TieUpModal({ projectId, draftName, onClose }: {
-  projectId: string;
-  draftName: string;
-  onClose: () => void;
+function TieUpModal({ projectId, draftName, showWarpPlanLink, onClose }: {
+  readonly projectId: string;
+  readonly draftName: string;
+  readonly showWarpPlanLink: boolean;
+  readonly onClose: () => void;
 }) {
   const { t } = useTranslation();
   const { data: plan, isLoading } = useQuery({
@@ -420,24 +421,26 @@ function TieUpModal({ projectId, draftName, onClose }: {
             </>
           )}
         </div>
-        <div className="flex items-center justify-end gap-2 px-4 py-3 border-t border-border">
-          <Link
-            to={`/projects/${projectId}/warping-plan`}
-            className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2"
-          >
-            {t("projectLandingPage.viewWeavePlan")}
-          </Link>
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => {
-              window.open(`/projects/${projectId}/warping-plan`, "_blank");
-            }}
-          >
-            <AppIcons.print className="h-4 w-4 mr-1.5" />
-            {t("projectLandingPage.printSavePdf")}
-          </Button>
-        </div>
+        {showWarpPlanLink && (
+          <div className="flex items-center justify-end gap-2 px-4 py-3 border-t border-border">
+            <Link
+              to={`/projects/${projectId}/warping-plan`}
+              className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2"
+            >
+              {t("projectLandingPage.viewWeavePlan")}
+            </Link>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                window.open(`/projects/${projectId}/warping-plan`, "_blank");
+              }}
+            >
+              <AppIcons.print className="h-4 w-4 mr-1.5" />
+              {t("projectLandingPage.printSavePdf")}
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   );
@@ -1888,12 +1891,14 @@ export function ProjectLandingPage() {
               {t("projectLandingPage.markComplete")}
             </Button>
           )}
-          <Link
-            to={`/projects/${project.id}/warping-plan`}
-            className={cn(buttonVariants({ variant: "outline" }), "ml-auto")}
-          >
-            {t("projectLandingPage.weavePlan")}
-          </Link>
+          {project.draft_count === 1 && (
+            <Link
+              to={`/projects/${project.id}/warping-plan`}
+              className={cn(buttonVariants({ variant: "outline" }), "ml-auto")}
+            >
+              {t("projectLandingPage.weavePlan")}
+            </Link>
+          )}
           {project.status === "created" && (() => {
             const missingDrafts = project.draft_sequence.length === 0;
             const missingLoom = !project.loom_id;
@@ -1957,6 +1962,7 @@ export function ProjectLandingPage() {
         <TieUpModal
           projectId={project.id}
           draftName={project.draft_name ?? ""}
+          showWarpPlanLink={project.draft_count === 1}
           onClose={() => setTieupOpen(false)}
         />
       )}

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -364,7 +364,6 @@ export function ProjectsPage() {
       {assigningProjectId && (
         <AssignLoomModal
           projectId={assigningProjectId}
-          activeProjects={projects.filter((p) => p.status === "active")}
           onSuccess={() => { setAssigningProjectId(null); queryClient.invalidateQueries({ queryKey: ["projects"] }); }}
           onClose={() => setAssigningProjectId(null)}
         />

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -61,6 +61,13 @@ function ProjectCard({ project, onAssign }: {
     ? Math.round((Math.min(project.current_pick - 1, project.total_picks) / project.total_picks) * 100)
     : 0;
 
+  let previewSrc = "";
+  if (project.has_drawdown_preview) {
+    previewSrc = projectDrawdownPreviewUrl(project.id);
+  } else if (project.draft_id) {
+    previewSrc = previewUrl(project.draft_id);
+  }
+
   return (
     <div className="relative rounded-lg border hover:border-ring transition-colors overflow-hidden">
       {project.has_drawdown_preview && (
@@ -162,7 +169,7 @@ function ProjectCard({ project, onAssign }: {
             </button>
             <p className="absolute -top-9 left-0 text-white/70 text-sm truncate max-w-xs">{project.name}</p>
             <AuthedImage
-              src={project.has_drawdown_preview ? projectDrawdownPreviewUrl(project.id) : (project.draft_id ? previewUrl(project.draft_id) : "")}
+              src={previewSrc}
               alt={t("projectsPage.previewAriaLabel")}
               className="w-full rounded-lg shadow-2xl"
               style={{ imageRendering: "pixelated" }}

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -105,7 +105,7 @@ function ProjectCard({ project, onAssign }: {
                 </span>
               </div>
             </div>
-            <p className="mt-0.5 text-sm text-muted-foreground">{PROJECT_TYPE_LABELS[project.project_type]}</p>
+            {project.project_type && <p className="mt-0.5 text-sm text-muted-foreground">{PROJECT_TYPE_LABELS[project.project_type]}</p>}
             {endDate && (
               <p className="mt-0.5 text-xs text-muted-foreground">{fmtDate(endDate)}</p>
             )}
@@ -162,7 +162,7 @@ function ProjectCard({ project, onAssign }: {
             </button>
             <p className="absolute -top-9 left-0 text-white/70 text-sm truncate max-w-xs">{project.name}</p>
             <AuthedImage
-              src={project.has_drawdown_preview ? projectDrawdownPreviewUrl(project.id) : previewUrl(project.draft_id)}
+              src={project.has_drawdown_preview ? projectDrawdownPreviewUrl(project.id) : (project.draft_id ? previewUrl(project.draft_id) : "")}
               alt={t("projectsPage.previewAriaLabel")}
               className="w-full rounded-lg shadow-2xl"
               style={{ imageRendering: "pixelated" }}


### PR DESCRIPTION
## Summary

- Replaces the single `draft_id` FK on `Project` with a `ProjectDraft` sequence table, enabling projects to contain multiple drafts with per-draft ordering, repeats, and pick tracking
- Adds full sequence CRUD API (`POST/PATCH/DELETE /{id}/sequence`, `POST /{id}/sequence/reorder`, `POST /{id}/sequence/{seq_id}/activate`)
- Frontend: `CreateProjectModal` no longer requires a draft upfront; `ProjectLandingPage` shows a Start Tracking gate with an "Add a draft" checklist item and a sequence management section
- Hides "Weave Plan" links (main actions, TieUpModal footer) when `draft_count > 1` — warp plan is single-draft-specific
- 31 new backend tests in `test_project_sequence.py`; all 1217 tests pass

## Key technical notes

- **Two-phase position swap**: PostgreSQL's non-deferrable `uq_project_draft_position` unique constraint checks per-row even within a single UPDATE; the reorder endpoint negates all positions first (phase 1), then sets final values (phase 2) to avoid collisions
- **`db.expire_all()` after raw SQL**: After phase 2 raw SQL updates, `_load_sequence` must reload from DB — SQLAlchemy's identity map would otherwise return stale in-memory positions
- **`await db.flush()` before renumber**: `autoflush=False` in test sessions means a deleted `ProjectDraft` stays in the DB until explicitly flushed, causing unique constraint violations during position renumbering

## Test plan

- [ ] Create a new project — no draft picker shown; project created in `created` state
- [ ] On ProjectLandingPage, confirm "Add a draft" checklist item is present for a project with no drafts
- [ ] Add a draft to the project sequence; confirm it appears and Start Tracking gate unlocks
- [ ] Add multiple drafts; reorder them; verify positions update correctly
- [ ] Remove an entry; verify remaining entries are renumbered 1..n
- [ ] Share a project with a draft attached — confirm 200; share a project with no drafts — confirm 400
- [ ] Run `pytest tests/routers/test_project_sequence.py -v` — all 31 pass
- [ ] For a multi-draft project, confirm "Weave Plan" button is hidden in the header and TieUpModal footer

Closes #994

🤖 Generated with [Claude Code](https://claude.com/claude-code)