### PR TITLE
feat: HSL-derived tag colors in TagChips and TagInput (#993)

### DIFF
--- a/frontend/src/components/ui/TagChips.tsx
+++ b/frontend/src/components/ui/TagChips.tsx
@@ -4,6 +4,16 @@ interface Props {
   className?: string;
 }
 
+function tagColor(tag: string): { background: string; color: string } {
+  let h = 0;
+  for (let i = 0; i < tag.length; i++) h = (h * 31 + tag.charCodeAt(i)) >>> 0;
+  const hue = h % 360;
+  return {
+    background: `hsl(${hue}, 60%, 88%)`,
+    color: `hsl(${hue}, 55%, 30%)`,
+  };
+}
+
 export function TagChips({ tags, max = 3, className = "" }: Props) {
   if (!tags.length) return null;
   const visible = tags.slice(0, max);
@@ -11,7 +21,7 @@ export function TagChips({ tags, max = 3, className = "" }: Props) {
   return (
     <div className={`flex flex-wrap gap-1 ${className}`}>
       {visible.map((t) => (
-        <span key={t} className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+        <span key={t} className="rounded px-1.5 py-0.5 text-xs font-medium" style={tagColor(t)}>
           {t}
         </span>
       ))}

--- a/frontend/src/components/ui/TagInput.tsx
+++ b/frontend/src/components/ui/TagInput.tsx
@@ -1,6 +1,13 @@
 import { useState, useRef } from "react";
 import { AppIcons } from "@/lib/icons";
 
+function tagColor(tag: string): { background: string; color: string } {
+  let h = 0;
+  for (let i = 0; i < tag.length; i++) h = (h * 31 + tag.charCodeAt(i)) >>> 0;
+  const hue = h % 360;
+  return { background: `hsl(${hue}, 60%, 88%)`, color: `hsl(${hue}, 55%, 30%)` };
+}
+
 interface Props {
   tags: string[];
   onChange: (tags: string[]) => void;
@@ -41,7 +48,8 @@ export function TagInput({ tags, onChange, placeholder = "Add a tag…", disable
       {tags.map((tag) => (
         <span
           key={tag}
-          className="flex items-center gap-1 rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+          className="flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium"
+          style={tagColor(tag)}
         >
           {tag}
           {!disabled && (


### PR DESCRIPTION
## Summary

- Tags derive a unique pastel background/text color pair from a deterministic hash of the tag string (djb2-style)
- Background: hsl(h, 60%, 88%) always a soft pastel; text: hsl(h, 55%, 30%) same hue darkened for contrast
- Same tag string -> same color on every page and every entity type (project, draft, collection)
- Colors appear immediately in TagInput edit mode (as chips are accepted) and in TagChips read-only display
- Zero DB changes - computed at render time; all existing tags colored automatically

## Files changed

- `frontend/src/components/ui/TagChips.tsx` - replaced hardcoded bg-muted with inline HSL style
- `frontend/src/components/ui/TagInput.tsx` - same, for the edit-mode chip spans

## Test plan

- [ ] Add tags to a project - chips show distinct pastel colors in the edit input
- [ ] Save and verify read-only TagChips shows the same colors
- [ ] Same tag string on different entities shows the same color
- [ ] Overflow +N chip remains neutral (bg-muted)

Generated with [Claude Code](https://claude.com/claude-code)