### PR TITLE
feat: optional Neon compute-usage dashboard, decoupled from POSTGRES_DSN

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -115,6 +115,13 @@ class Settings(BaseSettings):
             f"@{self.postgres_host}:{self.postgres_port}/{self.postgres_db}"
         )
 
+    # Neon usage dashboard (optional, independent of POSTGRES_DSN — see #1015).
+    # Purely observational: reads Neon's Consumption Metrics API for cost visibility.
+    # Blank by default; leave unset if not using Neon or not interested in this view.
+    neon_api_key: str = ""
+    neon_org_id: str = ""
+    neon_project_id: str = ""  # optional — filters to a single project when set
+
     # Clerk authentication
     clerk_publishable_key: str = ""
     clerk_secret_key: str = ""

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -137,6 +137,20 @@ class AdminDbInfoResponse(BaseModel):
     last_migrated_at: str | None
 
 
+class NeonUsageDay(BaseModel):
+    date: str
+    compute_seconds: float
+
+
+class NeonUsageResponse(BaseModel):
+    configured: bool
+    project_id: str | None = None
+    period_start: str | None = None
+    total_compute_seconds: float = 0.0
+    daily: list[NeonUsageDay] = []
+    error: str | None = None
+
+
 class StorageReportFile(BaseModel):
     entity_type: str
     entity_id: uuid.UUID
@@ -1625,6 +1639,77 @@ async def get_db_info(
     )
 
 
+NEON_CONSUMPTION_URL = "https://console.neon.tech/api/v2/consumption_history/v2/projects"
+
+
+async def _fetch_neon_usage(settings: Settings) -> NeonUsageResponse:
+    """Query Neon's Consumption Metrics API for the trailing 30 days of compute usage.
+
+    Entirely independent of POSTGRES_DSN — reads only the neon_api_key/neon_org_id
+    settings, which are unrelated to which Postgres the app actually connects to.
+    """
+    if not settings.neon_api_key or not settings.neon_org_id:
+        return NeonUsageResponse(configured=False)
+
+    now = datetime.now(timezone.utc)
+    from_dt = now - timedelta(days=30)
+    params: dict[str, str] = {
+        "from": from_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "to": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "granularity": "daily",
+        "org_id": settings.neon_org_id,
+        "metrics": "compute_unit_seconds",
+    }
+    if settings.neon_project_id:
+        params["project_ids"] = settings.neon_project_id
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            r = await client.get(
+                NEON_CONSUMPTION_URL,
+                params=params,
+                headers={"Authorization": f"Bearer {settings.neon_api_key}", "Accept": "application/json"},
+            )
+        if r.status_code != 200:
+            return NeonUsageResponse(configured=True, error=f"Neon API returned HTTP {r.status_code}")
+        data = r.json()
+    except httpx.TimeoutException:
+        return NeonUsageResponse(configured=True, error="Timed out after 10 s")
+    except Exception as exc:
+        return NeonUsageResponse(configured=True, error=str(exc)[:200])
+
+    daily: list[NeonUsageDay] = []
+    total = 0.0
+    project_id_out: str | None = None
+    period_start_out: str | None = None
+    for project in data.get("projects", []):
+        if settings.neon_project_id and project.get("project_id") != settings.neon_project_id:
+            continue
+        project_id_out = project.get("project_id")
+        for period in project.get("periods", []):
+            period_start_out = period.get("period_start")
+            for point in period.get("consumption", []):
+                value = 0.0
+                for m in point.get("metrics", []):
+                    if m.get("metric_name") == "compute_unit_seconds":
+                        value = float(m.get("value", 0))
+                daily.append(NeonUsageDay(date=point.get("timeframe_start", ""), compute_seconds=value))
+                total += value
+
+    return NeonUsageResponse(
+        configured=True,
+        project_id=project_id_out,
+        period_start=period_start_out,
+        total_compute_seconds=total,
+        daily=daily,
+    )
+
+
+@router.get("/neon-usage", response_model=NeonUsageResponse)
+async def get_neon_usage(_: User = Depends(require_admin)) -> NeonUsageResponse:
+    return await _fetch_neon_usage(get_settings())
+
+
 # ---------------------------------------------------------------------------
 # Clerk ↔ DB reconciliation (superuser only)
 # ---------------------------------------------------------------------------
@@ -2943,11 +3028,41 @@ async def _test_github(v: dict) -> ConfigTestResult:
         return ConfigTestResult(ok=False, message=str(exc))
 
 
+async def _test_neon(v: dict) -> ConfigTestResult:
+    try:
+        api_key = v.get("neon_api_key") or ""
+        org_id = v.get("neon_org_id") or ""
+        if not api_key or not org_id:
+            return ConfigTestResult(ok=False, message="neon_api_key and neon_org_id are both required")
+        now = datetime.now(timezone.utc)
+        params = {
+            "from": (now - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "to": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "granularity": "daily",
+            "org_id": org_id,
+            "metrics": "compute_unit_seconds",
+        }
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                NEON_CONSUMPTION_URL,
+                params=params,
+                headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
+                timeout=10,
+            )
+        if resp.status_code == 200:
+            project_count = len(resp.json().get("projects", []))
+            return ConfigTestResult(ok=True, message=f"Connected — {project_count} project(s) visible to this org")
+        return ConfigTestResult(ok=False, message=f"Neon API returned {resp.status_code}: {resp.text[:120]}")
+    except Exception as exc:
+        return ConfigTestResult(ok=False, message=str(exc))
+
+
 _SERVICE_TESTS = {
     "smtp": _test_smtp,
     "s3": _test_s3,
     "ravelry_read": _test_ravelry_read,
     "github": _test_github,
+    "neon": _test_neon,
 }
 
 

--- a/backend/app/services/config_file.py
+++ b/backend/app/services/config_file.py
@@ -26,6 +26,7 @@ SECRET_FIELDS = frozenset(
         "github_feedback_token",
         "clerk_webhook_secret",
         "maxmind_license_key",
+        "neon_api_key",
     }
 )
 
@@ -66,6 +67,10 @@ MANAGED_FIELDS: list[str] = [
     "maxmind_license_key",
     # Observability
     "otel_exporter_otlp_endpoint",
+    # Neon usage dashboard (optional — independent of POSTGRES_DSN, see #1015)
+    "neon_api_key",
+    "neon_org_id",
+    "neon_project_id",
 ]
 
 

--- a/backend/tests/routers/test_admin.py
+++ b/backend/tests/routers/test_admin.py
@@ -1165,6 +1165,26 @@ class TestAdminServices:
 
 
 # ---------------------------------------------------------------------------
+# GET /api/admin/neon-usage
+# ---------------------------------------------------------------------------
+
+
+class TestNeonUsageEndpoint:
+    async def test_returns_not_configured_by_default(self, admin_client: AsyncClient):
+        resp = await admin_client.get("/api/admin/neon-usage")
+        assert resp.status_code == 200
+        assert resp.json()["configured"] is False
+
+    async def test_non_admin_returns_403(self, auth_client: AsyncClient):
+        resp = await auth_client.get("/api/admin/neon-usage")
+        assert resp.status_code == 403
+
+    async def test_unauthenticated_returns_401(self, raw_client: AsyncClient):
+        resp = await raw_client.get("/api/admin/neon-usage")
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
 # POST /api/admin/test-email
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/routers/test_admin_probes.py
+++ b/backend/tests/routers/test_admin_probes.py
@@ -932,4 +932,238 @@ class TestConfigServiceSMTP:
             )
 
         assert result.ok is False
-        assert "refused" in result.message
+
+
+# ---------------------------------------------------------------------------
+# _fetch_neon_usage
+# ---------------------------------------------------------------------------
+
+
+class TestFetchNeonUsage:
+    async def test_not_configured_when_key_missing(self, monkeypatch):
+        from app.config import get_settings
+        from app.routers.admin import _fetch_neon_usage
+
+        s = get_settings()
+        monkeypatch.setattr(s, "neon_api_key", "")
+        monkeypatch.setattr(s, "neon_org_id", "")
+        result = await _fetch_neon_usage(s)
+        assert result.configured is False
+
+    async def test_not_configured_when_org_id_missing(self, monkeypatch):
+        from app.config import get_settings
+        from app.routers.admin import _fetch_neon_usage
+
+        s = get_settings()
+        monkeypatch.setattr(s, "neon_api_key", "napi_xyz")
+        monkeypatch.setattr(s, "neon_org_id", "")
+        result = await _fetch_neon_usage(s)
+        assert result.configured is False
+
+    async def test_non_200_returns_error(self, monkeypatch):
+        from app.config import get_settings
+        from app.routers.admin import _fetch_neon_usage
+
+        s = get_settings()
+        monkeypatch.setattr(s, "neon_api_key", "napi_xyz")
+        monkeypatch.setattr(s, "neon_org_id", "org_123")
+        monkeypatch.setattr(s, "neon_project_id", "")
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 401
+            mock_inst = AsyncMock()
+            mock_inst.get = AsyncMock(return_value=mock_resp)
+            mock_inst.__aenter__ = AsyncMock(return_value=mock_inst)
+            mock_inst.__aexit__ = AsyncMock(return_value=None)
+            mock_cls.return_value = mock_inst
+            result = await _fetch_neon_usage(s)
+
+        assert result.configured is True
+        assert result.error is not None
+        assert "401" in result.error
+
+    async def test_timeout_returns_error(self, monkeypatch):
+        import httpx
+
+        from app.config import get_settings
+        from app.routers.admin import _fetch_neon_usage
+
+        s = get_settings()
+        monkeypatch.setattr(s, "neon_api_key", "napi_xyz")
+        monkeypatch.setattr(s, "neon_org_id", "org_123")
+        monkeypatch.setattr(s, "neon_project_id", "")
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_inst = AsyncMock()
+            mock_inst.get = AsyncMock(side_effect=httpx.TimeoutException("timed out"))
+            mock_inst.__aenter__ = AsyncMock(return_value=mock_inst)
+            mock_inst.__aexit__ = AsyncMock(return_value=None)
+            mock_cls.return_value = mock_inst
+            result = await _fetch_neon_usage(s)
+
+        assert result.configured is True
+        assert result.error is not None
+        assert "Timed out" in result.error
+
+    async def test_success_aggregates_daily_totals(self, monkeypatch):
+        from app.config import get_settings
+        from app.routers.admin import _fetch_neon_usage
+
+        s = get_settings()
+        monkeypatch.setattr(s, "neon_api_key", "napi_xyz")
+        monkeypatch.setattr(s, "neon_org_id", "org_123")
+        monkeypatch.setattr(s, "neon_project_id", "")
+
+        payload = {
+            "projects": [
+                {
+                    "project_id": "proj_abc",
+                    "periods": [
+                        {
+                            "period_id": "p1",
+                            "period_plan": "launch",
+                            "period_start": "2026-07-01T00:00:00Z",
+                            "consumption": [
+                                {
+                                    "timeframe_start": "2026-07-01T00:00:00Z",
+                                    "timeframe_end": "2026-07-02T00:00:00Z",
+                                    "metrics": [{"metric_name": "compute_unit_seconds", "value": 100}],
+                                },
+                                {
+                                    "timeframe_start": "2026-07-02T00:00:00Z",
+                                    "timeframe_end": "2026-07-03T00:00:00Z",
+                                    "metrics": [{"metric_name": "compute_unit_seconds", "value": 50}],
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json = MagicMock(return_value=payload)
+            mock_inst = AsyncMock()
+            mock_inst.get = AsyncMock(return_value=mock_resp)
+            mock_inst.__aenter__ = AsyncMock(return_value=mock_inst)
+            mock_inst.__aexit__ = AsyncMock(return_value=None)
+            mock_cls.return_value = mock_inst
+            result = await _fetch_neon_usage(s)
+
+        assert result.configured is True
+        assert result.error is None
+        assert result.project_id == "proj_abc"
+        assert result.total_compute_seconds == 150.0
+        assert len(result.daily) == 2
+
+    async def test_filters_to_configured_project_id(self, monkeypatch):
+        from app.config import get_settings
+        from app.routers.admin import _fetch_neon_usage
+
+        s = get_settings()
+        monkeypatch.setattr(s, "neon_api_key", "napi_xyz")
+        monkeypatch.setattr(s, "neon_org_id", "org_123")
+        monkeypatch.setattr(s, "neon_project_id", "proj_keep")
+
+        payload = {
+            "projects": [
+                {
+                    "project_id": "proj_skip",
+                    "periods": [
+                        {
+                            "period_id": "p1",
+                            "period_plan": "launch",
+                            "period_start": "x",
+                            "consumption": [
+                                {
+                                    "timeframe_start": "d1",
+                                    "timeframe_end": "d2",
+                                    "metrics": [{"metric_name": "compute_unit_seconds", "value": 999}],
+                                }
+                            ],
+                        }
+                    ],
+                },
+                {
+                    "project_id": "proj_keep",
+                    "periods": [
+                        {
+                            "period_id": "p2",
+                            "period_plan": "launch",
+                            "period_start": "y",
+                            "consumption": [
+                                {
+                                    "timeframe_start": "d3",
+                                    "timeframe_end": "d4",
+                                    "metrics": [{"metric_name": "compute_unit_seconds", "value": 42}],
+                                }
+                            ],
+                        }
+                    ],
+                },
+            ],
+        }
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json = MagicMock(return_value=payload)
+            mock_inst = AsyncMock()
+            mock_inst.get = AsyncMock(return_value=mock_resp)
+            mock_inst.__aenter__ = AsyncMock(return_value=mock_inst)
+            mock_inst.__aexit__ = AsyncMock(return_value=None)
+            mock_cls.return_value = mock_inst
+            result = await _fetch_neon_usage(s)
+
+        assert result.project_id == "proj_keep"
+        assert result.total_compute_seconds == 42.0
+
+
+# ---------------------------------------------------------------------------
+# _test_neon
+# ---------------------------------------------------------------------------
+
+
+class TestTestNeon:
+    async def test_missing_credentials_returns_error(self):
+        from app.routers.admin import _test_neon
+
+        result = await _test_neon({"neon_api_key": "", "neon_org_id": ""})
+        assert result.ok is False
+
+    async def test_success(self):
+        from app.routers.admin import _test_neon
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json = MagicMock(return_value={"projects": [{"project_id": "a"}, {"project_id": "b"}]})
+            mock_inst = AsyncMock()
+            mock_inst.get = AsyncMock(return_value=mock_resp)
+            mock_inst.__aenter__ = AsyncMock(return_value=mock_inst)
+            mock_inst.__aexit__ = AsyncMock(return_value=None)
+            mock_cls.return_value = mock_inst
+            result = await _test_neon({"neon_api_key": "napi_xyz", "neon_org_id": "org_123"})
+
+        assert result.ok is True
+        assert "2 project" in result.message
+
+    async def test_non_200_returns_error(self):
+        from app.routers.admin import _test_neon
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 403
+            mock_resp.text = "forbidden"
+            mock_inst = AsyncMock()
+            mock_inst.get = AsyncMock(return_value=mock_resp)
+            mock_inst.__aenter__ = AsyncMock(return_value=mock_inst)
+            mock_inst.__aexit__ = AsyncMock(return_value=None)
+            mock_cls.return_value = mock_inst
+            result = await _test_neon({"neon_api_key": "napi_xyz", "neon_org_id": "org_123"})
+
+        assert result.ok is False
+        assert "403" in result.message

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -71,6 +71,20 @@ export interface AdminDbInfo {
   last_migrated_at: string | null;
 }
 
+export interface NeonUsageDay {
+  date: string;
+  compute_seconds: number;
+}
+
+export interface NeonUsage {
+  configured: boolean;
+  project_id: string | null;
+  period_start: string | null;
+  total_compute_seconds: number;
+  daily: NeonUsageDay[];
+  error: string | null;
+}
+
 export interface InviteRecord {
   id: string;
   email: string;
@@ -86,6 +100,7 @@ export const getAdminStats = () => api.get<AdminStats>("/api/admin/stats");
 export const getAdminHealth = () => api.get<AdminHealth>("/api/admin/health");
 export const getAdminVersions = () => api.get<AdminVersions>("/api/admin/versions");
 export const getAdminDbInfo = () => api.get<AdminDbInfo>("/api/admin/db-info");
+export const getNeonUsage = () => api.get<NeonUsage>("/api/admin/neon-usage");
 export const patchAdminUser = (userId: string, body: { is_active?: boolean; is_admin?: boolean; is_superuser?: boolean }) =>
   api.patch<AdminUser>(`/api/admin/users/${userId}`, body);
 export const banUser = (userId: string) => api.post<AdminUser>(`/api/admin/users/${userId}/ban`, {});

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -19,6 +19,7 @@ import {
   banPendingSignup,
   getAdminServices,
   getAdminDbInfo,
+  getNeonUsage,
   sendTestEmail,
   testWebhook,
   getAuditLog,
@@ -31,6 +32,7 @@ import {
   type AdminUser,
   type AdminHealth,
   type AdminDbInfo,
+  type NeonUsage,
   type AuditLogEntry,
   type InviteRecord,
   type PendingSignup,
@@ -1162,6 +1164,59 @@ function DbInfoPanel() {
   );
 }
 
+function NeonUsagePanel() {
+  const { data } = useQuery<NeonUsage>({
+    queryKey: ["admin", "neon-usage"],
+    queryFn: getNeonUsage,
+    staleTime: 60_000,
+  });
+
+  // Purely optional/observational — hidden entirely unless neon_api_key/neon_org_id
+  // are configured. Independent of which Postgres the app actually connects to.
+  if (!data || !data.configured) return null;
+
+  const totalHours = data.total_compute_seconds / 3600;
+  const maxDaily = Math.max(1, ...data.daily.map((d) => d.compute_seconds));
+
+  return (
+    <div>
+      <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
+        Neon Compute Usage (last 30 days)
+      </h2>
+      {data.error ? (
+        <div className="border rounded-lg px-4 py-2 bg-background text-sm text-destructive">{data.error}</div>
+      ) : (
+        <div className="border rounded-lg overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-2 bg-background border-b">
+            <span className="text-sm">Total compute time</span>
+            <span className="text-xs font-mono text-muted-foreground">{totalHours.toFixed(1)} hours</span>
+          </div>
+          {data.daily.length > 0 && (
+            <div className="px-4 py-2 bg-background space-y-1">
+              {data.daily.map((d) => (
+                <div key={d.date} className="flex items-center gap-2">
+                  <span className="text-xs font-mono text-muted-foreground w-20 shrink-0">
+                    {new Date(d.date).toLocaleDateString(undefined, { month: "short", day: "numeric" })}
+                  </span>
+                  <div className="flex-1 h-2 bg-muted rounded overflow-hidden">
+                    <div
+                      className="h-full bg-accent"
+                      style={{ width: `${Math.max(2, (d.compute_seconds / maxDaily) * 100)}%` }}
+                    />
+                  </div>
+                  <span className="text-xs font-mono text-muted-foreground w-16 text-right">
+                    {(d.compute_seconds / 3600).toFixed(2)}h
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function ServicesTab() {
   // Live status from /health/detailed — auto-refreshes every 30s
   const [detailed, setDetailed] = useState<ReadinessResponse | null>(null);
@@ -1219,6 +1274,7 @@ function ServicesTab() {
       )}
 
       <DbInfoPanel />
+      <NeonUsagePanel />
       <ServerEventsPanel />
     </div>
   );

--- a/frontend/src/pages/SuperuserPage.tsx
+++ b/frontend/src/pages/SuperuserPage.tsx
@@ -1630,6 +1630,11 @@ const GROUP_CONFIG: Record<string, { label: string; fields: string[]; testServic
     fields: ["otel_exporter_otlp_endpoint"],
     testService: null,
   },
+  neon: {
+    label: "Neon Usage Dashboard (optional)",
+    fields: ["neon_api_key", "neon_org_id", "neon_project_id"],
+    testService: "neon",
+  },
 };
 
 const CONFIG_SECRET_FIELDS = new Set([
@@ -1641,6 +1646,7 @@ const CONFIG_SECRET_FIELDS = new Set([
   "github_feedback_token",
   "clerk_webhook_secret",
   "maxmind_license_key",
+  "neon_api_key",
 ]);
 
 // These secrets show prefix + •••••••• when set and reveal as plain text when editing.
@@ -1675,6 +1681,9 @@ const CONFIG_FIELD_LABELS: Record<string, string> = {
   webhook_base_url: "Base URL",
   maxmind_license_key: "License Key",
   otel_exporter_otlp_endpoint: "OTLP Endpoint",
+  neon_api_key: "API Key",
+  neon_org_id: "Organization ID",
+  neon_project_id: "Project ID (optional filter)",
 };
 
 interface ConfigFieldRowProps {


### PR DESCRIPTION
## Summary

Closes #1015. Adds a read-only Neon Consumption Metrics API integration for cost/usage visibility, gated entirely on its own credentials — never on inspecting `POSTGRES_DSN` — so it stays opt-in and disappears with zero code changes if the DSN is ever pointed at a different provider (self-hosted, another managed Postgres, etc.).

- **Backend:** `GET /api/admin/neon-usage` (`require_admin`) queries Neon's consumption API for the trailing 30 days of `compute_unit_seconds`; returns `{"configured": false}` when `neon_api_key`/`neon_org_id` are unset. Registered `neon_api_key` / `neon_org_id` / `neon_project_id` as managed config fields (API key encrypted at rest, same pattern as SMTP/S3/Ravelry/GitHub), plus a "Test connection" handler (`POST /api/admin/config/test/neon`).
- **Frontend:** new "Neon Usage Dashboard (optional)" group in the Superuser Config UI, and a `NeonUsagePanel` in the admin Services tab that renders only when configured — total compute hours for the period plus a simple daily breakdown.

## How it's configured

Superuser → Config → "Neon Usage Dashboard (optional)" — enter API Key, Organization ID, optional Project ID, Test connection, Save (or set `NEON_API_KEY`/`NEON_ORG_ID`/`NEON_PROJECT_ID` env vars directly). Requires a backend restart to take effect, same as every other integration in this config system.

## Test plan

- [x] 58 backend tests pass, 12 new: 6 for `_fetch_neon_usage` (not-configured, timeout, HTTP error, success aggregation, project-id filtering), 3 for `_test_neon` connection check, 3 for the endpoint's admin-auth guard (401/403/200)
- [x] ruff, mypy, eslint, tsc all clean
- [ ] Manual: configure real Neon credentials in a dev/staging admin console and confirm the dashboard renders real data