### PR TITLE
docs: document the www-to-apex redirect requirement for future DNS/CDN migrations

### DIFF
--- a/docs/deployment/hosting-decisions.md
+++ b/docs/deployment/hosting-decisions.md
@@ -84,6 +84,10 @@
 
 **Estimated cost:** $0/mo (free plan covers DNS, CDN, and DDoS protection); ~$11/yr for domain renewal.
 
+**Required: canonical-hostname redirect.** Both `weftmark.com` and `www.weftmark.com` resolve and are independently proxied — without a redirect collapsing one into the other, the backend's Clerk `azp` check (which only accepts the single configured `FRONTEND_URL`) rejects every request from whichever hostname isn't canonical, producing a confusing "stuck on pending approval" symptom with no obvious error (see #1011). A Cloudflare Redirect Rule handles this today: `www.weftmark.com` → `301 https://weftmark.com` (preserving path/query — use a dynamic expression, not a static target, or query strings get silently dropped).
+
+**If migrating to a different DNS/CDN provider:** this redirect must be re-created there. It's easy to forget since it's invisible when working and the failure mode doesn't look like a redirect problem. Re-verify with `curl -I https://www.weftmark.com` (expect `301`/`308` → the apex domain) as part of any provider cutover checklist.
+
 ---
 
 ## 5. Container Registry — GitHub Container Registry (ghcr.io)


### PR DESCRIPTION
## Summary

Follow-up to #1011. The Cloudflare redirect fix (`www.weftmark.com` → `301 https://weftmark.com`) is dashboard config, not code, so it wouldn't automatically carry over if this project ever migrates to a different DNS/CDN provider. Rather than adding a code-level `azp` allow-list (considered and explicitly rejected — see #1011 discussion: it would only cover one of several places `frontend_url` is used, and adds a second source of truth to keep in sync), documented the requirement where hosting decisions already live and opened #1017 as a recurring QA check to catch this class of regression regardless of cause.

## Changes

- `docs/deployment/hosting-decisions.md` — added a note under section 4 (DNS/CDN/TLS) explaining why the redirect is required and flagging it for any future provider migration
- Opened #1017 — durable (non-closeable-once-verified) QA check with the exact `curl` commands to re-run after any DNS/CDN change

## Test plan

Docs-only change, no code touched.