### PR TITLE
fix: recover from PendingPage when Clerk status is already active

### DIFF
--- a/frontend/src/pages/PendingPage.tsx
+++ b/frontend/src/pages/PendingPage.tsx
@@ -33,6 +33,15 @@ export function PendingPage() {
     }
   }, [clerkLoaded, isSignedIn, navigate]);
 
+  // Clerk's own status can flip to "active" before the app's backend-derived
+  // isAuthenticated state catches up (or if that never resolves at all — see #1011).
+  // Without this, an already-approved user who lands here has no way out.
+  useEffect(() => {
+    if (clerkStatus === "active") {
+      navigate("/home", { replace: true });
+    }
+  }, [clerkStatus, navigate]);
+
   useEffect(() => {
     if (!clerkLoaded || !isSignedIn || !clerkUser) return;
     if (clerkStatus !== undefined) return;


### PR DESCRIPTION
## Summary

Closes #1011 (the last remaining item from that issue). `PendingPage.tsx` only branched on `clerkStatus === "denied" || "banned"` vs. everything else — there was no path back to `/home` if an already-approved user (`clerkStatus === "active"`) ever landed there, which is exactly what happened to users hitting the app via `www.weftmark.com` before the redirect fix. They'd see "request received" messaging indefinitely even though their account was fully approved.

Adds a `useEffect` that redirects to `/home` the moment `clerkStatus === "active"`, mirroring the existing `isAuthenticated`-based redirect effect immediately above it — this one reacts to Clerk's own status signal directly, so it doesn't depend on the app's backend-derived auth state catching up first.

## Test plan

- [x] eslint, tsc clean
- [x] Rebuilt via docker, loaded `/pending` directly with no session — renders cleanly, redirects to `/login` as before (pre-existing behavior, confirmed unaffected), no console errors
- [ ] Full end-to-end verification of the new redirect (a real Clerk account transitioning to `active` while sitting on `/pending`) needs a live test account — not reproducible from this environment. The change itself is a small, direct mirror of the adjacent existing effect.