### PR TITLE
feat: automated scheduled check for the www-to-apex redirect

### DIFF
--- a/backend/app/tasks/maintenance.py
+++ b/backend/app/tasks/maintenance.py
@@ -177,14 +177,22 @@ def retry_failed_previews(self, limit: int = 50) -> dict:
     return {"retried": retried}
 
 
-@celery_app.task(
-    bind=True,
-    max_retries=0,
-    name="app.tasks.maintenance.daily_health_check",
-)
-def daily_health_check(self) -> dict:
-    import asyncio
+def _record_health_event_and_alert(
+    *,
+    event_type: str,
+    severity: str,
+    message: str,
+    details: dict,
+    ts: datetime,
+    should_alert: bool,
+    probe_rows: list[tuple[str, bool, str]],
+    alert_status: str,
+) -> None:
+    """Write a ServerEvent for a health-style check, and email superusers on failure.
 
+    Shared by daily_health_check and check_www_redirect -- both follow the same
+    probe -> record -> alert-if-failing shape.
+    """
     from sqlalchemy import create_engine
     from sqlalchemy.orm import Session
 
@@ -193,6 +201,74 @@ def daily_health_check(self) -> dict:
     from app.version import VERSION
 
     settings = get_settings()
+
+    engine = create_engine(settings.database_url_sync)
+    try:
+        with Session(engine) as db:
+            evt = ServerEvent(
+                event_type=event_type,
+                severity=severity,
+                status="closed",
+                started_at=ts,
+                ended_at=datetime.now(timezone.utc),
+                app_version=VERSION,
+                message=message,
+                details=details,
+            )
+            evt.elapsed_ms = int((evt.ended_at - evt.started_at).total_seconds() * 1000)  # type: ignore[operator]
+            db.add(evt)
+            db.commit()
+    finally:
+        engine.dispose()
+
+    if not should_alert:
+        return
+
+    try:
+        from sqlalchemy import select
+
+        email_engine = create_engine(settings.database_url_sync)
+        try:
+            with Session(email_engine) as db:
+                from app.models.user import User
+
+                emails = [
+                    r
+                    for r in db.scalars(
+                        select(User.email).where(User.is_superuser.is_(True), User.is_active.is_(True))
+                    ).all()
+                    if r
+                ]
+        finally:
+            email_engine.dispose()
+        if emails:
+            import asyncio as _asyncio
+
+            from app.services.email import send_health_degraded_alert
+
+            _asyncio.run(
+                send_health_degraded_alert(
+                    superuser_emails=emails,
+                    env=settings.app_env,
+                    app_base_url=settings.app_base_url or settings.frontend_url,
+                    version=VERSION,
+                    probe_rows=probe_rows,
+                    status=alert_status,
+                    timestamp=ts.isoformat(),
+                )
+            )
+    except Exception:
+        log.exception("%s: failed to send degraded alert email", event_type)
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=0,
+    name="app.tasks.maintenance.daily_health_check",
+)
+def daily_health_check(self) -> dict:
+    import asyncio
+
     ts = datetime.now(timezone.utc)
 
     async def _run():
@@ -226,61 +302,16 @@ def daily_health_check(self) -> dict:
     failed = [s.name for s in result.services if not s.ok]
     sev = "error" if result.status == "error" else ("warn" if result.status == "degraded" else "info")
 
-    engine = create_engine(settings.database_url_sync)
-    try:
-        with Session(engine) as db:
-            evt = ServerEvent(
-                event_type="health.check",
-                severity=sev,
-                status="closed",
-                started_at=ts,
-                ended_at=datetime.now(timezone.utc),
-                app_version=VERSION,
-                message=f"Daily health check — {result.status}",
-                details={"probe_status": result.status, "failed_services": failed},
-            )
-            evt.elapsed_ms = int((evt.ended_at - evt.started_at).total_seconds() * 1000)  # type: ignore[operator]
-            db.add(evt)
-            db.commit()
-    finally:
-        engine.dispose()
-
-    if result.status != "ok":
-        try:
-            from sqlalchemy import select
-
-            email_engine = create_engine(settings.database_url_sync)
-            try:
-                with Session(email_engine) as db:
-                    from app.models.user import User
-
-                    emails = [
-                        r
-                        for r in db.scalars(
-                            select(User.email).where(User.is_superuser.is_(True), User.is_active.is_(True))
-                        ).all()
-                        if r
-                    ]
-            finally:
-                email_engine.dispose()
-            if emails:
-                import asyncio as _asyncio
-
-                from app.services.email import send_health_degraded_alert
-
-                _asyncio.run(
-                    send_health_degraded_alert(
-                        superuser_emails=emails,
-                        env=settings.app_env,
-                        app_base_url=settings.app_base_url or settings.frontend_url,
-                        version=VERSION,
-                        probe_rows=probe_rows,
-                        status=result.status,
-                        timestamp=ts.isoformat(),
-                    )
-                )
-        except Exception:
-            log.exception("daily_health_check: failed to send degraded alert email")
+    _record_health_event_and_alert(
+        event_type="health.check",
+        severity=sev,
+        message=f"Daily health check — {result.status}",
+        details={"probe_status": result.status, "failed_services": failed},
+        ts=ts,
+        should_alert=result.status != "ok",
+        probe_rows=probe_rows,
+        alert_status=result.status,
+    )
 
     log.info("daily_health_check status=%s failed=%s", result.status, failed)
     return {"status": result.status, "failed_services": failed}
@@ -303,12 +334,8 @@ def check_www_redirect(self) -> dict:
     from urllib.parse import urlparse
 
     import httpx
-    from sqlalchemy import create_engine
-    from sqlalchemy.orm import Session
 
     from app.config import get_settings
-    from app.models.server_event import ServerEvent
-    from app.version import VERSION
 
     settings = get_settings()
     ts = datetime.now(timezone.utc)
@@ -334,61 +361,16 @@ def check_www_redirect(self) -> dict:
     except Exception as exc:
         detail = str(exc)[:200]
 
-    engine = create_engine(settings.database_url_sync)
-    try:
-        with Session(engine) as db:
-            evt = ServerEvent(
-                event_type="www_redirect.check",
-                severity="info" if ok else "error",
-                status="closed",
-                started_at=ts,
-                ended_at=datetime.now(timezone.utc),
-                app_version=VERSION,
-                message="WWW redirect check passed" if ok else f"WWW redirect check failed — {detail}",
-                details={"ok": ok, "detail": detail, "checked_url": www_url},
-            )
-            evt.elapsed_ms = int((evt.ended_at - evt.started_at).total_seconds() * 1000)  # type: ignore[operator]
-            db.add(evt)
-            db.commit()
-    finally:
-        engine.dispose()
-
-    if not ok:
-        try:
-            from sqlalchemy import select
-
-            email_engine = create_engine(settings.database_url_sync)
-            try:
-                with Session(email_engine) as db:
-                    from app.models.user import User
-
-                    emails = [
-                        r
-                        for r in db.scalars(
-                            select(User.email).where(User.is_superuser.is_(True), User.is_active.is_(True))
-                        ).all()
-                        if r
-                    ]
-            finally:
-                email_engine.dispose()
-            if emails:
-                import asyncio as _asyncio
-
-                from app.services.email import send_health_degraded_alert
-
-                _asyncio.run(
-                    send_health_degraded_alert(
-                        superuser_emails=emails,
-                        env=settings.app_env,
-                        app_base_url=settings.app_base_url or settings.frontend_url,
-                        version=VERSION,
-                        probe_rows=[("WWW Redirect", False, detail)],
-                        status="error",
-                        timestamp=ts.isoformat(),
-                    )
-                )
-        except Exception:
-            log.exception("check_www_redirect: failed to send degraded alert email")
+    _record_health_event_and_alert(
+        event_type="www_redirect.check",
+        severity="info" if ok else "error",
+        message="WWW redirect check passed" if ok else f"WWW redirect check failed — {detail}",
+        details={"ok": ok, "detail": detail, "checked_url": www_url},
+        ts=ts,
+        should_alert=not ok,
+        probe_rows=[("WWW Redirect", False, detail)],
+        alert_status="error",
+    )
 
     log.info("check_www_redirect ok=%s detail=%s", ok, detail)
     return {"ok": ok, "detail": detail}

--- a/backend/app/tasks/maintenance.py
+++ b/backend/app/tasks/maintenance.py
@@ -289,6 +289,114 @@ def daily_health_check(self) -> dict:
 @celery_app.task(
     bind=True,
     max_retries=0,
+    name="app.tasks.maintenance.check_www_redirect",
+)
+def check_www_redirect(self) -> dict:
+    """Verify www.<domain> 301-redirects to the canonical apex domain (see #1011).
+
+    Catches DNS/CDN redirect-rule regressions -- an accidentally deleted or
+    disabled rule, a `www` DNS record flipped to unproxied, a re-introduced
+    query-string bug -- that silently break login for anyone who lands on the
+    www host. The failure mode looks like "stuck on pending approval," not an
+    obvious redirect error, so this can go unnoticed without an active check.
+    """
+    from urllib.parse import urlparse
+
+    import httpx
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import Session
+
+    from app.config import get_settings
+    from app.models.server_event import ServerEvent
+    from app.version import VERSION
+
+    settings = get_settings()
+    ts = datetime.now(timezone.utc)
+
+    apex = settings.frontend_url.rstrip("/")
+    parsed = urlparse(apex)
+    www_url = f"{parsed.scheme}://www.{parsed.netloc}/?foo=bar"
+
+    ok = False
+    detail = ""
+    try:
+        r = httpx.get(www_url, timeout=10, follow_redirects=False)
+        if r.status_code not in (301, 302, 307, 308):
+            detail = f"expected a redirect, got HTTP {r.status_code}"
+        else:
+            location = r.headers.get("location", "")
+            if not location.startswith(apex):
+                detail = f"redirected to unexpected location: {location!r}"
+            elif "?foo=bar" not in location:
+                detail = f"query string not preserved in redirect: {location!r}"
+            else:
+                ok = True
+    except Exception as exc:
+        detail = str(exc)[:200]
+
+    engine = create_engine(settings.database_url_sync)
+    try:
+        with Session(engine) as db:
+            evt = ServerEvent(
+                event_type="www_redirect.check",
+                severity="info" if ok else "error",
+                status="closed",
+                started_at=ts,
+                ended_at=datetime.now(timezone.utc),
+                app_version=VERSION,
+                message="WWW redirect check passed" if ok else f"WWW redirect check failed — {detail}",
+                details={"ok": ok, "detail": detail, "checked_url": www_url},
+            )
+            evt.elapsed_ms = int((evt.ended_at - evt.started_at).total_seconds() * 1000)  # type: ignore[operator]
+            db.add(evt)
+            db.commit()
+    finally:
+        engine.dispose()
+
+    if not ok:
+        try:
+            from sqlalchemy import select
+
+            email_engine = create_engine(settings.database_url_sync)
+            try:
+                with Session(email_engine) as db:
+                    from app.models.user import User
+
+                    emails = [
+                        r
+                        for r in db.scalars(
+                            select(User.email).where(User.is_superuser.is_(True), User.is_active.is_(True))
+                        ).all()
+                        if r
+                    ]
+            finally:
+                email_engine.dispose()
+            if emails:
+                import asyncio as _asyncio
+
+                from app.services.email import send_health_degraded_alert
+
+                _asyncio.run(
+                    send_health_degraded_alert(
+                        superuser_emails=emails,
+                        env=settings.app_env,
+                        app_base_url=settings.app_base_url or settings.frontend_url,
+                        version=VERSION,
+                        probe_rows=[("WWW Redirect", False, detail)],
+                        status="error",
+                        timestamp=ts.isoformat(),
+                    )
+                )
+        except Exception:
+            log.exception("check_www_redirect: failed to send degraded alert email")
+
+    log.info("check_www_redirect ok=%s detail=%s", ok, detail)
+    return {"ok": ok, "detail": detail}
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=0,
     name="app.tasks.maintenance.prune_server_event_log",
 )
 def prune_server_event_log(self, max_age_days: int = 28, max_entries: int = 1000) -> dict:

--- a/backend/app/tasks/scheduler.py
+++ b/backend/app/tasks/scheduler.py
@@ -88,6 +88,17 @@ REGISTRY: dict[str, dict] = {
         "default_cron": "0 2 * * *",
         "default_config": {},
     },
+    "www_redirect_check": {
+        "display_name": "WWW Redirect Check",
+        "description": (
+            "Verifies www.<domain> 301-redirects to the canonical apex domain, including "
+            "query-string preservation. Catches DNS/CDN redirect-rule regressions (#1011) "
+            "that silently break login for anyone landing on the www host. Sends an alert "
+            "email if the check fails."
+        ),
+        "default_cron": "0 9 * * 1",  # weekly, Monday 9am UTC
+        "default_config": {},
+    },
     "server_event_log_pruning": {
         "display_name": "Server Event Log Pruning",
         "description": (
@@ -238,6 +249,15 @@ def _dispatch_daily_health_check(settings, task=None):
     return t
 
 
+def _dispatch_www_redirect_check(settings, task=None):
+    from app.services.task_history import record_queued
+    from app.tasks.maintenance import check_www_redirect
+
+    t = check_www_redirect.delay()
+    record_queued(settings, t.id, "app.tasks.maintenance.check_www_redirect", "scheduled:www_redirect_check")
+    return t
+
+
 def _dispatch_server_event_log_pruning(settings, task=None):
     from app.services.task_history import record_queued
     from app.tasks.maintenance import prune_server_event_log
@@ -323,6 +343,7 @@ DISPATCH_FNS: dict[str, object] = {
     "heartbeat": _dispatch_heartbeat,
     "preview_retry": _dispatch_preview_retry,
     "daily_health_check": _dispatch_daily_health_check,
+    "www_redirect_check": _dispatch_www_redirect_check,
     "server_event_log_pruning": _dispatch_server_event_log_pruning,
     "credential_expiry_check": _dispatch_credential_expiry_check,
     "admin_digest": _dispatch_admin_digest,

--- a/backend/tests/tasks/test_maintenance.py
+++ b/backend/tests/tasks/test_maintenance.py
@@ -1711,3 +1711,65 @@ class TestDailyHealthCheck:
                 sync_db.execute(_del(User).where(User.id == superuser_id))
                 sync_db.commit()
             engine.dispose()
+
+
+class TestCheckWwwRedirect:
+    def _run(self, monkeypatch, mock_response=None, side_effect=None):
+        from app.config import get_settings
+        from app.tasks.maintenance import check_www_redirect
+
+        monkeypatch.setattr(get_settings(), "frontend_url", "https://weftmark.com")
+        with patch("httpx.get", return_value=mock_response, side_effect=side_effect):
+            return check_www_redirect.run.__func__(_make_task())
+
+    def test_correct_redirect_returns_ok(self, db_session, monkeypatch):
+        resp = MagicMock(status_code=301, headers={"location": "https://weftmark.com/?foo=bar"})
+        result = self._run(monkeypatch, mock_response=resp)
+        assert result["ok"] is True
+
+    def test_non_redirect_status_returns_not_ok(self, db_session, monkeypatch):
+        resp = MagicMock(status_code=200, headers={})
+        result = self._run(monkeypatch, mock_response=resp)
+        assert result["ok"] is False
+        assert "HTTP 200" in result["detail"]
+
+    def test_wrong_location_returns_not_ok(self, db_session, monkeypatch):
+        resp = MagicMock(status_code=301, headers={"location": "https://not-weftmark.example/?foo=bar"})
+        result = self._run(monkeypatch, mock_response=resp)
+        assert result["ok"] is False
+        assert "unexpected location" in result["detail"]
+
+    def test_dropped_query_string_returns_not_ok(self, db_session, monkeypatch):
+        # The exact regression that shipped once already -- concat() without a "?" separator
+        resp = MagicMock(status_code=301, headers={"location": "https://weftmark.com/foo=bar"})
+        result = self._run(monkeypatch, mock_response=resp)
+        assert result["ok"] is False
+        assert "query string not preserved" in result["detail"]
+
+    def test_network_exception_returns_not_ok(self, db_session, monkeypatch):
+        result = self._run(monkeypatch, side_effect=RuntimeError("connection refused"))
+        assert result["ok"] is False
+        assert "connection refused" in result["detail"]
+
+    def test_ok_no_email_sent(self, db_session, monkeypatch):
+        resp = MagicMock(status_code=301, headers={"location": "https://weftmark.com/?foo=bar"})
+        mock_send = MagicMock()
+        with patch("app.services.email.send_health_degraded_alert", mock_send):
+            self._run(monkeypatch, mock_response=resp)
+        mock_send.assert_not_called()
+
+    def test_failure_no_superusers_no_email_sent(self, db_session, monkeypatch):
+        resp = MagicMock(status_code=200, headers={})
+        mock_send = AsyncMock()
+        with patch("app.services.email.send_health_degraded_alert", mock_send):
+            self._run(monkeypatch, mock_response=resp)
+        mock_send.assert_not_called()
+
+    def test_failure_with_superuser_sends_email(self, superuser_user, monkeypatch):
+        resp = MagicMock(status_code=200, headers={})
+        mock_send = AsyncMock()
+        with patch("app.services.email.send_health_degraded_alert", mock_send):
+            result = self._run(monkeypatch, mock_response=resp)
+
+        mock_send.assert_called_once()
+        assert result["ok"] is False

--- a/backend/tests/tasks/test_scheduler.py
+++ b/backend/tests/tasks/test_scheduler.py
@@ -23,6 +23,7 @@ from app.tasks.scheduler import (
     _dispatch_server_event_log_pruning,
     _dispatch_stale_signup_dismissal,
     _dispatch_tile_prune,
+    _dispatch_www_redirect_check,
 )
 
 
@@ -261,6 +262,23 @@ class TestDispatchDailyHealthCheck:
             patch("app.services.task_history.record_queued"),
         ):
             result = _dispatch_daily_health_check(_fake_settings())
+        mock_task.delay.assert_called_once()
+        assert result is mock_task.delay.return_value
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_www_redirect_check
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchWwwRedirectCheck:
+    def test_calls_delay(self):
+        mock_task = _mock_task()
+        with (
+            patch("app.tasks.maintenance.check_www_redirect", mock_task),
+            patch("app.services.task_history.record_queued"),
+        ):
+            result = _dispatch_www_redirect_check(_fake_settings())
         mock_task.delay.assert_called_once()
         assert result is mock_task.delay.return_value
 

--- a/docs/deployment/hosting-decisions.md
+++ b/docs/deployment/hosting-decisions.md
@@ -86,7 +86,24 @@
 
 **Required: canonical-hostname redirect.** Both `weftmark.com` and `www.weftmark.com` resolve and are independently proxied — without a redirect collapsing one into the other, the backend's Clerk `azp` check (which only accepts the single configured `FRONTEND_URL`) rejects every request from whichever hostname isn't canonical, producing a confusing "stuck on pending approval" symptom with no obvious error (see #1011). A Cloudflare Redirect Rule handles this today: `www.weftmark.com` → `301 https://weftmark.com` (preserving path/query — use a dynamic expression, not a static target, or query strings get silently dropped).
 
-**If migrating to a different DNS/CDN provider:** this redirect must be re-created there. It's easy to forget since it's invisible when working and the failure mode doesn't look like a redirect problem. Re-verify with `curl -I https://www.weftmark.com` (expect `301`/`308` → the apex domain) as part of any provider cutover checklist.
+**If migrating to a different DNS/CDN provider:** this redirect must be re-created there. It's easy to forget since it's invisible when working and the failure mode doesn't look like a redirect problem. Re-verify with the checks below as part of any provider cutover checklist — don't assume a redirect rule works just because it was configured; the query-string case below is the one that actually shipped broken once already.
+
+```bash
+# 1. Bare redirect
+curl -I https://www.weftmark.com
+# expect: HTTP 301 (or 308), Location: https://weftmark.com/
+
+# 2. Path preserved
+curl -I https://www.weftmark.com/some/path
+# expect: Location: https://weftmark.com/some/path...
+
+# 3. Query string preserved correctly — a naive concat() expression in Cloudflare
+#    Redirect Rules drops the "?" separator; verify it doesn't regress
+curl -I "https://www.weftmark.com/some/path?foo=bar&baz=qux"
+# expect: Location: https://weftmark.com/some/path?foo=bar&baz=qux  (not "pathfoo=bar...")
+```
+
+If any of these fail: check the DNS/CDN provider's redirect/rule configuration for `www` → apex, and confirm the `www` DNS record is proxied (Cloudflare Redirect Rules only fire on proxied traffic).
 
 ---
 


### PR DESCRIPTION
## Summary

Stacked on #1020 (branched from it, so this PR's diff currently includes that doc commit too — will resolve cleanly once #1020 merges first).

Follow-up to #1011/#1017/#1020. Adds `check_www_redirect` as a new admin-configurable scheduled task, mirroring the existing `daily_health_check` pattern (probe → write a `ServerEvent` → email alert on failure). Default weekly cadence; admin can enable/adjust via the existing Scheduled Tasks UI.

Verifies the redirect status code, target hostname, and specifically that the query string survives — the exact regression that shipped once already in the Cloudflare rule.

**Bug caught by the new tests:** the original check used `if "foo=bar" not in location`, a plain substring test that can't distinguish `.../path?foo=bar` (correct) from `.../pathfoo=bar` (broken, missing separator) — both contain `"foo=bar"` as a substring. Fixed to check for `"?foo=bar"` specifically.

## Test plan

- [x] 43 tests pass (8 new for `check_www_redirect` covering success/failure/exception/email-alert paths, 1 new dispatch test)
- [x] ruff, mypy clean