### PR TITLE
chore: remove Dependabot ignore rule for fastapi 0.136.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,10 +28,6 @@ updates:
       # redis 7.x cannot be used until Celery ships a compatible kombu version.
       - dependency-name: redis
         versions: [">=7.0"]
-      # fastapi 0.136.3 is malicious (MAL-2026-4750) — hidden fastar typosquat dep.
-      # Remove this ignore once PyPI yanks the release or a clean 0.136.4+ ships.
-      - dependency-name: fastapi
-        versions: ["0.136.3"]
     groups:
       backend-deps:
         patterns:


### PR DESCRIPTION
## Summary
- Removes the `fastapi 0.136.3` ignore rule from `.github/dependabot.yml`, added in #935 as a precaution against MAL-2026-4750.
- OSV withdrew MAL-2026-4750 on 2026-05-26 as a false positive — `fastar` was a legitimate dependency added by the FastAPI maintainers, not a typosquat.
- `backend/requirements.txt` is already pinned to `fastapi==0.139.0`, well past the flagged release, so the rule was dead weight either way.

Closes #936

## Test plan
- [x] `.github/dependabot.yml` YAML is still valid (redis ignore rule untouched)
- [ ] CI (`ci-dev-pr.yml`) passes — lint/typecheck/dep-audit, no code changes to test