### PR TITLE
test: close remaining gap in images.py coverage

### DIFF
--- a/backend/tests/services/test_images.py
+++ b/backend/tests/services/test_images.py
@@ -15,6 +15,13 @@ def _make_png_bytes(width: int = 4, height: int = 4) -> bytes:
     return buf.getvalue()
 
 
+def _make_jpeg_bytes(width: int = 4, height: int = 4) -> bytes:
+    img = PILImage.new("RGB", (width, height), color=(100, 150, 200))
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
 def _make_gif_bytes(width: int = 4, height: int = 4) -> bytes:
     img = PILImage.new("P", (width, height))
     buf = io.BytesIO()
@@ -26,12 +33,15 @@ class TestValidateImageFormat:
     def test_valid_png_passes(self):
         validate_image_format(_make_png_bytes())  # no exception
 
+    def test_valid_jpeg_passes(self):
+        validate_image_format(_make_jpeg_bytes())  # no exception
+
     def test_non_image_bytes_raise(self):
         with pytest.raises(ValueError, match="Could not decode image"):
             validate_image_format(b"this is not an image")
 
     def test_unsupported_format_raises(self):
-        with pytest.raises(ValueError, match="Unsupported image format"):
+        with pytest.raises(ValueError, match="Unsupported image format: GIF"):
             validate_image_format(_make_gif_bytes())
 
     def test_empty_bytes_raise(self):


### PR DESCRIPTION
## Summary
- `backend/tests/services/test_images.py` already covered most of #962's checklist — it was added directly in commit a014fbd (May 27) but never linked to the issue, so it stayed open despite the work being mostly done.
- Adds the one missing checklist item: valid JPEG bytes → `validate_image_format` raises no exception (only PNG was covered before).
- Tightens the unsupported-format test to assert the format name (`GIF`) actually appears in the raised message, per the issue's "raises ValueError with format name in message" requirement.

Closes #962

## Test plan
- [x] `pytest backend/tests/services/test_images.py` — 9 passed, 0 failed
- [x] `ruff check` clean