### PR TITLE
fix: replace sync file I/O with async in loom_seed service (S7493)

### DIFF
--- a/backend/app/services/loom_seed.py
+++ b/backend/app/services/loom_seed.py
@@ -7,6 +7,7 @@ worker process without any sys.path manipulation.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import uuid
@@ -93,6 +94,11 @@ def locate_json() -> Path:
     raise FileNotFoundError("Could not find loom-data-master.json. Run from the repo root or inside the container.")
 
 
+def _read_json(path: Path) -> dict | list:
+    with path.open() as f:
+        return json.load(f)
+
+
 def _coerce_entry(raw: dict) -> dict:
     row: dict = {}
     for json_key, value in raw.items():
@@ -126,8 +132,7 @@ async def seed() -> dict:
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
 
     json_path = locate_json()
-    with json_path.open() as f:
-        data = json.load(f)
+    data = await asyncio.to_thread(_read_json, json_path)
 
     if isinstance(data, dict) and "looms" in data:
         entries = data["looms"]

--- a/backend/app/services/loom_seed.py
+++ b/backend/app/services/loom_seed.py
@@ -96,7 +96,7 @@ def locate_json() -> Path:
 
 def _read_json(path: Path) -> dict | list:
     with path.open() as f:
-        return json.load(f)
+        return json.load(f)  # type: ignore[no-any-return]
 
 
 def _coerce_entry(raw: dict) -> dict:

--- a/backend/tests/services/test_loom_seed.py
+++ b/backend/tests/services/test_loom_seed.py
@@ -1,8 +1,9 @@
 """Tests for app.services.loom_seed — JSON read helper (S7493, #957)."""
 
 import json
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from app.services.loom_seed import _read_json
+from app.services.loom_seed import _read_json, seed
 
 
 class TestReadJson:
@@ -15,3 +16,35 @@ class TestReadJson:
         p = tmp_path / "data.json"
         p.write_text(json.dumps({"looms": [{"brand": "Example"}]}))
         assert _read_json(p) == {"looms": [{"brand": "Example"}]}
+
+
+class _FakeSession:
+    """Minimal stand-in supporting the `async with session_factory() as session:`
+    / `async with session.begin():` shape used by seed()."""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    def begin(self):
+        return self
+
+
+class TestSeedOffloadsJsonRead:
+    async def test_seed_reads_json_via_thread(self, tmp_path, monkeypatch):
+        p = tmp_path / "data.json"
+        p.write_text(json.dumps({"looms": []}))
+        monkeypatch.setattr("app.services.loom_seed.locate_json", lambda: p)
+
+        mock_engine = MagicMock()
+        mock_engine.dispose = AsyncMock()
+
+        with (
+            patch("sqlalchemy.ext.asyncio.create_async_engine", return_value=mock_engine),
+            patch("sqlalchemy.ext.asyncio.async_sessionmaker", return_value=lambda: _FakeSession()),
+        ):
+            result = await seed()
+
+        assert result == {"inserted": 0, "updated": 0, "skipped": 0}

--- a/backend/tests/services/test_loom_seed.py
+++ b/backend/tests/services/test_loom_seed.py
@@ -1,0 +1,17 @@
+"""Tests for app.services.loom_seed — JSON read helper (S7493, #957)."""
+
+import json
+
+from app.services.loom_seed import _read_json
+
+
+class TestReadJson:
+    def test_reads_json_list(self, tmp_path):
+        p = tmp_path / "data.json"
+        p.write_text(json.dumps([{"brand": "Example"}]))
+        assert _read_json(p) == [{"brand": "Example"}]
+
+    def test_reads_json_dict_with_looms_key(self, tmp_path):
+        p = tmp_path / "data.json"
+        p.write_text(json.dumps({"looms": [{"brand": "Example"}]}))
+        assert _read_json(p) == {"looms": [{"brand": "Example"}]}


### PR DESCRIPTION
## Summary
- `loom_seed.seed()` read `loom-data-master.json` synchronously (`json_path.open()` + `json.load()`) inside an `async def`, blocking the event loop while parsing the file.
- Extracted the read into a small sync helper `_read_json()` and offload it via `asyncio.to_thread` — the established pattern for blocking I/O throughout this codebase (`main.py`, `storage.py`, `drafts.py`, `admin.py`, etc.), rather than introducing `anyio.open_file()` as the issue suggested, which would be a new, one-off dependency pattern.

Closes #957

## Test plan
- [x] New `tests/services/test_loom_seed.py` — covers `_read_json()` for both JSON shapes the loader accepts (bare list, `{looms: [...]}`)
- [x] `ruff check` clean
- [x] Full stack rebuilt via `rbd`; directly invoked `seed_loom_references.apply().get()` inside the backend container — returned `{'inserted': 0, 'updated': 68, 'skipped': 0}`, identical to the pre-fix result — no errors in backend/worker logs