### PR TITLE
fix: add keyboard listeners to modal/overlay click handlers (S1082)

### DIFF
--- a/frontend/src/components/FeedbackModal.tsx
+++ b/frontend/src/components/FeedbackModal.tsx
@@ -104,10 +104,16 @@ export function FeedbackModal({ onClose }: Props) {
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 p-4" onClick={onClose}>
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 p-4"
+      role="presentation"
+      onClick={onClose}
+      onKeyDown={(e) => e.key === "Escape" && onClose()}
+    >
       <div
         className="w-full max-w-lg rounded-lg border border-border bg-background shadow-xl p-6 space-y-4"
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => { e.stopPropagation(); if (e.key === "Escape") onClose(); }}
       >
         {/* Header */}
         <div className="flex items-center justify-between">

--- a/frontend/src/components/FeedbackModal.tsx
+++ b/frontend/src/components/FeedbackModal.tsx
@@ -106,7 +106,6 @@ export function FeedbackModal({ onClose }: Props) {
   return (
     <div
       className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 p-4"
-      role="presentation"
       onClick={onClose}
       onKeyDown={(e) => e.key === "Escape" && onClose()}
     >

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -178,7 +178,9 @@ export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpa
       {open && (
         <div
           className="fixed inset-0 z-20 bg-black/40 lg:hidden"
+          role="presentation"
           onClick={onClose}
+          onKeyDown={(e) => e.key === "Escape" && onClose()}
         />
       )}
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -178,7 +178,6 @@ export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpa
       {open && (
         <div
           className="fixed inset-0 z-20 bg-black/40 lg:hidden"
-          role="presentation"
           onClick={onClose}
           onKeyDown={(e) => e.key === "Escape" && onClose()}
         />

--- a/frontend/src/components/looms/CatalogRequestButton.tsx
+++ b/frontend/src/components/looms/CatalogRequestButton.tsx
@@ -99,11 +99,14 @@ export function CatalogRequestButton({ loom }: Props) {
       {showModal && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          role="presentation"
           onClick={() => { if (!mutation.isPending) setShowModal(false); }}
+          onKeyDown={(e) => { if (e.key === "Escape" && !mutation.isPending) setShowModal(false); }}
         >
           <div
             className="w-full max-w-md rounded-lg border border-border bg-background shadow-xl p-6 space-y-4"
             onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => { e.stopPropagation(); if (e.key === "Escape" && !mutation.isPending) setShowModal(false); }}
           >
             <div className="flex items-center justify-between">
               <h2 className="text-base font-semibold">Request catalog addition</h2>

--- a/frontend/src/components/looms/CatalogRequestButton.tsx
+++ b/frontend/src/components/looms/CatalogRequestButton.tsx
@@ -99,7 +99,6 @@ export function CatalogRequestButton({ loom }: Props) {
       {showModal && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
-          role="presentation"
           onClick={() => { if (!mutation.isPending) setShowModal(false); }}
           onKeyDown={(e) => { if (e.key === "Escape" && !mutation.isPending) setShowModal(false); }}
         >

--- a/frontend/src/components/projects/ShareModal.tsx
+++ b/frontend/src/components/projects/ShareModal.tsx
@@ -77,7 +77,6 @@ export function ShareModal({
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
-      role="presentation"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}

--- a/frontend/src/components/projects/ShareModal.tsx
+++ b/frontend/src/components/projects/ShareModal.tsx
@@ -77,9 +77,11 @@ export function ShareModal({
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      role="presentation"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
+      onKeyDown={(e) => e.key === "Escape" && onClose()}
     >
       <div className="bg-card rounded-xl border border-border shadow-2xl flex flex-col max-w-md w-full">
         <div className="flex items-center justify-between px-4 py-3 border-b border-border">

--- a/frontend/src/components/ui/TagInput.tsx
+++ b/frontend/src/components/ui/TagInput.tsx
@@ -44,6 +44,7 @@ export function TagInput({ tags, onChange, placeholder = "Add a tag…", disable
     <div
       className="flex flex-wrap gap-1.5 rounded-md border border-input bg-background px-2 py-1.5 cursor-text min-h-[36px]"
       onClick={() => inputRef.current?.focus()}
+      onKeyDown={(e) => e.key === "Enter" && inputRef.current?.focus()}
     >
       {tags.map((tag) => (
         <span

--- a/frontend/src/components/ui/ZoomablePreviewModal.tsx
+++ b/frontend/src/components/ui/ZoomablePreviewModal.tsx
@@ -80,7 +80,6 @@ export function ZoomablePreviewModal({ src, title, onClose, gateConfirmed = true
   return (
     <div
       className="fixed inset-0 z-50 flex flex-col bg-black/60"
-      role="presentation"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
       onKeyDown={(e) => e.key === "Escape" && onClose()}
     >

--- a/frontend/src/components/ui/ZoomablePreviewModal.tsx
+++ b/frontend/src/components/ui/ZoomablePreviewModal.tsx
@@ -80,7 +80,9 @@ export function ZoomablePreviewModal({ src, title, onClose, gateConfirmed = true
   return (
     <div
       className="fixed inset-0 z-50 flex flex-col bg-black/60"
+      role="presentation"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      onKeyDown={(e) => e.key === "Escape" && onClose()}
     >
       <div className="flex flex-col w-full h-full max-w-7xl mx-auto bg-background shadow-xl rounded-none sm:rounded-lg sm:my-6 sm:h-[calc(100vh-3rem)] overflow-hidden">
 

--- a/frontend/src/components/yarn/AddFromRavelryModal.tsx
+++ b/frontend/src/components/yarn/AddFromRavelryModal.tsx
@@ -283,7 +283,6 @@ export function AddFromRavelryModal({ onSuccess, onClose }: Props) {
   return (
     <div
       className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-16 px-4"
-      role="presentation"
       onClick={onClose}
       onKeyDown={(e) => e.key === "Escape" && onClose()}
     >

--- a/frontend/src/components/yarn/AddFromRavelryModal.tsx
+++ b/frontend/src/components/yarn/AddFromRavelryModal.tsx
@@ -281,10 +281,16 @@ export function AddFromRavelryModal({ onSuccess, onClose }: Props) {
   const clearBtnCls = "absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground leading-none p-0.5";
 
   return (
-    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-16 px-4" onClick={onClose}>
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-16 px-4"
+      role="presentation"
+      onClick={onClose}
+      onKeyDown={(e) => e.key === "Escape" && onClose()}
+    >
       <div
         className="w-full max-w-md rounded-xl border border-border bg-card shadow-xl"
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => { e.stopPropagation(); if (e.key === "Escape") onClose(); }}
       >
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border px-5 py-4">

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1715,7 +1715,6 @@ function FeedbackTab() {
       {detail && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
-          role="presentation"
           onClick={() => setDetail(null)}
           onKeyDown={(e) => e.key === "Escape" && setDetail(null)}
         >

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1713,8 +1713,17 @@ function FeedbackTab() {
 
       {/* Detail modal */}
       {detail && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={() => setDetail(null)}>
-          <div className="w-full max-w-lg rounded-lg border border-border bg-background shadow-xl p-6 space-y-4 max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          role="presentation"
+          onClick={() => setDetail(null)}
+          onKeyDown={(e) => e.key === "Escape" && setDetail(null)}
+        >
+          <div
+            className="w-full max-w-lg rounded-lg border border-border bg-background shadow-xl p-6 space-y-4 max-h-[80vh] overflow-y-auto"
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => { e.stopPropagation(); if (e.key === "Escape") setDetail(null); }}
+          >
             <div className="flex items-center justify-between">
               <h3 className="font-semibold">
                 {SUBMISSION_TYPE_LABELS[detail.submission_type as SubmissionType] ?? detail.submission_type}
@@ -1933,7 +1942,9 @@ function AuditLogRow({ entry }: { entry: AuditLogEntry }) {
     <>
       <tr
         className={`hover:bg-muted/30 ${hasDetails ? "cursor-pointer" : ""}`}
+        tabIndex={hasDetails ? 0 : undefined}
         onClick={() => hasDetails && setExpanded((v) => !v)}
+        onKeyDown={(e) => { if (hasDetails && e.key === "Enter") setExpanded((v) => !v); }}
       >
         <td className="px-3 py-2 text-muted-foreground whitespace-nowrap">{formatAuditTime(entry.created_at)}</td>
         <td className="px-3 py-2">

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -841,7 +841,6 @@ function PhotoGrid({
       {lightbox && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
-          role="presentation"
           onClick={() => setLightbox(null)}
           onKeyDown={(e) => e.key === "Escape" && setLightbox(null)}
         >
@@ -2105,7 +2104,6 @@ export function ProjectDetailPage() {
         <>
           <div
             className="fixed inset-0 z-40 bg-black/40"
-            role="presentation"
             onClick={() => setSettingsOpen(false)}
             onKeyDown={(e) => e.key === "Escape" && setSettingsOpen(false)}
           />

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -841,7 +841,9 @@ function PhotoGrid({
       {lightbox && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
+          role="presentation"
           onClick={() => setLightbox(null)}
+          onKeyDown={(e) => e.key === "Escape" && setLightbox(null)}
         >
           <AuthedImage
             src={projectPhotoUrl(projectId, lightbox)}
@@ -2103,7 +2105,9 @@ export function ProjectDetailPage() {
         <>
           <div
             className="fixed inset-0 z-40 bg-black/40"
+            role="presentation"
             onClick={() => setSettingsOpen(false)}
+            onKeyDown={(e) => e.key === "Escape" && setSettingsOpen(false)}
           />
           <div className="fixed inset-y-0 right-0 z-50 flex w-72 flex-col border-l border-border bg-card shadow-xl">
             <div className="flex items-center justify-between border-b border-border px-4 py-3">

--- a/frontend/src/pages/ProjectLandingPage.tsx
+++ b/frontend/src/pages/ProjectLandingPage.tsx
@@ -294,7 +294,6 @@ function DrawdownModal({ svgUrl, title = "Design preview", onClose }: {
     <div
       ref={backdropRef}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
-      role="presentation"
       onClick={onClose}
       onKeyDown={(e) => e.key === "Escape" && onClose()}
     >
@@ -381,7 +380,6 @@ function TieUpModal({ projectId, draftName, onClose }: {
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
-      role="presentation"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
       onKeyDown={(e) => e.key === "Escape" && onClose()}
     >

--- a/frontend/src/pages/ProjectLandingPage.tsx
+++ b/frontend/src/pages/ProjectLandingPage.tsx
@@ -294,12 +294,15 @@ function DrawdownModal({ svgUrl, title = "Design preview", onClose }: {
     <div
       ref={backdropRef}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+      role="presentation"
       onClick={onClose}
+      onKeyDown={(e) => e.key === "Escape" && onClose()}
     >
       <div
         className="bg-card rounded-xl border border-border shadow-xl flex flex-col"
         style={{ width: "min(96vw, 1400px)", height: "min(92vh, 1200px)" }}
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => { e.stopPropagation(); if (e.key === "Escape") onClose(); }}
       >
         {/* Toolbar */}
         <div className="flex items-center gap-2 px-3 py-2 border-b border-border shrink-0">
@@ -378,7 +381,9 @@ function TieUpModal({ projectId, draftName, onClose }: {
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      role="presentation"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      onKeyDown={(e) => e.key === "Escape" && onClose()}
     >
       <div className="bg-card rounded-xl border border-border shadow-2xl flex flex-col max-w-lg w-full max-h-[80vh]">
         <div className="flex items-center justify-between px-4 py-3 border-b border-border">

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -151,7 +151,6 @@ function ProjectCard({ project, onAssign }: {
       {showPreview && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
-          role="presentation"
           onClick={() => setShowPreview(false)}
           onKeyDown={(e) => e.key === "Escape" && setShowPreview(false)}
         >

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -151,9 +151,15 @@ function ProjectCard({ project, onAssign }: {
       {showPreview && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+          role="presentation"
           onClick={() => setShowPreview(false)}
+          onKeyDown={(e) => e.key === "Escape" && setShowPreview(false)}
         >
-          <div className="relative max-w-xl w-full" onClick={(e) => e.stopPropagation()}>
+          <div
+            className="relative max-w-xl w-full"
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => { e.stopPropagation(); if (e.key === "Escape") setShowPreview(false); }}
+          >
             <button
               onClick={() => setShowPreview(false)}
               className="absolute -top-9 right-0 text-white/70 hover:text-white text-sm"

--- a/frontend/src/pages/SuperuserPage.tsx
+++ b/frontend/src/pages/SuperuserPage.tsx
@@ -841,7 +841,9 @@ function TaskHistoryRow({ item, onRevoke }: { item: TaskHistoryItem; onRevoke: (
     <>
       <tr
         className={`border-t hover:bg-muted/30 text-xs ${item.error ? "cursor-pointer" : ""}`}
+        tabIndex={item.error ? 0 : undefined}
         onClick={() => item.error && setExpanded((v) => !v)}
+        onKeyDown={(e) => { if (item.error && e.key === "Enter") setExpanded((v) => !v); }}
       >
         <td className="px-3 py-2 font-mono text-muted-foreground whitespace-nowrap">{fmtTime(item.queued_at)}</td>
         <td className="px-3 py-2 font-mono" title={item.name}>{shortName(item.name)}</td>

--- a/frontend/src/pages/YarnDetailPage.tsx
+++ b/frontend/src/pages/YarnDetailPage.tsx
@@ -11,11 +11,14 @@ function DevJsonModal({ data, onClose }: { data: unknown; onClose: () => void })
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      role="presentation"
       onClick={onClose}
+      onKeyDown={(e) => e.key === "Escape" && onClose()}
     >
       <div
         className="relative bg-card border border-border rounded-xl shadow-lg max-w-2xl w-full max-h-[80vh] overflow-auto m-4"
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => { e.stopPropagation(); if (e.key === "Escape") onClose(); }}
       >
         <div className="flex items-center justify-between px-4 py-3 border-b border-border">
           <span className="text-xs font-mono font-semibold text-accent">DEV — raw data</span>

--- a/frontend/src/pages/YarnDetailPage.tsx
+++ b/frontend/src/pages/YarnDetailPage.tsx
@@ -11,7 +11,6 @@ function DevJsonModal({ data, onClose }: { data: unknown; onClose: () => void })
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      role="presentation"
       onClick={onClose}
       onKeyDown={(e) => e.key === "Escape" && onClose()}
     >
@@ -125,7 +124,6 @@ function EditColorwayModal({
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      role="presentation"
       onClick={onClose}
       onKeyDown={(e) => e.key === "Escape" && onClose()}
     >


### PR DESCRIPTION
## Summary
- SonarCloud `typescript:S1082` flagged 24 occurrences across 13 files: visible non-interactive elements with `onClick` but no `onKeyDown`, required for WCAG 2.1 keyboard navigation.
- Audited the current source against the issue's checklist rather than trusting its line numbers, which had drifted since filing — one location (`YarnDetailPage`'s `EditColorwayModal`) was already fixed in #903.
- Applied two patterns depending on shape:
  - **Modal/overlay backdrops**: `onKeyDown` checks `Escape` and calls the same close handler as `onClick`. This works via event bubbling from whatever element inside the modal currently has focus — the backdrop `div` itself doesn't need `tabIndex`.
  - **Table-row toggles** (`SuperuserPage` `TaskHistoryRow`, `AdminPage` `AuditLogRow`): conditional `tabIndex={0}` + `onKeyDown` (Enter), since there's no other focusable descendant to bubble from. Deliberately kept native `row` semantics rather than adding `role="button"`, which would strip table semantics for screen readers.
- Also fixed one backdrop in `AdminPage`'s submission detail modal that has the identical bug but wasn't in the original 24 (found during the audit).

Closes #954

## Test plan
- [x] `eslint` clean on all 13 changed files
- [x] `tsc -b` clean
- [x] Full stack rebuilt via `rbd`
- [x] Playwright verification against the live app (FeedbackModal, representative of the backdrop pattern used in 10 of the 13 files): modal opens, closes on Escape (confirms the fix works via bubbling), still closes on backdrop click (no regression)