### PR TITLE
feat: Neon project dropdown selector + fix stale config display after save

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -6,7 +6,7 @@ import platform
 import time
 import uuid
 from datetime import date, datetime, timedelta, timezone
-from typing import Literal
+from typing import Any, Literal
 
 import httpx
 import psutil
@@ -2888,6 +2888,26 @@ class ConfigTestResult(BaseModel):
     options: list[ConfigTestOption] | None = None
 
 
+def _resolve_field_source(field: str, env_var: str | None, file_values: dict[str, Any]) -> str:
+    if env_var:
+        return "env"
+    if field in file_values:
+        return "file"
+    return "default"
+
+
+def _resolve_field_value(source: str, live_value: str, file_value: str) -> tuple[str, bool]:
+    """Return (raw_value, pending_restart) for one field.
+
+    A file value the running process's Settings singleton hasn't picked up yet
+    (constructed once at startup — see #1031) would otherwise render as blank
+    immediately after save, reading as data loss rather than "saved, pending
+    restart". Prefer the on-disk value whenever it differs from what's live.
+    """
+    pending_restart = source == "file" and file_value != live_value
+    return (file_value if pending_restart else live_value), pending_restart
+
+
 def _get_config_state(settings: Settings) -> list[ConfigFieldState]:
     """Return current effective value and source for every managed field."""
     encryption_key = settings.config_encryption_key
@@ -2900,19 +2920,8 @@ def _get_config_state(settings: Settings) -> list[ConfigFieldState]:
         live_value: str = str(getattr(settings, field, "") or "")
         file_value: str = str(file_values.get(field, "") or "")
 
-        if env_var:
-            source = "env"
-        elif field in file_values:
-            source = "file"
-        else:
-            source = "default"
-
-        # A file value the running process's Settings singleton hasn't picked up yet
-        # (constructed once at startup — see #1031) would otherwise render as blank
-        # immediately after save, reading as data loss rather than "saved, pending
-        # restart". Prefer the on-disk value whenever it differs from what's live.
-        pending_restart = source == "file" and file_value != live_value
-        raw_value = file_value if pending_restart else live_value
+        source = _resolve_field_source(field, env_var, file_values)
+        raw_value, pending_restart = _resolve_field_value(source, live_value, file_value)
 
         is_secret = field in SECRET_FIELDS
         result.append(

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1640,6 +1640,7 @@ async def get_db_info(
 
 
 NEON_CONSUMPTION_URL = "https://console.neon.tech/api/v2/consumption_history/v2/projects"
+NEON_PROJECTS_URL = "https://console.neon.tech/api/v2/projects"
 
 
 async def _fetch_neon_usage(settings: Settings) -> NeonUsageResponse:
@@ -2863,6 +2864,7 @@ class ConfigFieldState(BaseModel):
     secret_prefix: str | None  # first 8 chars of the secret, for display
     source: str  # "env" | "file" | "default"
     env_var: str | None
+    pending_restart: bool = False  # file has a value the running process hasn't loaded yet
 
 
 class ConfigStateResponse(BaseModel):
@@ -2875,9 +2877,15 @@ class ConfigSaveRequest(BaseModel):
     values: dict[str, str | None]
 
 
+class ConfigTestOption(BaseModel):
+    value: str
+    label: str
+
+
 class ConfigTestResult(BaseModel):
     ok: bool
     message: str
+    options: list[ConfigTestOption] | None = None
 
 
 def _get_config_state(settings: Settings) -> list[ConfigFieldState]:
@@ -2889,7 +2897,8 @@ def _get_config_state(settings: Settings) -> list[ConfigFieldState]:
     result: list[ConfigFieldState] = []
     for field in MANAGED_FIELDS:
         env_var = env_sources.get(field)
-        raw_value: str = str(getattr(settings, field, "") or "")
+        live_value: str = str(getattr(settings, field, "") or "")
+        file_value: str = str(file_values.get(field, "") or "")
 
         if env_var:
             source = "env"
@@ -2897,6 +2906,13 @@ def _get_config_state(settings: Settings) -> list[ConfigFieldState]:
             source = "file"
         else:
             source = "default"
+
+        # A file value the running process's Settings singleton hasn't picked up yet
+        # (constructed once at startup — see #1031) would otherwise render as blank
+        # immediately after save, reading as data loss rather than "saved, pending
+        # restart". Prefer the on-disk value whenever it differs from what's live.
+        pending_restart = source == "file" and file_value != live_value
+        raw_value = file_value if pending_restart else live_value
 
         is_secret = field in SECRET_FIELDS
         result.append(
@@ -2907,6 +2923,7 @@ def _get_config_state(settings: Settings) -> list[ConfigFieldState]:
                 secret_prefix=raw_value[:8] if (is_secret and raw_value) else None,
                 source=source,
                 env_var=env_var,
+                pending_restart=pending_restart,
             )
         )
     return result
@@ -3042,17 +3059,28 @@ async def _test_neon(v: dict) -> ConfigTestResult:
             "org_id": org_id,
             "metrics": "compute_unit_seconds",
         }
+        headers = {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
         async with httpx.AsyncClient() as client:
-            resp = await client.get(
-                NEON_CONSUMPTION_URL,
-                params=params,
-                headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
-                timeout=10,
-            )
-        if resp.status_code == 200:
-            project_count = len(resp.json().get("projects", []))
-            return ConfigTestResult(ok=True, message=f"Connected — {project_count} project(s) visible to this org")
-        return ConfigTestResult(ok=False, message=f"Neon API returned {resp.status_code}: {resp.text[:120]}")
+            resp = await client.get(NEON_CONSUMPTION_URL, params=params, headers=headers, timeout=10)
+        if resp.status_code != 200:
+            return ConfigTestResult(ok=False, message=f"Neon API returned {resp.status_code}: {resp.text[:120]}")
+        project_count = len(resp.json().get("projects", []))
+
+        options: list[ConfigTestOption] | None = None
+        try:
+            async with httpx.AsyncClient() as client:
+                proj_resp = await client.get(NEON_PROJECTS_URL, params={"org_id": org_id}, headers=headers, timeout=10)
+            if proj_resp.status_code == 200:
+                options = [
+                    ConfigTestOption(value=p["id"], label=p.get("name") or p["id"])
+                    for p in proj_resp.json().get("projects", [])
+                ]
+        except Exception:
+            pass  # project listing is a nice-to-have — the connection test above already succeeded
+
+        return ConfigTestResult(
+            ok=True, message=f"Connected — {project_count} project(s) visible to this org", options=options
+        )
     except Exception as exc:
         return ConfigTestResult(ok=False, message=str(exc))
 

--- a/backend/tests/routers/test_admin_probes.py
+++ b/backend/tests/routers/test_admin_probes.py
@@ -1167,3 +1167,120 @@ class TestTestNeon:
 
         assert result.ok is False
         assert "403" in result.message
+
+    async def test_success_populates_project_options(self):
+        from app.routers.admin import _test_neon
+
+        consumption_resp = MagicMock()
+        consumption_resp.status_code = 200
+        consumption_resp.json = MagicMock(return_value={"projects": [{"project_id": "a"}, {"project_id": "b"}]})
+
+        projects_resp = MagicMock()
+        projects_resp.status_code = 200
+        projects_resp.json = MagicMock(
+            return_value={"projects": [{"id": "a", "name": "Alpha"}, {"id": "b", "name": "Beta"}]}
+        )
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_inst = AsyncMock()
+            mock_inst.get = AsyncMock(side_effect=[consumption_resp, projects_resp])
+            mock_inst.__aenter__ = AsyncMock(return_value=mock_inst)
+            mock_inst.__aexit__ = AsyncMock(return_value=None)
+            mock_cls.return_value = mock_inst
+            result = await _test_neon({"neon_api_key": "napi_xyz", "neon_org_id": "org_123"})
+
+        assert result.ok is True
+        assert [o.model_dump() for o in result.options] == [
+            {"value": "a", "label": "Alpha"},
+            {"value": "b", "label": "Beta"},
+        ]
+
+    async def test_project_listing_failure_leaves_options_none(self):
+        from app.routers.admin import _test_neon
+
+        consumption_resp = MagicMock()
+        consumption_resp.status_code = 200
+        consumption_resp.json = MagicMock(return_value={"projects": []})
+
+        projects_resp = MagicMock()
+        projects_resp.status_code = 500
+        projects_resp.text = "internal error"
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_inst = AsyncMock()
+            mock_inst.get = AsyncMock(side_effect=[consumption_resp, projects_resp])
+            mock_inst.__aenter__ = AsyncMock(return_value=mock_inst)
+            mock_inst.__aexit__ = AsyncMock(return_value=None)
+            mock_cls.return_value = mock_inst
+            result = await _test_neon({"neon_api_key": "napi_xyz", "neon_org_id": "org_123"})
+
+        assert result.ok is True
+        assert result.options is None
+
+
+# ---------------------------------------------------------------------------
+# _get_config_state — pending_restart flag (#1031)
+# ---------------------------------------------------------------------------
+
+
+class TestGetConfigState:
+    def test_no_encryption_key_no_fields_pending(self, monkeypatch):
+        from app.config import get_settings
+        from app.routers.admin import _get_config_state
+
+        s = get_settings()
+        monkeypatch.setattr(s, "config_encryption_key", "")
+        result = _get_config_state(s)
+
+        assert all(f.pending_restart is False for f in result)
+
+    def test_file_value_differing_from_live_is_pending_restart(self, monkeypatch):
+        from app.config import get_settings
+        from app.routers import admin
+        from app.routers.admin import _get_config_state
+
+        s = get_settings()
+        monkeypatch.setattr(s, "config_encryption_key", "test-key")
+        monkeypatch.setattr(s, "neon_org_id", "")  # live process hasn't picked up the save yet
+        monkeypatch.setattr(admin, "_load_config", lambda path, key: {"neon_org_id": "org_new"})
+
+        result = _get_config_state(s)
+        field = next(f for f in result if f.field == "neon_org_id")
+
+        assert field.pending_restart is True
+        assert field.source == "file"
+        assert field.value == "org_new"  # reflects the on-disk value, not the stale live one
+
+    def test_file_value_matching_live_is_not_pending_restart(self, monkeypatch):
+        from app.config import get_settings
+        from app.routers import admin
+        from app.routers.admin import _get_config_state
+
+        s = get_settings()
+        monkeypatch.setattr(s, "config_encryption_key", "test-key")
+        monkeypatch.setattr(s, "neon_org_id", "org_current")  # post-restart: live matches file
+        monkeypatch.setattr(admin, "_load_config", lambda path, key: {"neon_org_id": "org_current"})
+
+        result = _get_config_state(s)
+        field = next(f for f in result if f.field == "neon_org_id")
+
+        assert field.pending_restart is False
+        assert field.value == "org_current"
+
+    def test_secret_field_pending_restart_reports_prefix_not_value(self, monkeypatch):
+        from app.config import get_settings
+        from app.routers import admin
+        from app.routers.admin import _get_config_state
+
+        s = get_settings()
+        monkeypatch.setattr(s, "config_encryption_key", "test-key")
+        monkeypatch.setattr(s, "neon_api_key", "")
+        monkeypatch.setattr(admin, "_load_config", lambda path, key: {"neon_api_key": "napi_freshly_saved"})
+
+        result = _get_config_state(s)
+        field = next(f for f in result if f.field == "neon_api_key")
+
+        assert field.pending_restart is True
+        assert field.secret_set is True
+        assert field.value is None  # secrets never round-trip in plaintext
+        assert field.secret_prefix == "napi_fre"

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -536,6 +536,7 @@ export interface ConfigFieldState {
   secret_prefix: string | null;
   source: "env" | "file" | "default";
   env_var: string | null;
+  pending_restart: boolean;
 }
 
 export interface ConfigStateResponse {
@@ -544,9 +545,15 @@ export interface ConfigStateResponse {
   api_url: string;
 }
 
+export interface ConfigTestOption {
+  value: string;
+  label: string;
+}
+
 export interface ConfigTestResult {
   ok: boolean;
   message: string;
+  options?: ConfigTestOption[] | null;
 }
 
 export const getConfig = () => api.get<ConfigStateResponse>("/api/admin/config");

--- a/frontend/src/pages/SuperuserPage.tsx
+++ b/frontend/src/pages/SuperuserPage.tsx
@@ -1690,16 +1690,16 @@ const CONFIG_FIELD_LABELS: Record<string, string> = {
 };
 
 interface ConfigFieldRowProps {
-  field: string;
-  groupFieldCount: number;
-  state: ConfigFieldState | undefined;
-  isZeroTrustEnabled: boolean;
-  drafts: Record<string, string>;
-  setDrafts: React.Dispatch<React.SetStateAction<Record<string, string>>>;
-  editingFields: Set<string>;
-  setEditingFields: React.Dispatch<React.SetStateAction<Set<string>>>;
-  apiUrl: string;
-  selectOptions?: ConfigTestOption[];
+  readonly field: string;
+  readonly groupFieldCount: number;
+  readonly state: ConfigFieldState | undefined;
+  readonly isZeroTrustEnabled: boolean;
+  readonly drafts: Record<string, string>;
+  readonly setDrafts: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+  readonly editingFields: Set<string>;
+  readonly setEditingFields: React.Dispatch<React.SetStateAction<Set<string>>>;
+  readonly apiUrl: string;
+  readonly selectOptions?: ConfigTestOption[];
 }
 
 function ConfigFieldRow({ field, groupFieldCount, state, isZeroTrustEnabled, drafts, setDrafts, editingFields, setEditingFields, apiUrl, selectOptions }: ConfigFieldRowProps) {
@@ -1750,6 +1750,41 @@ function ConfigFieldRow({ field, groupFieldCount, state, isZeroTrustEnabled, dra
   if (isSecret && isSet) placeholder = "Enter new value to replace";
   else if (field === "webhook_base_url" && !isSet) placeholder = apiUrl || "http://localhost:8000";
 
+  const inputCls = "w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring font-mono";
+  let fieldControl: React.ReactNode;
+  if (showMasked) {
+    fieldControl = (
+      <div
+        className={`${inputCls} text-muted-foreground cursor-text select-none`}
+        onClick={() => setEditingFields((prev) => new Set([...prev, field]))}
+        title="Click to change"
+      >
+        {state?.secret_prefix ? state.secret_prefix + "••••••••" : "••••••••"}
+      </div>
+    );
+  } else if (selectOptions?.length) {
+    fieldControl = (
+      <select className={inputCls} value={inputValue} onChange={(e) => setDrafts((prev) => ({ ...prev, [field]: e.target.value }))}>
+        <option value="">— none (no filter) —</option>
+        {selectOptions.map((o) => (
+          <option key={o.value} value={o.value}>{o.label}</option>
+        ))}
+      </select>
+    );
+  } else {
+    fieldControl = (
+      <input
+        type={inputType}
+        className={inputCls}
+        value={inputValue}
+        placeholder={placeholder}
+        onChange={(e) => setDrafts((prev) => ({ ...prev, [field]: e.target.value }))}
+        autoComplete="off"
+        autoFocus={isPrefixMasked && isEditing && !hasDraft}
+      />
+    );
+  }
+
   return (
     <div className={isFullWidth ? "sm:col-span-2" : ""}>
       <div className="flex items-center gap-1.5 mb-1">
@@ -1776,36 +1811,7 @@ function ConfigFieldRow({ field, groupFieldCount, state, isZeroTrustEnabled, dra
           </span>
         )}
       </div>
-      {showMasked ? (
-        <div
-          className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm font-mono text-muted-foreground cursor-text select-none"
-          onClick={() => setEditingFields((prev) => new Set([...prev, field]))}
-          title="Click to change"
-        >
-          {state?.secret_prefix ? state.secret_prefix + "••••••••" : "••••••••"}
-        </div>
-      ) : selectOptions?.length ? (
-        <select
-          className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring font-mono"
-          value={inputValue}
-          onChange={(e) => setDrafts((prev) => ({ ...prev, [field]: e.target.value }))}
-        >
-          <option value="">— none (no filter) —</option>
-          {selectOptions.map((o) => (
-            <option key={o.value} value={o.value}>{o.label}</option>
-          ))}
-        </select>
-      ) : (
-        <input
-          type={inputType}
-          className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring font-mono"
-          value={inputValue}
-          placeholder={placeholder}
-          onChange={(e) => setDrafts((prev) => ({ ...prev, [field]: e.target.value }))}
-          autoComplete="off"
-          autoFocus={isPrefixMasked && isEditing && !hasDraft}
-        />
-      )}
+      {fieldControl}
       {fromEnv && hasDraft && (
         <p className="text-[11px] text-amber-600 dark:text-amber-400 mt-0.5">
           ENV var active — file value won't take effect until removed from .env

--- a/frontend/src/pages/SuperuserPage.tsx
+++ b/frontend/src/pages/SuperuserPage.tsx
@@ -48,6 +48,7 @@ import {
   type CredentialExpiry,
   type CredentialResource,
   type ConfigTestResult,
+  type ConfigTestOption,
   type ConfigFieldState,
 } from "@/api/admin";
 import { EulaContent } from "@/components/EulaContent";
@@ -1698,9 +1699,10 @@ interface ConfigFieldRowProps {
   editingFields: Set<string>;
   setEditingFields: React.Dispatch<React.SetStateAction<Set<string>>>;
   apiUrl: string;
+  selectOptions?: ConfigTestOption[];
 }
 
-function ConfigFieldRow({ field, groupFieldCount, state, isZeroTrustEnabled, drafts, setDrafts, editingFields, setEditingFields, apiUrl }: ConfigFieldRowProps) {
+function ConfigFieldRow({ field, groupFieldCount, state, isZeroTrustEnabled, drafts, setDrafts, editingFields, setEditingFields, apiUrl, selectOptions }: ConfigFieldRowProps) {
   if ((field === "cf_access_client_id" || field === "cf_access_client_secret") && !isZeroTrustEnabled) return null;
 
   const isBoolean = BOOLEAN_FIELDS.has(field);
@@ -1758,8 +1760,14 @@ function ConfigFieldRow({ field, groupFieldCount, state, isZeroTrustEnabled, dra
           </span>
         )}
         {isSet && !fromEnv && !hasDraft && (
-          <span className="text-[10px] border rounded px-1 text-green-700 dark:text-green-400 border-green-300 dark:border-green-700 leading-4">
-            Set
+          <span
+            className={`text-[10px] border rounded px-1 leading-4 ${
+              state?.pending_restart
+                ? "text-amber-600 dark:text-amber-400 border-amber-300 dark:border-amber-700"
+                : "text-green-700 dark:text-green-400 border-green-300 dark:border-green-700"
+            }`}
+          >
+            {state?.pending_restart ? "Set — pending restart" : "Set"}
           </span>
         )}
         {field === "webhook_base_url" && !isSet && !hasDraft && (
@@ -1776,6 +1784,17 @@ function ConfigFieldRow({ field, groupFieldCount, state, isZeroTrustEnabled, dra
         >
           {state?.secret_prefix ? state.secret_prefix + "••••••••" : "••••••••"}
         </div>
+      ) : selectOptions?.length ? (
+        <select
+          className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring font-mono"
+          value={inputValue}
+          onChange={(e) => setDrafts((prev) => ({ ...prev, [field]: e.target.value }))}
+        >
+          <option value="">— none (no filter) —</option>
+          {selectOptions.map((o) => (
+            <option key={o.value} value={o.value}>{o.label}</option>
+          ))}
+        </select>
       ) : (
         <input
           type={inputType}
@@ -1945,6 +1964,7 @@ function ConfigSection() {
                     editingFields={editingFields}
                     setEditingFields={setEditingFields}
                     apiUrl={configState.api_url}
+                    selectOptions={field === "neon_project_id" ? (testResult?.options ?? undefined) : undefined}
                   />
                 ))}
               </div>


### PR DESCRIPTION
## Summary

Two related pieces, both surfaced from the same admin-config testing session:

**1. Neon project dropdown** — `POST /admin/config/test/neon` already reported how many Neon projects the API key could see, but only a count. `_test_neon` now makes a second call to Neon's Projects API after a successful connection check and returns `options: [{value, label}]` on `ConfigTestResult`. The frontend renders `neon_project_id` as a `<select>` populated from the last successful test, falling back to free text before any test has run.

**2. Fixes stale "unset" display after save** — found while testing #1: after saving config (any field, not just Neon), the field would show as completely blank/unset until the backend process restarted, which reads as data loss even though the value was correctly persisted to the encrypted file. Root cause: `Settings` (`backend/app/config.py`) is constructed once per process via `get_settings()`'s `@lru_cache`, and `_ConfigFileSource` only reads the config file at that construction time — a save afterward writes the file correctly but the already-constructed `Settings` singleton has no way to see it. `_get_config_state` now independently compares the on-disk value against what's live, prefers the on-disk value when they differ, and flags the field `pending_restart` so the UI shows \"Set — pending restart\" instead of blank.

Closes #1031

## Test plan
- [x] New tests in `TestGetConfigState` (`backend/tests/routers/test_admin_probes.py`) — no-encryption-key case, file-differs-from-live → `pending_restart=True` with on-disk value surfaced, file-matches-live → `pending_restart=False`, secret fields report prefix/`secret_set` correctly under `pending_restart` without ever round-tripping plaintext
- [x] Extended `TestTestNeon` — success path populates `options` correctly from the Projects API; project-listing failure leaves `options=None` without failing the overall test result (best-effort, doesn't block the primary connection check)
- [x] `ruff`, `mypy`, `eslint`, `tsc` all clean
- [x] Full stack rebuilt via `rbd`; verified live in browser — Neon config group renders correctly, `neon_project_id` falls back to a plain input when no test has run yet (no console/page errors), existing secret-field validation behavior (re-test requires a fresh value) unaffected
- [x] Isolated unit tests for the changed logic pass cleanly and repeatably; a local full-suite run hit unrelated failures from a corrupted local test DB (concurrent pytest sessions colliding — a known false-failure mode, documented in `docs/testing.md` context) — deferring to CI's isolated DB for the full-suite signal