### PR TITLE
fix: /jump concurrency protection — row lock, out-of-order guard

### DIFF
--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -1210,7 +1210,10 @@ async def jump_project(
     current_user: User = Depends(get_effective_user),
     db: AsyncSession = Depends(get_db),
 ) -> ProjectDetail:
-    project = await _get_owned_project(project_id, current_user, db)
+    # FOR UPDATE serializes against concurrent /step and /jump requests on the same
+    # project row — matches step_project (see #1028: jump previously overwrote
+    # current_pick with no lock, letting a stale request clobber newer progress).
+    project = await _get_owned_project(project_id, current_user, db, with_for_update=True)
     if project.status not in ("created", "active"):
         raise HTTPException(status_code=400, detail="Project is not active")
     project.current_pick = max(1, min(body.pick, project.total_picks + 1))

--- a/backend/tests/routers/test_projects.py
+++ b/backend/tests/routers/test_projects.py
@@ -1386,6 +1386,55 @@ class TestJumpProject:
         resp = await auth_client.post(f"/api/projects/{uuid.uuid4()}/jump", json={"pick": 1})
         assert resp.status_code == 404
 
+    async def test_locks_row_for_update(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        """Regression test for #1028 — jump previously read the project without a row
+        lock, letting a concurrent/out-of-order request clobber newer progress. Verify
+        the same with_for_update=True path used by step_project is now used here too."""
+        from unittest.mock import AsyncMock, patch
+
+        import app.routers.projects as projects_module
+
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+
+        original = projects_module._get_owned_project
+        with patch.object(projects_module, "_get_owned_project", new=AsyncMock(wraps=original)) as mock_get:
+            resp = await auth_client.post(f"/api/projects/{project.id}/jump", json={"pick": 2})
+
+        assert resp.status_code == 200
+        mock_get.assert_called_once()
+        assert mock_get.call_args.kwargs.get("with_for_update") is True
+
+    async def test_jump_then_step_produces_consistent_state(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        """Sequential jump + step interleaving must never lose or duplicate progress —
+        true concurrent-request serialization is provided by SELECT FOR UPDATE (see
+        test_locks_row_for_update); here we verify the resulting state is coherent."""
+        draft = await _insert_draft(db_session, test_user)
+        project = Project(
+            owner_id=test_user.id,
+            draft_id=draft.id,
+            name="Jump-then-step project",
+            project_type="treadle",
+            status="active",
+            current_pick=1,
+            total_picks=10,
+        )
+        db_session.add(project)
+        await db_session.commit()
+
+        jump_body = (await auth_client.post(f"/api/projects/{project.id}/jump", json={"pick": 5})).json()
+        assert jump_body["current_pick"] == 5
+
+        step_body = (await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})).json()
+        assert step_body["current_pick"] == 6
+
+        reverse_body = (
+            await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "reverse"})
+        ).json()
+        assert reverse_body["current_pick"] == 5
+
 
 # ---------------------------------------------------------------------------
 # TestCompleteProject

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -583,12 +583,14 @@ function StepControls({
   onStep,
   onJump,
   stepping,
+  jumpDisabled = false,
 }: {
   currentPick: number;
   total: number;
   onStep: (dir: "advance" | "reverse") => void;
   onJump: (pick: number) => void;
   stepping: boolean;
+  jumpDisabled?: boolean;
 }) {
   const { t } = useTranslation();
   const atStart = currentPick <= 1;
@@ -600,7 +602,7 @@ function StepControls({
       {/* ‹‹ back 10 — visible on sm+ */}
       <button
         onClick={() => onJump(Math.max(1, currentPick - 10))}
-        disabled={atStart || disabled}
+        disabled={atStart || disabled || jumpDisabled}
         className="hidden sm:flex h-12 w-12 items-center justify-center rounded-full border-2 border-primary/40 text-primary/70 text-lg font-medium transition-colors hover:border-primary hover:bg-primary/10 disabled:opacity-30 disabled:cursor-not-allowed"
         aria-label="Back 10 picks"
         title="Back 10"
@@ -636,7 +638,7 @@ function StepControls({
       {/* ›› forward 10 — visible on sm+ */}
       <button
         onClick={() => onJump(Math.min(total + 1, currentPick + 10))}
-        disabled={pastEnd || disabled}
+        disabled={pastEnd || disabled || jumpDisabled}
         className="hidden sm:flex h-12 w-12 items-center justify-center rounded-full border-2 border-primary/40 text-primary/70 text-lg font-medium transition-colors hover:border-primary hover:bg-primary/10 disabled:opacity-30 disabled:cursor-not-allowed"
         aria-label="Forward 10 picks"
         title="Forward 10"
@@ -1125,32 +1127,46 @@ export function ProjectDetailPage() {
 
   const invalidate = () => queryClient.invalidateQueries({ queryKey: ["project", id] });
 
+  // Counts in-flight step + jump requests together. Used to suppress intermediate
+  // server responses during rapid tapping/jumping — only the last response in a
+  // burst settles the cache, so a stale response from either endpoint arriving
+  // late over a flaky connection can't revert a more recent one (see #1028).
+  const pendingStepsRef = useRef(0);
+
   const handleJump = useCallback(async (pick: number) => {
     if (!id || stepping) return;
+    // Jump is a deliberate correction, not continuous tracking like step — require
+    // connectivity rather than queueing it for later replay against a since-changed
+    // current_pick (see #1028).
+    if (!isOnline) return;
     setStepping(true);
+    pendingStepsRef.current += 1;
     try {
       const updated = await jumpProject(id, pick);
-      // Merge only the fields a jump can change — preserves loom/draft metadata
-      // that determines shaft/treadle display count.
-      queryClient.setQueryData<typeof project>(["project", id], (old) => {
-        if (!old) return updated;
-        return {
-          ...old,
-          current_pick: updated.current_pick,
-          current_item: updated.current_item,
-          total_picks: updated.total_picks,
-          num_items: updated.num_items,
-          status: updated.status,
-        };
-      });
+      pendingStepsRef.current -= 1;
+      if (pendingStepsRef.current === 0) {
+        // Merge only the fields a jump can change — preserves loom/draft metadata
+        // that determines shaft/treadle display count.
+        queryClient.setQueryData<typeof project>(["project", id], (old) => {
+          if (!old) return updated;
+          return {
+            ...old,
+            current_pick: updated.current_pick,
+            current_item: updated.current_item,
+            total_picks: updated.total_picks,
+            num_items: updated.num_items,
+            status: updated.status,
+          };
+        });
+      }
+    } catch {
+      pendingStepsRef.current -= 1;
+      queryClient.invalidateQueries({ queryKey: ["project", id] });
     } finally {
       setStepping(false);
     }
-  }, [id, stepping, queryClient]);
+  }, [id, stepping, isOnline, queryClient]);
 
-  // Counts in-flight step requests. Used to suppress intermediate server responses
-  // during rapid tapping — only the last response in a burst settles the cache.
-  const pendingStepsRef = useRef(0);
   const drainingRef = useRef(false);
 
   // Drain buffered offline steps when connectivity is restored
@@ -1752,7 +1768,7 @@ export function ProjectDetailPage() {
                 <JumpToPick
                   total={project.total_picks}
                   onJump={isPlanning ? handleLocalJump : handleJump}
-                  disabled={stepping}
+                  disabled={stepping || (!isPlanning && !isOnline)}
                 />
               </div>
               {/* Center 1/3 on desktop, top on mobile */}
@@ -1763,6 +1779,7 @@ export function ProjectDetailPage() {
                   onStep={isPlanning ? handleLocalStep : handleStep}
                   onJump={isPlanning ? handleLocalJump : handleJump}
                   stepping={stepping}
+                  jumpDisabled={!isPlanning && !isOnline}
                 />
               </div>
               {/* Right 1/3 reserved for future use */}


### PR DESCRIPTION
## Summary

Root cause of the reported \"wonky\" tracking / \"kept kicking me back\" bug (diagnosed in #1028): `jump_project` overwrote `current_pick` as an absolute value with **no row lock**, while `step_project` safely applies a relative ±1 under `SELECT ... FOR UPDATE`. Combined with the frontend having an out-of-order response guard for step but not jump, a flaky connection could let a stale response from either endpoint silently clobber more recent progress.

**Backend** (`backend/app/routers/projects.py`):
- `jump_project` now calls `_get_owned_project` with `with_for_update=True`, matching `step_project` — serializes concurrent/out-of-order requests against the same project row.

**Frontend** (`frontend/src/pages/ProjectDetailPage.tsx`):
- `handleJump` now shares the same in-flight counter (`pendingStepsRef`) `handleStep` already used, so a late response from either endpoint can't revert a more recent one from the other.
- Per the plan's item 3: jump requires connectivity rather than getting offline-queue parity with step. It's a deliberate correction (\"go to pick N\", ±10), not continuous tracking, and replaying a stale jump against a since-changed `current_pick` is semantically riskier than replaying a queued relative step. `JumpToPick` and the ±10 `StepControls` buttons now disable while offline; the ±1 step buttons are unaffected and keep queueing as before.

Closes #1028

## Test plan
- [x] New regression test asserting `jump_project` requests the row lock (`with_for_update=True`)
- [x] New jump-then-step sequential-consistency test
- [x] Full `TestJumpProject`/`TestStepProject` suite (18 tests) passes
- [x] `ruff`, `mypy`, `eslint`, `tsc` all clean
- [x] Full stack rebuilt via `rbd`; verified live in browser — step (±1) and jump (±10, jump-to-pick) both work correctly online, in-flight counter correctly merges responses, no console/page errors from this change (an unrelated pre-existing S3 access-denied error surfaced from a synthetic test project's WIF lookup, not from this fix)
- [ ] Offline-disable behavior verified by code inspection (matches the exact `isOnline` signal `handleStep`'s already-shipped offline-queueing depends on) rather than live Playwright — `context.setOffline()` flips `navigator.onLine` correctly but doesn't reliably fire the `window` `offline` event in this Playwright/Chromium combination, which affects both the pre-existing step-offline-queue path and the new jump-disable path equally, so it's a test-environment gap rather than something to chase further here