### PR TITLE
feat: live cross-device sync for the project tracking screen

### DIFF
--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1075,10 +1075,33 @@ export function ProjectDetailPage() {
   const isOnline = useOnlineStatus();
   const { enqueue: enqueueStep, pending: pendingOfflineSteps, drainAll } = useStepQueue();
 
+  // Counts in-flight step + jump requests together. Used to suppress intermediate
+  // server responses during rapid tapping/jumping — only the last response in a
+  // burst settles the cache, so a stale response from either endpoint arriving
+  // late over a flaky connection can't revert a more recent one (see #1028).
+  const pendingStepsRef = useRef(0);
+
   const { data: project, isLoading, error } = useQuery({
     queryKey: ["project", id],
-    queryFn: () => getProject(id!),
+    queryFn: async () => {
+      const fetched = await getProject(id!);
+      // Live cross-device sync (#1035) polls this query every few seconds while
+      // active. If that poll resolves while a step/jump mutation is in flight,
+      // never let it revert the optimistic pick below what's already displayed —
+      // same guard used for out-of-order mutation responses (see #1028).
+      if (pendingStepsRef.current > 0) {
+        const cached = queryClient.getQueryData<typeof fetched>(["project", id]);
+        if (cached) return { ...fetched, current_pick: Math.max(cached.current_pick, fetched.current_pick) };
+      }
+      return fetched;
+    },
     enabled: !!id,
+    // Live cross-device sync (#1035) — only while actively tracked with a loom
+    // assigned; a loom-less "planning" project uses purely local optimistic state
+    // (handleLocalStep/handleLocalJump) and never round-trips current_pick to the
+    // server, so polling it would be pointless. Matches the project-metrics gate below.
+    refetchInterval: (query) =>
+      query.state.data?.status === "active" && !!query.state.data?.loom_id ? 5_000 : false,
   });
 
   const { data: picksData } = useQuery({
@@ -1126,12 +1149,6 @@ export function ProjectDetailPage() {
   });
 
   const invalidate = () => queryClient.invalidateQueries({ queryKey: ["project", id] });
-
-  // Counts in-flight step + jump requests together. Used to suppress intermediate
-  // server responses during rapid tapping/jumping — only the last response in a
-  // burst settles the cache, so a stale response from either endpoint arriving
-  // late over a flaky connection can't revert a more recent one (see #1028).
-  const pendingStepsRef = useRef(0);
 
   const handleJump = useCallback(async (pick: number) => {
     if (!id || stepping) return;


### PR DESCRIPTION
## Summary

The main project query (\`["project", id]\`) had no periodic refetch — only mount, window-focus (once stale past 30s), or after the viewing device's own mutations. Two tabs/devices open on the same project could show different pick counts indefinitely, which was the display-drift half of the concurrency problem investigated in #1028 (data safety is now fixed via #1033's row locks; this closes the remaining \"screens don't match\" gap, split out into #1035 as a lower-priority follow-up).

## Approach

- Polls \`["project", id]\` every 5s while \`status === "active"\` and a loom is assigned — mirrors the existing \`project-metrics\` 30s poll gate. A loom-less \"planning\" project uses purely local optimistic state (\`handleLocalStep\`/\`handleLocalJump\`) and never round-trips \`current_pick\` to the server, so polling it would be pointless.
- Bounded to intentional, active use of the tracking page — not a background always-on poll — so it doesn't carry the same compute-cost concern that motivated widening the health-check/scheduled-task polling intervals elsewhere in this project.
- No new infrastructure — no WebSocket/SSE, just tuning an existing polling pattern. True push was considered and explicitly deferred (see #1035's description) since it'd require new transport infra plus proxy config changes across nginx + Traefik + Cloudflare.

## Race safety

The 5s poll could land while a step/jump mutation is in flight and revert the optimistic UI to a slightly-stale fetched value — the same class of bug #1028 fixed for out-of-order mutation responses, just from a GET poll this time. Guarded the same way: the \`queryFn\` checks the in-flight-request counter (\`pendingStepsRef\`, already used by \`handleStep\`/\`handleJump\`) and takes \`Math.max\` of the cached vs. fetched \`current_pick\` whenever a mutation is in flight.

Closes #1035

## Test plan
- [x] \`eslint\`, \`tsc\` clean
- [x] Full stack rebuilt via \`rbd\`
- [x] Live two-tab verification via Playwright (two contexts, same auth, same project): tab B correctly still showed the stale pick immediately after tab A's 3 steps (proving it wasn't already synced some other way), then converged to match tab A's value after ~6s — confirming the poll fires and propagates correctly
- [x] No console/page errors from this change (hit the same unrelated pre-existing S3 access-denied error from the synthetic test project's WIF lookup seen in prior verification passes — not from this fix)