### PR TITLE
fix: add localeCompare to string .sort() calls (S2871)

### DIFF
--- a/frontend/src/components/yarn/AddYarnModal.tsx
+++ b/frontend/src/components/yarn/AddYarnModal.tsx
@@ -67,7 +67,7 @@ export function AddYarnModal({ onSuccess, onClose }: Props) {
     if (!q) return [];
     return [...new Set(existingYarns.map((y) => y.brand))]
       .filter((b) => b.toLowerCase().includes(q))
-      .sort();
+      .sort((a, b) => a.localeCompare(b));
   }, [existingYarns, brand]);
 
   const nameSuggestions = useMemo(() => {
@@ -79,7 +79,7 @@ export function AddYarnModal({ onSuccess, onClose }: Props) {
       : existingYarns;
     return [...new Set(pool.map((y) => y.name))]
       .filter((n) => n.toLowerCase().includes(q))
-      .sort();
+      .sort((a, b) => a.localeCompare(b));
   }, [existingYarns, brand, name]);
 
   const handleSubmit = async (e: React.FormEvent) => {

--- a/frontend/src/pages/DraftsPage.tsx
+++ b/frontend/src/pages/DraftsPage.tsx
@@ -42,7 +42,7 @@ export function DraftsPage() {
   const allTags = useMemo(() => {
     const set = new Set<string>();
     drafts.forEach((d) => d.tags?.forEach((t) => set.add(t)));
-    return [...set].sort();
+    return [...set].sort((a, b) => a.localeCompare(b));
   }, [drafts]);
 
   const handleUploadSuccess = () => {

--- a/frontend/src/pages/LoomCatalogPage.tsx
+++ b/frontend/src/pages/LoomCatalogPage.tsx
@@ -104,7 +104,7 @@ export function LoomCatalogPage() {
 
   // Derive dropdown options from the full server result (stable across client filters)
   const manufacturerOptions = useMemo(
-    () => [...new Set(allLooms.map((l) => l.brand))].sort(),
+    () => [...new Set(allLooms.map((l) => l.brand))].sort((a, b) => a.localeCompare(b)),
     [allLooms],
   );
 
@@ -129,7 +129,7 @@ export function LoomCatalogPage() {
     });
   }, [allLooms, loomType, manufacturer, shaftCount]);
 
-  const brands = [...new Set(looms.map((l) => l.brand))].sort();
+  const brands = [...new Set(looms.map((l) => l.brand))].sort((a, b) => a.localeCompare(b));
   const grouped = Object.fromEntries(
     brands.map((brand) => [brand, looms.filter((l) => l.brand === brand)]),
   );

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -226,7 +226,7 @@ export function ProjectsPage() {
   const allTags = useMemo(() => {
     const set = new Set<string>();
     projects.forEach((p) => p.tags?.forEach((t) => set.add(t)));
-    return [...set].sort();
+    return [...set].sort((a, b) => a.localeCompare(b));
   }, [projects]);
 
   const filteredProjects = activeTagFilter

--- a/frontend/src/pages/YarnPage.tsx
+++ b/frontend/src/pages/YarnPage.tsx
@@ -402,7 +402,7 @@ function FilterPopover({
   }, [open]);
 
   const availableBrands = useMemo(
-    () => [...new Set(allYarns.map((y) => y.brand))].sort(),
+    () => [...new Set(allYarns.map((y) => y.brand))].sort((a, b) => a.localeCompare(b)),
     [allYarns],
   );
   const availableWeights = useMemo(() => {


### PR DESCRIPTION
## Summary
- Bare \`.sort()\` on string arrays uses default lexicographic ordering by UTF-16 code unit, which produces incorrect results for accented/non-ASCII characters — a weaver with a yarn brand like \"Ångström\" or a project tagged \"Réal\" would see it sorted after plain-ASCII entries instead of alphabetically.
- Fixed all 7 locations flagged in the issue: brand/name autocomplete suggestions (\`AddYarnModal.tsx\`), brand filter options (\`YarnPage.tsx\`, \`LoomCatalogPage.tsx\` ×2), and tag lists (\`DraftsPage.tsx\`, \`ProjectsPage.tsx\`).
- Swept the rest of the frontend for any other bare \`.sort()\` calls beyond the issue's original list — none found.

Closes #953

## Test plan
- [x] \`eslint\`, \`tsc\` clean
- [x] Full stack rebuilt via \`rbd\`; verified live in browser — \`/yarn\`, \`/drafts\`, \`/projects\`, \`/catalog/looms\` (all pages touched by this change) load with zero console/page errors