### PR TITLE
feat: session lock for active weaving-session tracking (#1029)

### DIFF
--- a/backend/alembic/versions/6e23527ac637_add_tracker_lock_to_projects.py
+++ b/backend/alembic/versions/6e23527ac637_add_tracker_lock_to_projects.py
@@ -1,0 +1,27 @@
+"""add tracker lock to projects
+
+Revision ID: 6e23527ac637
+Revises: 0001_squash_902
+Create Date: 2026-07-20 17:31:51.978619
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '6e23527ac637'
+down_revision: Union[str, None] = '0001_squash_902'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("projects", sa.Column("active_tracker_session_id", sa.String(length=64), nullable=True))
+    op.add_column("projects", sa.Column("active_tracker_claimed_at", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("projects", "active_tracker_claimed_at")
+    op.drop_column("projects", "active_tracker_session_id")

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -71,6 +71,12 @@ class Project(Base, TimestampMixin, SoftDeleteMixin):
     drawdown_preview_path: Mapped[str | None] = mapped_column(String(500), nullable=True)
     drawdown_svg_path: Mapped[str | None] = mapped_column(String(500), nullable=True)
 
+    # Tracker lock — which device/tab currently owns pick-position writes (see #1029).
+    # NULL means unclaimed. A claim older than the owner's idle_timeout_minutes is stale
+    # and self-heals on the next write/claim attempt.
+    active_tracker_session_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    active_tracker_claimed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
     steps: Mapped[list["ProjectStep"]] = relationship(
         "ProjectStep", back_populates="project", order_by="ProjectStep.created_at"
     )

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -5,6 +5,7 @@ import secrets
 import uuid
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from fastapi.responses import Response
@@ -360,7 +361,7 @@ async def _check_loom_conflict(
         raise HTTPException(status_code=409, detail="This loom already has an active project")
 
 
-async def _check_tracker_lock(project: Project, tracker_session_id: str, current_user: User) -> None:
+def _check_tracker_lock(project: Project, tracker_session_id: str, current_user: User) -> None:
     """Raise 409 if a different, still-live tracker session holds the lock.
 
     Otherwise (re)stamp the claim for the calling token — acts as a heartbeat so an
@@ -520,8 +521,8 @@ def _to_detail(
 @router.post("", response_model=ProjectDetail, status_code=201)
 async def create_project(
     body: CreateProjectRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectDetail:
     if body.project_type not in ("treadle", "lift"):
         raise HTTPException(status_code=400, detail="project_type must be 'treadle' or 'lift'")
@@ -617,11 +618,11 @@ async def create_project(
 
 @router.get("", response_model=list[ProjectSummary])
 async def list_projects(
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     draft_id: uuid.UUID | None = Query(None),
     loom_id: uuid.UUID | None = Query(None),
     tags: list[str] | None = Query(None),
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
 ) -> list[ProjectSummary]:
     q = select(Project).where(Project.owner_id == current_user.id, Project.deleted_at.is_(None))
     if draft_id is not None:
@@ -638,12 +639,12 @@ async def list_projects(
 @router.get("/{project_id}/drawdown")
 async def get_project_drawdown(
     project_id: uuid.UUID,
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     start_row: int | None = Query(None, ge=0),
     row_count: int | None = Query(None, ge=1),
     start_col: int | None = Query(None, ge=0),
     col_count: int | None = Query(None, ge=1),
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
 ) -> Response:
     from app.config import get_settings
     from app.services import rendering
@@ -751,10 +752,10 @@ async def get_project_drawdown(
 @router.get("/{project_id}/drawdown/svg")
 async def get_project_drawdown_svg(
     project_id: uuid.UUID,
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     cell_px: int = Query(20, ge=1, le=30),
     color_replacements: str | None = Query(None),
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
 ) -> Response:
     import json
 
@@ -807,9 +808,9 @@ async def get_project_drawdown_svg(
 @router.get("/{project_id}/drawdown/preview")
 async def get_project_drawdown_preview(
     project_id: uuid.UUID,
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     color_replacements: str | None = Query(None),
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
 ) -> Response:
     """Full draft PNG (threading + tieup + drawdown), optionally with colour replacements applied."""
     import json
@@ -858,8 +859,8 @@ async def get_project_drawdown_preview(
 @router.get("/{project_id}/drawdown_preview")
 async def get_project_drawdown_preview_cached(
     project_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Response:
     """Return the pre-rendered drawdown thumbnail PNG for a project, or 404 if not yet generated."""
     project = await _get_owned_project(project_id, current_user, db, allow_superuser=True)
@@ -876,8 +877,8 @@ async def get_project_drawdown_preview_cached(
 @router.get("/{project_id}/drawdown_svg")
 async def get_project_drawdown_svg_cached(
     project_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Response:
     """Return the pre-rendered drawdown SVG for a project, or 404 if not yet generated."""
     project = await _get_owned_project(project_id, current_user, db, allow_superuser=True)
@@ -894,9 +895,9 @@ async def get_project_drawdown_svg_cached(
 @router.get("/{project_id}/drawdown/data")
 async def get_project_drawdown_data(
     project_id: uuid.UUID,
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     cell_px: int = Query(20, ge=4, le=30),
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
 ) -> Response:
     from app.services import rendering
     from app.services.storage import afile_exists, aread_file
@@ -941,8 +942,8 @@ async def get_project_drawdown_data(
 @router.get("/{project_id}", response_model=ProjectDetail)
 async def get_project(
     project_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectDetail:
     stmt = (
         select(Project)
@@ -985,8 +986,8 @@ async def get_project(
 async def rename_project(
     project_id: uuid.UUID,
     body: RenameProjectRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectDetail:
     if body.name is None and body.notes is None and body.hide_unused_shafts_treadles is None and body.tags is None:
         raise HTTPException(status_code=400, detail="At least one field must be provided")
@@ -1014,8 +1015,8 @@ async def rename_project(
 async def set_color_replacements(
     project_id: uuid.UUID,
     body: ColorReplacementsRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectDetail:
     import re
 
@@ -1040,8 +1041,8 @@ async def set_color_replacements(
 async def update_warp_setup(
     project_id: uuid.UUID,
     body: WarpSetupRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectDetail:
     project = await _get_owned_project(project_id, current_user, db)
     fields = body.model_fields_set
@@ -1071,8 +1072,8 @@ async def update_warp_setup(
 async def set_reed(
     project_id: uuid.UUID,
     body: SetReedRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectDetail:
     if body.reed_dents_per_inch is not None and body.reed_dents_per_inch <= 0:
         raise HTTPException(status_code=400, detail="reed_dents_per_inch must be positive")
@@ -1097,8 +1098,8 @@ async def set_reed(
 async def assign_loom(
     project_id: uuid.UUID,
     body: AssignLoomRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectDetail:
     project = await _get_owned_project(project_id, current_user, db)
     if project.status not in ("created", "active"):
@@ -1146,8 +1147,8 @@ async def assign_loom(
 @router.post("/{project_id}/start", response_model=ProjectDetail)
 async def start_project(
     project_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectDetail:
     """Transition a project from 'created' to 'active'. Idempotent if already active."""
     project = await _get_owned_project(project_id, current_user, db)
@@ -1163,12 +1164,15 @@ async def start_project(
     return _to_detail(project, draft, loom, loom_version=loom_version)  # type: ignore[arg-type]
 
 
-@router.post("/{project_id}/claim-tracking", response_model=ProjectDetail)
+@router.post(
+    "/{project_id}/claim-tracking",
+    responses={409: {"description": "This project is being tracked from another device"}},
+)
 async def claim_tracking(
     project_id: uuid.UUID,
     body: ClaimTrackingRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectDetail:
     """Claim the tracker lock for this device (see #1029).
 
@@ -1198,12 +1202,12 @@ async def claim_tracking(
     return _to_detail(project, draft, loom)  # type: ignore[arg-type]
 
 
-@router.post("/{project_id}/release-tracking", response_model=ProjectDetail)
+@router.post("/{project_id}/release-tracking")
 async def release_tracking(
     project_id: uuid.UUID,
     body: ReleaseTrackingRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectDetail:
     """Release the tracker lock — a no-op if this device doesn't currently hold it.
 
@@ -1221,12 +1225,16 @@ async def release_tracking(
     return _to_detail(project, draft, loom)  # type: ignore[arg-type]
 
 
-@router.post("/{project_id}/step", response_model=StepResponse)
+@router.post(
+    "/{project_id}/step",
+    response_model=StepResponse,
+    responses={409: {"description": "This project is being tracked from another device"}},
+)
 async def step_project(
     project_id: uuid.UUID,
     body: StepRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> StepResponse:
     if body.direction not in ("advance", "reverse"):
         raise HTTPException(status_code=400, detail="direction must be 'advance' or 'reverse'")
@@ -1237,7 +1245,7 @@ async def step_project(
     project = await _get_owned_project(project_id, current_user, db, with_for_update=True)
     if project.status not in ("created", "active"):
         raise HTTPException(status_code=400, detail="Project is not active")
-    await _check_tracker_lock(project, body.tracker_session_id, current_user)
+    _check_tracker_lock(project, body.tracker_session_id, current_user)
     if project.status == "created":
         project.status = "active"
 
@@ -1301,12 +1309,16 @@ async def step_project(
     )
 
 
-@router.post("/{project_id}/jump", response_model=ProjectDetail)
+@router.post(
+    "/{project_id}/jump",
+    response_model=ProjectDetail,
+    responses={409: {"description": "This project is being tracked from another device"}},
+)
 async def jump_project(
     project_id: uuid.UUID,
     body: JumpRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectDetail:
     # FOR UPDATE serializes against concurrent /step and /jump requests on the same
     # project row — matches step_project (see #1028: jump previously overwrote
@@ -1314,7 +1326,7 @@ async def jump_project(
     project = await _get_owned_project(project_id, current_user, db, with_for_update=True)
     if project.status not in ("created", "active"):
         raise HTTPException(status_code=400, detail="Project is not active")
-    await _check_tracker_lock(project, body.tracker_session_id, current_user)
+    _check_tracker_lock(project, body.tracker_session_id, current_user)
     project.current_pick = max(1, min(body.pick, project.total_picks + 1))
     await db.commit()
     await db.refresh(project)
@@ -1323,17 +1335,21 @@ async def jump_project(
     return _to_detail(project, draft, loom)  # type: ignore[arg-type]
 
 
-@router.post("/{project_id}/advance-item", response_model=StepResponse)
+@router.post(
+    "/{project_id}/advance-item",
+    response_model=StepResponse,
+    responses={409: {"description": "This project is being tracked from another device"}},
+)
 async def advance_item(
     project_id: uuid.UUID,
     body: AdvanceItemRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> StepResponse:
     project = await _get_owned_project(project_id, current_user, db, with_for_update=True)
     if project.status not in ("created", "active"):
         raise HTTPException(status_code=400, detail="Project is not active")
-    await _check_tracker_lock(project, body.tracker_session_id, current_user)
+    _check_tracker_lock(project, body.tracker_session_id, current_user)
     if project.current_pick <= project.total_picks:
         raise HTTPException(status_code=400, detail="Current item is not finished — advance to the last pick first")
     if project.current_item >= project.num_items:
@@ -1352,17 +1368,21 @@ async def advance_item(
     )
 
 
-@router.post("/{project_id}/jump-item", response_model=ProjectDetail)
+@router.post(
+    "/{project_id}/jump-item",
+    response_model=ProjectDetail,
+    responses={409: {"description": "This project is being tracked from another device"}},
+)
 async def jump_item(
     project_id: uuid.UUID,
     body: JumpItemRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectDetail:
     project = await _get_owned_project(project_id, current_user, db, with_for_update=True)
     if project.status not in ("created", "active"):
         raise HTTPException(status_code=400, detail="Project is not active")
-    await _check_tracker_lock(project, body.tracker_session_id, current_user)
+    _check_tracker_lock(project, body.tracker_session_id, current_user)
     picks = dict(project.item_picks or {})
     picks[str(project.current_item)] = project.current_pick
     target = max(1, min(body.item, project.num_items))
@@ -1379,9 +1399,9 @@ async def jump_item(
 @router.post("/{project_id}/complete", response_model=ProjectDetail)
 async def complete_project(
     project_id: uuid.UUID,
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     force: bool = Query(False, description="Complete even if not all picks are logged"),
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
 ) -> ProjectDetail:
     project = await _get_owned_project(project_id, current_user, db)
     if project.status not in ("created", "active"):
@@ -1404,8 +1424,8 @@ async def complete_project(
 @router.post("/{project_id}/abandon", response_model=ProjectDetail)
 async def abandon_project(
     project_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectDetail:
     project = await _get_owned_project(project_id, current_user, db)
     if project.status not in ("created", "active"):
@@ -1423,8 +1443,8 @@ async def abandon_project(
 @router.post("/{project_id}/restart", response_model=ProjectDetail)
 async def restart_project(
     project_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectDetail:
     project = await _get_owned_project(project_id, current_user, db)
     if project.status != "abandoned":
@@ -1444,8 +1464,8 @@ async def restart_project(
 @router.get("/{project_id}/metrics", response_model=ProjectMetricsResponse)
 async def get_project_metrics(
     project_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectMetricsResponse:
     await _get_owned_project(project_id, current_user, db, allow_superuser=True)
 
@@ -1505,8 +1525,8 @@ async def get_project_metrics(
 @router.post("/{project_id}/clone", response_model=ProjectDetail, status_code=201)
 async def clone_project(
     project_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectDetail:
     source = await _get_owned_project(project_id, current_user, db)
     if source.loom_id:
@@ -1540,8 +1560,8 @@ async def clone_project(
 @router.delete("/{project_id}", status_code=204)
 async def delete_project(
     project_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     project = await _get_owned_project(project_id, current_user, db)
     project.soft_delete()
@@ -1551,9 +1571,9 @@ async def delete_project(
 @router.post("/{project_id}/photos", response_model=ProjectPhotoSchema, status_code=201)
 async def upload_project_photo(
     project_id: uuid.UUID,
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     file: UploadFile = File(...),
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
 ) -> ProjectPhotoSchema:
     project = await _get_owned_project(project_id, current_user, db)
 
@@ -1609,8 +1629,8 @@ async def upload_project_photo(
 async def get_project_photo(
     project_id: uuid.UUID,
     photo_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Response:
     await _get_owned_project(project_id, current_user, db, allow_superuser=True)
     photo = await db.scalar(
@@ -1627,8 +1647,8 @@ async def get_project_photo(
 async def delete_project_photo(
     project_id: uuid.UUID,
     photo_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     await _get_owned_project(project_id, current_user, db)
     photo = await db.scalar(
@@ -1644,8 +1664,8 @@ async def delete_project_photo(
 @router.get("/{project_id}/picks", response_model=PicksResponse)
 async def get_picks(
     project_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> PicksResponse:
     project = await _get_owned_project(project_id, current_user, db, allow_superuser=True)
     draft = await db.get(Draft, project.draft_id)
@@ -1759,8 +1779,8 @@ def _compute_epi(draft: Draft) -> float | None:
 @router.get("/{project_id}/warping-plan", response_model=WarpingPlanResponse)
 async def get_warping_plan(
     project_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> WarpingPlanResponse:
     project = await _get_owned_project(project_id, current_user, db, allow_superuser=True)
     draft = await db.get(Draft, project.draft_id)
@@ -1810,8 +1830,8 @@ async def get_warping_plan(
 async def update_project_share(
     project_id: uuid.UUID,
     body: ShareProjectRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectDetail:
     if body.visibility != "link":
         raise HTTPException(status_code=400, detail="visibility must be 'link'")
@@ -1843,8 +1863,8 @@ async def update_project_share(
 @router.delete("/{project_id}/share", status_code=204)
 async def revoke_project_share(
     project_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     project = await _get_owned_project(project_id, current_user, db, with_for_update=True)
     project.share_slug = None
@@ -1861,7 +1881,7 @@ async def revoke_project_share(
 @share_router.get("/projects/{slug}", response_model=SharedProjectResponse)
 async def get_shared_project(
     slug: str,
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> SharedProjectResponse:
     project = await db.scalar(
         select(Project).where(
@@ -1915,7 +1935,7 @@ async def get_shared_project(
 @share_router.get("/projects/{slug}/preview")
 async def get_shared_project_preview(
     slug: str,
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Response:
     """Return the pre-rendered drawdown preview PNG for a shared project (no auth required)."""
     project = await db.scalar(select(Project).where(Project.share_slug == slug, Project.deleted_at.is_(None)))
@@ -1945,11 +1965,11 @@ class PatchYarnColorRequest(BaseModel):
     use_yarn_photo: bool
 
 
-@router.get("/{project_id}/yarn-colors", response_model=list[ProjectYarnColorSchema])
+@router.get("/{project_id}/yarn-colors")
 async def list_project_yarn_colors(
     project_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> list[ProjectYarnColorSchema]:
     await _get_owned_project(project_id, current_user, db)
     stmt = (
@@ -1962,13 +1982,17 @@ async def list_project_yarn_colors(
     return [_yarn_color_schema(r) for r in rows]
 
 
-@router.put("/{project_id}/yarn-colors/{color_hex}", response_model=ProjectYarnColorSchema, status_code=200)
+@router.put(
+    "/{project_id}/yarn-colors/{color_hex}",
+    status_code=200,
+    responses={404: {"description": "Yarn not found"}},
+)
 async def link_yarn_color(
     project_id: uuid.UUID,
     color_hex: str,
     body: LinkYarnColorRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectYarnColorSchema:
     await _get_owned_project(project_id, current_user, db)
     yarn = await db.scalar(
@@ -2002,13 +2026,16 @@ async def link_yarn_color(
     return _yarn_color_schema(row)
 
 
-@router.patch("/{project_id}/yarn-colors/{color_hex}", response_model=ProjectYarnColorSchema)
+@router.patch(
+    "/{project_id}/yarn-colors/{color_hex}",
+    responses={404: {"description": "Yarn color assignment not found"}},
+)
 async def patch_yarn_color(
     project_id: uuid.UUID,
     color_hex: str,
     body: PatchYarnColorRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ProjectYarnColorSchema:
     await _get_owned_project(project_id, current_user, db)
     row = await db.scalar(
@@ -2024,12 +2051,16 @@ async def patch_yarn_color(
     return _yarn_color_schema(row)
 
 
-@router.delete("/{project_id}/yarn-colors/{color_hex}", status_code=204)
+@router.delete(
+    "/{project_id}/yarn-colors/{color_hex}",
+    status_code=204,
+    responses={404: {"description": "Yarn color assignment not found"}},
+)
 async def unlink_yarn_color(
     project_id: uuid.UUID,
     color_hex: str,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     await _get_owned_project(project_id, current_user, db)
     row = await db.scalar(
@@ -2047,7 +2078,7 @@ async def unlink_yarn_color(
 @share_router.get("/projects/{slug}/svg")
 async def get_shared_project_svg(
     slug: str,
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Response:
     """Return the pre-rendered drawdown SVG for a shared project (no auth required)."""
     project = await db.scalar(select(Project).where(Project.share_slug == slug, Project.deleted_at.is_(None)))

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -3,7 +3,7 @@ import mimetypes
 import re
 import secrets
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
@@ -173,14 +173,30 @@ class SetReedRequest(BaseModel):
 
 class JumpRequest(BaseModel):
     pick: int
+    tracker_session_id: str
 
 
 class JumpItemRequest(BaseModel):
     item: int
+    tracker_session_id: str
 
 
 class StepRequest(BaseModel):
     direction: str  # "advance" | "reverse"
+    tracker_session_id: str
+
+
+class AdvanceItemRequest(BaseModel):
+    tracker_session_id: str
+
+
+class ClaimTrackingRequest(BaseModel):
+    tracker_session_id: str
+    force: bool = False
+
+
+class ReleaseTrackingRequest(BaseModel):
+    tracker_session_id: str
 
 
 class StepResponse(BaseModel):
@@ -342,6 +358,29 @@ async def _check_loom_conflict(
         q = q.where(Project.id != exclude_id)
     if await db.scalar(q) is not None:
         raise HTTPException(status_code=409, detail="This loom already has an active project")
+
+
+async def _check_tracker_lock(project: Project, tracker_session_id: str, current_user: User) -> None:
+    """Raise 409 if a different, still-live tracker session holds the lock.
+
+    Otherwise (re)stamp the claim for the calling token — acts as a heartbeat so an
+    actively-writing device never loses its own lock to idle-timeout. A lock is "live"
+    if claimed within idle_timeout_minutes; past that it's treated as an abandoned/crashed
+    session and silently self-heals to whichever device asks next. See #1029.
+    """
+    if project.active_tracker_session_id is None or project.active_tracker_session_id == tracker_session_id:
+        project.active_tracker_session_id = tracker_session_id
+        project.active_tracker_claimed_at = datetime.now(timezone.utc)
+        return
+    claimed_at = project.active_tracker_claimed_at
+    if claimed_at is not None and claimed_at.tzinfo is None:
+        claimed_at = claimed_at.replace(tzinfo=timezone.utc)
+    idle_timeout = timedelta(minutes=current_user.idle_timeout_minutes)
+    if claimed_at is None or datetime.now(timezone.utc) - claimed_at >= idle_timeout:
+        project.active_tracker_session_id = tracker_session_id
+        project.active_tracker_claimed_at = datetime.now(timezone.utc)
+        return
+    raise HTTPException(status_code=409, detail="This project is being tracked from another device")
 
 
 async def _wif_path_for_project(draft: Draft, project_type: str) -> str:
@@ -1124,6 +1163,64 @@ async def start_project(
     return _to_detail(project, draft, loom, loom_version=loom_version)  # type: ignore[arg-type]
 
 
+@router.post("/{project_id}/claim-tracking", response_model=ProjectDetail)
+async def claim_tracking(
+    project_id: uuid.UUID,
+    body: ClaimTrackingRequest,
+    current_user: User = Depends(get_effective_user),
+    db: AsyncSession = Depends(get_db),
+) -> ProjectDetail:
+    """Claim the tracker lock for this device (see #1029).
+
+    Silently succeeds if the lock is free, already held by this same tracker_session_id,
+    or has gone stale (older than idle_timeout_minutes). Otherwise 409s unless force=true,
+    which is only ever sent after the user explicitly confirms a "take over" prompt.
+    """
+    project = await _get_owned_project(project_id, current_user, db, with_for_update=True)
+    now = datetime.now(timezone.utc)
+    is_free_or_self = (
+        project.active_tracker_session_id is None or project.active_tracker_session_id == body.tracker_session_id
+    )
+    is_expired = False
+    if not is_free_or_self and project.active_tracker_claimed_at is not None:
+        claimed_at = project.active_tracker_claimed_at
+        if claimed_at.tzinfo is None:
+            claimed_at = claimed_at.replace(tzinfo=timezone.utc)
+        is_expired = now - claimed_at >= timedelta(minutes=current_user.idle_timeout_minutes)
+    if not (is_free_or_self or is_expired or body.force):
+        raise HTTPException(status_code=409, detail="This project is being tracked from another device")
+    project.active_tracker_session_id = body.tracker_session_id
+    project.active_tracker_claimed_at = now
+    await db.commit()
+    await db.refresh(project)
+    draft = await db.get(Draft, project.draft_id)
+    loom = await db.get(Loom, project.loom_id) if project.loom_id else None
+    return _to_detail(project, draft, loom)  # type: ignore[arg-type]
+
+
+@router.post("/{project_id}/release-tracking", response_model=ProjectDetail)
+async def release_tracking(
+    project_id: uuid.UUID,
+    body: ReleaseTrackingRequest,
+    current_user: User = Depends(get_effective_user),
+    db: AsyncSession = Depends(get_db),
+) -> ProjectDetail:
+    """Release the tracker lock — a no-op if this device doesn't currently hold it.
+
+    Called best-effort on tracker-screen unmount. Idempotency here matters: a stale
+    unmount firing after another device already took over must not clobber that claim.
+    """
+    project = await _get_owned_project(project_id, current_user, db, with_for_update=True)
+    if project.active_tracker_session_id == body.tracker_session_id:
+        project.active_tracker_session_id = None
+        project.active_tracker_claimed_at = None
+        await db.commit()
+        await db.refresh(project)
+    draft = await db.get(Draft, project.draft_id)
+    loom = await db.get(Loom, project.loom_id) if project.loom_id else None
+    return _to_detail(project, draft, loom)  # type: ignore[arg-type]
+
+
 @router.post("/{project_id}/step", response_model=StepResponse)
 async def step_project(
     project_id: uuid.UUID,
@@ -1140,6 +1237,7 @@ async def step_project(
     project = await _get_owned_project(project_id, current_user, db, with_for_update=True)
     if project.status not in ("created", "active"):
         raise HTTPException(status_code=400, detail="Project is not active")
+    await _check_tracker_lock(project, body.tracker_session_id, current_user)
     if project.status == "created":
         project.status = "active"
 
@@ -1216,6 +1314,7 @@ async def jump_project(
     project = await _get_owned_project(project_id, current_user, db, with_for_update=True)
     if project.status not in ("created", "active"):
         raise HTTPException(status_code=400, detail="Project is not active")
+    await _check_tracker_lock(project, body.tracker_session_id, current_user)
     project.current_pick = max(1, min(body.pick, project.total_picks + 1))
     await db.commit()
     await db.refresh(project)
@@ -1227,12 +1326,14 @@ async def jump_project(
 @router.post("/{project_id}/advance-item", response_model=StepResponse)
 async def advance_item(
     project_id: uuid.UUID,
+    body: AdvanceItemRequest,
     current_user: User = Depends(get_effective_user),
     db: AsyncSession = Depends(get_db),
 ) -> StepResponse:
-    project = await _get_owned_project(project_id, current_user, db)
+    project = await _get_owned_project(project_id, current_user, db, with_for_update=True)
     if project.status not in ("created", "active"):
         raise HTTPException(status_code=400, detail="Project is not active")
+    await _check_tracker_lock(project, body.tracker_session_id, current_user)
     if project.current_pick <= project.total_picks:
         raise HTTPException(status_code=400, detail="Current item is not finished — advance to the last pick first")
     if project.current_item >= project.num_items:
@@ -1258,9 +1359,10 @@ async def jump_item(
     current_user: User = Depends(get_effective_user),
     db: AsyncSession = Depends(get_db),
 ) -> ProjectDetail:
-    project = await _get_owned_project(project_id, current_user, db)
+    project = await _get_owned_project(project_id, current_user, db, with_for_update=True)
     if project.status not in ("created", "active"):
         raise HTTPException(status_code=400, detail="Project is not active")
+    await _check_tracker_lock(project, body.tracker_session_id, current_user)
     picks = dict(project.item_picks or {})
     picks[str(project.current_item)] = project.current_pick
     target = max(1, min(body.item, project.num_items))

--- a/backend/tests/routers/test_projects.py
+++ b/backend/tests/routers/test_projects.py
@@ -14,6 +14,11 @@ from app.models.project import Project
 from app.models.project import ProjectPhoto as ProjectPhotoModel
 from app.models.user import User
 
+# Default tracker-session token for tests that don't care about lock behavior itself
+# (see TestTrackerLock for lock-specific coverage). Every /step, /jump, /jump-item,
+# /advance-item call requires one (#1029).
+_TRACKER_TOKEN = "test-tracker-session"
+
 
 @pytest.fixture(autouse=True)
 def _mock_preview_task(monkeypatch):
@@ -1243,7 +1248,11 @@ class TestStepProject:
     async def test_advance_increments_pick(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
-        body = (await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})).json()
+        body = (
+            await auth_client.post(
+                f"/api/projects/{project.id}/step", json={"direction": "advance", "tracker_session_id": _TRACKER_TOKEN}
+            )
+        ).json()
         assert body["current_pick"] == 2
 
     async def test_reverse_decrements_pick(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
@@ -1251,7 +1260,11 @@ class TestStepProject:
         project = await _insert_active_project(db_session, test_user, draft, None)
         project.current_pick = 2
         await db_session.commit()
-        body = (await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "reverse"})).json()
+        body = (
+            await auth_client.post(
+                f"/api/projects/{project.id}/step", json={"direction": "reverse", "tracker_session_id": _TRACKER_TOKEN}
+            )
+        ).json()
         assert body["current_pick"] == 1
 
     async def test_reverse_at_first_pick_returns_400(
@@ -1259,7 +1272,9 @@ class TestStepProject:
     ):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
-        resp = await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "reverse"})
+        resp = await auth_client.post(
+            f"/api/projects/{project.id}/step", json={"direction": "reverse", "tracker_session_id": _TRACKER_TOKEN}
+        )
         assert resp.status_code == 400
 
     async def test_advance_past_last_pick_returns_400(
@@ -1269,7 +1284,9 @@ class TestStepProject:
         project = await _insert_active_project(db_session, test_user, draft, None)
         project.current_pick = project.total_picks + 1
         await db_session.commit()
-        resp = await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
+        resp = await auth_client.post(
+            f"/api/projects/{project.id}/step", json={"direction": "advance", "tracker_session_id": _TRACKER_TOKEN}
+        )
         assert resp.status_code == 400
 
     async def test_invalid_direction_returns_400(
@@ -1277,7 +1294,9 @@ class TestStepProject:
     ):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
-        resp = await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "sideways"})
+        resp = await auth_client.post(
+            f"/api/projects/{project.id}/step", json={"direction": "sideways", "tracker_session_id": _TRACKER_TOKEN}
+        )
         assert resp.status_code == 400
 
     async def test_completed_project_returns_400(
@@ -1287,23 +1306,33 @@ class TestStepProject:
         project = await _insert_active_project(db_session, test_user, draft, None)
         project.status = "completed"
         await db_session.commit()
-        resp = await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
+        resp = await auth_client.post(
+            f"/api/projects/{project.id}/step", json={"direction": "advance", "tracker_session_id": _TRACKER_TOKEN}
+        )
         assert resp.status_code == 400
 
     async def test_not_found_returns_404(self, auth_client: AsyncClient):
-        resp = await auth_client.post(f"/api/projects/{uuid.uuid4()}/step", json={"direction": "advance"})
+        resp = await auth_client.post(
+            f"/api/projects/{uuid.uuid4()}/step", json={"direction": "advance", "tracker_session_id": _TRACKER_TOKEN}
+        )
         assert resp.status_code == 404
 
     async def test_unauthenticated_returns_401(self, client: AsyncClient, db_session: AsyncSession, test_user: User):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
-        resp = await client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
+        resp = await client.post(
+            f"/api/projects/{project.id}/step", json={"direction": "advance", "tracker_session_id": _TRACKER_TOKEN}
+        )
         assert resp.status_code == 401
 
     async def test_response_is_lightweight(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
-        body = (await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})).json()
+        body = (
+            await auth_client.post(
+                f"/api/projects/{project.id}/step", json={"direction": "advance", "tracker_session_id": _TRACKER_TOKEN}
+            )
+        ).json()
         assert set(body.keys()) == {"current_pick", "total_picks", "current_item", "num_items"}
 
     async def test_logs_step_to_database(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
@@ -1313,7 +1342,9 @@ class TestStepProject:
 
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
-        await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
+        await auth_client.post(
+            f"/api/projects/{project.id}/step", json={"direction": "advance", "tracker_session_id": _TRACKER_TOKEN}
+        )
         step = await db_session.scalar(select(ProjectStep).where(ProjectStep.project_id == project.id))
         assert step is not None
         assert step.event_type == "advance"
@@ -1340,10 +1371,186 @@ class TestStepProject:
         await db_session.commit()
         picks = []
         for _ in range(4):
-            resp = await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
+            resp = await auth_client.post(
+                f"/api/projects/{project.id}/step", json={"direction": "advance", "tracker_session_id": _TRACKER_TOKEN}
+            )
             assert resp.status_code == 200
             picks.append(resp.json()["current_pick"])
         assert picks == sorted(set(picks)), f"Duplicate or out-of-order picks: {picks}"
+
+
+# ---------------------------------------------------------------------------
+# TestTrackerLock (#1029)
+# ---------------------------------------------------------------------------
+
+
+async def _claim(client: AsyncClient, project_id, token: str, force: bool = False):
+    return await client.post(
+        f"/api/projects/{project_id}/claim-tracking",
+        json={"tracker_session_id": token, "force": force},
+    )
+
+
+async def _release(client: AsyncClient, project_id, token: str):
+    return await client.post(
+        f"/api/projects/{project_id}/release-tracking",
+        json={"tracker_session_id": token},
+    )
+
+
+class TestTrackerLock:
+    async def test_claim_succeeds_when_free(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        resp = await _claim(auth_client, project.id, "token-a")
+        assert resp.status_code == 200
+
+    async def test_claim_idempotent_for_same_token(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        assert (await _claim(auth_client, project.id, "token-a")).status_code == 200
+        assert (await _claim(auth_client, project.id, "token-a")).status_code == 200
+
+    async def test_claim_blocked_by_other_live_token_returns_409(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        assert (await _claim(auth_client, project.id, "token-a")).status_code == 200
+        resp = await _claim(auth_client, project.id, "token-b")
+        assert resp.status_code == 409
+
+    async def test_claim_with_force_steals_lock(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        assert (await _claim(auth_client, project.id, "token-a")).status_code == 200
+        assert (await _claim(auth_client, project.id, "token-b", force=True)).status_code == 200
+        # Subsequent write from the original holder is now blocked.
+        resp = await auth_client.post(
+            f"/api/projects/{project.id}/step",
+            json={"direction": "advance", "tracker_session_id": "token-a"},
+        )
+        assert resp.status_code == 409
+
+    async def test_step_blocked_by_other_tracker_session_returns_409(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        assert (await _claim(auth_client, project.id, "token-a")).status_code == 200
+        resp = await auth_client.post(
+            f"/api/projects/{project.id}/step",
+            json={"direction": "advance", "tracker_session_id": "token-b"},
+        )
+        assert resp.status_code == 409
+
+    async def test_step_without_prior_claim_auto_claims(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        resp = await auth_client.post(
+            f"/api/projects/{project.id}/step",
+            json={"direction": "advance", "tracker_session_id": "token-a"},
+        )
+        assert resp.status_code == 200
+
+    async def test_step_from_holder_refreshes_claim_timestamp(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        from sqlalchemy import select
+
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        project_id = project.id
+        assert (await _claim(auth_client, project_id, "token-a")).status_code == 200
+        db_session.expire(project)
+        first = await db_session.execute(select(Project).where(Project.id == project_id))
+        first_claimed_at = first.scalar_one().active_tracker_claimed_at
+
+        resp = await auth_client.post(
+            f"/api/projects/{project_id}/step",
+            json={"direction": "advance", "tracker_session_id": "token-a"},
+        )
+        assert resp.status_code == 200
+        db_session.expire(project)
+        refreshed = (await db_session.execute(select(Project).where(Project.id == project_id))).scalar_one()
+        assert refreshed.active_tracker_session_id == "token-a"
+        assert refreshed.active_tracker_claimed_at >= first_claimed_at
+
+    async def test_expired_lock_self_heals_on_step(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        project.active_tracker_session_id = "token-a"
+        project.active_tracker_claimed_at = datetime.now(timezone.utc) - timedelta(
+            minutes=test_user.idle_timeout_minutes + 5
+        )
+        await db_session.commit()
+
+        resp = await auth_client.post(
+            f"/api/projects/{project.id}/step",
+            json={"direction": "advance", "tracker_session_id": "token-b"},
+        )
+        assert resp.status_code == 200
+
+    async def test_advance_item_and_jump_item_gated(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        project.current_pick = project.total_picks + 1
+        project.num_items = 2
+        await db_session.commit()
+        assert (await _claim(auth_client, project.id, "token-a")).status_code == 200
+
+        resp = await auth_client.post(
+            f"/api/projects/{project.id}/advance-item", json={"tracker_session_id": "token-b"}
+        )
+        assert resp.status_code == 409
+
+        resp = await auth_client.post(
+            f"/api/projects/{project.id}/jump-item", json={"item": 1, "tracker_session_id": "token-b"}
+        )
+        assert resp.status_code == 409
+
+        resp = await auth_client.post(
+            f"/api/projects/{project.id}/advance-item", json={"tracker_session_id": "token-a"}
+        )
+        assert resp.status_code == 200
+
+    async def test_release_clears_lock_for_holder(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        assert (await _claim(auth_client, project.id, "token-a")).status_code == 200
+        assert (await _release(auth_client, project.id, "token-a")).status_code == 200
+        # Now free — a different token can claim without force.
+        resp = await _claim(auth_client, project.id, "token-b")
+        assert resp.status_code == 200
+
+    async def test_release_by_non_holder_is_noop(
+        self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User
+    ):
+        from sqlalchemy import select
+
+        draft = await _insert_draft(db_session, test_user)
+        project = await _insert_active_project(db_session, test_user, draft, None)
+        project_id = project.id
+        assert (await _claim(auth_client, project_id, "token-a")).status_code == 200
+        assert (await _release(auth_client, project_id, "token-b")).status_code == 200
+        db_session.expire(project)
+        refreshed = (await db_session.execute(select(Project).where(Project.id == project_id))).scalar_one()
+        assert refreshed.active_tracker_session_id == "token-a"
+        # Still locked — a non-force claim from token-b is blocked.
+        resp = await _claim(auth_client, project_id, "token-b")
+        assert resp.status_code == 409
 
 
 # ---------------------------------------------------------------------------
@@ -1355,7 +1562,11 @@ class TestJumpProject:
     async def test_jumps_to_pick(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
-        body = (await auth_client.post(f"/api/projects/{project.id}/jump", json={"pick": 2})).json()
+        body = (
+            await auth_client.post(
+                f"/api/projects/{project.id}/jump", json={"pick": 2, "tracker_session_id": _TRACKER_TOKEN}
+            )
+        ).json()
         assert body["current_pick"] == 2
 
     async def test_clamps_above_total_plus_one(
@@ -1363,13 +1574,21 @@ class TestJumpProject:
     ):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
-        body = (await auth_client.post(f"/api/projects/{project.id}/jump", json={"pick": 999})).json()
+        body = (
+            await auth_client.post(
+                f"/api/projects/{project.id}/jump", json={"pick": 999, "tracker_session_id": _TRACKER_TOKEN}
+            )
+        ).json()
         assert body["current_pick"] == project.total_picks + 1
 
     async def test_clamps_below_one(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
-        body = (await auth_client.post(f"/api/projects/{project.id}/jump", json={"pick": 0})).json()
+        body = (
+            await auth_client.post(
+                f"/api/projects/{project.id}/jump", json={"pick": 0, "tracker_session_id": _TRACKER_TOKEN}
+            )
+        ).json()
         assert body["current_pick"] == 1
 
     async def test_completed_project_returns_400(
@@ -1379,11 +1598,15 @@ class TestJumpProject:
         project = await _insert_active_project(db_session, test_user, draft, None)
         project.status = "completed"
         await db_session.commit()
-        resp = await auth_client.post(f"/api/projects/{project.id}/jump", json={"pick": 1})
+        resp = await auth_client.post(
+            f"/api/projects/{project.id}/jump", json={"pick": 1, "tracker_session_id": _TRACKER_TOKEN}
+        )
         assert resp.status_code == 400
 
     async def test_not_found_returns_404(self, auth_client: AsyncClient):
-        resp = await auth_client.post(f"/api/projects/{uuid.uuid4()}/jump", json={"pick": 1})
+        resp = await auth_client.post(
+            f"/api/projects/{uuid.uuid4()}/jump", json={"pick": 1, "tracker_session_id": _TRACKER_TOKEN}
+        )
         assert resp.status_code == 404
 
     async def test_locks_row_for_update(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
@@ -1399,7 +1622,9 @@ class TestJumpProject:
 
         original = projects_module._get_owned_project
         with patch.object(projects_module, "_get_owned_project", new=AsyncMock(wraps=original)) as mock_get:
-            resp = await auth_client.post(f"/api/projects/{project.id}/jump", json={"pick": 2})
+            resp = await auth_client.post(
+                f"/api/projects/{project.id}/jump", json={"pick": 2, "tracker_session_id": _TRACKER_TOKEN}
+            )
 
         assert resp.status_code == 200
         mock_get.assert_called_once()
@@ -1424,14 +1649,24 @@ class TestJumpProject:
         db_session.add(project)
         await db_session.commit()
 
-        jump_body = (await auth_client.post(f"/api/projects/{project.id}/jump", json={"pick": 5})).json()
+        jump_body = (
+            await auth_client.post(
+                f"/api/projects/{project.id}/jump", json={"pick": 5, "tracker_session_id": _TRACKER_TOKEN}
+            )
+        ).json()
         assert jump_body["current_pick"] == 5
 
-        step_body = (await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})).json()
+        step_body = (
+            await auth_client.post(
+                f"/api/projects/{project.id}/step", json={"direction": "advance", "tracker_session_id": _TRACKER_TOKEN}
+            )
+        ).json()
         assert step_body["current_pick"] == 6
 
         reverse_body = (
-            await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "reverse"})
+            await auth_client.post(
+                f"/api/projects/{project.id}/step", json={"direction": "reverse", "tracker_session_id": _TRACKER_TOKEN}
+            )
         ).json()
         assert reverse_body["current_pick"] == 5
 
@@ -1598,7 +1833,11 @@ class TestAdvanceItem:
         project.current_item = 1
         project.current_pick = project.total_picks + 1
         await db_session.commit()
-        body = (await auth_client.post(f"/api/projects/{project.id}/advance-item")).json()
+        body = (
+            await auth_client.post(
+                f"/api/projects/{project.id}/advance-item", json={"tracker_session_id": _TRACKER_TOKEN}
+            )
+        ).json()
         assert body["current_item"] == 2
         assert body["current_pick"] == 1
 
@@ -1612,14 +1851,18 @@ class TestAdvanceItem:
         project.current_pick = project.total_picks + 1
         await db_session.commit()
         # Advance to item 2
-        await auth_client.post(f"/api/projects/{project.id}/advance-item")
+        await auth_client.post(f"/api/projects/{project.id}/advance-item", json={"tracker_session_id": _TRACKER_TOKEN})
         # Work a bit on item 2
         project2 = await db_session.get(type(project), project.id)
         assert project2 is not None
         project2.current_pick = 2
         await db_session.commit()
         # Jump back to item 1 — should restore to total_picks + 1 (completed state)
-        body = (await auth_client.post(f"/api/projects/{project.id}/jump-item", json={"item": 1})).json()
+        body = (
+            await auth_client.post(
+                f"/api/projects/{project.id}/jump-item", json={"item": 1, "tracker_session_id": _TRACKER_TOKEN}
+            )
+        ).json()
         assert body["current_item"] == 1
         assert body["current_pick"] == project.total_picks + 1
 
@@ -1636,9 +1879,13 @@ class TestAdvanceItem:
         # Advance from item 2 (at end) to item 3 — item 2's pick (2) should be saved
         project.current_pick = project.total_picks + 1
         await db_session.commit()
-        await auth_client.post(f"/api/projects/{project.id}/advance-item")
+        await auth_client.post(f"/api/projects/{project.id}/advance-item", json={"tracker_session_id": _TRACKER_TOKEN})
         # Jump back to item 2 — should restore pick 2
-        body = (await auth_client.post(f"/api/projects/{project.id}/jump-item", json={"item": 2})).json()
+        body = (
+            await auth_client.post(
+                f"/api/projects/{project.id}/jump-item", json={"item": 2, "tracker_session_id": _TRACKER_TOKEN}
+            )
+        ).json()
         assert body["current_pick"] == project.total_picks + 1  # saved at end
 
     async def test_response_includes_num_items(
@@ -1650,7 +1897,11 @@ class TestAdvanceItem:
         project.current_item = 1
         project.current_pick = project.total_picks + 1
         await db_session.commit()
-        body = (await auth_client.post(f"/api/projects/{project.id}/advance-item")).json()
+        body = (
+            await auth_client.post(
+                f"/api/projects/{project.id}/advance-item", json={"tracker_session_id": _TRACKER_TOKEN}
+            )
+        ).json()
         assert body["num_items"] == 3
 
     async def test_fails_if_not_at_item_end_returns_400(
@@ -1662,7 +1913,9 @@ class TestAdvanceItem:
         project.current_item = 1
         # current_pick still at 1, not at item end
         await db_session.commit()
-        resp = await auth_client.post(f"/api/projects/{project.id}/advance-item")
+        resp = await auth_client.post(
+            f"/api/projects/{project.id}/advance-item", json={"tracker_session_id": _TRACKER_TOKEN}
+        )
         assert resp.status_code == 400
 
     async def test_fails_if_on_last_item_returns_400(
@@ -1674,7 +1927,9 @@ class TestAdvanceItem:
         project.current_item = 3
         project.current_pick = project.total_picks + 1
         await db_session.commit()
-        resp = await auth_client.post(f"/api/projects/{project.id}/advance-item")
+        resp = await auth_client.post(
+            f"/api/projects/{project.id}/advance-item", json={"tracker_session_id": _TRACKER_TOKEN}
+        )
         assert resp.status_code == 400
 
     async def test_single_item_project_returns_400(
@@ -1684,7 +1939,9 @@ class TestAdvanceItem:
         project = await _insert_active_project(db_session, test_user, draft, None)
         project.current_pick = project.total_picks + 1
         await db_session.commit()
-        resp = await auth_client.post(f"/api/projects/{project.id}/advance-item")
+        resp = await auth_client.post(
+            f"/api/projects/{project.id}/advance-item", json={"tracker_session_id": _TRACKER_TOKEN}
+        )
         assert resp.status_code == 400
 
     async def test_inactive_project_returns_400(
@@ -1694,17 +1951,23 @@ class TestAdvanceItem:
         project = await _insert_active_project(db_session, test_user, draft, None)
         project.status = "completed"
         await db_session.commit()
-        resp = await auth_client.post(f"/api/projects/{project.id}/advance-item")
+        resp = await auth_client.post(
+            f"/api/projects/{project.id}/advance-item", json={"tracker_session_id": _TRACKER_TOKEN}
+        )
         assert resp.status_code == 400
 
     async def test_not_found_returns_404(self, auth_client: AsyncClient):
-        resp = await auth_client.post(f"/api/projects/{uuid.uuid4()}/advance-item")
+        resp = await auth_client.post(
+            f"/api/projects/{uuid.uuid4()}/advance-item", json={"tracker_session_id": _TRACKER_TOKEN}
+        )
         assert resp.status_code == 404
 
     async def test_unauthenticated_returns_401(self, client: AsyncClient, db_session: AsyncSession, test_user: User):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
-        resp = await client.post(f"/api/projects/{project.id}/advance-item")
+        resp = await client.post(
+            f"/api/projects/{project.id}/advance-item", json={"tracker_session_id": _TRACKER_TOKEN}
+        )
         assert resp.status_code == 401
 
 
@@ -1721,7 +1984,11 @@ class TestJumpItem:
         project.current_item = 3
         project.current_pick = 2
         await db_session.commit()
-        body = (await auth_client.post(f"/api/projects/{project.id}/jump-item", json={"item": 2})).json()
+        body = (
+            await auth_client.post(
+                f"/api/projects/{project.id}/jump-item", json={"item": 2, "tracker_session_id": _TRACKER_TOKEN}
+            )
+        ).json()
         assert body["current_item"] == 2
         assert body["current_pick"] == 1  # item 2 never visited → defaults to 1
 
@@ -1735,7 +2002,11 @@ class TestJumpItem:
         project.current_pick = 7
         project.item_picks = {"1": project.total_picks + 1}  # item 1 was completed
         await db_session.commit()
-        body = (await auth_client.post(f"/api/projects/{project.id}/jump-item", json={"item": 1})).json()
+        body = (
+            await auth_client.post(
+                f"/api/projects/{project.id}/jump-item", json={"item": 1, "tracker_session_id": _TRACKER_TOKEN}
+            )
+        ).json()
         assert body["current_item"] == 1
         assert body["current_pick"] == project.total_picks + 1
 
@@ -1749,7 +2020,9 @@ class TestJumpItem:
         project.current_item = 2
         project.current_pick = 7
         await db_session.commit()
-        await auth_client.post(f"/api/projects/{project.id}/jump-item", json={"item": 1})
+        await auth_client.post(
+            f"/api/projects/{project.id}/jump-item", json={"item": 1, "tracker_session_id": _TRACKER_TOKEN}
+        )
         await db_session.refresh(project)
         assert project.item_picks.get("2") == 7
 
@@ -1758,7 +2031,11 @@ class TestJumpItem:
         project = await _insert_active_project(db_session, test_user, draft, None)
         project.num_items = 3
         await db_session.commit()
-        body = (await auth_client.post(f"/api/projects/{project.id}/jump-item", json={"item": 99})).json()
+        body = (
+            await auth_client.post(
+                f"/api/projects/{project.id}/jump-item", json={"item": 99, "tracker_session_id": _TRACKER_TOKEN}
+            )
+        ).json()
         assert body["current_item"] == 3
 
     async def test_clamps_below_one(self, auth_client: AsyncClient, db_session: AsyncSession, test_user: User):
@@ -1766,7 +2043,11 @@ class TestJumpItem:
         project = await _insert_active_project(db_session, test_user, draft, None)
         project.num_items = 3
         await db_session.commit()
-        body = (await auth_client.post(f"/api/projects/{project.id}/jump-item", json={"item": 0})).json()
+        body = (
+            await auth_client.post(
+                f"/api/projects/{project.id}/jump-item", json={"item": 0, "tracker_session_id": _TRACKER_TOKEN}
+            )
+        ).json()
         assert body["current_item"] == 1
 
     async def test_inactive_project_returns_400(
@@ -1776,17 +2057,23 @@ class TestJumpItem:
         project = await _insert_active_project(db_session, test_user, draft, None)
         project.status = "completed"
         await db_session.commit()
-        resp = await auth_client.post(f"/api/projects/{project.id}/jump-item", json={"item": 1})
+        resp = await auth_client.post(
+            f"/api/projects/{project.id}/jump-item", json={"item": 1, "tracker_session_id": _TRACKER_TOKEN}
+        )
         assert resp.status_code == 400
 
     async def test_not_found_returns_404(self, auth_client: AsyncClient):
-        resp = await auth_client.post(f"/api/projects/{uuid.uuid4()}/jump-item", json={"item": 1})
+        resp = await auth_client.post(
+            f"/api/projects/{uuid.uuid4()}/jump-item", json={"item": 1, "tracker_session_id": _TRACKER_TOKEN}
+        )
         assert resp.status_code == 404
 
     async def test_unauthenticated_returns_401(self, client: AsyncClient, db_session: AsyncSession, test_user: User):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
-        resp = await client.post(f"/api/projects/{project.id}/jump-item", json={"item": 1})
+        resp = await client.post(
+            f"/api/projects/{project.id}/jump-item", json={"item": 1, "tracker_session_id": _TRACKER_TOKEN}
+        )
         assert resp.status_code == 401
 
 
@@ -2251,7 +2538,9 @@ class TestWeaveSessions:
 
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
-        await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
+        await auth_client.post(
+            f"/api/projects/{project.id}/step", json={"direction": "advance", "tracker_session_id": _TRACKER_TOKEN}
+        )
         session = await db_session.scalar(select(WeaveSession).where(WeaveSession.project_id == project.id))
         assert session is not None
         assert session.ended_at is None
@@ -2266,8 +2555,12 @@ class TestWeaveSessions:
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
 
-        await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
-        await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
+        await auth_client.post(
+            f"/api/projects/{project.id}/step", json={"direction": "advance", "tracker_session_id": _TRACKER_TOKEN}
+        )
+        await auth_client.post(
+            f"/api/projects/{project.id}/step", json={"direction": "advance", "tracker_session_id": _TRACKER_TOKEN}
+        )
 
         sessions = (await db_session.scalars(select(WeaveSession).where(WeaveSession.project_id == project.id))).all()
         assert len(sessions) == 1
@@ -2311,7 +2604,9 @@ class TestWeaveSessions:
         await db_session.commit()
 
         # Trigger a new step — gap is > 30 min, so should close old session and open new
-        resp = await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
+        resp = await auth_client.post(
+            f"/api/projects/{project.id}/step", json={"direction": "advance", "tracker_session_id": _TRACKER_TOKEN}
+        )
         assert resp.status_code == 200
 
         await db_session.refresh(old_session)
@@ -2349,7 +2644,9 @@ class TestWeaveSessions:
         )
         await db_session.commit()
 
-        await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
+        await auth_client.post(
+            f"/api/projects/{project.id}/step", json={"direction": "advance", "tracker_session_id": _TRACKER_TOKEN}
+        )
 
         new_step = await db_session.scalar(
             select(ProjectStep)
@@ -2429,9 +2726,15 @@ class TestProjectMetrics:
     ):
         draft = await _insert_draft(db_session, test_user)
         project = await _insert_active_project(db_session, test_user, draft, None)
-        await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
-        await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "advance"})
-        await auth_client.post(f"/api/projects/{project.id}/step", json={"direction": "reverse"})
+        await auth_client.post(
+            f"/api/projects/{project.id}/step", json={"direction": "advance", "tracker_session_id": _TRACKER_TOKEN}
+        )
+        await auth_client.post(
+            f"/api/projects/{project.id}/step", json={"direction": "advance", "tracker_session_id": _TRACKER_TOKEN}
+        )
+        await auth_client.post(
+            f"/api/projects/{project.id}/step", json={"direction": "reverse", "tracker_session_id": _TRACKER_TOKEN}
+        )
         body = (await auth_client.get(f"/api/projects/{project.id}/metrics")).json()
         assert body["total_advance_steps"] == 2
         assert body["total_reverse_steps"] == 1

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -23,7 +23,7 @@
 | `app/models/draft.py` | 100% | |
 | `app/models/user.py` | 100% | Defaults, soft delete, all fields covered |
 | `app/models/yarn.py` | 100% | |
-| `app/routers/projects.py` | 97% | 9 missing: error branches (treadle/lift validation, loom version), picks endpoint edge case |
+| `app/routers/projects.py` | 97% | 9 missing: error branches (treadle/lift validation, loom version), picks endpoint edge case. `claim_tracking`/`release_tracking`/`_check_tracker_lock` (#1029) fully covered by `TestTrackerLock` (11 tests: claim/idempotent/blocked/force-steal, step/advance-item/jump-item gating, expiry self-heal, release + non-holder no-op) |
 | `app/routers/auth.py` | 81% | `/me`, logout, token validation, invite flow, webhook handlers covered; OIDC callback not tested |
 | `app/routers/health.py` | 78% | `/health` covered; DB-down error branches not tested |
 | `app/routers/admin.py` | 72% | Most admin CRUD covered; Clerk API integration paths missing |

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weaving-site",
-  "version": "0.205.2",
+  "version": "0.210.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weaving-site",
-      "version": "0.205.2",
+      "version": "0.210.2",
       "dependencies": {
         "@clerk/clerk-react": "^5.61.9",
         "@sentry/react": "^10.66.0",
@@ -2050,9 +2050,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -338,11 +338,31 @@ export function startProject(id: string): Promise<ProjectDetail> {
   return req(`/api/projects/${id}/start`, { method: "POST" });
 }
 
-export function stepProject(id: string, direction: "advance" | "reverse"): Promise<StepResponse> {
+export function claimTracking(id: string, trackerSessionId: string, force = false): Promise<ProjectDetail> {
+  return req(`/api/projects/${id}/claim-tracking`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ tracker_session_id: trackerSessionId, force }),
+  });
+}
+
+export function releaseTracking(id: string, trackerSessionId: string): Promise<ProjectDetail> {
+  return req(`/api/projects/${id}/release-tracking`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ tracker_session_id: trackerSessionId }),
+  });
+}
+
+export function stepProject(
+  id: string,
+  direction: "advance" | "reverse",
+  trackerSessionId: string
+): Promise<StepResponse> {
   return req(`/api/projects/${id}/step`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ direction }),
+    body: JSON.stringify({ direction, tracker_session_id: trackerSessionId }),
   });
 }
 
@@ -415,23 +435,27 @@ export function cloneProject(id: string): Promise<ProjectDetail> {
   return req(`/api/projects/${id}/clone`, { method: "POST" });
 }
 
-export function jumpProject(id: string, pick: number): Promise<ProjectDetail> {
+export function jumpProject(id: string, pick: number, trackerSessionId: string): Promise<ProjectDetail> {
   return req(`/api/projects/${id}/jump`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ pick }),
+    body: JSON.stringify({ pick, tracker_session_id: trackerSessionId }),
   });
 }
 
-export function advanceItem(id: string): Promise<StepResponse> {
-  return req(`/api/projects/${id}/advance-item`, { method: "POST" });
+export function advanceItem(id: string, trackerSessionId: string): Promise<StepResponse> {
+  return req(`/api/projects/${id}/advance-item`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ tracker_session_id: trackerSessionId }),
+  });
 }
 
-export function jumpItem(id: string, item: number): Promise<ProjectDetail> {
+export function jumpItem(id: string, item: number, trackerSessionId: string): Promise<ProjectDetail> {
   return req(`/api/projects/${id}/jump-item`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ item }),
+    body: JSON.stringify({ item, tracker_session_id: trackerSessionId }),
   });
 }
 

--- a/frontend/src/hooks/useTrackerSession.ts
+++ b/frontend/src/hooks/useTrackerSession.ts
@@ -1,0 +1,29 @@
+import { useMemo } from "react";
+
+const STORAGE_KEY_PREFIX = "weftmark_tracker_session:";
+
+// crypto.randomUUID() requires a secure context (HTTPS or localhost) and throws
+// otherwise — fall back to a non-cryptographic ID so a device on plain HTTP (e.g.
+// a LAN hostname during local dev) doesn't crash the whole page on render.
+function generateTrackerToken(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+// Per-tab, per-project identity for the tracker lock (#1029). sessionStorage (not
+// localStorage) is required — each browser tab must be a distinct "device" so an
+// idle tab left open elsewhere doesn't share identity with the tab actively in use.
+export function useTrackerSession(projectId: string | undefined): string | null {
+  return useMemo(() => {
+    if (!projectId) return null;
+    const key = `${STORAGE_KEY_PREFIX}${projectId}`;
+    let token = sessionStorage.getItem(key);
+    if (!token) {
+      token = generateTrackerToken();
+      sessionStorage.setItem(key, token);
+    }
+    return token;
+  }, [projectId]);
+}

--- a/frontend/src/hooks/useTrackerSession.ts
+++ b/frontend/src/hooks/useTrackerSession.ts
@@ -3,13 +3,18 @@ import { useMemo } from "react";
 const STORAGE_KEY_PREFIX = "weftmark_tracker_session:";
 
 // crypto.randomUUID() requires a secure context (HTTPS or localhost) and throws
-// otherwise — fall back to a non-cryptographic ID so a device on plain HTTP (e.g.
-// a LAN hostname during local dev) doesn't crash the whole page on render.
+// otherwise — fall back to crypto.getRandomValues(), which (unlike randomUUID)
+// works in insecure contexts too, so a LAN hostname during local dev still gets
+// an unpredictable id instead of crashing the whole page on render.
 function generateTrackerToken(): string {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
     return crypto.randomUUID();
   }
-  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  if (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
+    const bytes = crypto.getRandomValues(new Uint8Array(16));
+    return `${Date.now().toString(36)}-${Array.from(bytes, (b) => b.toString(36)).join("")}`;
+  }
+  return Date.now().toString(36);
 }
 
 // Per-tab, per-project identity for the tracker lock (#1029). sessionStorage (not

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -733,6 +733,8 @@
     "resumeFromPick": "Ab Schuss {{pick}} fortsetzen?",
     "loomHasActive": "Dieser Webstuhl hat ein aktives Projekt:",
     "resolveToRestart": "Löse es auf, um dieses neu zu starten.",
+    "trackerLockedElsewhere": "Dieses Projekt wird gerade von einem anderen Gerät verfolgt.",
+    "takeOverTracking": "Übernehmen",
     "working": "Wird verarbeitet…",
     "markCompletedAndRestart": "Abschließen & neu starten",
     "abandonAndRestart": "Aufgeben & neu starten",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -733,6 +733,8 @@
     "resumeFromPick": "Resume from pick {{pick}}?",
     "loomHasActive": "This loom has an active project:",
     "resolveToRestart": "Resolve it to restart this one.",
+    "trackerLockedElsewhere": "This project is being tracked from another device.",
+    "takeOverTracking": "Take over",
     "working": "Working…",
     "markCompletedAndRestart": "Mark completed & restart",
     "abandonAndRestart": "Abandon & restart",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -732,6 +732,8 @@
     "resumeFromPick": "¿Reanudar desde la pasada {{pick}}?",
     "loomHasActive": "Este telar tiene un proyecto activo:",
     "resolveToRestart": "Resuélvelo para reiniciar este.",
+    "trackerLockedElsewhere": "Este proyecto se está siguiendo desde otro dispositivo.",
+    "takeOverTracking": "Tomar el control",
     "working": "Procesando…",
     "markCompletedAndRestart": "Completar y reiniciar",
     "abandonAndRestart": "Abandonar y reiniciar",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -732,6 +732,8 @@
     "resumeFromPick": "Reprendre à partir de la duite {{pick}} ?",
     "loomHasActive": "Ce métier a un projet actif :",
     "resolveToRestart": "Résolvez-le pour redémarrer celui-ci.",
+    "trackerLockedElsewhere": "Ce projet est actuellement suivi depuis un autre appareil.",
+    "takeOverTracking": "Prendre le relais",
     "working": "En cours…",
     "markCompletedAndRestart": "Terminer & redémarrer",
     "abandonAndRestart": "Abandonner & redémarrer",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -732,6 +732,8 @@
     "resumeFromPick": "Hervatten vanaf inslag {{pick}}?",
     "loomHasActive": "Dit weefgetouw heeft een actief project:",
     "resolveToRestart": "Los het op om dit opnieuw te starten.",
+    "trackerLockedElsewhere": "Dit project wordt momenteel vanaf een ander apparaat bijgehouden.",
+    "takeOverTracking": "Overnemen",
     "working": "Bezig…",
     "markCompletedAndRestart": "Voltooien & herstarten",
     "abandonAndRestart": "Opgeven & herstarten",

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -6,6 +6,7 @@ import { AppIcons } from "@/lib/icons";
 import { usePresentMode } from "@/hooks/usePresentMode";
 import { useOnlineStatus } from "@/hooks/useOnlineStatus";
 import { useStepQueue } from "@/hooks/useStepQueue";
+import { useTrackerSession } from "@/hooks/useTrackerSession";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuthContext } from "@/context/AuthContext";
 import { measurementSystemToUnit, displayLength } from "@/lib/units";
@@ -13,7 +14,7 @@ import {
   getProject, getProjectPicks, getProjectMetrics, stepProject, jumpProject, completeProject, abandonProject,
   restartProject, cloneProject, listProjects, deleteProject, startProject,
   renameProject, updateProjectNotes, uploadProjectPhoto, deleteProjectPhoto, projectPhotoUrl,
-  advanceItem, jumpItem,
+  advanceItem, jumpItem, claimTracking, releaseTracking,
   ApiError, PROJECT_TYPE_LABELS, PROJECT_STATUS_LABELS,
   type ProjectSummary, type ProjectPhoto, type PickRow, type ProjectMetrics,
 } from "@/api/projects";
@@ -1070,6 +1071,9 @@ export function ProjectDetailPage() {
   const [cloneConflict, setCloneConflict] = useState<ProjectSummary | null>(null);
   const [restartConflict, setRestartConflict] = useState<ProjectSummary | null>(null);
   const [localPick, setLocalPick] = useState(1);
+  // Tracker lock (#1029) — which device currently owns pick-position writes.
+  const trackerSessionId = useTrackerSession(id);
+  const [trackerLocked, setTrackerLocked] = useState(false);
 
   const { isPresent, isSupported: presentModeSupported, toggle: togglePresentMode } = usePresentMode();
   const isOnline = useOnlineStatus();
@@ -1129,6 +1133,33 @@ export function ProjectDetailPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isCreated, id]);
 
+  // Tracker lock (#1029) — silently claim on mount if free; block writes and show
+  // a banner if another device already holds it. Release is best-effort on unmount
+  // (a crashed tab's lock simply goes stale and self-heals server-side).
+  const isActivelyTracked = project?.status === "active" && !!project?.loom_id;
+  useEffect(() => {
+    if (!id || !trackerSessionId || !isActivelyTracked) return;
+    let cancelled = false;
+    claimTracking(id, trackerSessionId)
+      .then(() => { if (!cancelled) setTrackerLocked(false); })
+      .catch((err) => { if (!cancelled && err instanceof ApiError && err.status === 409) setTrackerLocked(true); });
+    return () => {
+      cancelled = true;
+      releaseTracking(id, trackerSessionId).catch(() => {});
+    };
+  }, [id, trackerSessionId, isActivelyTracked]);
+
+  const handleTakeOverTracking = async () => {
+    if (!id || !trackerSessionId) return;
+    setActionLoading(true);
+    try {
+      await claimTracking(id, trackerSessionId, true);
+      setTrackerLocked(false);
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
   const { data: allProjects = [] } = useQuery({
     queryKey: ["projects"],
     queryFn: () => listProjects(),
@@ -1151,7 +1182,7 @@ export function ProjectDetailPage() {
   const invalidate = () => queryClient.invalidateQueries({ queryKey: ["project", id] });
 
   const handleJump = useCallback(async (pick: number) => {
-    if (!id || stepping) return;
+    if (!id || stepping || !trackerSessionId) return;
     // Jump is a deliberate correction, not continuous tracking like step — require
     // connectivity rather than queueing it for later replay against a since-changed
     // current_pick (see #1028).
@@ -1159,7 +1190,7 @@ export function ProjectDetailPage() {
     setStepping(true);
     pendingStepsRef.current += 1;
     try {
-      const updated = await jumpProject(id, pick);
+      const updated = await jumpProject(id, pick, trackerSessionId);
       pendingStepsRef.current -= 1;
       if (pendingStepsRef.current === 0) {
         // Merge only the fields a jump can change — preserves loom/draft metadata
@@ -1176,30 +1207,31 @@ export function ProjectDetailPage() {
           };
         });
       }
-    } catch {
+    } catch (err) {
       pendingStepsRef.current -= 1;
+      if (err instanceof ApiError && err.status === 409) setTrackerLocked(true);
       queryClient.invalidateQueries({ queryKey: ["project", id] });
     } finally {
       setStepping(false);
     }
-  }, [id, stepping, isOnline, queryClient]);
+  }, [id, stepping, isOnline, queryClient, trackerSessionId]);
 
   const drainingRef = useRef(false);
 
   // Drain buffered offline steps when connectivity is restored
   useEffect(() => {
-    if (!isOnline || drainingRef.current || pendingOfflineSteps === 0) return;
+    if (!isOnline || drainingRef.current || pendingOfflineSteps === 0 || !trackerSessionId) return;
     drainingRef.current = true;
     drainAll(async (projectId, direction) => {
-      await stepProject(projectId, direction);
+      await stepProject(projectId, direction, trackerSessionId);
     }).then(() => {
       drainingRef.current = false;
       if (id) queryClient.invalidateQueries({ queryKey: ["project", id] });
     });
-  }, [isOnline, pendingOfflineSteps, drainAll, id, queryClient]);
+  }, [isOnline, pendingOfflineSteps, drainAll, id, queryClient, trackerSessionId]);
 
   const handleStep = useCallback(async (direction: "advance" | "reverse") => {
-    if (!id) return;
+    if (!id || !trackerSessionId) return;
     // Read latest cached value so rapid taps each see the up-to-date pick
     const cached = queryClient.getQueryData<NonNullable<typeof project>>(["project", id]);
     if (!cached) return;
@@ -1221,7 +1253,7 @@ export function ProjectDetailPage() {
 
     pendingStepsRef.current += 1;
     try {
-      const result = await stepProject(id, direction);
+      const result = await stepProject(id, direction, trackerSessionId);
       pendingStepsRef.current -= 1;
       // Only settle once all in-flight steps have resolved. Earlier responses
       // are stale relative to the optimistic state (server serializes via FOR UPDATE,
@@ -1235,12 +1267,13 @@ export function ProjectDetailPage() {
           return { ...old, current_pick: safePick, total_picks: result.total_picks, current_item: result.current_item };
         });
       }
-    } catch {
+    } catch (err) {
       pendingStepsRef.current -= 1;
+      if (err instanceof ApiError && err.status === 409) setTrackerLocked(true);
       // On error, invalidate to let the server state win
       queryClient.invalidateQueries({ queryKey: ["project", id] });
     }
-  }, [id, queryClient, isOnline, enqueueStep]);
+  }, [id, queryClient, isOnline, enqueueStep, trackerSessionId]);
 
   const handleLocalStep = useCallback((direction: "advance" | "reverse") => {
     setLocalPick((prev) => {
@@ -1293,21 +1326,23 @@ export function ProjectDetailPage() {
   };
 
   const handleAdvanceItem = useCallback(async () => {
-    if (!id) return;
+    if (!id || !trackerSessionId) return;
     setActionLoading(true);
     try {
-      const result = await advanceItem(id);
+      const result = await advanceItem(id, trackerSessionId);
       queryClient.setQueryData<typeof project>(["project", id], (old) =>
         old ? { ...old, current_pick: result.current_pick, current_item: result.current_item } : old
       );
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) setTrackerLocked(true);
     } finally { setActionLoading(false); }
-  }, [id, queryClient]);
+  }, [id, queryClient, trackerSessionId]);
 
   const handleJumpItem = useCallback(async (item: number) => {
-    if (!id) return;
+    if (!id || !trackerSessionId) return;
     setActionLoading(true);
     try {
-      const updated = await jumpItem(id, item);
+      const updated = await jumpItem(id, item, trackerSessionId);
       queryClient.setQueryData<typeof project>(["project", id], (old) => {
         if (!old) return updated;
         return {
@@ -1319,8 +1354,10 @@ export function ProjectDetailPage() {
           status: updated.status,
         };
       });
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) setTrackerLocked(true);
     } finally { setActionLoading(false); }
-  }, [id, queryClient]);
+  }, [id, queryClient, trackerSessionId]);
 
   const handleRestart = async () => {
     if (!id) return;
@@ -1630,7 +1667,7 @@ export function ProjectDetailPage() {
                     <button
                       key={i}
                       onClick={() => isActiveTracking && handleJumpItem(i + 1)}
-                      disabled={!isActiveTracking || actionLoading}
+                      disabled={!isActiveTracking || actionLoading || trackerLocked}
                       title={t("projectDetailPage.jumpToItem", { n: i + 1 })}
                       className={`h-2.5 rounded-full transition-all ${
                         i + 1 === project.current_item
@@ -1638,7 +1675,7 @@ export function ProjectDetailPage() {
                           : i + 1 < project.current_item
                           ? "w-2.5 bg-primary/40"
                           : "w-2.5 bg-muted-foreground/30"
-                      } ${isActiveTracking && !actionLoading ? "cursor-pointer hover:opacity-80" : "cursor-default"}`}
+                      } ${isActiveTracking && !actionLoading && !trackerLocked ? "cursor-pointer hover:opacity-80" : "cursor-default"}`}
                     />
                   ))}
                 </div>
@@ -1661,7 +1698,7 @@ export function ProjectDetailPage() {
               </p>
               {isActiveTracking && (
                 <div className="mt-6">
-                  <Button variant="success" onClick={handleAdvanceItem} disabled={actionLoading}>
+                  <Button variant="success" onClick={handleAdvanceItem} disabled={actionLoading || trackerLocked}>
                     {actionLoading ? "…" : t("projectDetailPage.startItem", { n: project.current_item + 1 })}
                   </Button>
                 </div>
@@ -1778,6 +1815,15 @@ export function ProjectDetailPage() {
 
         {/* Step controls — active tracking and planning */}
         <div className="w-full px-4 pb-6">
+          {!isReadOnly && trackerLocked && !isPlanning && (
+            <div className="mb-4 rounded-md border border-copper-subtle bg-copper-subtle px-3 py-3 text-sm space-y-2">
+              <p className="font-medium text-copper-on-subtle">{t("projectDetailPage.trackerLockedElsewhere")}</p>
+              <Button type="button" size="sm" onClick={handleTakeOverTracking} disabled={actionLoading}>
+                {actionLoading ? t("projectDetailPage.working") : t("projectDetailPage.takeOverTracking")}
+              </Button>
+            </div>
+          )}
+
           {!isReadOnly && (isActiveTracking || isPlanning) && (
             <div className="flex flex-col gap-6 lg:grid lg:grid-cols-[1fr_auto_1fr] lg:items-center lg:gap-8 mb-4">
               {/* Left 1/3 on desktop, below step buttons on mobile */}
@@ -1785,7 +1831,7 @@ export function ProjectDetailPage() {
                 <JumpToPick
                   total={project.total_picks}
                   onJump={isPlanning ? handleLocalJump : handleJump}
-                  disabled={stepping || (!isPlanning && !isOnline)}
+                  disabled={stepping || (!isPlanning && !isOnline) || (!isPlanning && trackerLocked)}
                 />
               </div>
               {/* Center 1/3 on desktop, top on mobile */}
@@ -1795,8 +1841,8 @@ export function ProjectDetailPage() {
                   total={project.total_picks}
                   onStep={isPlanning ? handleLocalStep : handleStep}
                   onJump={isPlanning ? handleLocalJump : handleJump}
-                  stepping={stepping}
-                  jumpDisabled={!isPlanning && !isOnline}
+                  stepping={stepping || (!isPlanning && trackerLocked)}
+                  jumpDisabled={!isPlanning && (!isOnline || trackerLocked)}
                 />
               </div>
               {/* Right 1/3 reserved for future use */}

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -59,6 +59,7 @@ function CollapsibleSection({
   return (
     <section className="border-t">
       <button
+        type="button"
         onClick={() => setOpen((v) => !v)}
         className="flex w-full items-center justify-between py-3 text-xs font-medium uppercase tracking-wide text-muted-foreground transition-colors hover:text-foreground"
       >
@@ -602,6 +603,7 @@ function StepControls({
     <div className="flex items-center justify-center gap-2 sm:gap-3">
       {/* ‹‹ back 10 — visible on sm+ */}
       <button
+        type="button"
         onClick={() => onJump(Math.max(1, currentPick - 10))}
         disabled={atStart || disabled || jumpDisabled}
         className="hidden sm:flex h-12 w-12 items-center justify-center rounded-full border-2 border-primary/40 text-primary/70 text-lg font-medium transition-colors hover:border-primary hover:bg-primary/10 disabled:opacity-30 disabled:cursor-not-allowed"
@@ -612,6 +614,7 @@ function StepControls({
       </button>
 
       <button
+        type="button"
         onClick={() => onStep("reverse")}
         disabled={atStart || disabled}
         className="flex h-20 w-20 items-center justify-center rounded-full border-2 border-primary text-primary text-3xl font-light transition-colors hover:bg-primary hover:text-primary-foreground disabled:opacity-30 disabled:cursor-not-allowed"
@@ -628,6 +631,7 @@ function StepControls({
       </div>
 
       <button
+        type="button"
         onClick={() => onStep("advance")}
         disabled={pastEnd || disabled}
         className="flex h-20 w-20 items-center justify-center rounded-full border-2 border-primary text-primary text-3xl font-light transition-colors hover:bg-primary hover:text-primary-foreground disabled:opacity-30 disabled:cursor-not-allowed"
@@ -638,6 +642,7 @@ function StepControls({
 
       {/* ›› forward 10 — visible on sm+ */}
       <button
+        type="button"
         onClick={() => onJump(Math.min(total + 1, currentPick + 10))}
         disabled={pastEnd || disabled || jumpDisabled}
         className="hidden sm:flex h-12 w-12 items-center justify-center rounded-full border-2 border-primary/40 text-primary/70 text-lg font-medium transition-colors hover:border-primary hover:bg-primary/10 disabled:opacity-30 disabled:cursor-not-allowed"
@@ -854,6 +859,7 @@ function PhotoGrid({
             onClick={(e) => e.stopPropagation()}
           />
           <button
+            type="button"
             onClick={() => setLightbox(null)}
             className="absolute top-4 right-4 text-white/70 hover:text-white text-sm"
           >
@@ -1538,6 +1544,7 @@ export function ProjectDetailPage() {
             </form>
           ) : (
             <button
+              type="button"
               onClick={() => { setNameInput(project.name); setEditingName(true); }}
               className="font-semibold hover:underline decoration-dashed underline-offset-2 cursor-text truncate"
               title={t("projectDetailPage.clickToRename")}
@@ -1549,6 +1556,7 @@ export function ProjectDetailPage() {
         </div>
         <div className="flex items-center gap-2 shrink-0">
           <button
+            type="button"
             onClick={() => setShowDesignPreview(true)}
             className="rounded-md border border-primary/30 bg-primary/5 px-3 py-1.5 text-xs font-medium text-primary transition-colors hover:bg-primary/10"
             title={t("projectDetailPage.viewDesignTitle")}
@@ -1564,6 +1572,7 @@ export function ProjectDetailPage() {
           </Link>
           {!isReadOnly && (
             <button
+              type="button"
               onClick={() => setShareModalOpen(true)}
               className="rounded-md border border-border bg-background px-2.5 py-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
               title={t("projectDetailPage.shareProject")}
@@ -1574,6 +1583,7 @@ export function ProjectDetailPage() {
           )}
           {!isReadOnly && (
             <button
+              type="button"
               onClick={() => setSettingsOpen(true)}
               className="rounded-md border border-border bg-background px-2.5 py-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
               title={t("projectDetailPage.viewSettings")}
@@ -1587,6 +1597,7 @@ export function ProjectDetailPage() {
           </span>
           {!isReadOnly && project.share_slug && project.share_visibility !== "private" && (
             <button
+              type="button"
               onClick={() => setShareModalOpen(true)}
               className="rounded px-2 py-0.5 text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/60 dark:text-blue-300 flex items-center gap-1 hover:opacity-80 transition-opacity"
               title={t("projectDetailPage.projectSharedManage")}
@@ -1597,6 +1608,7 @@ export function ProjectDetailPage() {
           )}
           {presentModeSupported && (
             <button
+              type="button"
               onClick={togglePresentMode}
               className="ml-3 rounded-md border border-border bg-background px-2.5 py-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
               title={isPresent ? t("projectDetailPage.exitPresentMode") : t("projectDetailPage.presentModeTitle")}
@@ -1665,6 +1677,7 @@ export function ProjectDetailPage() {
                 <div className="flex items-center gap-1">
                   {Array.from({ length: project.num_items }, (_, i) => (
                     <button
+                      type="button"
                       key={i}
                       onClick={() => isActiveTracking && handleJumpItem(i + 1)}
                       disabled={!isActiveTracking || actionLoading || trackerLocked}
@@ -1862,6 +1875,7 @@ export function ProjectDetailPage() {
       {/* Details & settings panel — toggle bar always visible; sections scroll when open */}
       <div className="shrink-0 border-t bg-card">
         <button
+          type="button"
           onClick={() => {
             const next = !panelOpen;
             setPanelOpen(next);
@@ -1933,6 +1947,7 @@ export function ProjectDetailPage() {
               />
             ) : (
               <button
+                type="button"
                 onClick={() => { setNotesInput(project.notes ?? ""); setEditingNotes(true); }}
                 className="w-full text-left text-sm"
                 title={t("projectDetailPage.clickToEditNotes")}
@@ -2191,6 +2206,7 @@ export function ProjectDetailPage() {
             <div className="flex items-center justify-between border-b border-border px-4 py-3">
               <span className="text-sm font-semibold">{t("projectDetailPage.viewSettings")}</span>
               <button
+                type="button"
                 onClick={() => setSettingsOpen(false)}
                 className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
                 aria-label="Close settings"
@@ -2212,6 +2228,7 @@ export function ProjectDetailPage() {
                   <div key={label} className={`flex items-center justify-between${disabled ? " opacity-40" : ""}`} title={disabled ? disabledTitle : undefined}>
                     <span className="text-sm">{label}</span>
                     <button
+                      type="button"
                       role="switch"
                       aria-checked={value}
                       disabled={disabled}
@@ -2240,6 +2257,7 @@ export function ProjectDetailPage() {
                       </p>
                     </div>
                     <button
+                      type="button"
                       role="switch"
                       aria-checked={hideTrailingUnused}
                       onClick={() => {
@@ -2261,6 +2279,7 @@ export function ProjectDetailPage() {
                 <div className="inline-flex rounded-md border border-input overflow-hidden text-sm w-full">
                   {(["theme", "strip", "filled"] as ColorMode[]).map((mode) => (
                     <button
+                      type="button"
                       key={mode}
                       onClick={() => { setColorMode(mode); localStorage.setItem("proj-view:colorMode", mode); }}
                       className={`flex-1 px-2.5 py-1.5 capitalize transition-colors ${


### PR DESCRIPTION
## Summary
- Adds a lightweight "confirm-to-take-over" tracker lock so an idle second device can't silently apply real step/jump writes against a project someone else is actively tracking (#1029)
- A device silently claims the lock on tracker-screen mount if it's free; if another live device holds it, writes are blocked and a banner offers an explicit "Take over" action
- A crashed/abandoned session self-heals via the existing `idle_timeout_minutes` threshold — no new user-facing setting
- Also closes a pre-existing gap: `advance-item` and `jump-item` now use `SELECT ... FOR UPDATE` like `step`/`jump` already did

## Changes
- Backend: 2 new nullable `Project` columns + migration, `_check_tracker_lock` helper, new `claim-tracking`/`release-tracking` endpoints, gated `step`/`jump`/`advance-item`/`jump-item`
- Frontend: `useTrackerSession` hook (per-tab token via `sessionStorage`), claim-on-mount/release-on-unmount effect, 409 handling → conflict banner, disabled controls while locked
- i18n keys added to all 5 locales
- `docs/testing.md` updated

## Out of scope (by design)
- Photo upload and all read-only endpoints — untouched
- Device-naming/labeling UI — banner text stays generic
- Any new realtime channel (WebSocket/SSE) — relies on the existing 5s poll + write-time 409s
- Impersonation special-casing — lock is scoped to `project_id`, not `user_id`, so it isn't needed

## Test plan
- [x] 11 new `TestTrackerLock` backend tests (claim/idempotent/blocked/force-steal, step/advance-item/jump-item gating, expiry self-heal, release + non-holder no-op) — all pass
- [x] Full `test_projects.py` (298 tests) — pass, no regressions
- [x] Full backend suite — 2812 passed, 1 unrelated pre-existing failure (missing `sentry_sdk` in local conda env, unrelated to this change)
- [x] `tsc` and `eslint` clean
- [x] Manual two-tab browser verification via Playwright against a local rebuild: silent claim → conflict banner + disabled controls on second device → successful take-over, all confirmed
- [x] Migration applies and reverses cleanly (`alembic upgrade head` verified via container restart)