### PR TITLE
feat: dedicated Neon dashboard with account + project usage (#1041)

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -30,6 +30,7 @@ from app.models.server_event import ServerEvent
 from app.models.user import User
 from app.models.user_export import UserExportRequest
 from app.models.yarn import Yarn
+from app.services import neon
 from app.services.audit import write_audit_log
 from app.services.clerk import ban_clerk_user, get_clerk_user, list_clerk_users, set_user_metadata, unban_clerk_user
 from app.services.config_file import MANAGED_FIELDS, SECRET_FIELDS, env_source_fields
@@ -135,20 +136,6 @@ class AdminDbInfoResponse(BaseModel):
     is_at_head: bool
     last_squash_at: str | None
     last_migrated_at: str | None
-
-
-class NeonUsageDay(BaseModel):
-    date: str
-    compute_seconds: float
-
-
-class NeonUsageResponse(BaseModel):
-    configured: bool
-    project_id: str | None = None
-    period_start: str | None = None
-    total_compute_seconds: float = 0.0
-    daily: list[NeonUsageDay] = []
-    error: str | None = None
 
 
 class StorageReportFile(BaseModel):
@@ -1639,76 +1626,9 @@ async def get_db_info(
     )
 
 
-NEON_CONSUMPTION_URL = "https://console.neon.tech/api/v2/consumption_history/v2/projects"
-NEON_PROJECTS_URL = "https://console.neon.tech/api/v2/projects"
-
-
-async def _fetch_neon_usage(settings: Settings) -> NeonUsageResponse:
-    """Query Neon's Consumption Metrics API for the trailing 30 days of compute usage.
-
-    Entirely independent of POSTGRES_DSN — reads only the neon_api_key/neon_org_id
-    settings, which are unrelated to which Postgres the app actually connects to.
-    """
-    if not settings.neon_api_key or not settings.neon_org_id:
-        return NeonUsageResponse(configured=False)
-
-    now = datetime.now(timezone.utc)
-    from_dt = now - timedelta(days=30)
-    params: dict[str, str] = {
-        "from": from_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "to": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "granularity": "daily",
-        "org_id": settings.neon_org_id,
-        "metrics": "compute_unit_seconds",
-    }
-    if settings.neon_project_id:
-        params["project_ids"] = settings.neon_project_id
-
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            r = await client.get(
-                NEON_CONSUMPTION_URL,
-                params=params,
-                headers={"Authorization": f"Bearer {settings.neon_api_key}", "Accept": "application/json"},
-            )
-        if r.status_code != 200:
-            return NeonUsageResponse(configured=True, error=f"Neon API returned HTTP {r.status_code}")
-        data = r.json()
-    except httpx.TimeoutException:
-        return NeonUsageResponse(configured=True, error="Timed out after 10 s")
-    except Exception as exc:
-        return NeonUsageResponse(configured=True, error=str(exc)[:200])
-
-    daily: list[NeonUsageDay] = []
-    total = 0.0
-    project_id_out: str | None = None
-    period_start_out: str | None = None
-    for project in data.get("projects", []):
-        if settings.neon_project_id and project.get("project_id") != settings.neon_project_id:
-            continue
-        project_id_out = project.get("project_id")
-        for period in project.get("periods", []):
-            period_start_out = period.get("period_start")
-            for point in period.get("consumption", []):
-                value = 0.0
-                for m in point.get("metrics", []):
-                    if m.get("metric_name") == "compute_unit_seconds":
-                        value = float(m.get("value", 0))
-                daily.append(NeonUsageDay(date=point.get("timeframe_start", ""), compute_seconds=value))
-                total += value
-
-    return NeonUsageResponse(
-        configured=True,
-        project_id=project_id_out,
-        period_start=period_start_out,
-        total_compute_seconds=total,
-        daily=daily,
-    )
-
-
-@router.get("/neon-usage", response_model=NeonUsageResponse)
-async def get_neon_usage(_: User = Depends(require_admin)) -> NeonUsageResponse:
-    return await _fetch_neon_usage(get_settings())
+@router.get("/neon-dashboard", response_model=neon.NeonDashboardResponse)
+async def get_neon_dashboard(_: User = Depends(require_superuser)) -> neon.NeonDashboardResponse:
+    return await neon.fetch_dashboard(get_settings())
 
 
 # ---------------------------------------------------------------------------
@@ -3056,39 +2976,11 @@ async def _test_github(v: dict) -> ConfigTestResult:
 
 async def _test_neon(v: dict) -> ConfigTestResult:
     try:
-        api_key = v.get("neon_api_key") or ""
-        org_id = v.get("neon_org_id") or ""
-        if not api_key or not org_id:
-            return ConfigTestResult(ok=False, message="neon_api_key and neon_org_id are both required")
-        now = datetime.now(timezone.utc)
-        params = {
-            "from": (now - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ"),
-            "to": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
-            "granularity": "daily",
-            "org_id": org_id,
-            "metrics": "compute_unit_seconds",
-        }
-        headers = {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(NEON_CONSUMPTION_URL, params=params, headers=headers, timeout=10)
-        if resp.status_code != 200:
-            return ConfigTestResult(ok=False, message=f"Neon API returned {resp.status_code}: {resp.text[:120]}")
-        project_count = len(resp.json().get("projects", []))
-
-        options: list[ConfigTestOption] | None = None
-        try:
-            async with httpx.AsyncClient() as client:
-                proj_resp = await client.get(NEON_PROJECTS_URL, params={"org_id": org_id}, headers=headers, timeout=10)
-            if proj_resp.status_code == 200:
-                options = [
-                    ConfigTestOption(value=p["id"], label=p.get("name") or p["id"])
-                    for p in proj_resp.json().get("projects", [])
-                ]
-        except Exception:
-            pass  # project listing is a nice-to-have — the connection test above already succeeded
-
+        ok, message, options = await neon.test_connection(v)
         return ConfigTestResult(
-            ok=True, message=f"Connected — {project_count} project(s) visible to this org", options=options
+            ok=ok,
+            message=message,
+            options=[ConfigTestOption(value=o["value"], label=o["label"]) for o in options] if options else None,
         )
     except Exception as exc:
         return ConfigTestResult(ok=False, message=str(exc))

--- a/backend/app/services/neon.py
+++ b/backend/app/services/neon.py
@@ -86,8 +86,7 @@ def _parse_consumption(
                 for m in point.get("metrics", []):
                     if m.get("metric_name") == "compute_unit_seconds":
                         value = float(m.get("value", 0))
-                if project_id_filter:
-                    daily.append(NeonUsageDay(date=point.get("timeframe_start", ""), compute_seconds=value))
+                daily.append(NeonUsageDay(date=point.get("timeframe_start", ""), compute_seconds=value))
                 total += value
                 project_total += value
         if pid:

--- a/backend/app/services/neon.py
+++ b/backend/app/services/neon.py
@@ -1,0 +1,292 @@
+"""Client for the subset of Neon's Console API this app uses (#1041, formerly inline in
+app/routers/admin.py — see #1016/#1032 for the original project-scoped usage panel).
+
+Neon's public API has no invoice/actual-spend endpoint — only a spending *limit* (cap) and
+plan tier are exposed, so "billing" here means those two fields, not a dollar-spent figure.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import httpx
+from pydantic import BaseModel
+
+from app.config import Settings
+
+NEON_API_BASE = "https://console.neon.tech/api/v2"
+NEON_CONSUMPTION_URL = f"{NEON_API_BASE}/consumption_history/v2/projects"
+NEON_PROJECTS_URL = f"{NEON_API_BASE}/projects"
+_REQUEST_TIMEOUT = 10.0
+
+
+class NeonUsageDay(BaseModel):
+    date: str
+    compute_seconds: float
+
+
+class NeonUsageResponse(BaseModel):
+    """Trailing-30-day compute usage for a single project."""
+
+    configured: bool
+    project_id: str | None = None
+    period_start: str | None = None
+    total_compute_seconds: float = 0.0
+    daily: list[NeonUsageDay] = []
+    error: str | None = None
+
+
+class NeonProjectUsage(BaseModel):
+    project_id: str
+    project_name: str | None = None
+    total_compute_seconds: float
+
+
+class NeonAccountResponse(BaseModel):
+    """Trailing-30-day compute usage across every project in the org, plus whatever
+    account-level plan/billing info Neon's API exposes (see module docstring)."""
+
+    configured: bool
+    org_name: str | None = None
+    plan: str | None = None
+    spending_limit_cents: int | None = None
+    period_start: str | None = None
+    total_compute_seconds: float = 0.0
+    daily: list[NeonUsageDay] = []
+    by_project: list[NeonProjectUsage] = []
+    error: str | None = None
+
+
+class NeonDashboardResponse(BaseModel):
+    account: NeonAccountResponse
+    project: NeonUsageResponse
+
+
+def _auth_headers(api_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
+
+
+def _parse_consumption(
+    data: dict[str, Any], project_id_filter: str | None
+) -> tuple[list[NeonUsageDay], float, str | None, dict[str, float]]:
+    """Shared parsing for consumption_history/v2/projects — daily totals, grand total,
+    the first period_start seen, and a per-project total map (for the account rollup)."""
+    daily: list[NeonUsageDay] = []
+    total = 0.0
+    period_start_out: str | None = None
+    by_project: dict[str, float] = {}
+    for project in data.get("projects", []):
+        pid = project.get("project_id")
+        if project_id_filter and pid != project_id_filter:
+            continue
+        project_total = 0.0
+        for period in project.get("periods", []):
+            period_start_out = period_start_out or period.get("period_start")
+            for point in period.get("consumption", []):
+                value = 0.0
+                for m in point.get("metrics", []):
+                    if m.get("metric_name") == "compute_unit_seconds":
+                        value = float(m.get("value", 0))
+                if project_id_filter:
+                    daily.append(NeonUsageDay(date=point.get("timeframe_start", ""), compute_seconds=value))
+                total += value
+                project_total += value
+        if pid:
+            by_project[pid] = by_project.get(pid, 0.0) + project_total
+    return daily, total, period_start_out, by_project
+
+
+class _NeonHttpError(Exception):
+    def __init__(self, status_code: int, text: str) -> None:
+        super().__init__(f"Neon API returned HTTP {status_code}")
+        self.status_code = status_code
+        self.text = text
+
+
+async def _fetch_consumption(settings: Settings, project_ids: str | None) -> dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    params: dict[str, str] = {
+        "from": (now - timedelta(days=30)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "to": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "granularity": "daily",
+        "org_id": settings.neon_org_id,
+        "metrics": "compute_unit_seconds",
+    }
+    if project_ids:
+        params["project_ids"] = project_ids
+    async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT) as client:
+        r = await client.get(NEON_CONSUMPTION_URL, params=params, headers=_auth_headers(settings.neon_api_key))
+    if r.status_code != 200:
+        raise _NeonHttpError(r.status_code, r.text)
+    return dict(r.json())
+
+
+async def fetch_project_usage(settings: Settings) -> NeonUsageResponse:
+    """Trailing 30 days of compute usage for settings.neon_project_id (or all projects
+    the org exposes, if unset). Entirely independent of POSTGRES_DSN."""
+    if not settings.neon_api_key or not settings.neon_org_id:
+        return NeonUsageResponse(configured=False)
+    try:
+        data = await _fetch_consumption(settings, settings.neon_project_id or None)
+    except httpx.TimeoutException:
+        return NeonUsageResponse(configured=True, error="Timed out after 10 s")
+    except _NeonHttpError as exc:
+        return NeonUsageResponse(configured=True, error=str(exc))
+    except Exception as exc:
+        return NeonUsageResponse(configured=True, error=str(exc)[:200])
+
+    daily, total, period_start, by_project = _parse_consumption(data, settings.neon_project_id or None)
+    project_id_out = settings.neon_project_id or (next(iter(by_project), None) if by_project else None)
+    return NeonUsageResponse(
+        configured=True,
+        project_id=project_id_out,
+        period_start=period_start,
+        total_compute_seconds=total,
+        daily=daily,
+    )
+
+
+async def fetch_project_names(settings: Settings) -> dict[str, str]:
+    """Best-effort project id -> name map, used to label the account rollup. Empty on any error."""
+    try:
+        async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT) as client:
+            r = await client.get(
+                NEON_PROJECTS_URL, params={"org_id": settings.neon_org_id}, headers=_auth_headers(settings.neon_api_key)
+            )
+        if r.status_code != 200:
+            return {}
+        return {p["id"]: p.get("name") or p["id"] for p in r.json().get("projects", [])}
+    except Exception:
+        return {}
+
+
+async def fetch_org_info(settings: Settings) -> tuple[str | None, str | None, int | None, str | None]:
+    """Returns (org_name, plan, spending_limit_cents, error). Neon's org response schema
+    isn't fully documented publicly, so field extraction here is defensive/best-effort —
+    a parsing miss degrades to None rather than breaking the rest of the dashboard."""
+    headers = _auth_headers(settings.neon_api_key)
+    org_name: str | None = None
+    plan: str | None = None
+    try:
+        async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT) as client:
+            r = await client.get(f"{NEON_API_BASE}/organizations/{settings.neon_org_id}", headers=headers)
+        if r.status_code != 200:
+            return None, None, None, f"Neon API returned HTTP {r.status_code}"
+        org_data = r.json()
+        org_name = org_data.get("name")
+        plan_field = org_data.get("plan_id") or org_data.get("plan")
+        plan = plan_field.get("id") if isinstance(plan_field, dict) else plan_field
+    except Exception as exc:
+        return None, None, None, str(exc)[:200]
+
+    spending_limit_cents: int | None = None
+    try:
+        async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT) as client:
+            r = await client.get(
+                f"{NEON_API_BASE}/organizations/{settings.neon_org_id}/billing/spending_limit", headers=headers
+            )
+        if r.status_code == 200:
+            spending_limit_cents = r.json().get("spending_limit_cents")
+        # Non-200 (e.g. 403 on plans below Launch) just leaves the cap unset — not an error.
+    except Exception:
+        pass
+
+    return org_name, plan, spending_limit_cents, None
+
+
+async def fetch_account_usage(settings: Settings) -> NeonAccountResponse:
+    """Trailing 30 days of compute usage aggregated across every project in the org,
+    plus org name/plan/spending-limit where Neon's API makes them available."""
+    if not settings.neon_api_key or not settings.neon_org_id:
+        return NeonAccountResponse(configured=False)
+
+    org_name, plan, spending_limit_cents, org_error = await fetch_org_info(settings)
+
+    try:
+        data = await _fetch_consumption(settings, None)
+    except httpx.TimeoutException:
+        return NeonAccountResponse(
+            configured=True,
+            org_name=org_name,
+            plan=plan,
+            spending_limit_cents=spending_limit_cents,
+            error="Timed out after 10 s",
+        )
+    except _NeonHttpError as exc:
+        return NeonAccountResponse(
+            configured=True,
+            org_name=org_name,
+            plan=plan,
+            spending_limit_cents=spending_limit_cents,
+            error=str(exc),
+        )
+    except Exception as exc:
+        return NeonAccountResponse(
+            configured=True,
+            org_name=org_name,
+            plan=plan,
+            spending_limit_cents=spending_limit_cents,
+            error=str(exc)[:200],
+        )
+
+    daily, total, period_start, by_project = _parse_consumption(data, None)
+    names = await fetch_project_names(settings)
+    by_project_list = [
+        NeonProjectUsage(project_id=pid, project_name=names.get(pid), total_compute_seconds=seconds)
+        for pid, seconds in sorted(by_project.items(), key=lambda kv: kv[1], reverse=True)
+    ]
+
+    return NeonAccountResponse(
+        configured=True,
+        org_name=org_name,
+        plan=plan,
+        spending_limit_cents=spending_limit_cents,
+        period_start=period_start,
+        total_compute_seconds=total,
+        daily=daily,
+        by_project=by_project_list,
+        error=org_error,
+    )
+
+
+async def fetch_dashboard(settings: Settings) -> NeonDashboardResponse:
+    account = await fetch_account_usage(settings)
+    project = await fetch_project_usage(settings)
+    return NeonDashboardResponse(account=account, project=project)
+
+
+async def test_connection(v: dict) -> tuple[bool, str, list[dict[str, str]] | None]:
+    """Validate neon_api_key/neon_org_id and return a project picker's worth of options.
+    Returns (ok, message, options) — mirrors the ConfigTestResult/ConfigTestOption shape
+    used by app.routers.admin's service-test endpoint."""
+    api_key = v.get("neon_api_key") or ""
+    org_id = v.get("neon_org_id") or ""
+    if not api_key or not org_id:
+        return False, "neon_api_key and neon_org_id are both required", None
+
+    now = datetime.now(timezone.utc)
+    params = {
+        "from": (now - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "to": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "granularity": "daily",
+        "org_id": org_id,
+        "metrics": "compute_unit_seconds",
+    }
+    headers = _auth_headers(api_key)
+    async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT) as client:
+        resp = await client.get(NEON_CONSUMPTION_URL, params=params, headers=headers)
+    if resp.status_code != 200:
+        return False, f"Neon API returned {resp.status_code}: {resp.text[:120]}", None
+    project_count = len(resp.json().get("projects", []))
+
+    options: list[dict[str, str]] | None = None
+    try:
+        async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT) as client:
+            proj_resp = await client.get(NEON_PROJECTS_URL, params={"org_id": org_id}, headers=headers)
+        if proj_resp.status_code == 200:
+            options = [
+                {"value": p["id"], "label": p.get("name") or p["id"]} for p in proj_resp.json().get("projects", [])
+            ]
+    except Exception:
+        pass  # project listing is a nice-to-have — the connection test above already succeeded
+
+    return True, f"Connected — {project_count} project(s) visible to this org", options

--- a/backend/tests/routers/test_admin.py
+++ b/backend/tests/routers/test_admin.py
@@ -1165,22 +1165,28 @@ class TestAdminServices:
 
 
 # ---------------------------------------------------------------------------
-# GET /api/admin/neon-usage
+# GET /api/admin/neon-dashboard
 # ---------------------------------------------------------------------------
 
 
-class TestNeonUsageEndpoint:
-    async def test_returns_not_configured_by_default(self, admin_client: AsyncClient):
-        resp = await admin_client.get("/api/admin/neon-usage")
+class TestNeonDashboardEndpoint:
+    async def test_returns_not_configured_by_default(self, superuser_client: AsyncClient):
+        resp = await superuser_client.get("/api/admin/neon-dashboard")
         assert resp.status_code == 200
-        assert resp.json()["configured"] is False
+        body = resp.json()
+        assert body["account"]["configured"] is False
+        assert body["project"]["configured"] is False
+
+    async def test_admin_non_superuser_returns_403(self, admin_client: AsyncClient):
+        resp = await admin_client.get("/api/admin/neon-dashboard")
+        assert resp.status_code == 403
 
     async def test_non_admin_returns_403(self, auth_client: AsyncClient):
-        resp = await auth_client.get("/api/admin/neon-usage")
+        resp = await auth_client.get("/api/admin/neon-dashboard")
         assert resp.status_code == 403
 
     async def test_unauthenticated_returns_401(self, raw_client: AsyncClient):
-        resp = await raw_client.get("/api/admin/neon-usage")
+        resp = await raw_client.get("/api/admin/neon-dashboard")
         assert resp.status_code == 401
 
 

--- a/backend/tests/routers/test_admin_probes.py
+++ b/backend/tests/routers/test_admin_probes.py
@@ -935,34 +935,34 @@ class TestConfigServiceSMTP:
 
 
 # ---------------------------------------------------------------------------
-# _fetch_neon_usage
+# app.services.neon.fetch_project_usage
 # ---------------------------------------------------------------------------
 
 
-class TestFetchNeonUsage:
+class TestFetchProjectUsage:
     async def test_not_configured_when_key_missing(self, monkeypatch):
         from app.config import get_settings
-        from app.routers.admin import _fetch_neon_usage
+        from app.services.neon import fetch_project_usage
 
         s = get_settings()
         monkeypatch.setattr(s, "neon_api_key", "")
         monkeypatch.setattr(s, "neon_org_id", "")
-        result = await _fetch_neon_usage(s)
+        result = await fetch_project_usage(s)
         assert result.configured is False
 
     async def test_not_configured_when_org_id_missing(self, monkeypatch):
         from app.config import get_settings
-        from app.routers.admin import _fetch_neon_usage
+        from app.services.neon import fetch_project_usage
 
         s = get_settings()
         monkeypatch.setattr(s, "neon_api_key", "napi_xyz")
         monkeypatch.setattr(s, "neon_org_id", "")
-        result = await _fetch_neon_usage(s)
+        result = await fetch_project_usage(s)
         assert result.configured is False
 
     async def test_non_200_returns_error(self, monkeypatch):
         from app.config import get_settings
-        from app.routers.admin import _fetch_neon_usage
+        from app.services.neon import fetch_project_usage
 
         s = get_settings()
         monkeypatch.setattr(s, "neon_api_key", "napi_xyz")
@@ -972,12 +972,13 @@ class TestFetchNeonUsage:
         with patch("httpx.AsyncClient") as mock_cls:
             mock_resp = MagicMock()
             mock_resp.status_code = 401
+            mock_resp.text = "unauthorized"
             mock_inst = AsyncMock()
             mock_inst.get = AsyncMock(return_value=mock_resp)
             mock_inst.__aenter__ = AsyncMock(return_value=mock_inst)
             mock_inst.__aexit__ = AsyncMock(return_value=None)
             mock_cls.return_value = mock_inst
-            result = await _fetch_neon_usage(s)
+            result = await fetch_project_usage(s)
 
         assert result.configured is True
         assert result.error is not None
@@ -987,7 +988,7 @@ class TestFetchNeonUsage:
         import httpx
 
         from app.config import get_settings
-        from app.routers.admin import _fetch_neon_usage
+        from app.services.neon import fetch_project_usage
 
         s = get_settings()
         monkeypatch.setattr(s, "neon_api_key", "napi_xyz")
@@ -1000,7 +1001,7 @@ class TestFetchNeonUsage:
             mock_inst.__aenter__ = AsyncMock(return_value=mock_inst)
             mock_inst.__aexit__ = AsyncMock(return_value=None)
             mock_cls.return_value = mock_inst
-            result = await _fetch_neon_usage(s)
+            result = await fetch_project_usage(s)
 
         assert result.configured is True
         assert result.error is not None
@@ -1008,7 +1009,7 @@ class TestFetchNeonUsage:
 
     async def test_success_aggregates_daily_totals(self, monkeypatch):
         from app.config import get_settings
-        from app.routers.admin import _fetch_neon_usage
+        from app.services.neon import fetch_project_usage
 
         s = get_settings()
         monkeypatch.setattr(s, "neon_api_key", "napi_xyz")
@@ -1051,7 +1052,7 @@ class TestFetchNeonUsage:
             mock_inst.__aenter__ = AsyncMock(return_value=mock_inst)
             mock_inst.__aexit__ = AsyncMock(return_value=None)
             mock_cls.return_value = mock_inst
-            result = await _fetch_neon_usage(s)
+            result = await fetch_project_usage(s)
 
         assert result.configured is True
         assert result.error is None
@@ -1061,7 +1062,7 @@ class TestFetchNeonUsage:
 
     async def test_filters_to_configured_project_id(self, monkeypatch):
         from app.config import get_settings
-        from app.routers.admin import _fetch_neon_usage
+        from app.services.neon import fetch_project_usage
 
         s = get_settings()
         monkeypatch.setattr(s, "neon_api_key", "napi_xyz")
@@ -1116,10 +1117,150 @@ class TestFetchNeonUsage:
             mock_inst.__aenter__ = AsyncMock(return_value=mock_inst)
             mock_inst.__aexit__ = AsyncMock(return_value=None)
             mock_cls.return_value = mock_inst
-            result = await _fetch_neon_usage(s)
+            result = await fetch_project_usage(s)
 
         assert result.project_id == "proj_keep"
         assert result.total_compute_seconds == 42.0
+
+
+# ---------------------------------------------------------------------------
+# app.services.neon.fetch_account_usage / fetch_org_info / fetch_dashboard
+# ---------------------------------------------------------------------------
+
+
+class TestFetchAccountUsage:
+    async def test_not_configured_when_key_missing(self, monkeypatch):
+        from app.config import get_settings
+        from app.services.neon import fetch_account_usage
+
+        s = get_settings()
+        monkeypatch.setattr(s, "neon_api_key", "")
+        monkeypatch.setattr(s, "neon_org_id", "")
+        result = await fetch_account_usage(s)
+        assert result.configured is False
+
+    async def test_success_aggregates_across_all_projects(self, monkeypatch):
+        from app.config import get_settings
+        from app.services.neon import fetch_account_usage
+
+        s = get_settings()
+        monkeypatch.setattr(s, "neon_api_key", "napi_xyz")
+        monkeypatch.setattr(s, "neon_org_id", "org_123")
+        monkeypatch.setattr(s, "neon_project_id", "")
+
+        org_resp = MagicMock()
+        org_resp.status_code = 200
+        org_resp.json = MagicMock(return_value={"name": "Acme Weaving", "plan_id": "launch"})
+
+        limit_resp = MagicMock()
+        limit_resp.status_code = 200
+        limit_resp.json = MagicMock(return_value={"spending_limit_cents": 5000})
+
+        consumption_payload = {
+            "projects": [
+                {
+                    "project_id": "proj_a",
+                    "periods": [
+                        {
+                            "period_start": "2026-07-01T00:00:00Z",
+                            "consumption": [
+                                {
+                                    "timeframe_start": "2026-07-01T00:00:00Z",
+                                    "metrics": [{"metric_name": "compute_unit_seconds", "value": 100}],
+                                }
+                            ],
+                        }
+                    ],
+                },
+                {
+                    "project_id": "proj_b",
+                    "periods": [
+                        {
+                            "period_start": "2026-07-01T00:00:00Z",
+                            "consumption": [
+                                {
+                                    "timeframe_start": "2026-07-01T00:00:00Z",
+                                    "metrics": [{"metric_name": "compute_unit_seconds", "value": 25}],
+                                }
+                            ],
+                        }
+                    ],
+                },
+            ],
+        }
+        consumption_resp = MagicMock()
+        consumption_resp.status_code = 200
+        consumption_resp.json = MagicMock(return_value=consumption_payload)
+
+        projects_resp = MagicMock()
+        projects_resp.status_code = 200
+        projects_resp.json = MagicMock(
+            return_value={"projects": [{"id": "proj_a", "name": "Alpha"}, {"id": "proj_b", "name": "Beta"}]}
+        )
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_inst = AsyncMock()
+            mock_inst.get = AsyncMock(side_effect=[org_resp, limit_resp, consumption_resp, projects_resp])
+            mock_inst.__aenter__ = AsyncMock(return_value=mock_inst)
+            mock_inst.__aexit__ = AsyncMock(return_value=None)
+            mock_cls.return_value = mock_inst
+            result = await fetch_account_usage(s)
+
+        assert result.configured is True
+        assert result.error is None
+        assert result.org_name == "Acme Weaving"
+        assert result.plan == "launch"
+        assert result.spending_limit_cents == 5000
+        assert result.total_compute_seconds == 125.0
+        assert [p.project_id for p in result.by_project] == ["proj_a", "proj_b"]
+        assert result.by_project[0].project_name == "Alpha"
+
+    async def test_org_info_failure_still_returns_usage(self, monkeypatch):
+        from app.config import get_settings
+        from app.services.neon import fetch_account_usage
+
+        s = get_settings()
+        monkeypatch.setattr(s, "neon_api_key", "napi_xyz")
+        monkeypatch.setattr(s, "neon_org_id", "org_123")
+        monkeypatch.setattr(s, "neon_project_id", "")
+
+        org_resp = MagicMock()
+        org_resp.status_code = 403
+        org_resp.text = "forbidden"
+
+        consumption_resp = MagicMock()
+        consumption_resp.status_code = 200
+        consumption_resp.json = MagicMock(return_value={"projects": []})
+
+        projects_resp = MagicMock()
+        projects_resp.status_code = 200
+        projects_resp.json = MagicMock(return_value={"projects": []})
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_inst = AsyncMock()
+            mock_inst.get = AsyncMock(side_effect=[org_resp, consumption_resp, projects_resp])
+            mock_inst.__aenter__ = AsyncMock(return_value=mock_inst)
+            mock_inst.__aexit__ = AsyncMock(return_value=None)
+            mock_cls.return_value = mock_inst
+            result = await fetch_account_usage(s)
+
+        assert result.configured is True
+        assert result.org_name is None
+        assert result.plan is None
+        assert result.total_compute_seconds == 0.0
+
+
+class TestFetchDashboard:
+    async def test_not_configured_returns_both_unconfigured(self, monkeypatch):
+        from app.config import get_settings
+        from app.services.neon import fetch_dashboard
+
+        s = get_settings()
+        monkeypatch.setattr(s, "neon_api_key", "")
+        monkeypatch.setattr(s, "neon_org_id", "")
+        result = await fetch_dashboard(s)
+        assert result.account.configured is False
+        assert result.project.configured is False
 
 
 # ---------------------------------------------------------------------------

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -27,6 +27,7 @@
 | `app/routers/auth.py` | 81% | `/me`, logout, token validation, invite flow, webhook handlers covered; OIDC callback not tested |
 | `app/routers/health.py` | 78% | `/health` covered; DB-down error branches not tested |
 | `app/routers/admin.py` | 72% | Most admin CRUD covered; Clerk API integration paths missing |
+| `app/services/neon.py` | ~85% | Extracted from `admin.py` (#1041): `fetch_project_usage`/`fetch_account_usage`/`fetch_dashboard`/`test_connection` covered (not-configured, success, timeout, HTTP error, project filter, org-info failure fallback); exact % not yet measured |
 | `app/routers/looms.py` | 97% | 9 missing: photo replace + file-size error branches |
 | `app/routers/drafts.py` | 93% | 14 missing: `file_too_large`, preview happy path, liftplan edge case |
 | `app/routers/yarn.py` | 99% | 3 missing: file-size error branches |

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -85,6 +85,29 @@ export interface NeonUsage {
   error: string | null;
 }
 
+export interface NeonProjectUsage {
+  project_id: string;
+  project_name: string | null;
+  total_compute_seconds: number;
+}
+
+export interface NeonAccountUsage {
+  configured: boolean;
+  org_name: string | null;
+  plan: string | null;
+  spending_limit_cents: number | null;
+  period_start: string | null;
+  total_compute_seconds: number;
+  daily: NeonUsageDay[];
+  by_project: NeonProjectUsage[];
+  error: string | null;
+}
+
+export interface NeonDashboard {
+  account: NeonAccountUsage;
+  project: NeonUsage;
+}
+
 export interface InviteRecord {
   id: string;
   email: string;
@@ -100,7 +123,7 @@ export const getAdminStats = () => api.get<AdminStats>("/api/admin/stats");
 export const getAdminHealth = () => api.get<AdminHealth>("/api/admin/health");
 export const getAdminVersions = () => api.get<AdminVersions>("/api/admin/versions");
 export const getAdminDbInfo = () => api.get<AdminDbInfo>("/api/admin/db-info");
-export const getNeonUsage = () => api.get<NeonUsage>("/api/admin/neon-usage");
+export const getNeonDashboard = () => api.get<NeonDashboard>("/api/admin/neon-dashboard");
 export const patchAdminUser = (userId: string, body: { is_active?: boolean; is_admin?: boolean; is_superuser?: boolean }) =>
   api.patch<AdminUser>(`/api/admin/users/${userId}`, body);
 export const banUser = (userId: string) => api.post<AdminUser>(`/api/admin/users/${userId}/ban`, {});

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -169,6 +169,7 @@ export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpa
     { id: "schedule", label: t("superuserSections.schedule") },
     { id: "exports", label: t("superuserSections.exports") },
     { id: "credentials", label: t("superuserSections.credentials") },
+    { id: "neon", label: t("superuserSections.neon") },
     { id: "sandbox", label: t("superuserSections.sandbox") },
   ];
 

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -47,6 +47,7 @@
     "schedule": "Geplante Aufgaben",
     "exports": "Datenexporte",
     "credentials": "Zugangsdaten",
+    "neon": "Neon-Dashboard",
     "sandbox": "Sandbox"
   },
   "loomTypes": {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -47,6 +47,7 @@
     "schedule": "Scheduled Tasks",
     "exports": "Data Exports",
     "credentials": "Credentials",
+    "neon": "Neon Dashboard",
     "sandbox": "Sandbox"
   },
   "loomTypes": {

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -47,6 +47,7 @@
     "schedule": "Tareas programadas",
     "exports": "Exportaciones de datos",
     "credentials": "Credenciales",
+    "neon": "Panel de Neon",
     "sandbox": "Sandbox"
   },
   "loomTypes": {

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -47,6 +47,7 @@
     "schedule": "Tâches planifiées",
     "exports": "Exports de données",
     "credentials": "Identifiants",
+    "neon": "Tableau de bord Neon",
     "sandbox": "Sandbox"
   },
   "loomTypes": {

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -47,6 +47,7 @@
     "schedule": "Geplande taken",
     "exports": "Gegevensexports",
     "credentials": "Inloggegevens",
+    "neon": "Neon-dashboard",
     "sandbox": "Sandbox"
   },
   "loomTypes": {

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -19,7 +19,6 @@ import {
   banPendingSignup,
   getAdminServices,
   getAdminDbInfo,
-  getNeonUsage,
   sendTestEmail,
   testWebhook,
   getAuditLog,
@@ -32,7 +31,6 @@ import {
   type AdminUser,
   type AdminHealth,
   type AdminDbInfo,
-  type NeonUsage,
   type AuditLogEntry,
   type InviteRecord,
   type PendingSignup,
@@ -1164,59 +1162,6 @@ function DbInfoPanel() {
   );
 }
 
-function NeonUsagePanel() {
-  const { data } = useQuery<NeonUsage>({
-    queryKey: ["admin", "neon-usage"],
-    queryFn: getNeonUsage,
-    staleTime: 60_000,
-  });
-
-  // Purely optional/observational — hidden entirely unless neon_api_key/neon_org_id
-  // are configured. Independent of which Postgres the app actually connects to.
-  if (!data || !data.configured) return null;
-
-  const totalHours = data.total_compute_seconds / 3600;
-  const maxDaily = Math.max(1, ...data.daily.map((d) => d.compute_seconds));
-
-  return (
-    <div>
-      <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
-        Neon Compute Usage (last 30 days)
-      </h2>
-      {data.error ? (
-        <div className="border rounded-lg px-4 py-2 bg-background text-sm text-destructive">{data.error}</div>
-      ) : (
-        <div className="border rounded-lg overflow-hidden">
-          <div className="flex items-center justify-between px-4 py-2 bg-background border-b">
-            <span className="text-sm">Total compute time</span>
-            <span className="text-xs font-mono text-muted-foreground">{totalHours.toFixed(1)} hours</span>
-          </div>
-          {data.daily.length > 0 && (
-            <div className="px-4 py-2 bg-background space-y-1">
-              {data.daily.map((d) => (
-                <div key={d.date} className="flex items-center gap-2">
-                  <span className="text-xs font-mono text-muted-foreground w-20 shrink-0">
-                    {new Date(d.date).toLocaleDateString(undefined, { month: "short", day: "numeric" })}
-                  </span>
-                  <div className="flex-1 h-2 bg-muted rounded overflow-hidden">
-                    <div
-                      className="h-full bg-accent"
-                      style={{ width: `${Math.max(2, (d.compute_seconds / maxDaily) * 100)}%` }}
-                    />
-                  </div>
-                  <span className="text-xs font-mono text-muted-foreground w-16 text-right">
-                    {(d.compute_seconds / 3600).toFixed(2)}h
-                  </span>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
 function ServicesTab() {
   // Live status from /health/detailed — auto-refreshes every 30s
   const [detailed, setDetailed] = useState<ReadinessResponse | null>(null);
@@ -1274,7 +1219,6 @@ function ServicesTab() {
       )}
 
       <DbInfoPanel />
-      <NeonUsagePanel />
       <ServerEventsPanel />
     </div>
   );

--- a/frontend/src/pages/SuperuserPage.tsx
+++ b/frontend/src/pages/SuperuserPage.tsx
@@ -35,6 +35,7 @@ import {
   saveConfig,
   testConfigService,
   sendBackendSentryTest,
+  getNeonDashboard,
   type ScheduledTask,
   type TaskHistoryItem,
   type ReconcileReport,
@@ -71,7 +72,7 @@ function formatUptime(seconds: number): string {
   return parts.join(", ");
 }
 
-type SuperuserSection = "eula" | "storage" | "cve" | "workers" | "deletion" | "reconcile" | "maintenance" | "schedule" | "exports" | "credentials" | "sandbox" | "users";
+type SuperuserSection = "eula" | "storage" | "cve" | "workers" | "deletion" | "reconcile" | "maintenance" | "schedule" | "exports" | "credentials" | "neon" | "sandbox" | "users";
 
 // ---------------------------------------------------------------------------
 // EULA tab
@@ -2020,6 +2021,146 @@ function ConfigSection() {
   );
 }
 
+function NeonUsageBars({ daily }: { daily: { date: string; compute_seconds: number }[] }) {
+  if (daily.length === 0) return null;
+  const maxDaily = Math.max(1, ...daily.map((d) => d.compute_seconds));
+  return (
+    <div className="px-4 py-2 bg-background space-y-1">
+      {daily.map((d) => (
+        <div key={d.date} className="flex items-center gap-2">
+          <span className="text-xs font-mono text-muted-foreground w-20 shrink-0">
+            {new Date(d.date).toLocaleDateString(undefined, { month: "short", day: "numeric" })}
+          </span>
+          <div className="flex-1 h-2 bg-muted rounded overflow-hidden">
+            <div
+              className="h-full bg-accent"
+              style={{ width: `${Math.max(2, (d.compute_seconds / maxDaily) * 100)}%` }}
+            />
+          </div>
+          <span className="text-xs font-mono text-muted-foreground w-16 text-right">
+            {(d.compute_seconds / 3600).toFixed(2)}h
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function NeonDashboardTab() {
+  const { data, isLoading } = useQuery({
+    queryKey: ["admin", "neon-dashboard"],
+    queryFn: getNeonDashboard,
+    staleTime: 60_000,
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1 pb-2 border-b">
+        <h1 className="text-lg font-semibold">Neon Dashboard</h1>
+        <p className="text-sm text-muted-foreground">
+          Compute usage and plan info from Neon's Console API. Configure neon_api_key / neon_org_id / neon_project_id
+          under Credentials to enable this.
+        </p>
+      </div>
+
+      {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+
+      {data && !data.account.configured && (
+        <p className="text-sm text-muted-foreground">
+          Not configured — add neon_api_key and neon_org_id in the Credentials tab.
+        </p>
+      )}
+
+      {data?.account.configured && (
+        <div className="space-y-6">
+          <div>
+            <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
+              Account (last 30 days)
+            </h3>
+            {data.account.error ? (
+              <div className="border rounded-lg px-4 py-2 bg-background text-sm text-destructive">
+                {data.account.error}
+              </div>
+            ) : (
+              <div className="border rounded-lg overflow-hidden divide-y">
+                {data.account.org_name && (
+                  <div className="flex items-center justify-between px-4 py-2 bg-background">
+                    <span className="text-sm">Organization</span>
+                    <span className="text-xs font-mono text-muted-foreground">{data.account.org_name}</span>
+                  </div>
+                )}
+                {data.account.plan && (
+                  <div className="flex items-center justify-between px-4 py-2 bg-background">
+                    <span className="text-sm">Plan</span>
+                    <span className="text-xs font-mono text-muted-foreground">{data.account.plan}</span>
+                  </div>
+                )}
+                {data.account.spending_limit_cents != null && (
+                  <div className="flex items-center justify-between px-4 py-2 bg-background">
+                    <span className="text-sm">Monthly spending limit</span>
+                    <span className="text-xs font-mono text-muted-foreground">
+                      ${(data.account.spending_limit_cents / 100).toFixed(2)}
+                    </span>
+                  </div>
+                )}
+                <div className="flex items-center justify-between px-4 py-2 bg-background">
+                  <span className="text-sm">Total compute time (all projects)</span>
+                  <span className="text-xs font-mono text-muted-foreground">
+                    {(data.account.total_compute_seconds / 3600).toFixed(1)} hours
+                  </span>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {data.account.by_project.length > 0 && (
+            <div>
+              <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
+                By project
+              </h3>
+              <div className="border rounded-lg divide-y overflow-hidden">
+                {data.account.by_project.map((p) => (
+                  <div key={p.project_id} className="flex items-center justify-between px-4 py-2 bg-background">
+                    <span className="text-sm font-mono">{p.project_name ?? p.project_id}</span>
+                    <span className="text-xs font-mono text-muted-foreground">
+                      {(p.total_compute_seconds / 3600).toFixed(2)}h
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div>
+            <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
+              Configured project (last 30 days)
+            </h3>
+            {!data.project.configured ? (
+              <div className="border rounded-lg px-4 py-2 bg-background text-sm text-muted-foreground">
+                neon_project_id isn't set — showing account-wide usage above only.
+              </div>
+            ) : data.project.error ? (
+              <div className="border rounded-lg px-4 py-2 bg-background text-sm text-destructive">
+                {data.project.error}
+              </div>
+            ) : (
+              <div className="border rounded-lg overflow-hidden">
+                <div className="flex items-center justify-between px-4 py-2 bg-background border-b">
+                  <span className="text-sm">Total compute time</span>
+                  <span className="text-xs font-mono text-muted-foreground">
+                    {(data.project.total_compute_seconds / 3600).toFixed(1)} hours
+                  </span>
+                </div>
+                <NeonUsageBars daily={data.project.daily} />
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function CredentialsTab() {
   const queryClient = useQueryClient();
 
@@ -2440,6 +2581,7 @@ export function SuperuserPage() {
       {activeSection === "schedule" && <ScheduledTasksTab />}
       {activeSection === "exports" && <ExportsTab />}
       {activeSection === "credentials" && <CredentialsTab />}
+      {activeSection === "neon" && <NeonDashboardTab />}
       {activeSection === "sandbox" && <SandboxTab />}
       {activeSection === "users" && <UsersTab />}
     </div>


### PR DESCRIPTION
## Summary
- Breaks the Neon usage panel out of Admin → Services into its own superuser-gated page at `/superuser/neon`
- Adds an account-level section (org plan, spending-limit cap, CU-hours aggregated across every project in the org) above the existing project-scoped view
- Extracts all Neon API logic out of `admin.py` into a new `app/services/neon.py`
- Replaces `GET /api/admin/neon-usage` (admin-gated) with `GET /api/admin/neon-dashboard` (superuser-gated, matching where the Neon credentials already live)

Note: Neon's public API has no invoice/actual-spend endpoint — only a spending-limit cap and plan tier are exposed, so "billing" here means those two fields, not a dollar-spent figure.

Closes #1041

## Test plan
- [x] `ruff`, `mypy`, `tsc`, `eslint` all clean
- [x] Backend: 9 Neon-focused tests passing locally (not-configured, success, timeout, HTTP error, project filtering, org-info-failure degrades gracefully, endpoint auth gating for admin vs superuser vs anon)
- [x] Feature CI (lint + typecheck) green on push
- [ ] Full local `pytest` on `test_admin.py`/`test_admin_probes.py` didn't finish locally (Windows↔Docker DB overhead) — will be covered by the Dev PR CI gate
- [ ] No live browser verification — page is superuser-gated and this session has no login session; e2e Playwright setup only has `user`/`admin` storage states wired, not `superuser`, despite an `eqasuperuser` test account existing in `e2e/credentials/eqa-accounts.json`