### PR TITLE
chore: reduce cognitive complexity in Sidebar and ConfigFieldRow (S3776, #1034)

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -8,6 +8,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useImpersonation } from "@/context/ImpersonationContext";
 import { FeedbackModal } from "@/components/FeedbackModal";
 import { OnboardingChecklist } from "@/components/layout/OnboardingChecklist";
+import type { User } from "@/context/AuthContext";
 
 interface NavItem {
   label: string;
@@ -108,22 +109,65 @@ function NavGroupSection({
   );
 }
 
-export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpand, onDesktopCollapse }: Props) {
-  const location = useLocation();
-  const { user } = useAuth();
-  const { isImpersonating, impersonatedUser, endImpersonation } = useImpersonation();
-  // For nav visibility: use the impersonated user when active, so the primary
-  // nav shows and reflects the impersonated user's role. Admin/superuser
-  // console guards below still use the real `user`.
-  const effectiveUser = isImpersonating ? impersonatedUser : user;
-  const { signOut } = useClerk();
-  const { t } = useTranslation();
-  const [feedbackOpen, setFeedbackOpen] = useState(false);
-  const [expandedGroup, setExpandedGroup] = useState<NavGroup | null>(null);
+interface SidebarHeaderProps {
+  readonly desktopCollapsed: boolean;
+  readonly onClose: () => void;
+  readonly onDesktopExpand?: () => void;
+  readonly onDesktopCollapse?: () => void;
+}
 
-  function toggleGroup(group: NavGroup) {
-    setExpandedGroup((prev) => (prev === group ? null : group));
-  }
+function SidebarHeader({ desktopCollapsed, onClose, onDesktopExpand, onDesktopCollapse }: SidebarHeaderProps) {
+  return (
+    <div className={`shrink-0 border-b border-border flex h-16 items-center justify-between px-4 ${
+      desktopCollapsed ? "lg:flex-col lg:items-center lg:justify-center lg:h-auto lg:px-2 lg:py-3 lg:gap-2" : ""
+    }`}>
+      <Link
+        to="/home"
+        className={`flex items-center gap-2.5 ${desktopCollapsed ? "lg:w-full lg:justify-center" : ""}`}
+        onClick={onClose}
+        title={desktopCollapsed ? "Dashboard" : undefined}
+      >
+        <WeftmarkLogo className={`h-6 text-primary ${desktopCollapsed ? "lg:h-auto lg:w-full" : "w-auto"}`} />
+        <span className={`text-sm font-semibold tracking-tight text-foreground ${desktopCollapsed ? "lg:hidden" : ""}`} style={{ fontFamily: '"Segoe UI", system-ui, sans-serif' }}>weftmark</span>
+      </Link>
+      {/* Mobile close button */}
+      <button
+        onClick={onClose}
+        className="rounded-md p-1 text-muted-foreground hover:text-subdued lg:hidden"
+        aria-label="Close menu"
+      >
+        <AppIcons.close className="h-4 w-4" />
+      </button>
+      {/* Desktop sidebar toggle — only on detail pages where rail/expand applies */}
+      {(desktopCollapsed || onDesktopCollapse) && (
+        <button
+          onClick={desktopCollapsed ? onDesktopExpand : onDesktopCollapse}
+          className={`hidden lg:flex rounded-md text-muted-foreground hover:bg-muted hover:text-foreground ${desktopCollapsed ? "p-1" : "p-1.5"}`}
+          aria-label={desktopCollapsed ? "Expand navigation" : "Collapse navigation"}
+          title={desktopCollapsed ? "Expand navigation" : "Collapse navigation"}
+        >
+          {desktopCollapsed
+            ? <ExpandIcon className="h-3.5 w-3.5" />
+            : <CollapseIcon className="h-5 w-5" />}
+        </button>
+      )}
+    </div>
+  );
+}
+
+interface SidebarMainNavProps {
+  readonly isSuperuser: boolean;
+  readonly desktopCollapsed: boolean;
+  readonly onClose: () => void;
+}
+
+function SidebarMainNav({ isSuperuser, desktopCollapsed, onClose }: SidebarMainNavProps) {
+  const { t } = useTranslation();
+  const location = useLocation();
+
+  // Superusers only use /admin — no primary nav, just a flex spacer above the bottom nav
+  // (not shown during impersonation, since effectiveUser reflects the impersonated user there).
+  if (isSuperuser) return <div className="flex-1" />;
 
   const NAV_ITEMS: NavItem[] = [
     { label: t("nav.dashboard"), href: "/home", icon: AppIcons.dashboard, exact: true },
@@ -133,6 +177,45 @@ export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpa
     { label: t("nav.equipment"), href: "/looms", icon: AppIcons.equipment },
     { label: t("nav.yarn"), href: "/yarn", icon: AppIcons.yarn },
   ];
+
+  return (
+    <>
+      <div className="shrink-0 pt-2">
+        <OnboardingChecklist collapsed={desktopCollapsed} />
+      </div>
+      <nav className="flex-1 overflow-y-auto px-3 py-3 space-y-0.5">
+        {NAV_ITEMS.map(({ label, href, icon: Icon, exact }) => (
+          <Link
+            key={href}
+            to={href}
+            onClick={onClose}
+            className={navCls(isActive(location.pathname, href, exact), desktopCollapsed)}
+            title={desktopCollapsed ? label : undefined}
+          >
+            <Icon className={iconCls(isActive(location.pathname, href, exact))} strokeWidth={1.75} />
+            <span className={desktopCollapsed ? "lg:hidden" : ""}>{label}</span>
+          </Link>
+        ))}
+      </nav>
+    </>
+  );
+}
+
+interface SidebarBottomNavProps {
+  readonly user: User | null;
+  readonly desktopCollapsed: boolean;
+  readonly onClose: () => void;
+  readonly onFeedbackClick: () => void;
+}
+
+function SidebarBottomNav({ user, desktopCollapsed, onClose, onFeedbackClick }: SidebarBottomNavProps) {
+  const { t } = useTranslation();
+  const { signOut } = useClerk();
+  const [expandedGroup, setExpandedGroup] = useState<NavGroup | null>(null);
+
+  function toggleGroup(group: NavGroup) {
+    setExpandedGroup((prev) => (prev === group ? null : group));
+  }
 
   const SETTINGS_SECTIONS = [
     { id: "appearance", label: t("settingsSections.appearance") },
@@ -174,6 +257,127 @@ export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpa
   ];
 
   return (
+    <div className={`shrink-0 border-t border-border px-3 py-3 space-y-0.5 ${desktopCollapsed ? "lg:px-2" : ""}`}>
+      <NavGroupSection
+        group="settings"
+        icon={SettingsIcon}
+        label={t("nav.settings")}
+        expanded={expandedGroup === "settings"}
+        onToggle={() => toggleGroup("settings")}
+        desktopCollapsed={desktopCollapsed}
+        onClose={onClose}
+        sections={SETTINGS_SECTIONS}
+        basePath="/settings"
+      />
+
+      {user?.is_admin && (
+        <NavGroupSection
+          group="admin"
+          icon={AdminIcon}
+          label={t("nav.admin")}
+          expanded={expandedGroup === "admin"}
+          onToggle={() => toggleGroup("admin")}
+          desktopCollapsed={desktopCollapsed}
+          onClose={onClose}
+          sections={ADMIN_SECTIONS}
+          basePath="/admin"
+        />
+      )}
+
+      {user?.is_superuser && (
+        <NavGroupSection
+          group="superuser"
+          icon={SuperuserIcon}
+          label={t("nav.superuser")}
+          expanded={expandedGroup === "superuser"}
+          onToggle={() => toggleGroup("superuser")}
+          desktopCollapsed={desktopCollapsed}
+          onClose={onClose}
+          sections={SUPERUSER_SECTIONS}
+          basePath="/superuser"
+        />
+      )}
+
+      <button
+        onClick={onFeedbackClick}
+        className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground ${desktopCollapsed ? "lg:justify-center lg:px-2" : ""}`}
+        title={desktopCollapsed ? t("nav.sendFeedback") : undefined}
+      >
+        <AppIcons.feedback className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} />
+        <span className={desktopCollapsed ? "lg:hidden" : ""}>{t("nav.sendFeedback")}</span>
+      </button>
+
+      <Link
+        to="/costs"
+        onClick={onClose}
+        className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground ${desktopCollapsed ? "lg:justify-center lg:px-2" : ""}`}
+        title={desktopCollapsed ? t("nav.supportWeftmark") : undefined}
+      >
+        <AppIcons.support className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} />
+        <span className={desktopCollapsed ? "lg:hidden" : ""}>{t("nav.supportWeftmark")}</span>
+      </Link>
+
+      <button
+        onClick={() => signOut()}
+        className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-subdued transition-colors hover:bg-muted hover:text-foreground ${desktopCollapsed ? "lg:justify-center lg:px-2" : ""}`}
+        title={desktopCollapsed ? t("nav.signOut") : undefined}
+      >
+        <AppIcons.logout className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} />
+        <span className={desktopCollapsed ? "lg:hidden" : ""}>{t("nav.signOut")}</span>
+      </button>
+    </div>
+  );
+}
+
+interface SidebarUserFooterProps {
+  readonly user: User | null;
+  readonly isImpersonating: boolean;
+  readonly impersonatedUser: User | null;
+  readonly endImpersonation: () => void;
+  readonly desktopCollapsed: boolean;
+}
+
+function SidebarUserFooter({ user, isImpersonating, impersonatedUser, endImpersonation, desktopCollapsed }: SidebarUserFooterProps) {
+  const { t } = useTranslation();
+  return (
+    <>
+      {/* Impersonated user identity — shown above real user when impersonating */}
+      {isImpersonating && impersonatedUser && (
+        <div className={`shrink-0 border-t border-amber-500/40 bg-amber-500/10 px-4 py-3 ${desktopCollapsed ? "lg:hidden" : ""}`}>
+          <div className="flex items-center gap-2">
+            <p className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">{impersonatedUser.display_name}</p>
+            <button
+              onClick={endImpersonation}
+              className="shrink-0 rounded px-1.5 py-0.5 text-xs font-medium text-amber-700 ring-1 ring-amber-500/50 hover:bg-amber-500/20 dark:text-amber-400 transition-colors"
+            >
+              {t("impersonation.stop")}
+            </button>
+          </div>
+          <p className="truncate text-xs text-muted-foreground">{impersonatedUser.email}</p>
+        </div>
+      )}
+
+      {/* User identity — hidden on desktop in rail mode */}
+      {user && (
+        <div className={`shrink-0 border-t border-border bg-muted px-4 py-3 ${desktopCollapsed ? "lg:hidden" : ""}`}>
+          <p className="truncate text-xs font-medium text-foreground">{user.display_name}</p>
+          <p className="truncate text-xs text-muted-foreground">{user.email}</p>
+        </div>
+      )}
+    </>
+  );
+}
+
+export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpand, onDesktopCollapse }: Props) {
+  const { user } = useAuth();
+  const { isImpersonating, impersonatedUser, endImpersonation } = useImpersonation();
+  // For nav visibility: use the impersonated user when active, so the primary
+  // nav shows and reflects the impersonated user's role. Admin/superuser
+  // console guards below still use the real `user`.
+  const effectiveUser = isImpersonating ? impersonatedUser : user;
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
+
+  return (
     <>
       {/* Mobile backdrop */}
       {open && (
@@ -190,165 +394,33 @@ export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpa
           open ? "translate-x-0 w-60" : "-translate-x-full w-60"
         } ${desktopCollapsed ? "lg:w-14" : "lg:w-60"}`}
       >
-        {/* Logo */}
-        <div className={`shrink-0 border-b border-border flex h-16 items-center justify-between px-4 ${
-          desktopCollapsed ? "lg:flex-col lg:items-center lg:justify-center lg:h-auto lg:px-2 lg:py-3 lg:gap-2" : ""
-        }`}>
-          <Link
-            to="/home"
-            className={`flex items-center gap-2.5 ${desktopCollapsed ? "lg:w-full lg:justify-center" : ""}`}
-            onClick={onClose}
-            title={desktopCollapsed ? "Dashboard" : undefined}
-          >
-            <WeftmarkLogo className={`h-6 text-primary ${desktopCollapsed ? "lg:h-auto lg:w-full" : "w-auto"}`} />
-            <span className={`text-sm font-semibold tracking-tight text-foreground ${desktopCollapsed ? "lg:hidden" : ""}`} style={{ fontFamily: '"Segoe UI", system-ui, sans-serif' }}>weftmark</span>
-          </Link>
-          {/* Mobile close button */}
-          <button
-            onClick={onClose}
-            className="rounded-md p-1 text-muted-foreground hover:text-subdued lg:hidden"
-            aria-label="Close menu"
-          >
-            <AppIcons.close className="h-4 w-4" />
-          </button>
-          {/* Desktop sidebar toggle — only on detail pages where rail/expand applies */}
-          {(desktopCollapsed || onDesktopCollapse) && (
-            <button
-              onClick={desktopCollapsed ? onDesktopExpand : onDesktopCollapse}
-              className={`hidden lg:flex rounded-md text-muted-foreground hover:bg-muted hover:text-foreground ${desktopCollapsed ? "p-1" : "p-1.5"}`}
-              aria-label={desktopCollapsed ? "Expand navigation" : "Collapse navigation"}
-              title={desktopCollapsed ? "Expand navigation" : "Collapse navigation"}
-            >
-              {desktopCollapsed
-                ? <ExpandIcon className="h-3.5 w-3.5" />
-                : <CollapseIcon className="h-5 w-5" />}
-            </button>
-          )}
-        </div>
+        <SidebarHeader
+          desktopCollapsed={desktopCollapsed}
+          onClose={onClose}
+          onDesktopExpand={onDesktopExpand}
+          onDesktopCollapse={onDesktopCollapse}
+        />
 
-        {/* Onboarding checklist — above primary nav, hidden for superusers */}
-        {!effectiveUser?.is_superuser && (
-          <div className="shrink-0 pt-2">
-            <OnboardingChecklist collapsed={desktopCollapsed} />
-          </div>
-        )}
+        <SidebarMainNav
+          isSuperuser={!!effectiveUser?.is_superuser}
+          desktopCollapsed={desktopCollapsed}
+          onClose={onClose}
+        />
 
-        {/* Primary nav — hidden for superusers (they only use /admin).
-            Uses effectiveUser so the nav appears during impersonation. */}
-        {!effectiveUser?.is_superuser && (
-          <nav className="flex-1 overflow-y-auto px-3 py-3 space-y-0.5">
-            {NAV_ITEMS.map(({ label, href, icon: Icon, exact }) => (
-              <Link
-                key={href}
-                to={href}
-                onClick={onClose}
-                className={navCls(isActive(location.pathname, href, exact), desktopCollapsed)}
-                title={desktopCollapsed ? label : undefined}
-              >
-                <Icon className={iconCls(isActive(location.pathname, href, exact))} strokeWidth={1.75} />
-                <span className={desktopCollapsed ? "lg:hidden" : ""}>{label}</span>
-              </Link>
-            ))}
-          </nav>
-        )}
+        <SidebarBottomNav
+          user={user}
+          desktopCollapsed={desktopCollapsed}
+          onClose={onClose}
+          onFeedbackClick={() => setFeedbackOpen(true)}
+        />
 
-        {/* Spacer for superusers (not during impersonation — primary nav provides flex-1) */}
-        {effectiveUser?.is_superuser && <div className="flex-1" />}
-
-        {/* Bottom nav */}
-        <div className={`shrink-0 border-t border-border px-3 py-3 space-y-0.5 ${desktopCollapsed ? "lg:px-2" : ""}`}>
-          <NavGroupSection
-            group="settings"
-            icon={SettingsIcon}
-            label={t("nav.settings")}
-            expanded={expandedGroup === "settings"}
-            onToggle={() => toggleGroup("settings")}
-            desktopCollapsed={desktopCollapsed}
-            onClose={onClose}
-            sections={SETTINGS_SECTIONS}
-            basePath="/settings"
-          />
-
-          {user?.is_admin && (
-            <NavGroupSection
-              group="admin"
-              icon={AdminIcon}
-              label={t("nav.admin")}
-              expanded={expandedGroup === "admin"}
-              onToggle={() => toggleGroup("admin")}
-              desktopCollapsed={desktopCollapsed}
-              onClose={onClose}
-              sections={ADMIN_SECTIONS}
-              basePath="/admin"
-            />
-          )}
-
-          {user?.is_superuser && (
-            <NavGroupSection
-              group="superuser"
-              icon={SuperuserIcon}
-              label={t("nav.superuser")}
-              expanded={expandedGroup === "superuser"}
-              onToggle={() => toggleGroup("superuser")}
-              desktopCollapsed={desktopCollapsed}
-              onClose={onClose}
-              sections={SUPERUSER_SECTIONS}
-              basePath="/superuser"
-            />
-          )}
-
-          <button
-            onClick={() => setFeedbackOpen(true)}
-            className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground ${desktopCollapsed ? "lg:justify-center lg:px-2" : ""}`}
-            title={desktopCollapsed ? t("nav.sendFeedback") : undefined}
-          >
-            <AppIcons.feedback className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} />
-            <span className={desktopCollapsed ? "lg:hidden" : ""}>{t("nav.sendFeedback")}</span>
-          </button>
-
-          <Link
-            to="/costs"
-            onClick={onClose}
-            className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground ${desktopCollapsed ? "lg:justify-center lg:px-2" : ""}`}
-            title={desktopCollapsed ? t("nav.supportWeftmark") : undefined}
-          >
-            <AppIcons.support className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} />
-            <span className={desktopCollapsed ? "lg:hidden" : ""}>{t("nav.supportWeftmark")}</span>
-          </Link>
-
-          <button
-            onClick={() => signOut()}
-            className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-subdued transition-colors hover:bg-muted hover:text-foreground ${desktopCollapsed ? "lg:justify-center lg:px-2" : ""}`}
-            title={desktopCollapsed ? t("nav.signOut") : undefined}
-          >
-            <AppIcons.logout className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} />
-            <span className={desktopCollapsed ? "lg:hidden" : ""}>{t("nav.signOut")}</span>
-          </button>
-        </div>
-
-        {/* Impersonated user identity — shown above real user when impersonating */}
-        {isImpersonating && impersonatedUser && (
-          <div className={`shrink-0 border-t border-amber-500/40 bg-amber-500/10 px-4 py-3 ${desktopCollapsed ? "lg:hidden" : ""}`}>
-            <div className="flex items-center gap-2">
-              <p className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">{impersonatedUser.display_name}</p>
-              <button
-                onClick={endImpersonation}
-                className="shrink-0 rounded px-1.5 py-0.5 text-xs font-medium text-amber-700 ring-1 ring-amber-500/50 hover:bg-amber-500/20 dark:text-amber-400 transition-colors"
-              >
-                {t("impersonation.stop")}
-              </button>
-            </div>
-            <p className="truncate text-xs text-muted-foreground">{impersonatedUser.email}</p>
-          </div>
-        )}
-
-        {/* User identity — hidden on desktop in rail mode */}
-        {user && (
-          <div className={`shrink-0 border-t border-border bg-muted px-4 py-3 ${desktopCollapsed ? "lg:hidden" : ""}`}>
-            <p className="truncate text-xs font-medium text-foreground">{user.display_name}</p>
-            <p className="truncate text-xs text-muted-foreground">{user.email}</p>
-          </div>
-        )}
+        <SidebarUserFooter
+          user={user}
+          isImpersonating={isImpersonating}
+          impersonatedUser={impersonatedUser}
+          endImpersonation={endImpersonation}
+          desktopCollapsed={desktopCollapsed}
+        />
       </aside>
 
       {feedbackOpen && <FeedbackModal onClose={() => setFeedbackOpen(false)} />}

--- a/frontend/src/pages/SuperuserPage.tsx
+++ b/frontend/src/pages/SuperuserPage.tsx
@@ -1703,6 +1703,139 @@ interface ConfigFieldRowProps {
   readonly selectOptions?: ConfigTestOption[];
 }
 
+function isConfigFieldFullWidth(field: string, groupFieldCount: number): boolean {
+  return groupFieldCount === 1
+    || field === "smtp_from_email"
+    || field === "ravelry_oauth_redirect_uri"
+    || field === "webhook_base_url"
+    || field === "otel_exporter_otlp_endpoint";
+}
+
+function configFieldPlaceholder(field: string, isSecret: boolean, isSet: boolean, apiUrl: string): string {
+  if (isSecret && isSet) return "Enter new value to replace";
+  if (field === "webhook_base_url" && !isSet) return apiUrl || "http://localhost:8000";
+  return "";
+}
+
+interface ConfigBooleanFieldProps {
+  readonly field: string;
+  readonly isOn: boolean;
+  readonly fromEnv: boolean;
+  readonly isFullWidth: boolean;
+  readonly onToggle: () => void;
+}
+
+function ConfigBooleanField({ field, isOn, fromEnv, isFullWidth, onToggle }: ConfigBooleanFieldProps) {
+  return (
+    <div className={`flex items-center justify-between gap-3 py-1 ${isFullWidth ? "sm:col-span-2" : ""}`}>
+      <div className="flex items-center gap-1.5">
+        <label className="text-xs font-medium">{CONFIG_FIELD_LABELS[field] ?? field}</label>
+        {fromEnv && (
+          <span className="text-[10px] border rounded px-1 text-blue-600 dark:text-blue-400 border-blue-300 dark:border-blue-700 leading-4">ENV</span>
+        )}
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={isOn}
+        onClick={onToggle}
+        className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${isOn ? "bg-accent" : "bg-input"}`}
+      >
+        <span className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform ${isOn ? "translate-x-4" : "translate-x-0.5"}`} />
+      </button>
+    </div>
+  );
+}
+
+const CONFIG_INPUT_CLS = "w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring font-mono";
+
+interface ConfigFieldControlProps {
+  readonly field: string;
+  readonly state: ConfigFieldState | undefined;
+  readonly showMasked: boolean;
+  readonly selectOptions?: ConfigTestOption[];
+  readonly inputType: string;
+  readonly inputValue: string;
+  readonly placeholder: string;
+  readonly autoFocus: boolean;
+  readonly setDrafts: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+  readonly setEditingFields: React.Dispatch<React.SetStateAction<Set<string>>>;
+}
+
+function ConfigFieldControl({
+  field, state, showMasked, selectOptions, inputType, inputValue, placeholder, autoFocus, setDrafts, setEditingFields,
+}: ConfigFieldControlProps) {
+  if (showMasked) {
+    return (
+      <div
+        className={`${CONFIG_INPUT_CLS} text-muted-foreground cursor-text select-none`}
+        onClick={() => setEditingFields((prev) => new Set([...prev, field]))}
+        title="Click to change"
+      >
+        {state?.secret_prefix ? state.secret_prefix + "••••••••" : "••••••••"}
+      </div>
+    );
+  }
+  if (selectOptions?.length) {
+    return (
+      <select className={CONFIG_INPUT_CLS} value={inputValue} onChange={(e) => setDrafts((prev) => ({ ...prev, [field]: e.target.value }))}>
+        <option value="">— none (no filter) —</option>
+        {selectOptions.map((o) => (
+          <option key={o.value} value={o.value}>{o.label}</option>
+        ))}
+      </select>
+    );
+  }
+  return (
+    <input
+      type={inputType}
+      className={CONFIG_INPUT_CLS}
+      value={inputValue}
+      placeholder={placeholder}
+      onChange={(e) => setDrafts((prev) => ({ ...prev, [field]: e.target.value }))}
+      autoComplete="off"
+      autoFocus={autoFocus}
+    />
+  );
+}
+
+interface ConfigFieldBadgesProps {
+  readonly field: string;
+  readonly state: ConfigFieldState | undefined;
+  readonly fromEnv: boolean;
+  readonly isSet: boolean;
+  readonly hasDraft: boolean;
+}
+
+function ConfigFieldBadges({ field, state, fromEnv, isSet, hasDraft }: ConfigFieldBadgesProps) {
+  return (
+    <div className="flex items-center gap-1.5 mb-1">
+      <label className="text-xs font-medium">{CONFIG_FIELD_LABELS[field] ?? field}</label>
+      {fromEnv && (
+        <span className="text-[10px] border rounded px-1 text-blue-600 dark:text-blue-400 border-blue-300 dark:border-blue-700 leading-4">
+          ENV
+        </span>
+      )}
+      {isSet && !fromEnv && !hasDraft && (
+        <span
+          className={`text-[10px] border rounded px-1 leading-4 ${
+            state?.pending_restart
+              ? "text-amber-600 dark:text-amber-400 border-amber-300 dark:border-amber-700"
+              : "text-green-700 dark:text-green-400 border-green-300 dark:border-green-700"
+          }`}
+        >
+          {state?.pending_restart ? "Set — pending restart" : "Set"}
+        </span>
+      )}
+      {field === "webhook_base_url" && !isSet && !hasDraft && (
+        <span className="text-[10px] border rounded px-1 text-muted-foreground border-border leading-4">
+          Default
+        </span>
+      )}
+    </div>
+  );
+}
+
 function ConfigFieldRow({ field, groupFieldCount, state, isZeroTrustEnabled, drafts, setDrafts, editingFields, setEditingFields, apiUrl, selectOptions }: ConfigFieldRowProps) {
   if ((field === "cf_access_client_id" || field === "cf_access_client_secret") && !isZeroTrustEnabled) return null;
 
@@ -1711,34 +1844,20 @@ function ConfigFieldRow({ field, groupFieldCount, state, isZeroTrustEnabled, dra
   const fromEnv = state?.source === "env";
   const hasDraft = field in drafts;
   const isSet = isSecret ? (state?.secret_set ?? false) : !!(state?.value);
-  const isFullWidth = groupFieldCount === 1
-    || field === "smtp_from_email"
-    || field === "ravelry_oauth_redirect_uri"
-    || field === "webhook_base_url"
-    || field === "otel_exporter_otlp_endpoint";
+  const isFullWidth = isConfigFieldFullWidth(field, groupFieldCount);
 
   if (isBoolean) {
     const isOn = hasDraft
       ? drafts[field] === "true"
       : (state?.value === "True" || state?.value === "true");
     return (
-      <div className={`flex items-center justify-between gap-3 py-1 ${isFullWidth ? "sm:col-span-2" : ""}`}>
-        <div className="flex items-center gap-1.5">
-          <label className="text-xs font-medium">{CONFIG_FIELD_LABELS[field] ?? field}</label>
-          {fromEnv && (
-            <span className="text-[10px] border rounded px-1 text-blue-600 dark:text-blue-400 border-blue-300 dark:border-blue-700 leading-4">ENV</span>
-          )}
-        </div>
-        <button
-          type="button"
-          role="switch"
-          aria-checked={isOn}
-          onClick={() => setDrafts((prev) => ({ ...prev, [field]: isOn ? "false" : "true" }))}
-          className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${isOn ? "bg-accent" : "bg-input"}`}
-        >
-          <span className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform ${isOn ? "translate-x-4" : "translate-x-0.5"}`} />
-        </button>
-      </div>
+      <ConfigBooleanField
+        field={field}
+        isOn={isOn}
+        fromEnv={fromEnv}
+        isFullWidth={isFullWidth}
+        onToggle={() => setDrafts((prev) => ({ ...prev, [field]: isOn ? "false" : "true" }))}
+      />
     );
   }
 
@@ -1747,72 +1866,23 @@ function ConfigFieldRow({ field, groupFieldCount, state, isZeroTrustEnabled, dra
   const showMasked = isPrefixMasked && isSet && !hasDraft && !isEditing;
   const inputType = isPrefixMasked ? "text" : isSecret ? "password" : "text";
   const inputValue = isSecret ? (hasDraft ? drafts[field] : "") : (hasDraft ? drafts[field] : (state?.value ?? ""));
-  let placeholder = "";
-  if (isSecret && isSet) placeholder = "Enter new value to replace";
-  else if (field === "webhook_base_url" && !isSet) placeholder = apiUrl || "http://localhost:8000";
-
-  const inputCls = "w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring font-mono";
-  let fieldControl: React.ReactNode;
-  if (showMasked) {
-    fieldControl = (
-      <div
-        className={`${inputCls} text-muted-foreground cursor-text select-none`}
-        onClick={() => setEditingFields((prev) => new Set([...prev, field]))}
-        title="Click to change"
-      >
-        {state?.secret_prefix ? state.secret_prefix + "••••••••" : "••••••••"}
-      </div>
-    );
-  } else if (selectOptions?.length) {
-    fieldControl = (
-      <select className={inputCls} value={inputValue} onChange={(e) => setDrafts((prev) => ({ ...prev, [field]: e.target.value }))}>
-        <option value="">— none (no filter) —</option>
-        {selectOptions.map((o) => (
-          <option key={o.value} value={o.value}>{o.label}</option>
-        ))}
-      </select>
-    );
-  } else {
-    fieldControl = (
-      <input
-        type={inputType}
-        className={inputCls}
-        value={inputValue}
-        placeholder={placeholder}
-        onChange={(e) => setDrafts((prev) => ({ ...prev, [field]: e.target.value }))}
-        autoComplete="off"
-        autoFocus={isPrefixMasked && isEditing && !hasDraft}
-      />
-    );
-  }
+  const placeholder = configFieldPlaceholder(field, isSecret, isSet, apiUrl);
 
   return (
     <div className={isFullWidth ? "sm:col-span-2" : ""}>
-      <div className="flex items-center gap-1.5 mb-1">
-        <label className="text-xs font-medium">{CONFIG_FIELD_LABELS[field] ?? field}</label>
-        {fromEnv && (
-          <span className="text-[10px] border rounded px-1 text-blue-600 dark:text-blue-400 border-blue-300 dark:border-blue-700 leading-4">
-            ENV
-          </span>
-        )}
-        {isSet && !fromEnv && !hasDraft && (
-          <span
-            className={`text-[10px] border rounded px-1 leading-4 ${
-              state?.pending_restart
-                ? "text-amber-600 dark:text-amber-400 border-amber-300 dark:border-amber-700"
-                : "text-green-700 dark:text-green-400 border-green-300 dark:border-green-700"
-            }`}
-          >
-            {state?.pending_restart ? "Set — pending restart" : "Set"}
-          </span>
-        )}
-        {field === "webhook_base_url" && !isSet && !hasDraft && (
-          <span className="text-[10px] border rounded px-1 text-muted-foreground border-border leading-4">
-            Default
-          </span>
-        )}
-      </div>
-      {fieldControl}
+      <ConfigFieldBadges field={field} state={state} fromEnv={fromEnv} isSet={isSet} hasDraft={hasDraft} />
+      <ConfigFieldControl
+        field={field}
+        state={state}
+        showMasked={showMasked}
+        selectOptions={selectOptions}
+        inputType={inputType}
+        inputValue={inputValue}
+        placeholder={placeholder}
+        autoFocus={isPrefixMasked && isEditing && !hasDraft}
+        setDrafts={setDrafts}
+        setEditingFields={setEditingFields}
+      />
       {fromEnv && hasDraft && (
         <p className="text-[11px] text-amber-600 dark:text-amber-400 mt-0.5">
           ENV var active — file value won't take effect until removed from .env


### PR DESCRIPTION
## Summary
- Decomposes `Sidebar` (cognitive complexity 26, allowed 15) into `SidebarHeader`, `SidebarMainNav`, `SidebarBottomNav` (now owns its own `expandedGroup` state), and `SidebarUserFooter`
- Decomposes `ConfigFieldRow` (cognitive complexity 29, allowed 15) into `ConfigBooleanField`, `ConfigFieldControl` (the masked/select/input branch), `ConfigFieldBadges`, plus two pure helpers (`isConfigFieldFullWidth`, `configFieldPlaceholder`)
- Refactor only — no behavior change, every className/label/interaction preserved exactly

Closes #1034 (and combines the now-closed #1030, whose findings this addresses)

## Test plan
- [x] `tsc`, `eslint` clean
- [x] Rebuilt containers (`rbd`)
- [x] Real Playwright browser verification as regular user: nav renders, Settings group toggles and navigates, feedback modal opens
- [x] Real Playwright browser verification as admin: Admin nav group renders and navigates
- [x] Real Playwright browser verification as superuser (`eqasuperuser` EQA account) on `/superuser/credentials`: `ConfigFieldRow`'s boolean toggle renders and correctly flips state on click, text/secret field labels render correctly