### PR TITLE
fix: widen ci-dev-pr.yml trigger paths; move SonarCloud full scan to a manual workflow

### DIFF
--- a/.github/workflows/ci-dev-pr.yml
+++ b/.github/workflows/ci-dev-pr.yml
@@ -13,7 +13,8 @@ on:
     paths:
       - "backend/**"
       - "frontend/**"
-      - ".github/workflows/ci-dev-pr.yml"
+      - "tools/**"
+      - ".github/workflows/**"
 
 concurrency:
   group: dev-pr-${{ github.head_ref }}

--- a/.github/workflows/ci-dev-push.yml
+++ b/.github/workflows/ci-dev-push.yml
@@ -16,7 +16,13 @@ name: Dev push
 # issues showing as open on the dashboard and — because each PR's "new code"
 # period is computed against that stale baseline — causes SonarCloud to keep
 # attributing unrelated pre-existing findings to whichever PR happens to
-# touch a line near them (see #1030, #1032, #1033, #1034).
+# touch a line near them (see #1030, #1032, #1033, #1034). Deliberately just
+# checkout + scan, no pytest run: this fires on every merge to dev, and a
+# full backend test run for coverage.xml would add ~10 minutes to what was
+# a <1 minute post-merge job. SonarCloud's coverage ingestion is optional —
+# without it this scan still refreshes bugs/vulnerabilities/complexity/the
+# new-code baseline, which is the actual point; Codecov (in ci-dev-pr.yml)
+# already owns real coverage tracking.
 #
 # All jobs are skipped when weftmark-bot[bot] pushes (version bump commits
 # would otherwise re-trigger this workflow infinitely).
@@ -178,36 +184,10 @@ jobs:
     name: SonarCloud full re-scan
     runs-on: ubuntu-latest
     if: github.actor != 'weftmark-bot[bot]'
-    services:
-      postgres:
-        image: postgres:17
-        env:
-          POSTGRES_DB: weaving_site
-          POSTGRES_USER: weaving_user
-          POSTGRES_PASSWORD: ci_test_password
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-      - run: pip install -r backend/requirements-dev.txt
-      - run: sudo apt-get install -y --no-install-recommends fonts-dejavu-core
-      - name: Run backend tests for coverage
-        run: cd backend && python -m pytest tests/ -q
-        env:
-          POSTGRES_HOST: localhost
-          POSTGRES_PORT: 5432
-          POSTGRES_USER: weaving_user
-          POSTGRES_PASSWORD: ci_test_password
       - name: SonarCloud scan
         uses: SonarSource/sonarqube-scan-action@v8.1.0
         env:

--- a/.github/workflows/ci-dev-push.yml
+++ b/.github/workflows/ci-dev-push.yml
@@ -1,28 +1,12 @@
 name: Dev push
 
 # Post-merge bookkeeping for pushes to dev.
-# Tests already passed on the PR — this workflow only does SBOM updates,
-# version bumping, and a full SonarCloud re-scan. No PR-gating validation
-# (lint/typecheck/etc.) runs here.
+# Tests already passed on the PR — this workflow only does SBOM updates
+# and version bumping. No validation jobs run here.
 #
 # sbom-backend and sbom-frontend run in parallel — they write to separate
 # files so git pull --rebase handles ordering without conflicts.
 # bump-version waits for both before running.
-#
-# sonarcloud re-analyzes the whole dev branch (not just the PR's new-code
-# diff) so the project-wide issue list and the "new code" baseline used by
-# every subsequent PR stay current. Without this, dev's SonarCloud snapshot
-# never advances past whenever it last ran, which both leaves long-fixed
-# issues showing as open on the dashboard and — because each PR's "new code"
-# period is computed against that stale baseline — causes SonarCloud to keep
-# attributing unrelated pre-existing findings to whichever PR happens to
-# touch a line near them (see #1030, #1032, #1033, #1034). Deliberately just
-# checkout + scan, no pytest run: this fires on every merge to dev, and a
-# full backend test run for coverage.xml would add ~10 minutes to what was
-# a <1 minute post-merge job. SonarCloud's coverage ingestion is optional —
-# without it this scan still refreshes bugs/vulnerabilities/complexity/the
-# new-code baseline, which is the actual point; Codecov (in ci-dev-pr.yml)
-# already owns real coverage tracking.
 #
 # All jobs are skipped when weftmark-bot[bot] pushes (version bump commits
 # would otherwise re-trigger this workflow infinitely).
@@ -30,16 +14,17 @@ name: Dev push
 # into merge commit bodies and suppress PR workflows on the target branch.
 #
 # On scheduled runs (weekly Monday 03:00 UTC) both SBOMs are regenerated
-# unconditionally regardless of whether package files changed, and the
-# SonarCloud scan runs too, as a safety net in case a push-triggered scan
-# was ever skipped or failed silently. This ensures the backend SBOM stays
-# current even when requirements.txt is unchanged for extended periods
-# (backend packages change less often than frontend npm deps).
+# unconditionally regardless of whether package files changed. This ensures
+# the backend SBOM stays current even when requirements.txt is unchanged for
+# extended periods (backend packages change less often than frontend npm deps).
+#
+# A full SonarCloud re-scan of the dev branch is a separate, manually
+# triggered workflow — see sonarcloud-full-scan.yml — rather than running
+# on every push here.
 #
 # Required secrets:
 #   WEFTMARK_BOT_CLIENT_ID   — GitHub App client ID
 #   WEFTMARK_BOT_PRIVATE_KEY — GitHub App private key
-#   SONAR_TOKEN              — SonarCloud analysis token
 
 on:
   push:
@@ -179,21 +164,6 @@ jobs:
           name: sbom-frontend-${{ github.sha }}
           path: sbom/sbom-frontend.json
           retention-days: 90
-
-  sonarcloud:
-    name: SonarCloud full re-scan
-    runs-on: ubuntu-latest
-    if: github.actor != 'weftmark-bot[bot]'
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: SonarCloud scan
-        uses: SonarSource/sonarqube-scan-action@v8.1.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: https://sonarcloud.io
 
   bump-version:
     name: Bump version

--- a/.github/workflows/sonarcloud-full-scan.yml
+++ b/.github/workflows/sonarcloud-full-scan.yml
@@ -1,0 +1,39 @@
+name: SonarCloud full scan
+
+# On-demand full re-analysis of the dev branch (not just a PR's new-code
+# diff). Manually triggered — not part of any CI push/PR gate, so it never
+# adds time to a merge or a PR check.
+#
+# Without occasionally re-running this, dev's SonarCloud snapshot never
+# advances past whenever it last ran, which both leaves long-fixed issues
+# showing as open on the dashboard and — because each PR's "new code" period
+# is computed against that stale baseline — causes SonarCloud to keep
+# attributing unrelated pre-existing findings to whichever PR happens to
+# touch a line near them (see #1030, #1032, #1033, #1034). Run this after a
+# batch of merges, or whenever the SonarCloud dashboard looks stale.
+#
+# Deliberately just checkout + scan, no pytest run: SonarCloud's coverage
+# ingestion is optional, and Codecov (wired into ci-dev-pr.yml) already
+# owns real coverage tracking.
+#
+# Required secrets:
+#   SONAR_TOKEN — SonarCloud analysis token
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sonarcloud:
+    name: SonarCloud full re-scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 0
+      - name: SonarCloud scan
+        uses: SonarSource/sonarqube-scan-action@v8.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io


### PR DESCRIPTION
## Summary
Three commits, all follow-ups from #1045:

- **`ci-dev-pr.yml` path filter** — only matched `backend/**`, `frontend/**`, and literally `ci-dev-pr.yml` itself, so #1045 (touching only other workflow files and `tools/`) never triggered its own required status checks and needed an admin bypass to merge. Widened to `tools/**` and all of `.github/workflows/**`.
- ~~Dropped the pytest/coverage step from the dev-push `sonarcloud` job~~ — superseded by the next point.
- **Moved the SonarCloud full re-scan out of `ci-dev-push.yml` entirely**, into a new manually-triggered `sonarcloud-full-scan.yml` (`workflow_dispatch` only). It doesn't need to run on every merge — fire it off after a batch of merges, or whenever the dashboard looks stale. This was the actual fix for the concern raised on #1045 (it had added ~10 minutes to what was previously a <1 minute post-merge job); trimming just the pytest step wasn't enough on its own, since even a fast scan doesn't need to run unconditionally on every push.

## Test plan
- [x] YAML syntax validated (`yaml.safe_load`) for all three workflow files
- [x] `sonarcloud-full-scan.yml` pins `ref: dev` explicitly in its checkout step, since `workflow_dispatch` otherwise runs against whatever branch is selected in the Actions UI (defaults to the repo default branch, not necessarily `dev`)
- [ ] Can only fully verify `sonarcloud-full-scan.yml` by actually dispatching it once merged