### PR TITLE
fix: document remaining HTTPException status codes across routers (S8415, #1047)

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -552,7 +552,16 @@ async def list_users(
     ]
 
 
-@router.patch("/users/{user_id}", response_model=AdminUserResponse)
+@router.patch(
+    "/users/{user_id}",
+    response_model=AdminUserResponse,
+    responses={
+        400: {"description": "Cannot modify your own account"},
+        403: {"description": "Superuser required to change admin or superuser roles"},
+        404: {"description": "User not found"},
+        422: {"description": "Remove admin rights before deactivating this user"},
+    },
+)
 async def patch_user(
     user_id: uuid.UUID,
     body: AdminUserPatch,
@@ -670,7 +679,15 @@ async def patch_user(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/users/{user_id}/ban", status_code=200)
+@router.post(
+    "/users/{user_id}/ban",
+    status_code=200,
+    responses={
+        400: {"description": "Cannot ban your own account"},
+        404: {"description": "User not found"},
+        422: {"description": "Remove admin rights before banning this user"},
+    },
+)
 async def ban_user(
     user_id: uuid.UUID,
     admin: User = Depends(require_admin),
@@ -722,7 +739,11 @@ async def ban_user(
     )
 
 
-@router.post("/users/{user_id}/unban", status_code=200)
+@router.post(
+    "/users/{user_id}/unban",
+    status_code=200,
+    responses={400: {"description": "User has no Clerk account"}, 404: {"description": "User not found"}},
+)
 async def unban_user(
     user_id: uuid.UUID,
     admin: User = Depends(require_admin),
@@ -779,7 +800,16 @@ class DeleteUserRequest(BaseModel):
     confirm: str
 
 
-@router.post("/users/{user_id}/delete", status_code=202)
+@router.post(
+    "/users/{user_id}/delete",
+    status_code=202,
+    responses={
+        400: {"description": "Cannot delete your own account via admin panel"},
+        404: {"description": "User not found"},
+        409: {"description": "Deletion already in state"},
+        422: {"description": 'confirm must be exactly "DELETE USER"'},
+    },
+)
 async def delete_user(
     user_id: uuid.UUID,
     body: DeleteUserRequest,
@@ -812,7 +842,11 @@ async def delete_user(
     return {"status": "pending", "user_id": str(user_id)}
 
 
-@router.get("/users/{user_id}/storage-report", response_model=UserStorageReportResponse)
+@router.get(
+    "/users/{user_id}/storage-report",
+    response_model=UserStorageReportResponse,
+    responses={404: {"description": "User not found"}},
+)
 async def get_user_storage_report(
     user_id: uuid.UUID,
     verify_s3: bool = False,
@@ -1223,7 +1257,15 @@ class ElevateRequest(BaseModel):
     confirm_delete_content: bool = False
 
 
-@router.post("/users/{user_id}/elevate-to-superuser", status_code=200)
+@router.post(
+    "/users/{user_id}/elevate-to-superuser",
+    status_code=200,
+    responses={
+        400: {"description": "User must be an admin before being elevated to superuser"},
+        404: {"description": "User not found"},
+        409: {"description": "User owns projects, looms, drafts, or yarn; confirm_delete_content required"},
+    },
+)
 async def elevate_to_superuser(
     user_id: uuid.UUID,
     body: ElevateRequest,
@@ -1321,7 +1363,12 @@ async def list_pending_signups(
     return list(result.all())
 
 
-@router.post("/pending-signups/{signup_id}/approve", response_model=None, status_code=201)
+@router.post(
+    "/pending-signups/{signup_id}/approve",
+    response_model=None,
+    status_code=201,
+    responses={404: {"description": "Pending signup not found"}},
+)
 async def approve_pending_signup(
     signup_id: uuid.UUID,
     admin: User = Depends(require_admin),
@@ -1403,7 +1450,9 @@ async def approve_pending_signup(
     return {"status": "created"}
 
 
-@router.post("/pending-signups/{signup_id}/ban", status_code=204)
+@router.post(
+    "/pending-signups/{signup_id}/ban", status_code=204, responses={404: {"description": "Pending signup not found"}}
+)
 async def ban_pending_signup(
     signup_id: uuid.UUID,
     admin: User = Depends(require_admin),
@@ -1424,7 +1473,9 @@ async def ban_pending_signup(
         log.exception("Failed to send account denied email to %s", email)
 
 
-@router.delete("/pending-signups/{signup_id}", status_code=204)
+@router.delete(
+    "/pending-signups/{signup_id}", status_code=204, responses={404: {"description": "Pending signup not found"}}
+)
 async def dismiss_pending_signup(
     signup_id: uuid.UUID,
     admin: User = Depends(require_admin),
@@ -1470,7 +1521,7 @@ class EulaCurrentAdminResponse(BaseModel):
     created_at: datetime
 
 
-@router.get("/eula", response_model=EulaCurrentAdminResponse)
+@router.get("/eula", response_model=EulaCurrentAdminResponse, responses={404: {"description": "No EULA version found"}})
 async def get_eula_admin(
     _: User = Depends(require_superuser),
     db: AsyncSession = Depends(get_db),
@@ -1487,7 +1538,12 @@ async def get_eula_admin(
     )
 
 
-@router.post("/eula", response_model=EulaVersionResponse, status_code=201)
+@router.post(
+    "/eula",
+    response_model=EulaVersionResponse,
+    status_code=201,
+    responses={409: {"description": "EULA version already exists"}},
+)
 async def create_eula_version(
     body: EulaCreateRequest,
     admin: User = Depends(require_superuser),
@@ -1714,7 +1770,12 @@ async def get_reconcile_report(
     return ReconcileReport(clerk_only=clerk_only, db_only=db_only)
 
 
-@router.post("/reconcile/backfill/{clerk_user_id}", response_model=BackfillResponse, status_code=201)
+@router.post(
+    "/reconcile/backfill/{clerk_user_id}",
+    response_model=BackfillResponse,
+    status_code=201,
+    responses={404: {"description": "Clerk user not found"}, 409: {"description": "User already exists in DB"}},
+)
 async def backfill_clerk_user(
     clerk_user_id: str,
     body: BackfillRequest = Body(default_factory=BackfillRequest),
@@ -2421,7 +2482,10 @@ async def list_scheduled_tasks(
     return result
 
 
-@router.patch("/scheduled-tasks/{name}")
+@router.patch(
+    "/scheduled-tasks/{name}",
+    responses={404: {"description": "Scheduled task not found"}, 422: {"description": "Invalid cron expression"}},
+)
 async def patch_scheduled_task(
     name: str,
     body: PatchScheduledTaskBody,
@@ -2523,7 +2587,12 @@ async def list_credentials(
     return [_credential_to_response(r) for r in rows.all()]
 
 
-@router.post("/credentials", response_model=CredentialExpiryResponse, status_code=201)
+@router.post(
+    "/credentials",
+    response_model=CredentialExpiryResponse,
+    status_code=201,
+    responses={422: {"description": "Invalid resource. Must be one of"}},
+)
 async def create_credential(
     body: CreateCredentialBody,
     db: AsyncSession = Depends(get_db),
@@ -2544,7 +2613,11 @@ async def create_credential(
     return _credential_to_response(cred)
 
 
-@router.patch("/credentials/{credential_id}", response_model=CredentialExpiryResponse)
+@router.patch(
+    "/credentials/{credential_id}",
+    response_model=CredentialExpiryResponse,
+    responses={404: {"description": "Credential not found"}, 422: {"description": "Invalid resource. Must be one of"}},
+)
 async def patch_credential(
     credential_id: uuid.UUID,
     body: PatchCredentialBody,
@@ -2570,7 +2643,9 @@ async def patch_credential(
     return _credential_to_response(cred)
 
 
-@router.delete("/credentials/{credential_id}", status_code=204)
+@router.delete(
+    "/credentials/{credential_id}", status_code=204, responses={404: {"description": "Credential not found"}}
+)
 async def delete_credential(
     credential_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
@@ -2634,7 +2709,7 @@ async def list_project_slugs(
     ]
 
 
-@router.delete("/project-slugs/{slug}", status_code=204)
+@router.delete("/project-slugs/{slug}", status_code=204, responses={404: {"description": "Slug not found"}})
 async def admin_revoke_project_slug(
     slug: str,
     db: AsyncSession = Depends(get_db),
@@ -2730,7 +2805,7 @@ async def list_exports(
     ]
 
 
-@router.delete("/exports/{export_id}", status_code=204)
+@router.delete("/exports/{export_id}", status_code=204, responses={404: {"description": "Export not found"}})
 async def delete_export(
     export_id: uuid.UUID,
     _: User = Depends(require_superuser),
@@ -2875,7 +2950,7 @@ async def get_config_state(
     )
 
 
-@router.put("/config")
+@router.put("/config", responses={503: {"description": "CONFIG_ENCRYPTION_KEY is not set — cannot write config file"}})
 def save_config(
     body: ConfigSaveRequest,
     _: User = Depends(require_superuser),
@@ -3000,7 +3075,7 @@ _SERVICE_TESTS = {
 }
 
 
-@router.post("/config/test/{service}")
+@router.post("/config/test/{service}", responses={400: {"description": "Unknown service"}})
 async def test_config_service(
     service: str,
     body: ConfigSaveRequest,

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -385,7 +385,16 @@ class InviteResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
-@router.post("/invite", response_model=InviteResponse, status_code=201)
+@router.post(
+    "/invite",
+    response_model=InviteResponse,
+    status_code=201,
+    responses={
+        403: {"description": "Only superusers can invite admins"},
+        409: {"description": "A user with this email already exists"},
+        422: {"description": "role must be one of"},
+    },
+)
 async def create_invite(
     body: InviteRequest,
     admin: User = Depends(require_admin),
@@ -468,7 +477,11 @@ async def list_invites(
     return list(result.all())
 
 
-@router.delete("/invite/{invite_id}", status_code=204)
+@router.delete(
+    "/invite/{invite_id}",
+    status_code=204,
+    responses={400: {"description": "Invite already accepted"}, 404: {"description": "Invite not found"}},
+)
 async def revoke_invite(
     invite_id: uuid.UUID,
     admin: User = Depends(require_admin),

--- a/backend/app/routers/collections.py
+++ b/backend/app/routers/collections.py
@@ -162,7 +162,9 @@ async def list_collections(
     return [_summary(c) for c in result.all()]
 
 
-@router.get("/{collection_id}", response_model=CollectionDetail)
+@router.get(
+    "/{collection_id}", response_model=CollectionDetail, responses={404: {"description": "Collection not found"}}
+)
 async def get_collection(
     collection_id: uuid.UUID,
     current_user: User = Depends(get_effective_user),
@@ -224,7 +226,9 @@ async def get_collection(
     )
 
 
-@router.patch("/{collection_id}", response_model=CollectionSummary)
+@router.patch(
+    "/{collection_id}", response_model=CollectionSummary, responses={404: {"description": "Collection not found"}}
+)
 async def update_collection(
     collection_id: uuid.UUID,
     body: UpdateCollectionRequest,
@@ -254,7 +258,7 @@ async def update_collection(
     return _summary(c)  # type: ignore[arg-type]
 
 
-@router.delete("/{collection_id}", status_code=204)
+@router.delete("/{collection_id}", status_code=204, responses={404: {"description": "Collection not found"}})
 async def delete_collection(
     collection_id: uuid.UUID,
     current_user: User = Depends(get_effective_user),
@@ -270,7 +274,11 @@ async def delete_collection(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/{collection_id}/drafts", status_code=204)
+@router.post(
+    "/{collection_id}/drafts",
+    status_code=204,
+    responses={404: {"description": "Draft not found"}, 409: {"description": "Draft already in collection"}},
+)
 async def add_draft(
     collection_id: uuid.UUID,
     body: AddDraftRequest,
@@ -295,7 +303,9 @@ async def add_draft(
     await db.commit()
 
 
-@router.delete("/{collection_id}/drafts/{draft_id}", status_code=204)
+@router.delete(
+    "/{collection_id}/drafts/{draft_id}", status_code=204, responses={404: {"description": "Draft not in collection"}}
+)
 async def remove_draft(
     collection_id: uuid.UUID,
     draft_id: uuid.UUID,
@@ -321,7 +331,11 @@ async def remove_draft(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/{collection_id}/projects", status_code=204)
+@router.post(
+    "/{collection_id}/projects",
+    status_code=204,
+    responses={404: {"description": "Project not found"}, 409: {"description": "Project already in collection"}},
+)
 async def add_project(
     collection_id: uuid.UUID,
     body: AddProjectRequest,
@@ -350,7 +364,11 @@ async def add_project(
     await db.commit()
 
 
-@router.delete("/{collection_id}/projects/{project_id}", status_code=204)
+@router.delete(
+    "/{collection_id}/projects/{project_id}",
+    status_code=204,
+    responses={404: {"description": "Project not in collection"}},
+)
 async def remove_project(
     collection_id: uuid.UUID,
     project_id: uuid.UUID,

--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -124,7 +124,12 @@ class UpdateDraftRequest(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-@router.post("", response_model=DraftSummary, status_code=201)
+@router.post(
+    "",
+    response_model=DraftSummary,
+    status_code=201,
+    responses={400: {"description": "File must have a .wif extension"}, 413: {"description": "File too large"}},
+)
 async def create_draft(
     name: Annotated[str, Form()],
     wif_file: Annotated[UploadFile, File()],
@@ -237,7 +242,7 @@ async def list_drafts(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/{draft_id}", response_model=DraftDetail)
+@router.get("/{draft_id}", response_model=DraftDetail, responses={404: {"description": "Draft not found"}})
 async def get_draft(
     draft_id: uuid.UUID,
     current_user: User = Depends(get_effective_user),
@@ -247,7 +252,11 @@ async def get_draft(
     return DraftDetail(**_draft_detail_data(draft))
 
 
-@router.patch("/{draft_id}", response_model=DraftDetail)
+@router.patch(
+    "/{draft_id}",
+    response_model=DraftDetail,
+    responses={400: {"description": "At least one field must be provided"}, 404: {"description": "Draft not found"}},
+)
 async def update_draft(
     draft_id: uuid.UUID,
     body: UpdateDraftRequest,
@@ -276,7 +285,7 @@ async def update_draft(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/{draft_id}/preview")
+@router.get("/{draft_id}/preview", responses={404: {"description": "Preview not available"}})
 async def get_preview(
     draft_id: uuid.UUID,
     current_user: User = Depends(get_effective_user),
@@ -289,7 +298,7 @@ async def get_preview(
     return Response(content=png, media_type=_MEDIA_TYPE_PNG)
 
 
-@router.get("/{draft_id}/drawdown_preview")
+@router.get("/{draft_id}/drawdown_preview", responses={404: {"description": "Drawdown preview not available"}})
 async def get_drawdown_preview(
     draft_id: uuid.UUID,
     current_user: User = Depends(get_effective_user),
@@ -302,7 +311,10 @@ async def get_drawdown_preview(
     return Response(content=png, media_type=_MEDIA_TYPE_PNG)
 
 
-@router.get("/{draft_id}/preview/svg")
+@router.get(
+    "/{draft_id}/preview/svg",
+    responses={404: {"description": "No WIF file for this draft"}, 500: {"description": "SVG rendering failed"}},
+)
 async def get_preview_svg(
     draft_id: uuid.UUID,
     current_user: User = Depends(get_effective_user),
@@ -325,7 +337,10 @@ async def get_preview_svg(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/{draft_id}/drawdown")
+@router.get(
+    "/{draft_id}/drawdown",
+    responses={404: {"description": "No WIF file for this draft"}, 500: {"description": "Drawdown rendering failed"}},
+)
 async def get_drawdown(
     draft_id: uuid.UUID,
     start_row: int | None = Query(None, ge=0),
@@ -500,7 +515,7 @@ async def get_drawdown(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/{draft_id}/wif")
+@router.get("/{draft_id}/wif", responses={404: {"description": "WIF file not available for this draft"}})
 async def download_wif(
     draft_id: uuid.UUID,
     current_user: User = Depends(get_effective_user),
@@ -523,7 +538,7 @@ async def download_wif(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/{draft_id}/wif-modified")
+@router.get("/{draft_id}/wif-modified", responses={404: {"description": "No modified WIF file for this draft"}})
 async def download_wif_modified(
     draft_id: uuid.UUID,
     current_user: User = Depends(get_effective_user),
@@ -547,7 +562,14 @@ async def download_wif_modified(
 # ---------------------------------------------------------------------------
 
 
-@router.delete("/{draft_id}", status_code=204)
+@router.delete(
+    "/{draft_id}",
+    status_code=204,
+    responses={
+        404: {"description": "Draft not found"},
+        409: {"description": "Draft is used by one or more active projects; pass force=true to delete anyway"},
+    },
+)
 async def delete_draft(
     draft_id: uuid.UUID,
     force: bool = Query(False),
@@ -582,7 +604,7 @@ async def delete_draft(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/{draft_id}/archive", status_code=204)
+@router.post("/{draft_id}/archive", status_code=204, responses={404: {"description": "Draft not found"}})
 async def archive_draft(
     draft_id: uuid.UUID,
     current_user: User = Depends(get_effective_user),
@@ -593,7 +615,7 @@ async def archive_draft(
     await db.commit()
 
 
-@router.post("/{draft_id}/unarchive", status_code=204)
+@router.post("/{draft_id}/unarchive", status_code=204, responses={404: {"description": "Draft not found"}})
 async def unarchive_draft(
     draft_id: uuid.UUID,
     current_user: User = Depends(get_effective_user),
@@ -609,7 +631,14 @@ async def unarchive_draft(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/{draft_id}/generate-liftplan", response_model=DraftDetail)
+@router.post(
+    "/{draft_id}/generate-liftplan",
+    response_model=DraftDetail,
+    responses={
+        400: {"description": "WIF file has no [TREADLING] section — cannot compute lift plan"},
+        404: {"description": "Draft not found"},
+    },
+)
 async def generate_liftplan(
     draft_id: uuid.UUID,
     current_user: User = Depends(get_effective_user),
@@ -661,7 +690,14 @@ class OverrideMetadataRequest(BaseModel):
     value: int
 
 
-@router.post("/{draft_id}/override-metadata", response_model=DraftDetail)
+@router.post(
+    "/{draft_id}/override-metadata",
+    response_model=DraftDetail,
+    responses={
+        400: {"description": "Unsupported field; must be one of num_treadles or num_shafts"},
+        404: {"description": "Draft not found"},
+    },
+)
 async def override_metadata(
     draft_id: uuid.UUID,
     body: OverrideMetadataRequest,
@@ -730,7 +766,11 @@ class PatchMeasurementsRequest(BaseModel):
     unit: str = "cm"  # "cm" | "in" — applies to warp_length and weaving_width; epi is always ends/inch
 
 
-@router.patch("/{draft_id}/measurements", response_model=DraftDetail)
+@router.patch(
+    "/{draft_id}/measurements",
+    response_model=DraftDetail,
+    responses={400: {"description": "unit must be 'cm' or 'in'"}, 404: {"description": "Draft not found"}},
+)
 async def patch_measurements(
     draft_id: uuid.UUID,
     body: PatchMeasurementsRequest,

--- a/backend/app/routers/feedback.py
+++ b/backend/app/routers/feedback.py
@@ -180,7 +180,7 @@ class FeedbackStatusResponse(BaseModel):
     github_discussion_state: str | None
 
 
-@router.get("/{feedback_id}/status")
+@router.get("/{feedback_id}/status", responses={404: {"description": "Feedback not found"}})
 async def get_feedback_status(
     feedback_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
@@ -238,7 +238,7 @@ async def list_feedback(
     )
 
 
-@admin_router.get("/{feedback_id}")
+@admin_router.get("/{feedback_id}", responses={404: {"description": "Feedback not found"}})
 async def get_feedback_detail(
     feedback_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
@@ -256,7 +256,7 @@ async def get_feedback_detail(
     return _serialize(row, include_user_email=True)
 
 
-@admin_router.delete("/{feedback_id}")
+@admin_router.delete("/{feedback_id}", responses={404: {"description": "Feedback not found"}})
 async def soft_delete_feedback(
     feedback_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
@@ -271,7 +271,10 @@ async def soft_delete_feedback(
     return _serialize(row)
 
 
-@admin_router.post("/{feedback_id}/retry-dispatch")
+@admin_router.post(
+    "/{feedback_id}/retry-dispatch",
+    responses={400: {"description": "Cannot retry dispatch with status"}, 404: {"description": "Feedback not found"}},
+)
 async def retry_feedback_dispatch(
     feedback_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
@@ -290,7 +293,10 @@ async def retry_feedback_dispatch(
     return _serialize(row, include_user_email=True)
 
 
-@admin_router.post("/{feedback_id}/recover")
+@admin_router.post(
+    "/{feedback_id}/recover",
+    responses={400: {"description": "Feedback is not deleted"}, 404: {"description": "Feedback not found"}},
+)
 async def recover_feedback(
     feedback_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),

--- a/backend/app/routers/impersonation.py
+++ b/backend/app/routers/impersonation.py
@@ -42,7 +42,11 @@ class ImpersonationStartResponse(BaseModel):
     target: UserSummary
 
 
-@router.post("/start", response_model=ImpersonationStartResponse)
+@router.post(
+    "/start",
+    response_model=ImpersonationStartResponse,
+    responses={403: {"description": "Cannot impersonate a superuser"}, 404: {"description": "User not found"}},
+)
 async def impersonation_start(
     body: ImpersonationStartRequest,
     superuser: User = Depends(require_superuser),
@@ -70,7 +74,7 @@ async def impersonation_start(
     )
 
 
-@router.post("/end")
+@router.post("/end", responses={404: {"description": "User not found"}})
 async def impersonation_end(
     body: ImpersonationEndRequest,
     superuser: User = Depends(require_superuser),

--- a/backend/app/routers/loom_catalog.py
+++ b/backend/app/routers/loom_catalog.py
@@ -267,7 +267,9 @@ async def search_loom_catalog(
     return [LoomReferenceSummary.model_validate(r) for r in rows.all()]
 
 
-@public_router.get("/{ref_id}", response_model=LoomReferenceSchema)
+@public_router.get(
+    "/{ref_id}", response_model=LoomReferenceSchema, responses={404: {"description": "Loom reference not found"}}
+)
 async def get_loom_reference(
     ref_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
@@ -304,7 +306,12 @@ async def admin_list_loom_catalog(
     return [LoomReferenceSchema.model_validate(r) for r in rows.all()]
 
 
-@admin_catalog_router.post("", response_model=LoomReferenceSchema, status_code=201)
+@admin_catalog_router.post(
+    "",
+    response_model=LoomReferenceSchema,
+    status_code=201,
+    responses={409: {"description": "A loom reference with this brand and model already exists"}},
+)
 async def admin_create_loom_reference(
     body: CreateLoomReferenceRequest,
     db: AsyncSession = Depends(get_db),
@@ -325,7 +332,9 @@ async def admin_create_loom_reference(
     return LoomReferenceSchema.model_validate(ref)
 
 
-@admin_catalog_router.patch("/{ref_id}", response_model=LoomReferenceSchema)
+@admin_catalog_router.patch(
+    "/{ref_id}", response_model=LoomReferenceSchema, responses={404: {"description": "Loom reference not found"}}
+)
 async def admin_update_loom_reference(
     ref_id: uuid.UUID,
     body: UpdateLoomReferenceRequest,
@@ -342,7 +351,7 @@ async def admin_update_loom_reference(
     return LoomReferenceSchema.model_validate(ref)
 
 
-@admin_catalog_router.delete("/{ref_id}", status_code=204)
+@admin_catalog_router.delete("/{ref_id}", status_code=204, responses={404: {"description": "Loom reference not found"}})
 async def admin_delete_loom_reference(
     ref_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),

--- a/backend/app/routers/looms.py
+++ b/backend/app/routers/looms.py
@@ -430,7 +430,7 @@ def _ext(content_type: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-@router.post("", response_model=LoomDetail, status_code=201)
+@router.post("", response_model=LoomDetail, status_code=201, responses={404: {"description": "Loom not found"}})
 async def create_loom(
     body: CreateLoomRequest,
     current_user: User = Depends(get_effective_user),
@@ -498,7 +498,7 @@ async def list_looms(
     return [LoomSummary.from_loom(loom) for loom in result.all()]
 
 
-@router.get("/{loom_id}", response_model=LoomDetail)
+@router.get("/{loom_id}", response_model=LoomDetail, responses={404: {"description": "Loom not found"}})
 async def get_loom(
     loom_id: uuid.UUID,
     current_user: User = Depends(get_effective_user),
@@ -508,7 +508,7 @@ async def get_loom(
     return LoomDetail.from_loom(loom)
 
 
-@router.patch("/{loom_id}", response_model=LoomDetail)
+@router.patch("/{loom_id}", response_model=LoomDetail, responses={404: {"description": "Loom not found"}})
 async def update_loom(
     loom_id: uuid.UUID,
     body: UpdateLoomRequest,
@@ -527,7 +527,14 @@ async def update_loom(
     return LoomDetail.from_loom(loom)
 
 
-@router.delete("/{loom_id}", status_code=204)
+@router.delete(
+    "/{loom_id}",
+    status_code=204,
+    responses={
+        404: {"description": "Loom not found"},
+        409: {"description": "Loom is used by one or more active projects; pass force=true to delete anyway"},
+    },
+)
 async def delete_loom(
     loom_id: uuid.UUID,
     force: bool = Query(False),
@@ -563,7 +570,7 @@ async def delete_loom(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/{loom_id}/retire", status_code=204)
+@router.post("/{loom_id}/retire", status_code=204, responses={404: {"description": "Loom not found"}})
 async def retire_loom(
     loom_id: uuid.UUID,
     current_user: User = Depends(get_effective_user),
@@ -574,7 +581,7 @@ async def retire_loom(
     await db.commit()
 
 
-@router.post("/{loom_id}/unretire", status_code=204)
+@router.post("/{loom_id}/unretire", status_code=204, responses={404: {"description": "Loom not found"}})
 async def unretire_loom(
     loom_id: uuid.UUID,
     current_user: User = Depends(get_effective_user),
@@ -590,7 +597,11 @@ async def unretire_loom(
 # ---------------------------------------------------------------------------
 
 
-@router.put("/{loom_id}/photo", status_code=204)
+@router.put(
+    "/{loom_id}/photo",
+    status_code=204,
+    responses={400: {"description": "Invalid or corrupt image file"}, 404: {"description": "Loom not found"}},
+)
 async def upload_loom_photo(
     loom_id: uuid.UUID,
     file: UploadFile = File(...),
@@ -613,7 +624,7 @@ async def upload_loom_photo(
     await db.commit()
 
 
-@router.delete("/{loom_id}/photo", status_code=204)
+@router.delete("/{loom_id}/photo", status_code=204, responses={404: {"description": "Loom not found"}})
 async def delete_loom_photo(
     loom_id: uuid.UUID,
     current_user: User = Depends(get_effective_user),
@@ -626,7 +637,7 @@ async def delete_loom_photo(
         await db.commit()
 
 
-@router.get("/{loom_id}/photo")
+@router.get("/{loom_id}/photo", responses={404: {"description": "No photo"}})
 async def get_loom_photo(
     loom_id: uuid.UUID,
     current_user: User = Depends(get_effective_user),
@@ -645,7 +656,12 @@ async def get_loom_photo(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/{loom_id}/versions", response_model=LoomVersionSchema, status_code=201)
+@router.post(
+    "/{loom_id}/versions",
+    response_model=LoomVersionSchema,
+    status_code=201,
+    responses={404: {"description": "Loom not found"}},
+)
 async def add_version(
     loom_id: uuid.UUID,
     body: AddVersionRequest,
@@ -679,7 +695,12 @@ async def add_version(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/{loom_id}/versions/{version_id}/photos", response_model=LoomVersionPhotoSchema, status_code=201)
+@router.post(
+    "/{loom_id}/versions/{version_id}/photos",
+    response_model=LoomVersionPhotoSchema,
+    status_code=201,
+    responses={400: {"description": "Invalid or corrupt image file"}, 404: {"description": "Version not found"}},
+)
 async def upload_version_photo(
     loom_id: uuid.UUID,
     version_id: uuid.UUID,
@@ -717,7 +738,7 @@ async def upload_version_photo(
     return LoomVersionPhotoSchema.model_validate(photo)
 
 
-@router.get("/{loom_id}/versions/{version_id}/photos/{photo_id}")
+@router.get("/{loom_id}/versions/{version_id}/photos/{photo_id}", responses={404: {"description": "Photo not found"}})
 async def get_version_photo(
     loom_id: uuid.UUID,
     version_id: uuid.UUID,
@@ -734,7 +755,11 @@ async def get_version_photo(
     return Response(content=data, media_type=ct)
 
 
-@router.delete("/{loom_id}/versions/{version_id}/photos/{photo_id}", status_code=204)
+@router.delete(
+    "/{loom_id}/versions/{version_id}/photos/{photo_id}",
+    status_code=204,
+    responses={404: {"description": "Photo not found"}},
+)
 async def delete_version_photo(
     loom_id: uuid.UUID,
     version_id: uuid.UUID,
@@ -756,7 +781,12 @@ async def delete_version_photo(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/{loom_id}/versions/{version_id}/receipts", response_model=LoomVersionReceiptSchema, status_code=201)
+@router.post(
+    "/{loom_id}/versions/{version_id}/receipts",
+    response_model=LoomVersionReceiptSchema,
+    status_code=201,
+    responses={400: {"description": "File too large (max 5 MB)"}, 404: {"description": "Version not found"}},
+)
 async def upload_version_receipt(
     loom_id: uuid.UUID,
     version_id: uuid.UUID,
@@ -786,7 +816,9 @@ async def upload_version_receipt(
     return LoomVersionReceiptSchema.model_validate(receipt)
 
 
-@router.get("/{loom_id}/versions/{version_id}/receipts/{receipt_id}")
+@router.get(
+    "/{loom_id}/versions/{version_id}/receipts/{receipt_id}", responses={404: {"description": "Receipt not found"}}
+)
 async def get_version_receipt(
     loom_id: uuid.UUID,
     version_id: uuid.UUID,
@@ -809,7 +841,11 @@ async def get_version_receipt(
     )
 
 
-@router.delete("/{loom_id}/versions/{version_id}/receipts/{receipt_id}", status_code=204)
+@router.delete(
+    "/{loom_id}/versions/{version_id}/receipts/{receipt_id}",
+    status_code=204,
+    responses={404: {"description": "Receipt not found"}},
+)
 async def delete_version_receipt(
     loom_id: uuid.UUID,
     version_id: uuid.UUID,
@@ -831,7 +867,11 @@ async def delete_version_receipt(
 # ---------------------------------------------------------------------------
 
 
-@router.patch("/{loom_id}/versions/{version_id}", response_model=LoomVersionSchema)
+@router.patch(
+    "/{loom_id}/versions/{version_id}",
+    response_model=LoomVersionSchema,
+    responses={404: {"description": "Version not found"}},
+)
 async def update_version(
     loom_id: uuid.UUID,
     version_id: uuid.UUID,
@@ -852,7 +892,12 @@ async def update_version(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/{loom_id}/versions/{version_id}/clone", response_model=LoomVersionSchema, status_code=201)
+@router.post(
+    "/{loom_id}/versions/{version_id}/clone",
+    response_model=LoomVersionSchema,
+    status_code=201,
+    responses={404: {"description": "Version not found"}},
+)
 async def clone_version(
     loom_id: uuid.UUID,
     version_id: uuid.UUID,
@@ -898,7 +943,12 @@ async def clone_version(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/{loom_id}/versions/{version_id}/accessories", response_model=LoomVersionAccessorySchema, status_code=201)
+@router.post(
+    "/{loom_id}/versions/{version_id}/accessories",
+    response_model=LoomVersionAccessorySchema,
+    status_code=201,
+    responses={404: {"description": "Version not found"}},
+)
 async def add_accessory(
     loom_id: uuid.UUID,
     version_id: uuid.UUID,
@@ -914,7 +964,11 @@ async def add_accessory(
     return LoomVersionAccessorySchema.model_validate(acc)
 
 
-@router.delete("/{loom_id}/versions/{version_id}/accessories/{accessory_id}", status_code=204)
+@router.delete(
+    "/{loom_id}/versions/{version_id}/accessories/{accessory_id}",
+    status_code=204,
+    responses={404: {"description": "Accessory not found"}},
+)
 async def delete_accessory(
     loom_id: uuid.UUID,
     version_id: uuid.UUID,
@@ -935,7 +989,12 @@ async def delete_accessory(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/{loom_id}/reeds", response_model=LoomReedSchema, status_code=201)
+@router.post(
+    "/{loom_id}/reeds",
+    response_model=LoomReedSchema,
+    status_code=201,
+    responses={400: {"description": "dents_per_inch must be positive"}, 404: {"description": "Loom not found"}},
+)
 async def add_reed(
     loom_id: uuid.UUID,
     body: AddReedRequest,
@@ -958,7 +1017,7 @@ async def add_reed(
     return LoomReedSchema.model_validate(reed)
 
 
-@router.delete("/{loom_id}/reeds/{reed_id}", status_code=204)
+@router.delete("/{loom_id}/reeds/{reed_id}", status_code=204, responses={404: {"description": "Reed not found"}})
 async def delete_reed(
     loom_id: uuid.UUID,
     reed_id: uuid.UUID,
@@ -982,7 +1041,11 @@ class LinkReferenceRequest(BaseModel):
     loom_reference_id: uuid.UUID | None
 
 
-@router.post("/{loom_id}/versions/{version_id}/link-reference", response_model=LoomDetail)
+@router.post(
+    "/{loom_id}/versions/{version_id}/link-reference",
+    response_model=LoomDetail,
+    responses={404: {"description": "Loom reference not found"}},
+)
 async def link_version_reference(
     loom_id: uuid.UUID,
     version_id: uuid.UUID,

--- a/backend/app/routers/ravelry.py
+++ b/backend/app/routers/ravelry.py
@@ -80,7 +80,7 @@ class BulkStashPushResult(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-@router.get("/authorize")
+@router.get("/authorize", responses={503: {"description": "Ravelry integration is not configured on this server"}})
 async def authorize(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
@@ -151,7 +151,7 @@ async def status(
     )
 
 
-@router.delete("/connection", status_code=204)
+@router.delete("/connection", status_code=204, responses={404: {"description": "Not connected to Ravelry"}})
 async def disconnect(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
@@ -164,7 +164,7 @@ async def disconnect(
     await db.commit()
 
 
-@router.get("/yarn-detail/{ravelry_yarn_id}")
+@router.get("/yarn-detail/{ravelry_yarn_id}", responses={502: {"description": "Ravelry yarn detail fetch failed"}})
 async def yarn_detail(
     ravelry_yarn_id: int,
     _current_user: User = Depends(get_current_user),
@@ -178,7 +178,11 @@ async def yarn_detail(
     return data
 
 
-@router.get("/popular/companies", response_model=list[RavelryCompany])
+@router.get(
+    "/popular/companies",
+    response_model=list[RavelryCompany],
+    responses={502: {"description": "Ravelry request failed"}},
+)
 async def popular_companies(
     limit: int = Query(10, ge=1, le=20),
     _current_user: User = Depends(get_current_user),
@@ -192,7 +196,9 @@ async def popular_companies(
     return [RavelryCompany(**r) for r in results]
 
 
-@router.get("/popular/yarns", response_model=list[RavelryYarnResult])
+@router.get(
+    "/popular/yarns", response_model=list[RavelryYarnResult], responses={502: {"description": "Ravelry request failed"}}
+)
 async def popular_yarns(
     company_id: int = Query(...),
     company_name: str = Query(...),
@@ -208,7 +214,9 @@ async def popular_yarns(
     return [RavelryYarnResult(**r) for r in results]
 
 
-@router.get("/search/companies", response_model=list[RavelryCompany])
+@router.get(
+    "/search/companies", response_model=list[RavelryCompany], responses={502: {"description": "Ravelry search failed"}}
+)
 async def search_companies(
     q: str = Query(..., min_length=1),
     _current_user: User = Depends(get_current_user),
@@ -222,7 +230,9 @@ async def search_companies(
     return [RavelryCompany(**r) for r in results]
 
 
-@router.get("/search/yarns", response_model=list[RavelryYarnResult])
+@router.get(
+    "/search/yarns", response_model=list[RavelryYarnResult], responses={502: {"description": "Ravelry search failed"}}
+)
 async def search_yarns(
     q: str = Query(..., min_length=1),
     company_id: int | None = Query(None),
@@ -237,7 +247,10 @@ async def search_yarns(
     return [RavelryYarnResult(**r) for r in results]
 
 
-@router.post("/import-yarn")
+@router.post(
+    "/import-yarn",
+    responses={404: {"description": "Yarn not found or not importable"}, 502: {"description": "Ravelry import failed"}},
+)
 async def import_yarn(
     payload: ImportYarnPayload,
     current_user: User = Depends(get_current_user),
@@ -260,7 +273,13 @@ async def import_yarn(
     return {"id": str(yarn.id)}
 
 
-@router.post("/stash-push/bulk")
+@router.post(
+    "/stash-push/bulk",
+    responses={
+        404: {"description": "Not connected to Ravelry"},
+        502: {"description": "Ravelry bulk stash push failed"},
+    },
+)
 async def push_bulk_to_stash(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
@@ -277,7 +296,14 @@ async def push_bulk_to_stash(
     return BulkStashPushResult(**result)
 
 
-@router.post("/stash-push/{yarn_id}")
+@router.post(
+    "/stash-push/{yarn_id}",
+    responses={
+        404: {"description": "Yarn not found"},
+        422: {"description": "Yarn cannot be pushed to Ravelry stash"},
+        502: {"description": "Ravelry stash push failed"},
+    },
+)
 async def push_yarn_to_stash(
     yarn_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
@@ -296,7 +322,11 @@ async def push_yarn_to_stash(
     return StashPushResult(ravelry_stash_id=stash_id)
 
 
-@router.post("/sync", response_model=SyncResult)
+@router.post(
+    "/sync",
+    response_model=SyncResult,
+    responses={404: {"description": "Not connected to Ravelry"}, 502: {"description": "Ravelry stash sync failed"}},
+)
 async def sync_stash(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -150,7 +150,9 @@ class EulaCurrentResponse(BaseModel):
     effective_date: datetime
 
 
-@eula_router.get("/current", response_model=EulaCurrentResponse)
+@eula_router.get(
+    "/current", response_model=EulaCurrentResponse, responses={404: {"description": "No EULA version found"}}
+)
 async def get_current_eula(db: AsyncSession = Depends(get_db)) -> EulaCurrentResponse:
     row = await db.scalar(select(EulaVersion).order_by(EulaVersion.id.desc()).limit(1))
     if not row:
@@ -188,7 +190,9 @@ async def get_settings(
     return _to_response(current_user, version)
 
 
-@router.patch("/me", response_model=UserSettingsResponse)
+@router.patch(
+    "/me", response_model=UserSettingsResponse, responses={422: {"description": "display_name cannot be empty"}}
+)
 async def update_settings(
     body: UserSettingsUpdate,
     current_user: Annotated[User, Depends(get_current_user)],
@@ -276,7 +280,11 @@ async def update_settings(
     return _to_response(current_user, version)
 
 
-@router.post("/me/eula", response_model=UserSettingsResponse)
+@router.post(
+    "/me/eula",
+    response_model=UserSettingsResponse,
+    responses={422: {"description": "Version mismatch — current EULA is"}},
+)
 async def accept_eula(
     body: EulaAcceptRequest,
     current_user: User = Depends(get_current_user),
@@ -297,7 +305,7 @@ async def accept_eula(
     return _to_response(current_user, current_version)
 
 
-@router.delete("/me", status_code=204)
+@router.delete("/me", status_code=204, responses={422: {"description": 'confirm must be exactly "DELETE MY ACCOUNT"'}})
 async def delete_account(
     body: DeleteAccountRequest,
     response: Response,
@@ -406,7 +414,10 @@ async def get_export_status(
     )
 
 
-@router.get("/me/data-export/download/{request_id}")
+@router.get(
+    "/me/data-export/download/{request_id}",
+    responses={404: {"description": "Export not found"}, 410: {"description": "Export has expired"}},
+)
 async def download_data_export(
     request_id: uuid.UUID,
     current_user: User = Depends(get_current_user),

--- a/backend/app/routers/webhooks.py
+++ b/backend/app/routers/webhooks.py
@@ -13,7 +13,14 @@ from app.routers.auth import _handle_clerk_webhook
 router = APIRouter(prefix="/webhooks", tags=["webhooks"])
 
 
-@router.post("/clerk", status_code=200)
+@router.post(
+    "/clerk",
+    status_code=200,
+    responses={
+        400: {"description": "Invalid webhook signature"},
+        500: {"description": "Webhook not configured"},
+    },
+)
 async def clerk_webhook(request: Request, db: AsyncSession = Depends(get_db)) -> dict:
     """Receive and process Clerk user lifecycle events."""
     return await _handle_clerk_webhook(request, db)

--- a/backend/app/routers/yarn.py
+++ b/backend/app/routers/yarn.py
@@ -360,7 +360,7 @@ async def get_yarn_properties(
 # ---------------------------------------------------------------------------
 
 
-@router.post("", response_model=YarnDetail, status_code=201)
+@router.post("", response_model=YarnDetail, status_code=201, responses={404: {"description": "Yarn not found"}})
 async def create_yarn(
     body: CreateYarnRequest,
     current_user: User = Depends(get_effective_user),
@@ -391,7 +391,7 @@ async def list_yarn(
     return [YarnSummary.from_yarn(y) for y in result.all()]
 
 
-@router.get("/{yarn_id}", response_model=YarnDetail)
+@router.get("/{yarn_id}", response_model=YarnDetail, responses={404: {"description": "Yarn not found"}})
 async def get_yarn(
     yarn_id: uuid.UUID,
     current_user: User = Depends(get_effective_user),
@@ -401,7 +401,7 @@ async def get_yarn(
     return YarnDetail.from_yarn(yarn)
 
 
-@router.patch("/{yarn_id}", response_model=YarnDetail)
+@router.patch("/{yarn_id}", response_model=YarnDetail, responses={404: {"description": "Yarn not found"}})
 async def update_yarn(
     yarn_id: uuid.UUID,
     body: UpdateYarnRequest,
@@ -423,7 +423,7 @@ class PatchColorwayRequest(BaseModel):
     clear_photos: bool = False
 
 
-@router.patch("/{yarn_id}/colorway", response_model=YarnDetail)
+@router.patch("/{yarn_id}/colorway", response_model=YarnDetail, responses={404: {"description": "Yarn not found"}})
 async def patch_yarn_colorway(
     yarn_id: uuid.UUID,
     body: PatchColorwayRequest,
@@ -446,7 +446,7 @@ async def patch_yarn_colorway(
     return YarnDetail.from_yarn(yarn)
 
 
-@router.delete("/{yarn_id}", status_code=204)
+@router.delete("/{yarn_id}", status_code=204, responses={404: {"description": "Yarn not found"}})
 async def delete_yarn(
     yarn_id: uuid.UUID,
     current_user: User = Depends(get_effective_user),
@@ -462,7 +462,11 @@ async def delete_yarn(
 # ---------------------------------------------------------------------------
 
 
-@router.put("/{yarn_id}/photo", status_code=204)
+@router.put(
+    "/{yarn_id}/photo",
+    status_code=204,
+    responses={400: {"description": "File too large (max 5 MB)"}, 404: {"description": "Yarn not found"}},
+)
 async def upload_yarn_photo(
     yarn_id: uuid.UUID,
     file: UploadFile = File(...),
@@ -484,7 +488,7 @@ async def upload_yarn_photo(
     await db.commit()
 
 
-@router.get("/{yarn_id}/photo")
+@router.get("/{yarn_id}/photo", responses={404: {"description": "No photo"}})
 async def get_yarn_photo(
     yarn_id: uuid.UUID,
     current_user: User = Depends(get_effective_user),
@@ -498,7 +502,7 @@ async def get_yarn_photo(
     return Response(content=data, media_type=ct)
 
 
-@router.delete("/{yarn_id}/photo", status_code=204)
+@router.delete("/{yarn_id}/photo", status_code=204, responses={404: {"description": "Yarn not found"}})
 async def delete_yarn_photo(
     yarn_id: uuid.UUID,
     current_user: User = Depends(get_effective_user),
@@ -516,7 +520,12 @@ async def delete_yarn_photo(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/{yarn_id}/skeins", response_model=list[SkeinSchema], status_code=201)
+@router.post(
+    "/{yarn_id}/skeins",
+    response_model=list[SkeinSchema],
+    status_code=201,
+    responses={400: {"description": "Quantity must be between 1 and 100"}, 404: {"description": "Yarn not found"}},
+)
 async def add_skeins(
     yarn_id: uuid.UUID,
     body: AddSkeinsRequest,
@@ -545,7 +554,9 @@ async def add_skeins(
     return [SkeinSchema.model_validate(s) for s in new_skeins]
 
 
-@router.patch("/{yarn_id}/skeins/{skein_id}", response_model=SkeinSchema)
+@router.patch(
+    "/{yarn_id}/skeins/{skein_id}", response_model=SkeinSchema, responses={404: {"description": "Skein not found"}}
+)
 async def update_skein(
     yarn_id: uuid.UUID,
     skein_id: uuid.UUID,
@@ -561,7 +572,7 @@ async def update_skein(
     return SkeinSchema.model_validate(skein)
 
 
-@router.delete("/{yarn_id}/skeins/{skein_id}", status_code=204)
+@router.delete("/{yarn_id}/skeins/{skein_id}", status_code=204, responses={404: {"description": "Skein not found"}})
 async def delete_skein(
     yarn_id: uuid.UUID,
     skein_id: uuid.UUID,
@@ -578,7 +589,9 @@ async def delete_skein(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/{yarn_id}/clone", response_model=YarnDetail, status_code=201)
+@router.post(
+    "/{yarn_id}/clone", response_model=YarnDetail, status_code=201, responses={404: {"description": "Yarn not found"}}
+)
 async def clone_yarn(
     yarn_id: uuid.UUID,
     body: CloneYarnRequest,
@@ -626,7 +639,9 @@ class YarnProjectRef(BaseModel):
     model_config = {"from_attributes": True}
 
 
-@router.get("/{yarn_id}/projects", response_model=list[YarnProjectRef])
+@router.get(
+    "/{yarn_id}/projects", response_model=list[YarnProjectRef], responses={404: {"description": "Yarn not found"}}
+)
 async def get_yarn_projects(
     yarn_id: uuid.UUID,
     current_user: User = Depends(get_effective_user),


### PR DESCRIPTION
## Summary
- Sweeps `python:S8415` (undocumented `HTTPException` status code missing from `responses={}`) across all routers not covered by the `projects.py` pass in #1049: `admin.py`, `drafts.py`, `looms.py`, `ravelry.py`, `users.py`, `collections.py`, `auth.py`, `feedback.py`, `yarn.py`, `loom_catalog.py`, `impersonation.py`, and `webhooks.py`'s `/clerk` route (delegates to a shared helper in `auth.py`).
- Purely additive OpenAPI documentation — `responses=` is schema-only metadata consumed at doc-generation time, not at request-handling time, so no runtime behavior changes.
- Shared ownership/validation helpers (`_get_owned_*`, `_validate_*`) had their raised status codes propagated into every route that calls them, matching the pattern already used in `projects.py`.
- Part of #1047.

## Test plan
- [x] `ruff check` / `ruff format --check` / `mypy` clean on all 12 touched files
- [x] `app.openapi()` still generates 176 paths (unchanged) after every file's edit
- [x] Local pytest run in progress for the touched routers' test files (bounded scope; full local suite aborted as impractically slow on this machine's Docker networking — CI's native-Linux run is the actual merge gate and will validate the full suite in ~10 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)