### PR TITLE
fix: validate seed config path stays within backend dir (S8707, #1054)

### DIFF
--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -256,9 +256,13 @@ async def cmd_seed(config_path: str, poll_timeout: int) -> None:
     _ok("DB reachable")
 
     # ── Load config ────────────────────────────────────────────────────────
-    config_file = Path(config_path)
+    config_file = Path(config_path).resolve()
+    if not config_file.is_relative_to(_BACKEND_DIR):
+        _err(f"--config must resolve to a path under {_BACKEND_DIR}, got: {config_file}")
+        await engine.dispose()
+        sys.exit(1)
     if not config_file.exists():
-        _err(f"Seed config not found: {config_file.resolve()}")
+        _err(f"Seed config not found: {config_file}")
         await engine.dispose()
         sys.exit(1)
     try:

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -50,7 +50,7 @@ def _make_engine():
 
 async def test_seed_aborts_when_not_dev(tmp_path):
     settings = _make_settings(app_env="prod")
-    with patch("app.cli.get_settings", return_value=settings):
+    with patch("app.cli.get_settings", return_value=settings), patch("app.cli._BACKEND_DIR", tmp_path):
         with pytest.raises(SystemExit) as exc_info:
             await cmd_seed(str(tmp_path / "seed.json"), 5)
     assert exc_info.value.code == 1
@@ -63,7 +63,7 @@ async def test_seed_aborts_when_not_dev(tmp_path):
 
 async def test_seed_aborts_when_seed_disabled(tmp_path):
     settings = _make_settings(seed_enabled=False)
-    with patch("app.cli.get_settings", return_value=settings):
+    with patch("app.cli.get_settings", return_value=settings), patch("app.cli._BACKEND_DIR", tmp_path):
         with pytest.raises(SystemExit) as exc_info:
             await cmd_seed(str(tmp_path / "seed.json"), 5)
     assert exc_info.value.code == 1
@@ -76,7 +76,7 @@ async def test_seed_aborts_when_seed_disabled(tmp_path):
 
 async def test_seed_aborts_when_no_clerk_key(tmp_path):
     settings = _make_settings(clerk_secret_key="")
-    with patch("app.cli.get_settings", return_value=settings):
+    with patch("app.cli.get_settings", return_value=settings), patch("app.cli._BACKEND_DIR", tmp_path):
         with pytest.raises(SystemExit) as exc_info:
             await cmd_seed(str(tmp_path / "seed.json"), 5)
     assert exc_info.value.code == 1
@@ -92,6 +92,7 @@ async def test_seed_aborts_when_clerk_unreachable(tmp_path):
     with (
         patch("app.cli.get_settings", return_value=settings),
         patch("app.cli._clerk_list_users", AsyncMock(side_effect=Exception("connection refused"))),
+        patch("app.cli._BACKEND_DIR", tmp_path),
     ):
         with pytest.raises(SystemExit) as exc_info:
             await cmd_seed(str(tmp_path / "seed.json"), 5)
@@ -113,6 +114,7 @@ async def test_seed_proceeds_when_clerk_has_users(tmp_path):
         patch("app.cli._clerk_list_users", AsyncMock(return_value=[{"id": "user_abc"}])),
         patch("app.cli.create_async_engine", return_value=_make_engine()),
         patch("app.cli.async_sessionmaker", return_value=factory),
+        patch("app.cli._BACKEND_DIR", tmp_path),
     ):
         # Should exit on missing config, not on Clerk having users
         with pytest.raises(SystemExit) as exc_info:
@@ -138,6 +140,7 @@ async def test_seed_aborts_when_db_unreachable(tmp_path):
         patch("app.cli._clerk_list_users", AsyncMock(return_value=[])),
         patch("app.cli.create_async_engine", return_value=_make_engine()),
         patch("app.cli.async_sessionmaker", return_value=factory),
+        patch("app.cli._BACKEND_DIR", tmp_path),
     ):
         with pytest.raises(SystemExit) as exc_info:
             await cmd_seed(str(tmp_path / "seed.json"), 5)
@@ -145,8 +148,31 @@ async def test_seed_aborts_when_db_unreachable(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Precheck: seed config missing
+# Precheck: seed config path must resolve within the backend directory
 # ---------------------------------------------------------------------------
+
+
+async def test_seed_aborts_when_config_outside_backend_dir(tmp_path):
+    """A --config path resolving outside the allowed base dir is rejected before it's read."""
+    settings = _make_settings()
+    factory, _ = _make_session_factory()
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    allowed_dir = tmp_path / "backend"
+    allowed_dir.mkdir()
+    escaping_config = outside_dir / "seed.json"
+    escaping_config.write_text(json.dumps({"users": [{"email": "a@b.com", "username": "a"}]}))
+
+    with (
+        patch("app.cli.get_settings", return_value=settings),
+        patch("app.cli._clerk_list_users", AsyncMock(return_value=[])),
+        patch("app.cli.create_async_engine", return_value=_make_engine()),
+        patch("app.cli.async_sessionmaker", return_value=factory),
+        patch("app.cli._BACKEND_DIR", allowed_dir),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            await cmd_seed(str(escaping_config), 5)
+    assert exc_info.value.code == 1
 
 
 async def test_seed_aborts_when_config_missing(tmp_path):
@@ -158,6 +184,7 @@ async def test_seed_aborts_when_config_missing(tmp_path):
         patch("app.cli._clerk_list_users", AsyncMock(return_value=[])),
         patch("app.cli.create_async_engine", return_value=_make_engine()),
         patch("app.cli.async_sessionmaker", return_value=factory),
+        patch("app.cli._BACKEND_DIR", tmp_path),
     ):
         with pytest.raises(SystemExit) as exc_info:
             await cmd_seed(str(tmp_path / "nonexistent.json"), 5)
@@ -180,6 +207,7 @@ async def test_seed_aborts_when_no_users_in_config(tmp_path):
         patch("app.cli._clerk_list_users", AsyncMock(return_value=[])),
         patch("app.cli.create_async_engine", return_value=_make_engine()),
         patch("app.cli.async_sessionmaker", return_value=factory),
+        patch("app.cli._BACKEND_DIR", tmp_path),
     ):
         with pytest.raises(SystemExit) as exc_info:
             await cmd_seed(str(config), 5)
@@ -215,6 +243,7 @@ async def test_seed_deletes_clerk_users_before_alembic(tmp_path):
         patch("app.cli._preregister_user", AsyncMock(return_value=pre_user)),
         patch("app.cli._clerk_create_user", AsyncMock(return_value={"id": "user_new"})),
         patch("app.cli._poll_for_clerk_attach", AsyncMock(return_value=attached_user)),
+        patch("app.cli._BACKEND_DIR", tmp_path),
     ):
         await cmd_seed(str(config), 5)
 
@@ -238,6 +267,7 @@ async def test_seed_aborts_when_clerk_delete_fails(tmp_path):
         patch("app.cli._clerk_delete_all_users", AsyncMock(side_effect=Exception("clerk error"))),
         patch("app.cli.create_async_engine", return_value=_make_engine()),
         patch("app.cli.async_sessionmaker", return_value=factory),
+        patch("app.cli._BACKEND_DIR", tmp_path),
     ):
         with pytest.raises(SystemExit) as exc_info:
             await cmd_seed(str(config), 5)


### PR DESCRIPTION
## Summary
- Fixes `pythonsecurity:S8707` (the only VULNERABILITY-type SonarCloud finding): `app/cli.py`'s `seed` command read whatever file `--config` pointed to after only an `exists()` check. SonarCloud's message specifically calls out the "agentic tool invocation" threat model — an AI agent or automated script invoking this CLI with attacker-influenced arguments could escape file system restrictions.
- `config_file` is now resolved and rejected if it doesn't stay within `_BACKEND_DIR` before it's ever read.
- `_BACKEND_DIR` is a patchable module-level constant, so existing tests keep using pytest's `tmp_path` fixture for config fixtures by pointing `_BACKEND_DIR` at it too (`patch("app.cli._BACKEND_DIR", tmp_path)`) — no change to what each test actually verifies.
- Added a dedicated test (`test_seed_aborts_when_config_outside_backend_dir`) asserting a path resolving outside the allowed directory is rejected before the file is read.
- Closes #1054, part of #1047.

## Test plan
- [x] `ruff check` / `ruff format --check` / `mypy` clean on both touched files
- [x] `pytest tests/test_cli.py` — 17/17 passed (16 existing + 1 new)
- [x] New lines fully covered per `--cov-report=term-missing` (only pre-existing, unmodified lines remain uncovered)
- [x] `python -m app.cli seed --help` still works
- [x] App imports cleanly (`from app.main import app`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)