### PR TITLE
refactor: dedupe formatUptime between AdminPage and SuperuserPage (#1053)

### DIFF
--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,3 +4,14 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function formatUptime(seconds: number): string {
+  const d = Math.floor(seconds / 86400);
+  const h = Math.floor((seconds % 86400) / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const parts: string[] = [];
+  if (d > 0) parts.push(`${d} day${d !== 1 ? "s" : ""}`);
+  if (h > 0) parts.push(`${h} hour${h !== 1 ? "s" : ""}`);
+  parts.push(`${m} minute${m !== 1 ? "s" : ""}`);
+  return parts.join(", ");
+}

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -5,6 +5,7 @@ import { UserDetailModal, type UserDetailTarget } from "@/components/admin/UserD
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/useAuth";
+import { formatUptime } from "@/lib/utils";
 import {
   listAdminUsers,
   getAdminStats,
@@ -60,17 +61,6 @@ import {
 } from "@/api/looms";
 
 type Tab = "users" | "invites" | "stats" | "health" | "services" | "deps" | "audit" | "slugs" | "feedback" | "looms";
-
-function formatUptime(seconds: number): string {
-  const d = Math.floor(seconds / 86400);
-  const h = Math.floor((seconds % 86400) / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const parts: string[] = [];
-  if (d > 0) parts.push(`${d} day${d !== 1 ? "s" : ""}`);
-  if (h > 0) parts.push(`${h} hour${h !== 1 ? "s" : ""}`);
-  parts.push(`${m} minute${m !== 1 ? "s" : ""}`);
-  return parts.join(", ");
-}
 
 function formatLastActive(iso: string | null): string {
   if (!iso) return "Never";

--- a/frontend/src/pages/SuperuserPage.tsx
+++ b/frontend/src/pages/SuperuserPage.tsx
@@ -56,21 +56,11 @@ import { EulaContent } from "@/components/EulaContent";
 import { CveBanner } from "@/components/admin/CveBanner";
 import { CopyEmail } from "@/components/admin/CopyEmail";
 import { formatBytes } from "@/lib/image-utils";
+import { formatUptime } from "@/lib/utils";
 import { listAdminUsers } from "@/api/admin";
 import type { AdminUser } from "@/api/admin";
 
 declare const __FRONTEND_DEPS__: Record<string, string>;
-
-function formatUptime(seconds: number): string {
-  const d = Math.floor(seconds / 86400);
-  const h = Math.floor((seconds % 86400) / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const parts: string[] = [];
-  if (d > 0) parts.push(`${d} day${d !== 1 ? "s" : ""}`);
-  if (h > 0) parts.push(`${h} hour${h !== 1 ? "s" : ""}`);
-  parts.push(`${m} minute${m !== 1 ? "s" : ""}`);
-  return parts.join(", ");
-}
 
 type SuperuserSection = "eula" | "storage" | "cve" | "workers" | "deletion" | "reconcile" | "maintenance" | "schedule" | "exports" | "credentials" | "neon" | "sandbox" | "users";
 


### PR DESCRIPTION
## Summary
- First slice of #1053 — extracts `formatUptime()` (byte-identical in both files) from `AdminPage.tsx` and `SuperuserPage.tsx` into `lib/utils.ts`, fixing the 10-line duplicate block SonarCloud flagged between them.
- Pure utility function, moved verbatim (no logic change) — the lowest-risk of the 8 duplicate block-pairs tracked in #1053, so starting here.
- No buttons in this particular duplicate block, so no `type="button"` work applies to this slice. `AdminPage.tsx` still has its own internal 20-line duplicate plus pending S9011 button fixes — left for a follow-up slice per #1053's "don't bundle all 8 pairs into one PR" guidance.
- Part of #1053, #1047.

## Test plan
- [x] `eslint` / `tsc --noEmit` clean
- [x] Docker frontend + backend build succeeds
- [x] Full `rbd` cycle — all containers healthy, backend `/api/health` returns 200
- [x] Grepped for any other `formatUptime` usages — none missed
- [ ] Interactive browser click-through not performed directly (no browser automation tool available this session) — risk is minimal here since the function was moved character-for-character with identical input/output behavior, not rewritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)