### PR TITLE
chore: S8410 Annotated deps + S6759 readonly props + S7773 Number methods (#1047)

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -6,7 +6,7 @@ import platform
 import time
 import uuid
 from datetime import date, datetime, timedelta, timezone
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 import httpx
 import psutil
@@ -442,8 +442,8 @@ async def _probe_clerk() -> ServiceCheckResult:
 
 @router.get("/users", response_model=list[AdminUserResponse])
 async def list_users(
-    _: User = Depends(require_admin),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[User, Depends(require_admin)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> list[AdminUserResponse]:
     from sqlalchemy import or_
 
@@ -565,8 +565,8 @@ async def list_users(
 async def patch_user(
     user_id: uuid.UUID,
     body: AdminUserPatch,
-    admin: User = Depends(require_admin),
-    db: AsyncSession = Depends(get_db),
+    admin: Annotated[User, Depends(require_admin)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> AdminUserResponse:
     user = await db.scalar(select(User).where(User.id == user_id, User.deleted_at.is_(None)))
     if user is None:
@@ -690,8 +690,8 @@ async def patch_user(
 )
 async def ban_user(
     user_id: uuid.UUID,
-    admin: User = Depends(require_admin),
-    db: AsyncSession = Depends(get_db),
+    admin: Annotated[User, Depends(require_admin)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> AdminUserResponse:
     user = await db.scalar(select(User).where(User.id == user_id, User.deleted_at.is_(None)))
     if user is None:
@@ -746,8 +746,8 @@ async def ban_user(
 )
 async def unban_user(
     user_id: uuid.UUID,
-    admin: User = Depends(require_admin),
-    db: AsyncSession = Depends(get_db),
+    admin: Annotated[User, Depends(require_admin)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> AdminUserResponse:
     user = await db.scalar(select(User).where(User.id == user_id, User.deleted_at.is_(None)))
     if user is None:
@@ -813,8 +813,8 @@ class DeleteUserRequest(BaseModel):
 async def delete_user(
     user_id: uuid.UUID,
     body: DeleteUserRequest,
-    requesting_user: User = Depends(require_superuser),
-    db: AsyncSession = Depends(get_db),
+    requesting_user: Annotated[User, Depends(require_superuser)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> dict:
     if body.confirm != "DELETE USER":
         raise HTTPException(status_code=422, detail='confirm must be exactly "DELETE USER"')
@@ -849,9 +849,9 @@ async def delete_user(
 )
 async def get_user_storage_report(
     user_id: uuid.UUID,
+    _: Annotated[User, Depends(require_superuser)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     verify_s3: bool = False,
-    _: User = Depends(require_superuser),
-    db: AsyncSession = Depends(get_db),
 ) -> UserStorageReportResponse:
     from app.services.storage_quota import get_user_files_report
 
@@ -882,8 +882,8 @@ async def get_user_storage_report(
 
 @router.get("/stats", response_model=AdminStatsResponse)
 async def get_stats(
-    _: User = Depends(require_admin),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[User, Depends(require_admin)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> AdminStatsResponse:
     now = datetime.now(timezone.utc)
 
@@ -943,8 +943,8 @@ async def get_stats(
 
 @router.get("/health", response_model=AdminHealthResponse)
 async def get_health(
-    _: User = Depends(require_admin),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[User, Depends(require_admin)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> AdminHealthResponse:
     from app.main import start_time
 
@@ -1071,8 +1071,8 @@ async def _probe_config() -> ServiceCheckResult:
 
 @router.get("/services", response_model=list[ServiceCheckResult])
 async def check_services(
-    _: User = Depends(require_admin),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[User, Depends(require_admin)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> list[ServiceCheckResult]:
     db_result, s3_result, clerk_result, smtp_result, config_result = await asyncio.gather(
         _probe_postgres(db),
@@ -1116,7 +1116,7 @@ class WebhookProbeResponse(BaseModel):
 
 @router.post("/test-webhook", response_model=WebhookProbeResponse, status_code=200)
 async def test_webhook(
-    _: User = Depends(require_superuser),
+    _: Annotated[User, Depends(require_superuser)],
 ) -> WebhookProbeResponse:
     from app.services.clerk_webhook_probe import run_webhook_probe
 
@@ -1131,8 +1131,8 @@ async def test_webhook(
 
 @router.get("/audit-log", response_model=AuditLogPage)
 async def list_audit_log(
-    _: User = Depends(require_admin),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[User, Depends(require_admin)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     page: int = 1,
     page_size: int = 50,
     event_type: str | None = None,
@@ -1201,8 +1201,8 @@ class ServerEventPage(BaseModel):
 
 @router.get("/server-events", response_model=ServerEventPage)
 async def list_server_events(
-    _: User = Depends(require_admin),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[User, Depends(require_admin)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     page: int = 1,
     page_size: int = 50,
     event_type: str | None = None,
@@ -1230,7 +1230,7 @@ async def list_server_events(
 
 @router.post("/test-email", status_code=200)
 async def send_test_email_endpoint(
-    admin: User = Depends(require_admin),
+    admin: Annotated[User, Depends(require_admin)],
 ) -> dict:
     await send_test_email(admin.email)
     return {"status": "sent", "to": admin.email}
@@ -1269,8 +1269,8 @@ class ElevateRequest(BaseModel):
 async def elevate_to_superuser(
     user_id: uuid.UUID,
     body: ElevateRequest,
-    admin: User = Depends(require_superuser),
-    db: AsyncSession = Depends(get_db),
+    admin: Annotated[User, Depends(require_superuser)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> dict:
     user = await db.scalar(select(User).where(User.id == user_id, User.deleted_at.is_(None)))
     if user is None:
@@ -1356,8 +1356,8 @@ class PendingSignupResponse(BaseModel):
 
 @router.get("/pending-signups", response_model=list[PendingSignupResponse])
 async def list_pending_signups(
-    _: User = Depends(require_admin),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[User, Depends(require_admin)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> list[PendingSignup]:
     result = await db.scalars(select(PendingSignup).order_by(PendingSignup.created_at.desc()))
     return list(result.all())
@@ -1371,8 +1371,8 @@ async def list_pending_signups(
 )
 async def approve_pending_signup(
     signup_id: uuid.UUID,
-    admin: User = Depends(require_admin),
-    db: AsyncSession = Depends(get_db),
+    admin: Annotated[User, Depends(require_admin)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> dict:
     signup = await db.scalar(select(PendingSignup).where(PendingSignup.id == signup_id))
     if signup is None:
@@ -1455,8 +1455,8 @@ async def approve_pending_signup(
 )
 async def ban_pending_signup(
     signup_id: uuid.UUID,
-    admin: User = Depends(require_admin),
-    db: AsyncSession = Depends(get_db),
+    admin: Annotated[User, Depends(require_admin)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     signup = await db.scalar(select(PendingSignup).where(PendingSignup.id == signup_id))
     if signup is None:
@@ -1478,8 +1478,8 @@ async def ban_pending_signup(
 )
 async def dismiss_pending_signup(
     signup_id: uuid.UUID,
-    admin: User = Depends(require_admin),
-    db: AsyncSession = Depends(get_db),
+    admin: Annotated[User, Depends(require_admin)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     signup = await db.scalar(select(PendingSignup).where(PendingSignup.id == signup_id))
     if signup is None:
@@ -1523,8 +1523,8 @@ class EulaCurrentAdminResponse(BaseModel):
 
 @router.get("/eula", response_model=EulaCurrentAdminResponse, responses={404: {"description": "No EULA version found"}})
 async def get_eula_admin(
-    _: User = Depends(require_superuser),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[User, Depends(require_superuser)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> EulaCurrentAdminResponse:
     row = await db.scalar(select(EulaVersion).order_by(EulaVersion.id.desc()).limit(1))
     if not row:
@@ -1546,8 +1546,8 @@ async def get_eula_admin(
 )
 async def create_eula_version(
     body: EulaCreateRequest,
-    admin: User = Depends(require_superuser),
-    db: AsyncSession = Depends(get_db),
+    admin: Annotated[User, Depends(require_superuser)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> EulaVersionResponse:
     existing = await db.scalar(select(EulaVersion).where(EulaVersion.version == body.version))
     if existing:
@@ -1627,8 +1627,8 @@ async def _worker_version() -> str | None:
 
 @router.get("/versions", response_model=AdminVersionsResponse)
 async def get_versions(
-    _: User = Depends(require_admin),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[User, Depends(require_admin)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> AdminVersionsResponse:
     settings = get_settings()
 
@@ -1651,8 +1651,8 @@ async def get_versions(
 
 @router.get("/db-info", response_model=AdminDbInfoResponse)
 async def get_db_info(
-    _: User = Depends(require_admin),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[User, Depends(require_admin)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> AdminDbInfoResponse:
     from alembic.config import Config
     from alembic.script import ScriptDirectory
@@ -1688,7 +1688,9 @@ async def get_db_info(
 
 
 @router.get("/neon-dashboard", response_model=neon.NeonDashboardResponse)
-async def get_neon_dashboard(_: User = Depends(require_superuser)) -> neon.NeonDashboardResponse:
+async def get_neon_dashboard(
+    _: Annotated[User, Depends(require_superuser)],
+) -> neon.NeonDashboardResponse:
     return await neon.fetch_dashboard(get_settings())
 
 
@@ -1727,8 +1729,8 @@ class BackfillResponse(BaseModel):
 
 @router.get("/reconcile", response_model=ReconcileReport)
 async def get_reconcile_report(
-    _: User = Depends(require_superuser),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[User, Depends(require_superuser)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ReconcileReport:
     clerk_users = await list_clerk_users()
     clerk_ids = {u["id"] for u in clerk_users}
@@ -1778,9 +1780,9 @@ async def get_reconcile_report(
 )
 async def backfill_clerk_user(
     clerk_user_id: str,
+    admin: Annotated[User, Depends(require_superuser)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     body: BackfillRequest = Body(default_factory=BackfillRequest),
-    admin: User = Depends(require_superuser),
-    db: AsyncSession = Depends(get_db),
 ) -> BackfillResponse:
     existing = await db.scalar(select(User).where(User.clerk_user_id == clerk_user_id, User.deleted_at.is_(None)))
     if existing:
@@ -1872,7 +1874,7 @@ class S3CleanupResponse(BaseModel):
 
 @router.post("/s3-audit/scan", response_model=S3ScanResponse, status_code=202)
 async def start_s3_audit_scan(
-    _: User = Depends(require_superuser),
+    _: Annotated[User, Depends(require_superuser)],
 ) -> S3ScanResponse:
     from app.services.task_history import record_queued
     from app.tasks.s3_audit import run_s3_orphan_scan
@@ -1886,7 +1888,7 @@ async def start_s3_audit_scan(
 @router.get("/s3-audit/task/{task_id}", response_model=S3AuditTaskStatus)
 async def get_s3_audit_task(
     task_id: str,
-    _: User = Depends(require_superuser),
+    _: Annotated[User, Depends(require_superuser)],
 ) -> S3AuditTaskStatus:
     from celery.result import AsyncResult
 
@@ -1906,7 +1908,7 @@ async def get_s3_audit_task(
 @router.post("/s3-audit/cleanup", response_model=S3CleanupResponse)
 async def cleanup_s3_orphans(
     body: S3CleanupRequest,
-    admin: User = Depends(require_superuser),
+    admin: Annotated[User, Depends(require_superuser)],
 ) -> S3CleanupResponse:
     from app.services import storage
 
@@ -1972,7 +1974,7 @@ class CveScanSummary(BaseModel):
 @router.post("/cve-scan/start", response_model=CveScanStartResponse, status_code=202)
 async def start_cve_scan(
     body: CveScanStartRequest,
-    _: User = Depends(require_superuser),
+    _: Annotated[User, Depends(require_superuser)],
 ) -> CveScanStartResponse:
     from app.services.task_history import record_queued
     from app.tasks.cve_scan import run_cve_scan
@@ -1986,7 +1988,7 @@ async def start_cve_scan(
 @router.get("/cve-scan/task/{task_id}", response_model=CveScanTaskStatus)
 async def get_cve_scan_task(
     task_id: str,
-    _: User = Depends(require_superuser),
+    _: Annotated[User, Depends(require_superuser)],
 ) -> CveScanTaskStatus:
     from celery.result import AsyncResult
 
@@ -2005,7 +2007,7 @@ async def get_cve_scan_task(
 
 @router.get("/cve-scan/summary", response_model=CveScanSummary)
 async def get_cve_scan_summary(
-    _: User = Depends(require_superuser),
+    _: Annotated[User, Depends(require_superuser)],
 ) -> CveScanSummary:
     import json as _json
 
@@ -2039,7 +2041,7 @@ class S3AuditSummary(BaseModel):
 
 @router.get("/s3-audit/summary", response_model=S3AuditSummary)
 async def get_s3_audit_summary(
-    _: User = Depends(require_superuser),
+    _: Annotated[User, Depends(require_superuser)],
 ) -> S3AuditSummary:
     import json as _json
 
@@ -2101,7 +2103,9 @@ class WorkerStatus(BaseModel):
 
 
 @router.get("/worker-status", response_model=WorkerStatus)
-async def get_worker_status(_: User = Depends(require_superuser)) -> WorkerStatus:
+async def get_worker_status(
+    _: Annotated[User, Depends(require_superuser)],
+) -> WorkerStatus:
     from app.celery_app import celery_app
 
     checked_at = datetime.now(timezone.utc).isoformat()
@@ -2184,7 +2188,7 @@ class DebugSleepRequest(BaseModel):
 @router.post("/debug-sleep", status_code=202)
 async def start_debug_sleep(
     body: DebugSleepRequest,
-    _: User = Depends(require_superuser),
+    _: Annotated[User, Depends(require_superuser)],
 ) -> dict:
     from app.services.task_history import record_queued
     from app.tasks.debug import debug_sleep
@@ -2222,9 +2226,9 @@ class TaskHistoryResponse(BaseModel):
 
 @router.get("/task-history", response_model=TaskHistoryResponse)
 async def get_task_history(
+    _: Annotated[User, Depends(require_superuser)],
     page: int = 1,
     page_size: int = 25,
-    _: User = Depends(require_superuser),
 ) -> TaskHistoryResponse:
     from app.services.task_history import _iso, get_history
 
@@ -2264,7 +2268,7 @@ async def get_task_history(
 @router.post("/tasks/{task_id}/revoke")
 async def revoke_task(
     task_id: str,
-    _: User = Depends(require_superuser),
+    _: Annotated[User, Depends(require_superuser)],
 ) -> dict:
     from app.celery_app import celery_app
     from app.services.task_history import record_completed
@@ -2276,7 +2280,7 @@ async def revoke_task(
 
 @router.post("/purge-soft-deleted")
 async def run_purge_soft_deleted(
-    _: User = Depends(require_superuser),
+    _: Annotated[User, Depends(require_superuser)],
 ) -> dict:
     from app.services.task_history import record_queued
     from app.tasks.purge import purge_soft_deleted_records
@@ -2303,8 +2307,8 @@ class SoftDeleteQueueResponse(BaseModel):
 
 @router.get("/soft-delete-queue", response_model=SoftDeleteQueueResponse)
 async def get_soft_delete_queue(
-    _: User = Depends(require_superuser),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[User, Depends(require_superuser)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> SoftDeleteQueueResponse:
     settings = get_settings()
     retention_days = settings.soft_delete_retention_days
@@ -2358,8 +2362,8 @@ class DeletionQueueUser(BaseModel):
 
 @router.get("/deletion-queue", response_model=list[DeletionQueueUser])
 async def get_deletion_queue(
-    _: User = Depends(require_superuser),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[User, Depends(require_superuser)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> list[DeletionQueueUser]:
     rows = await db.scalars(
         select(User).where(User.deletion_state.is_not(None)).order_by(User.deletion_initiated_at.desc())
@@ -2453,8 +2457,8 @@ def _task_to_response(task) -> ScheduledTaskResponse:
 
 @router.get("/scheduled-tasks")
 async def list_scheduled_tasks(
-    db: AsyncSession = Depends(get_db),
-    _: User = Depends(require_superuser),
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _: Annotated[User, Depends(require_superuser)],
 ) -> list[ScheduledTaskResponse]:
     from app.models.scheduled_task import ScheduledTask
     from app.tasks.scheduler import REGISTRY
@@ -2489,8 +2493,8 @@ async def list_scheduled_tasks(
 async def patch_scheduled_task(
     name: str,
     body: PatchScheduledTaskBody,
-    db: AsyncSession = Depends(get_db),
-    _: User = Depends(require_superuser),
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _: Annotated[User, Depends(require_superuser)],
 ) -> ScheduledTaskResponse:
     from app.models.scheduled_task import ScheduledTask
     from app.tasks.scheduler import REGISTRY
@@ -2580,8 +2584,8 @@ def _credential_to_response(cred: CredentialExpiry) -> CredentialExpiryResponse:
 
 @router.get("/credentials", response_model=list[CredentialExpiryResponse])
 async def list_credentials(
-    db: AsyncSession = Depends(get_db),
-    _: User = Depends(require_admin),
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _: Annotated[User, Depends(require_admin)],
 ) -> list[CredentialExpiryResponse]:
     rows = await db.scalars(select(CredentialExpiry).order_by(CredentialExpiry.expires_on.asc().nulls_last()))
     return [_credential_to_response(r) for r in rows.all()]
@@ -2595,8 +2599,8 @@ async def list_credentials(
 )
 async def create_credential(
     body: CreateCredentialBody,
-    db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_superuser),
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(require_superuser)],
 ) -> CredentialExpiryResponse:
     if body.resource not in RESOURCE_CHOICES:
         raise HTTPException(status_code=422, detail=f"Invalid resource. Must be one of: {sorted(RESOURCE_CHOICES)}")
@@ -2621,8 +2625,8 @@ async def create_credential(
 async def patch_credential(
     credential_id: uuid.UUID,
     body: PatchCredentialBody,
-    db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_superuser),
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(require_superuser)],
 ) -> CredentialExpiryResponse:
     cred = await db.scalar(select(CredentialExpiry).where(CredentialExpiry.id == credential_id))
     if cred is None:
@@ -2648,8 +2652,8 @@ async def patch_credential(
 )
 async def delete_credential(
     credential_id: uuid.UUID,
-    db: AsyncSession = Depends(get_db),
-    _: User = Depends(require_superuser),
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _: Annotated[User, Depends(require_superuser)],
 ) -> None:
     cred = await db.scalar(select(CredentialExpiry).where(CredentialExpiry.id == credential_id))
     if cred is None:
@@ -2676,8 +2680,8 @@ class AdminSlugRecord(BaseModel):
 
 @router.get("/project-slugs", response_model=list[AdminSlugRecord])
 async def list_project_slugs(
-    db: AsyncSession = Depends(get_db),
-    _: User = Depends(require_admin),
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _: Annotated[User, Depends(require_admin)],
 ) -> list[AdminSlugRecord]:
     rows = await db.scalars(
         select(Project).where(
@@ -2712,8 +2716,8 @@ async def list_project_slugs(
 @router.delete("/project-slugs/{slug}", status_code=204, responses={404: {"description": "Slug not found"}})
 async def admin_revoke_project_slug(
     slug: str,
-    db: AsyncSession = Depends(get_db),
-    _: User = Depends(require_admin),
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _: Annotated[User, Depends(require_admin)],
 ) -> None:
     project = await db.scalar(select(Project).where(Project.share_slug == slug, Project.deleted_at.is_(None)))
     if project is None:
@@ -2736,9 +2740,9 @@ class AdminProjectStepRecord(BaseModel):
 @router.get("/project-steps", response_model=list[AdminProjectStepRecord])
 async def admin_list_project_steps(
     project_id: uuid.UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _: Annotated[User, Depends(require_admin)],
     limit: int = 200,
-    db: AsyncSession = Depends(get_db),
-    _: User = Depends(require_admin),
 ) -> list[AdminProjectStepRecord]:
     rows = await db.scalars(
         select(ProjectStep)
@@ -2779,8 +2783,8 @@ class AdminExportRecord(BaseModel):
 
 @router.get("/exports", response_model=list[AdminExportRecord])
 async def list_exports(
-    _: User = Depends(require_superuser),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[User, Depends(require_superuser)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> list[AdminExportRecord]:
     rows = await db.execute(
         select(UserExportRequest, User)
@@ -2808,8 +2812,8 @@ async def list_exports(
 @router.delete("/exports/{export_id}", status_code=204, responses={404: {"description": "Export not found"}})
 async def delete_export(
     export_id: uuid.UUID,
-    _: User = Depends(require_superuser),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[User, Depends(require_superuser)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     req = await db.get(UserExportRequest, export_id)
     if req is None:
@@ -2940,7 +2944,7 @@ def _get_config_state(settings: Settings) -> list[ConfigFieldState]:
 
 @router.get("/config")
 async def get_config_state(
-    _: User = Depends(require_superuser),
+    _: Annotated[User, Depends(require_superuser)],
 ) -> ConfigStateResponse:
     settings = get_settings()
     return ConfigStateResponse(
@@ -2953,7 +2957,7 @@ async def get_config_state(
 @router.put("/config", responses={503: {"description": "CONFIG_ENCRYPTION_KEY is not set — cannot write config file"}})
 def save_config(
     body: ConfigSaveRequest,
-    _: User = Depends(require_superuser),
+    _: Annotated[User, Depends(require_superuser)],
 ) -> ConfigStateResponse:
     """Save integration config values to the encrypted config file.
 
@@ -3079,7 +3083,7 @@ _SERVICE_TESTS = {
 async def test_config_service(
     service: str,
     body: ConfigSaveRequest,
-    _: User = Depends(require_superuser),
+    _: Annotated[User, Depends(require_superuser)],
 ) -> ConfigTestResult:
     """Test a service connection using the provided (unsaved) values."""
     handler = _SERVICE_TESTS.get(service)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -27,6 +27,7 @@ import logging
 import secrets
 import uuid
 from datetime import datetime, timedelta, timezone
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
@@ -328,8 +329,8 @@ class UserResponse(BaseModel):
 
 @router.get("/me", response_model=UserResponse)
 async def me(
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> UserResponse:
     from app.routers.users import get_current_eula_version
     from app.services.storage_quota import MAX_USER_STORAGE_BYTES, get_user_storage_used
@@ -397,9 +398,9 @@ class InviteResponse(BaseModel):
 )
 async def create_invite(
     body: InviteRequest,
-    admin: User = Depends(require_admin),
-    db: AsyncSession = Depends(get_db),
-    _rl: None = Depends(_invite_rate_limit),
+    admin: Annotated[User, Depends(require_admin)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _rl: Annotated[None, Depends(_invite_rate_limit)],
 ) -> Invite:
     from app.models.invite import INVITE_ROLES
 
@@ -470,8 +471,8 @@ async def create_invite(
 
 @router.get("/invites", response_model=list[InviteResponse])
 async def list_invites(
-    _: User = Depends(require_admin),
-    db: AsyncSession = Depends(get_db),
+    _: Annotated[User, Depends(require_admin)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> list[Invite]:
     result = await db.scalars(select(Invite).order_by(Invite.created_at.desc()).limit(50))
     return list(result.all())
@@ -484,8 +485,8 @@ async def list_invites(
 )
 async def revoke_invite(
     invite_id: uuid.UUID,
-    admin: User = Depends(require_admin),
-    db: AsyncSession = Depends(get_db),
+    admin: Annotated[User, Depends(require_admin)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     from datetime import datetime as _dt
 

--- a/backend/app/routers/collections.py
+++ b/backend/app/routers/collections.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime, timezone
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
@@ -129,8 +130,8 @@ def _summary(c: Collection) -> CollectionSummary:
 @router.post("", status_code=201, response_model=CollectionSummary)
 async def create_collection(
     body: CreateCollectionRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> CollectionSummary:
     c = Collection(owner_id=current_user.id, name=body.name, description=body.description, tags=body.tags)
     db.add(c)
@@ -150,8 +151,8 @@ async def create_collection(
 
 @router.get("", response_model=list[CollectionSummary])
 async def list_collections(
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> list[CollectionSummary]:
     result = await db.scalars(
         select(Collection)
@@ -167,8 +168,8 @@ async def list_collections(
 )
 async def get_collection(
     collection_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> CollectionDetail:
     c = await db.scalar(
         select(Collection)
@@ -232,8 +233,8 @@ async def get_collection(
 async def update_collection(
     collection_id: uuid.UUID,
     body: UpdateCollectionRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> CollectionSummary:
     c = await db.scalar(
         select(Collection).where(
@@ -261,8 +262,8 @@ async def update_collection(
 @router.delete("/{collection_id}", status_code=204, responses={404: {"description": "Collection not found"}})
 async def delete_collection(
     collection_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     c = await _get_owned_collection(collection_id, current_user, db)
     c.soft_delete()
@@ -282,8 +283,8 @@ async def delete_collection(
 async def add_draft(
     collection_id: uuid.UUID,
     body: AddDraftRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     c = await _get_owned_collection(collection_id, current_user, db)
 
@@ -309,8 +310,8 @@ async def add_draft(
 async def remove_draft(
     collection_id: uuid.UUID,
     draft_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     await _get_owned_collection(collection_id, current_user, db)
 
@@ -339,8 +340,8 @@ async def remove_draft(
 async def add_project(
     collection_id: uuid.UUID,
     body: AddProjectRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     c = await _get_owned_collection(collection_id, current_user, db)
 
@@ -372,8 +373,8 @@ async def add_project(
 async def remove_project(
     collection_id: uuid.UUID,
     project_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     await _get_owned_collection(collection_id, current_user, db)
 

--- a/backend/app/routers/dev.py
+++ b/backend/app/routers/dev.py
@@ -1,3 +1,5 @@
+from typing import Annotated
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -8,6 +10,8 @@ router = APIRouter(prefix="/dev", tags=["dev"])
 
 
 @router.get("/status")
-async def dev_status(db: AsyncSession = Depends(get_db)) -> dict:
+async def dev_status(
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict:
     seed_run = await db.get(SeedRun, 1)
     return {"last_seed": seed_run.ran_at.isoformat() if seed_run else None}

--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -133,11 +133,11 @@ class UpdateDraftRequest(BaseModel):
 async def create_draft(
     name: Annotated[str, Form()],
     wif_file: Annotated[UploadFile, File()],
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _rl: Annotated[None, Depends(_upload_rate_limit)],
     description: Annotated[str | None, Form()] = None,
     tags: Annotated[str | None, Form()] = None,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
-    _rl: None = Depends(_upload_rate_limit),
 ) -> DraftSummary:
     if not wif_file.filename or not wif_file.filename.lower().endswith(".wif"):
         raise HTTPException(status_code=400, detail="File must have a .wif extension")
@@ -221,10 +221,10 @@ async def create_draft(
 
 @router.get("", response_model=list[DraftSummary])
 async def list_drafts(
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     include_archived: bool = Query(False),
     tags: list[str] | None = Query(None),
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
 ) -> list[DraftSummary]:
     q = select(Draft).where(Draft.owner_id == current_user.id, Draft.deleted_at.is_(None))
     if not include_archived:
@@ -245,8 +245,8 @@ async def list_drafts(
 @router.get("/{draft_id}", response_model=DraftDetail, responses={404: {"description": "Draft not found"}})
 async def get_draft(
     draft_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> DraftDetail:
     draft = await _get_owned_draft(draft_id, current_user, db, allow_superuser=True)
     return DraftDetail(**_draft_detail_data(draft))
@@ -260,8 +260,8 @@ async def get_draft(
 async def update_draft(
     draft_id: uuid.UUID,
     body: UpdateDraftRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> DraftDetail:
     if body.name is None and body.description is None and body.tags is None:
         raise HTTPException(status_code=400, detail="At least one field must be provided")
@@ -288,8 +288,8 @@ async def update_draft(
 @router.get("/{draft_id}/preview", responses={404: {"description": "Preview not available"}})
 async def get_preview(
     draft_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Response:
     draft = await _get_owned_draft(draft_id, current_user, db, allow_superuser=True)
     if not await storage.afile_exists(draft.preview_path):
@@ -301,8 +301,8 @@ async def get_preview(
 @router.get("/{draft_id}/drawdown_preview", responses={404: {"description": "Drawdown preview not available"}})
 async def get_drawdown_preview(
     draft_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Response:
     draft = await _get_owned_draft(draft_id, current_user, db, allow_superuser=True)
     if not draft.drawdown_preview_path or not await storage.afile_exists(draft.drawdown_preview_path):
@@ -317,8 +317,8 @@ async def get_drawdown_preview(
 )
 async def get_preview_svg(
     draft_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Response:
     draft = await _get_owned_draft(draft_id, current_user, db, allow_superuser=True)
     if not draft.wif_path:
@@ -343,11 +343,11 @@ async def get_preview_svg(
 )
 async def get_drawdown(
     draft_id: uuid.UUID,
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     start_row: int | None = Query(None, ge=0),
     row_count: int | None = Query(None, ge=1),
     hide_unused_shafts_treadles: bool = Query(False),
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
 ) -> Response:
     draft = await _get_owned_draft(draft_id, current_user, db, allow_superuser=True)
 
@@ -518,8 +518,8 @@ async def get_drawdown(
 @router.get("/{draft_id}/wif", responses={404: {"description": "WIF file not available for this draft"}})
 async def download_wif(
     draft_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Response:
     draft = await _get_owned_draft(draft_id, current_user, db, allow_superuser=True)
     if not draft.wif_path or not await storage.afile_exists(draft.wif_path):
@@ -541,8 +541,8 @@ async def download_wif(
 @router.get("/{draft_id}/wif-modified", responses={404: {"description": "No modified WIF file for this draft"}})
 async def download_wif_modified(
     draft_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Response:
     draft = await _get_owned_draft(draft_id, current_user, db, allow_superuser=True)
     if not draft.wif_modified_path or not await storage.afile_exists(draft.wif_modified_path):
@@ -572,9 +572,9 @@ async def download_wif_modified(
 )
 async def delete_draft(
     draft_id: uuid.UUID,
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     force: bool = Query(False),
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
 ) -> None:
     from app.models.project import Project
 
@@ -607,8 +607,8 @@ async def delete_draft(
 @router.post("/{draft_id}/archive", status_code=204, responses={404: {"description": "Draft not found"}})
 async def archive_draft(
     draft_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     draft = await _get_owned_draft(draft_id, current_user, db)
     draft.retire()
@@ -618,8 +618,8 @@ async def archive_draft(
 @router.post("/{draft_id}/unarchive", status_code=204, responses={404: {"description": "Draft not found"}})
 async def unarchive_draft(
     draft_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     draft = await _get_owned_draft(draft_id, current_user, db)
     draft.unretire()
@@ -641,8 +641,8 @@ async def unarchive_draft(
 )
 async def generate_liftplan(
     draft_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> DraftDetail:
     draft = await _get_owned_draft(draft_id, current_user, db)
 
@@ -701,8 +701,8 @@ class OverrideMetadataRequest(BaseModel):
 async def override_metadata(
     draft_id: uuid.UUID,
     body: OverrideMetadataRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> DraftDetail:
     if body.field not in _OVERRIDE_FIELDS:
         raise HTTPException(
@@ -774,8 +774,8 @@ class PatchMeasurementsRequest(BaseModel):
 async def patch_measurements(
     draft_id: uuid.UUID,
     body: PatchMeasurementsRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> DraftDetail:
     if body.unit not in ("cm", "in"):
         raise HTTPException(status_code=400, detail="unit must be 'cm' or 'in'")

--- a/backend/app/routers/feedback.py
+++ b/backend/app/routers/feedback.py
@@ -1,6 +1,7 @@
 """In-app feedback submission and admin review endpoints."""
 
 import uuid
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, field_validator
@@ -109,9 +110,9 @@ def _serialize(row: UserFeedback, include_user_email: bool = False) -> FeedbackR
 @router.post("", status_code=201)
 async def submit_feedback(
     body: SubmitFeedbackRequest,
-    db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-    _rl: None = Depends(_submit_limit),
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_user)],
+    _rl: Annotated[None, Depends(_submit_limit)],
 ) -> FeedbackResponse:
     from app.config import get_settings
 
@@ -156,8 +157,8 @@ def _enqueue_dispatch(feedback_id: str) -> None:
 
 @router.get("/mine")
 async def list_my_feedback(
-    db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_user)],
 ) -> list[FeedbackResponse]:
     q = (
         select(UserFeedback)
@@ -183,8 +184,8 @@ class FeedbackStatusResponse(BaseModel):
 @router.get("/{feedback_id}/status", responses={404: {"description": "Feedback not found"}})
 async def get_feedback_status(
     feedback_id: uuid.UUID,
-    db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_user)],
 ) -> FeedbackStatusResponse:
     row = await db.get(UserFeedback, feedback_id)
     if not row or row.user_id != current_user.id:
@@ -203,13 +204,13 @@ async def get_feedback_status(
 
 @admin_router.get("")
 async def list_feedback(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _admin: Annotated[User, Depends(require_admin)],
     page: int = Query(1, ge=1),
     page_size: int = Query(25, ge=1, le=100),
     submission_type: str | None = None,
     dispatch_status: str | None = None,
     include_deleted: bool = False,
-    db: AsyncSession = Depends(get_db),
-    _admin: User = Depends(require_admin),
 ) -> FeedbackPage:
     from sqlalchemy.orm import selectinload
 
@@ -241,8 +242,8 @@ async def list_feedback(
 @admin_router.get("/{feedback_id}", responses={404: {"description": "Feedback not found"}})
 async def get_feedback_detail(
     feedback_id: uuid.UUID,
-    db: AsyncSession = Depends(get_db),
-    _admin: User = Depends(require_admin),
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _admin: Annotated[User, Depends(require_admin)],
 ) -> FeedbackResponse:
     from sqlalchemy.orm import selectinload
 
@@ -259,8 +260,8 @@ async def get_feedback_detail(
 @admin_router.delete("/{feedback_id}", responses={404: {"description": "Feedback not found"}})
 async def soft_delete_feedback(
     feedback_id: uuid.UUID,
-    db: AsyncSession = Depends(get_db),
-    _admin: User = Depends(require_admin),
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _admin: Annotated[User, Depends(require_admin)],
 ) -> FeedbackResponse:
     row = await db.get(UserFeedback, feedback_id)
     if not row:
@@ -277,8 +278,8 @@ async def soft_delete_feedback(
 )
 async def retry_feedback_dispatch(
     feedback_id: uuid.UUID,
-    db: AsyncSession = Depends(get_db),
-    _admin: User = Depends(require_admin),
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _admin: Annotated[User, Depends(require_admin)],
 ) -> FeedbackResponse:
     row = await db.get(UserFeedback, feedback_id)
     if not row:
@@ -299,8 +300,8 @@ async def retry_feedback_dispatch(
 )
 async def recover_feedback(
     feedback_id: uuid.UUID,
-    db: AsyncSession = Depends(get_db),
-    _admin: User = Depends(require_admin),
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _admin: Annotated[User, Depends(require_admin)],
 ) -> FeedbackResponse:
     row = await db.get(UserFeedback, feedback_id)
     if not row:

--- a/backend/app/routers/impersonation.py
+++ b/backend/app/routers/impersonation.py
@@ -1,6 +1,7 @@
 """Impersonation session endpoints — audit trail only; state is managed client-side."""
 
 import uuid
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
@@ -49,8 +50,8 @@ class ImpersonationStartResponse(BaseModel):
 )
 async def impersonation_start(
     body: ImpersonationStartRequest,
-    superuser: User = Depends(require_superuser),
-    db: AsyncSession = Depends(get_db),
+    superuser: Annotated[User, Depends(require_superuser)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ImpersonationStartResponse:
     """Validate the impersonation target and write the audit log entry."""
     target = await _get_target_user(db, body.target_user_id)
@@ -77,8 +78,8 @@ async def impersonation_start(
 @router.post("/end", responses={404: {"description": "User not found"}})
 async def impersonation_end(
     body: ImpersonationEndRequest,
-    superuser: User = Depends(require_superuser),
-    db: AsyncSession = Depends(get_db),
+    superuser: Annotated[User, Depends(require_superuser)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> dict:
     """Write the impersonation-ended audit log entry."""
     target = await _get_target_user(db, body.target_user_id)

--- a/backend/app/routers/logs.py
+++ b/backend/app/routers/logs.py
@@ -32,7 +32,7 @@ class ClientLogEvent(BaseModel):
 async def ingest_client_logs(
     events: Annotated[list[ClientLogEvent], Field(max_length=_MAX_EVENTS_PER_REQUEST)],
     request: Request,
-    current_user: User | None = Depends(get_optional_user),
+    current_user: Annotated[User | None, Depends(get_optional_user)],
 ) -> None:
     if current_user is None:
         return

--- a/backend/app/routers/loom_catalog.py
+++ b/backend/app/routers/loom_catalog.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import uuid
 from decimal import Decimal
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
@@ -209,12 +210,12 @@ public_router = APIRouter(prefix="/api/loom-catalog", tags=["loom-catalog"])
 
 @public_router.get("", response_model=list[LoomReferenceSummary])
 async def list_loom_catalog(
+    db: Annotated[AsyncSession, Depends(get_db)],
     q: str | None = Query(None, description="Search brand, model, or series"),
     category: str | None = Query(None),
     min_shafts: int | None = Query(None),
     foldable: bool | None = Query(None),
     origin_country: str | None = Query(None),
-    db: AsyncSession = Depends(get_db),
 ) -> list[LoomReferenceSummary]:
     stmt = select(LoomReference).order_by(LoomReference.brand, LoomReference.model_name)
 
@@ -245,9 +246,9 @@ async def list_loom_catalog(
 
 @public_router.get("/search", response_model=list[LoomReferenceSummary])
 async def search_loom_catalog(
+    db: Annotated[AsyncSession, Depends(get_db)],
     q: str = Query(..., min_length=1),
     limit: int = Query(20, le=50),
-    db: AsyncSession = Depends(get_db),
 ) -> list[LoomReferenceSummary]:
     """Typeahead search — returns summaries matching brand or model name."""
     ql = q.lower()
@@ -272,7 +273,7 @@ async def search_loom_catalog(
 )
 async def get_loom_reference(
     ref_id: uuid.UUID,
-    db: AsyncSession = Depends(get_db),
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> LoomReferenceSchema:
     ref = await db.get(LoomReference, ref_id)
     if ref is None:
@@ -289,9 +290,9 @@ admin_catalog_router = APIRouter(prefix="/api/admin/loom-catalog", tags=["admin"
 
 @admin_catalog_router.get("", response_model=list[LoomReferenceSchema])
 async def admin_list_loom_catalog(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _admin: Annotated[User, Depends(require_admin)],
     q: str | None = Query(None),
-    db: AsyncSession = Depends(get_db),
-    _admin: User = Depends(require_admin),
 ) -> list[LoomReferenceSchema]:
     stmt = select(LoomReference).order_by(LoomReference.brand, LoomReference.model_name)
     if q:
@@ -314,8 +315,8 @@ async def admin_list_loom_catalog(
 )
 async def admin_create_loom_reference(
     body: CreateLoomReferenceRequest,
-    db: AsyncSession = Depends(get_db),
-    _admin: User = Depends(require_admin),
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _admin: Annotated[User, Depends(require_admin)],
 ) -> LoomReferenceSchema:
     existing = await db.scalar(
         select(LoomReference).where(
@@ -338,8 +339,8 @@ async def admin_create_loom_reference(
 async def admin_update_loom_reference(
     ref_id: uuid.UUID,
     body: UpdateLoomReferenceRequest,
-    db: AsyncSession = Depends(get_db),
-    _admin: User = Depends(require_admin),
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _admin: Annotated[User, Depends(require_admin)],
 ) -> LoomReferenceSchema:
     ref = await db.get(LoomReference, ref_id)
     if ref is None:
@@ -354,8 +355,8 @@ async def admin_update_loom_reference(
 @admin_catalog_router.delete("/{ref_id}", status_code=204, responses={404: {"description": "Loom reference not found"}})
 async def admin_delete_loom_reference(
     ref_id: uuid.UUID,
-    db: AsyncSession = Depends(get_db),
-    _admin: User = Depends(require_admin),
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _admin: Annotated[User, Depends(require_admin)],
 ) -> None:
     ref = await db.get(LoomReference, ref_id)
     if ref is None:

--- a/backend/app/routers/looms.py
+++ b/backend/app/routers/looms.py
@@ -3,7 +3,7 @@ import urllib.parse
 import uuid
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Literal
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from fastapi.responses import Response
@@ -433,8 +433,8 @@ def _ext(content_type: str) -> str:
 @router.post("", response_model=LoomDetail, status_code=201, responses={404: {"description": "Loom not found"}})
 async def create_loom(
     body: CreateLoomRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> LoomDetail:
     lift, treadle = loom_tracking_flags(body.loom_type)
     loom = Loom(
@@ -476,9 +476,9 @@ async def create_loom(
 
 @router.get("", response_model=list[LoomSummary])
 async def list_looms(
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     include_retired: bool = Query(False),
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
 ) -> list[LoomSummary]:
     q = (
         select(Loom)
@@ -501,8 +501,8 @@ async def list_looms(
 @router.get("/{loom_id}", response_model=LoomDetail, responses={404: {"description": "Loom not found"}})
 async def get_loom(
     loom_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> LoomDetail:
     loom = await _get_owned_loom(loom_id, current_user, db, allow_superuser=True)
     return LoomDetail.from_loom(loom)
@@ -512,8 +512,8 @@ async def get_loom(
 async def update_loom(
     loom_id: uuid.UUID,
     body: UpdateLoomRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> LoomDetail:
     loom = await _get_owned_loom(loom_id, current_user, db)
     for field, value in body.model_dump(exclude_none=True).items():
@@ -537,9 +537,9 @@ async def update_loom(
 )
 async def delete_loom(
     loom_id: uuid.UUID,
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     force: bool = Query(False),
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
 ) -> None:
     from app.models.project import Project
 
@@ -573,8 +573,8 @@ async def delete_loom(
 @router.post("/{loom_id}/retire", status_code=204, responses={404: {"description": "Loom not found"}})
 async def retire_loom(
     loom_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     loom = await _get_owned_loom(loom_id, current_user, db)
     loom.retire()
@@ -584,8 +584,8 @@ async def retire_loom(
 @router.post("/{loom_id}/unretire", status_code=204, responses={404: {"description": "Loom not found"}})
 async def unretire_loom(
     loom_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     loom = await _get_owned_loom(loom_id, current_user, db)
     loom.unretire()
@@ -604,9 +604,9 @@ async def unretire_loom(
 )
 async def upload_loom_photo(
     loom_id: uuid.UUID,
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     file: UploadFile = File(...),
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
 ) -> None:
     _validate_image(file)
     loom = await _get_owned_loom(loom_id, current_user, db)
@@ -627,8 +627,8 @@ async def upload_loom_photo(
 @router.delete("/{loom_id}/photo", status_code=204, responses={404: {"description": "Loom not found"}})
 async def delete_loom_photo(
     loom_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     loom = await _get_owned_loom(loom_id, current_user, db)
     if loom.photo_path:
@@ -640,8 +640,8 @@ async def delete_loom_photo(
 @router.get("/{loom_id}/photo", responses={404: {"description": "No photo"}})
 async def get_loom_photo(
     loom_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Response:
     loom = await _get_owned_loom(loom_id, current_user, db, allow_superuser=True)
     if not loom.photo_path or not storage.file_exists(loom.photo_path):
@@ -665,8 +665,8 @@ async def get_loom_photo(
 async def add_version(
     loom_id: uuid.UUID,
     body: AddVersionRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> LoomVersionSchema:
     loom = await _get_owned_loom(loom_id, current_user, db)
     next_number = max((v.version_number for v in loom.versions), default=0) + 1
@@ -704,9 +704,9 @@ async def add_version(
 async def upload_version_photo(
     loom_id: uuid.UUID,
     version_id: uuid.UUID,
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     file: UploadFile = File(...),
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
 ) -> LoomVersionPhotoSchema:
     _validate_image(file)
     loom, version = await _get_owned_version(loom_id, version_id, current_user, db)
@@ -743,8 +743,8 @@ async def get_version_photo(
     loom_id: uuid.UUID,
     version_id: uuid.UUID,
     photo_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Response:
     loom, version = await _get_owned_version(loom_id, version_id, current_user, db, allow_superuser=True)
     photo = next((p for p in version.photos if p.id == photo_id), None)
@@ -764,8 +764,8 @@ async def delete_version_photo(
     loom_id: uuid.UUID,
     version_id: uuid.UUID,
     photo_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     loom, version = await _get_owned_version(loom_id, version_id, current_user, db)
     photo = next((p for p in version.photos if p.id == photo_id), None)
@@ -790,10 +790,10 @@ async def delete_version_photo(
 async def upload_version_receipt(
     loom_id: uuid.UUID,
     version_id: uuid.UUID,
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     file: UploadFile = File(...),
     description: str | None = None,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
 ) -> LoomVersionReceiptSchema:
     _validate_receipt(file)
     loom, version = await _get_owned_version(loom_id, version_id, current_user, db)
@@ -823,8 +823,8 @@ async def get_version_receipt(
     loom_id: uuid.UUID,
     version_id: uuid.UUID,
     receipt_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Response:
     loom, version = await _get_owned_version(loom_id, version_id, current_user, db, allow_superuser=True)
     receipt = next((r for r in version.receipts if r.id == receipt_id), None)
@@ -850,8 +850,8 @@ async def delete_version_receipt(
     loom_id: uuid.UUID,
     version_id: uuid.UUID,
     receipt_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     loom, version = await _get_owned_version(loom_id, version_id, current_user, db)
     receipt = next((r for r in version.receipts if r.id == receipt_id), None)
@@ -876,8 +876,8 @@ async def update_version(
     loom_id: uuid.UUID,
     version_id: uuid.UUID,
     body: UpdateVersionRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> LoomVersionSchema:
     loom, version = await _get_owned_version(loom_id, version_id, current_user, db)
     for field, value in body.model_dump(exclude_none=True).items():
@@ -902,8 +902,8 @@ async def clone_version(
     loom_id: uuid.UUID,
     version_id: uuid.UUID,
     body: CloneVersionRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> LoomVersionSchema:
     loom, source = await _get_owned_version(loom_id, version_id, current_user, db)
     next_number = max((v.version_number for v in loom.versions), default=0) + 1
@@ -953,8 +953,8 @@ async def add_accessory(
     loom_id: uuid.UUID,
     version_id: uuid.UUID,
     body: AddAccessoryRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> LoomVersionAccessorySchema:
     loom, version = await _get_owned_version(loom_id, version_id, current_user, db)
     acc = LoomVersionAccessory(loom_version_id=version_id, name=body.name.strip())
@@ -973,8 +973,8 @@ async def delete_accessory(
     loom_id: uuid.UUID,
     version_id: uuid.UUID,
     accessory_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     loom, version = await _get_owned_version(loom_id, version_id, current_user, db)
     acc = next((a for a in version.accessories if a.id == accessory_id), None)
@@ -998,8 +998,8 @@ async def delete_accessory(
 async def add_reed(
     loom_id: uuid.UUID,
     body: AddReedRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> LoomReedSchema:
     if body.dents_per_inch <= 0:
         raise HTTPException(status_code=400, detail="dents_per_inch must be positive")
@@ -1021,8 +1021,8 @@ async def add_reed(
 async def delete_reed(
     loom_id: uuid.UUID,
     reed_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     loom = await _get_owned_loom(loom_id, current_user, db)
     reed = next((r for r in loom.reeds if r.id == reed_id), None)
@@ -1050,8 +1050,8 @@ async def link_version_reference(
     loom_id: uuid.UUID,
     version_id: uuid.UUID,
     body: LinkReferenceRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> LoomDetail:
     """Link (or unlink) a specific loom version to a catalog entry."""
     loom, version = await _get_owned_version(loom_id, version_id, current_user, db)

--- a/backend/app/routers/ravelry.py
+++ b/backend/app/routers/ravelry.py
@@ -3,6 +3,7 @@
 import logging
 import uuid
 from datetime import datetime
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import RedirectResponse
@@ -82,8 +83,8 @@ class BulkStashPushResult(BaseModel):
 
 @router.get("/authorize", responses={503: {"description": "Ravelry integration is not configured on this server"}})
 async def authorize(
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> dict:
     """Return a Ravelry OAuth authorization URL for the current user."""
     settings = get_settings()
@@ -95,11 +96,11 @@ async def authorize(
 
 @router.get("/callback")
 async def oauth_callback(
+    db: Annotated[AsyncSession, Depends(get_db)],
     state: str = Query(...),
     code: str | None = Query(None),
     error: str | None = Query(None),
     error_description: str | None = Query(None),
-    db: AsyncSession = Depends(get_db),
 ) -> RedirectResponse:
     """Ravelry redirects here after the user approves or denies access.
 
@@ -138,8 +139,8 @@ async def oauth_callback(
 
 @router.get("/status", response_model=RavelryStatus)
 async def status(
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> RavelryStatus:
     cred = await svc.get_credential(current_user.id, db)
     if cred is None:
@@ -153,8 +154,8 @@ async def status(
 
 @router.delete("/connection", status_code=204, responses={404: {"description": "Not connected to Ravelry"}})
 async def disconnect(
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     """Remove stored Ravelry credentials for the current user."""
     cred = await svc.get_credential(current_user.id, db)
@@ -167,7 +168,7 @@ async def disconnect(
 @router.get("/yarn-detail/{ravelry_yarn_id}", responses={502: {"description": "Ravelry yarn detail fetch failed"}})
 async def yarn_detail(
     ravelry_yarn_id: int,
-    _current_user: User = Depends(get_current_user),
+    _current_user: Annotated[User, Depends(get_current_user)],
 ) -> dict:
     """Proxy a single yarn's full detail from the Ravelry API (no OAuth required)."""
     try:
@@ -184,8 +185,8 @@ async def yarn_detail(
     responses={502: {"description": "Ravelry request failed"}},
 )
 async def popular_companies(
+    _current_user: Annotated[User, Depends(get_current_user)],
     limit: int = Query(10, ge=1, le=20),
-    _current_user: User = Depends(get_current_user),
 ) -> list[RavelryCompany]:
     """Return popular yarn companies (uses dev read-only key, sort=best)."""
     try:
@@ -200,10 +201,10 @@ async def popular_companies(
     "/popular/yarns", response_model=list[RavelryYarnResult], responses={502: {"description": "Ravelry request failed"}}
 )
 async def popular_yarns(
+    _current_user: Annotated[User, Depends(get_current_user)],
     company_id: int = Query(...),
     company_name: str = Query(...),
     limit: int = Query(8, ge=1, le=20),
-    _current_user: User = Depends(get_current_user),
 ) -> list[RavelryYarnResult]:
     """Return popular yarns for a company (uses dev read-only key, seeded by company name)."""
     try:
@@ -218,8 +219,8 @@ async def popular_yarns(
     "/search/companies", response_model=list[RavelryCompany], responses={502: {"description": "Ravelry search failed"}}
 )
 async def search_companies(
+    _current_user: Annotated[User, Depends(get_current_user)],
     q: str = Query(..., min_length=1),
-    _current_user: User = Depends(get_current_user),
 ) -> list[RavelryCompany]:
     """Search Ravelry yarn companies by name (uses dev read-only key)."""
     try:
@@ -234,9 +235,9 @@ async def search_companies(
     "/search/yarns", response_model=list[RavelryYarnResult], responses={502: {"description": "Ravelry search failed"}}
 )
 async def search_yarns(
+    _current_user: Annotated[User, Depends(get_current_user)],
     q: str = Query(..., min_length=1),
     company_id: int | None = Query(None),
-    _current_user: User = Depends(get_current_user),
 ) -> list[RavelryYarnResult]:
     """Search Ravelry yarns, optionally filtered by company (uses dev read-only key)."""
     try:
@@ -253,8 +254,8 @@ async def search_yarns(
 )
 async def import_yarn(
     payload: ImportYarnPayload,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> dict:
     """Import a Ravelry yarn into the user's WeftMark inventory (uses dev read-only key)."""
     try:
@@ -281,8 +282,8 @@ async def import_yarn(
     },
 )
 async def push_bulk_to_stash(
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> BulkStashPushResult:
     """Push all eligible Tier 1 yarns to the user's Ravelry stash."""
     cred = await svc.get_credential(current_user.id, db)
@@ -306,8 +307,8 @@ async def push_bulk_to_stash(
 )
 async def push_yarn_to_stash(
     yarn_id: uuid.UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> StashPushResult:
     """Push a single yarn to the user's Ravelry stash."""
     try:
@@ -328,8 +329,8 @@ async def push_yarn_to_stash(
     responses={404: {"description": "Not connected to Ravelry"}, 502: {"description": "Ravelry stash sync failed"}},
 )
 async def sync_stash(
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> SyncResult:
     """Trigger an on-demand stash sync for the current user."""
     cred = await svc.get_credential(current_user.id, db)

--- a/backend/app/routers/system.py
+++ b/backend/app/routers/system.py
@@ -1,3 +1,5 @@
+from typing import Annotated
+
 from fastapi import APIRouter, Depends
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -9,6 +11,8 @@ router = APIRouter(prefix="/api/system", tags=["system"])
 
 
 @router.get("/status")
-async def system_status(db: AsyncSession = Depends(get_db)) -> dict:
+async def system_status(
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict:
     count = await db.scalar(select(func.count()).select_from(User).where(User.is_superuser.is_(True)))
     return {"initialized": (count or 0) > 0}

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -153,7 +153,9 @@ class EulaCurrentResponse(BaseModel):
 @eula_router.get(
     "/current", response_model=EulaCurrentResponse, responses={404: {"description": "No EULA version found"}}
 )
-async def get_current_eula(db: AsyncSession = Depends(get_db)) -> EulaCurrentResponse:
+async def get_current_eula(
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> EulaCurrentResponse:
     row = await db.scalar(select(EulaVersion).order_by(EulaVersion.id.desc()).limit(1))
     if not row:
         raise HTTPException(status_code=404, detail="No EULA version found")
@@ -183,8 +185,8 @@ class ActivityHeatmapResponse(BaseModel):
 
 @router.get("/me", response_model=UserSettingsResponse)
 async def get_settings(
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> UserSettingsResponse:
     version = await get_current_eula_version(db)
     return _to_response(current_user, version)
@@ -287,8 +289,8 @@ async def update_settings(
 )
 async def accept_eula(
     body: EulaAcceptRequest,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> UserSettingsResponse:
     current_version = await get_current_eula_version(db)
     if body.version != current_version:
@@ -309,8 +311,8 @@ async def accept_eula(
 async def delete_account(
     body: DeleteAccountRequest,
     response: Response,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     if body.confirm != "DELETE MY ACCOUNT":
         raise HTTPException(
@@ -345,8 +347,8 @@ _EXPORT_COOLDOWN_HOURS = 24
 
 @router.post("/me/data-export", status_code=202)
 async def request_data_export(
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ExportStatusResponse:
     """Queue a data export task. De-duplicated: one request per 24 h."""
     from datetime import timedelta
@@ -393,8 +395,8 @@ async def request_data_export(
 
 @router.get("/me/data-export/status", response_model=ExportStatusResponse)
 async def get_export_status(
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ExportStatusResponse:
     """Return the most recent export request for the current user."""
     req = await db.scalar(
@@ -420,8 +422,8 @@ async def get_export_status(
 )
 async def download_data_export(
     request_id: uuid.UUID,
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> StreamingResponse:
     """Stream the export archive. Auth-gated; returns 404 after expiry."""
     req = await db.get(UserExportRequest, request_id)
@@ -452,8 +454,8 @@ class OnboardingStatusResponse(BaseModel):
 
 @router.get("/me/onboarding-status", response_model=OnboardingStatusResponse)
 async def get_onboarding_status(
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> OnboardingStatusResponse:
     current_version = await get_current_eula_version(db)
     has_loom = await db.scalar(select(func.count()).select_from(Loom).where(Loom.owner_id == current_user.id)) or 0
@@ -471,9 +473,9 @@ async def get_onboarding_status(
 
 @router.get("/me/activity-heatmap", response_model=ActivityHeatmapResponse)
 async def get_activity_heatmap(
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     year: int | None = Query(default=None),
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
 ) -> ActivityHeatmapResponse:
     from collections import defaultdict
 

--- a/backend/app/routers/webhooks.py
+++ b/backend/app/routers/webhooks.py
@@ -4,6 +4,8 @@ POST /webhooks/clerk  — Clerk user lifecycle events (user.created, user.update
                         user.deleted, session.created, session.ended, webhook.test)
 """
 
+from typing import Annotated
+
 from fastapi import APIRouter, Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -21,6 +23,9 @@ router = APIRouter(prefix="/webhooks", tags=["webhooks"])
         500: {"description": "Webhook not configured"},
     },
 )
-async def clerk_webhook(request: Request, db: AsyncSession = Depends(get_db)) -> dict:
+async def clerk_webhook(
+    request: Request,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict:
     """Receive and process Clerk user lifecycle events."""
     return await _handle_clerk_webhook(request, db)

--- a/backend/app/routers/yarn.py
+++ b/backend/app/routers/yarn.py
@@ -3,7 +3,7 @@ import mimetypes
 import uuid
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Literal
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from fastapi.responses import Response
@@ -347,7 +347,7 @@ async def refresh_yarn_properties_loop() -> None:
 
 @router.get("/properties", response_model=list[YarnAttributeGroupSchema])
 async def get_yarn_properties(
-    current_user: User = Depends(get_effective_user),
+    current_user: Annotated[User, Depends(get_effective_user)],
 ) -> list[YarnAttributeGroupSchema]:
     """Yarn attribute groups — served from cache, lazy-fetched on first request."""
     if _properties_cache is None:
@@ -363,8 +363,8 @@ async def get_yarn_properties(
 @router.post("", response_model=YarnDetail, status_code=201, responses={404: {"description": "Yarn not found"}})
 async def create_yarn(
     body: CreateYarnRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> YarnDetail:
     data = body.model_dump()
     if data.get("yarn_attribute_ids") is None:
@@ -378,9 +378,9 @@ async def create_yarn(
 
 @router.get("", response_model=list[YarnSummary])
 async def list_yarn(
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     include_archived: bool = Query(False),
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
 ) -> list[YarnSummary]:
     filters = [Yarn.owner_id == current_user.id, Yarn.deleted_at.is_(None)]
     if not include_archived:
@@ -394,8 +394,8 @@ async def list_yarn(
 @router.get("/{yarn_id}", response_model=YarnDetail, responses={404: {"description": "Yarn not found"}})
 async def get_yarn(
     yarn_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> YarnDetail:
     yarn = await _get_owned_yarn(yarn_id, current_user, db)
     return YarnDetail.from_yarn(yarn)
@@ -405,8 +405,8 @@ async def get_yarn(
 async def update_yarn(
     yarn_id: uuid.UUID,
     body: UpdateYarnRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> YarnDetail:
     yarn = await _get_owned_yarn(yarn_id, current_user, db)
     for field, value in body.model_dump(exclude_none=True).items():
@@ -427,8 +427,8 @@ class PatchColorwayRequest(BaseModel):
 async def patch_yarn_colorway(
     yarn_id: uuid.UUID,
     body: PatchColorwayRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> YarnDetail:
     yarn = await _get_owned_yarn(yarn_id, current_user, db)
     if body.color_name is not None:
@@ -449,8 +449,8 @@ async def patch_yarn_colorway(
 @router.delete("/{yarn_id}", status_code=204, responses={404: {"description": "Yarn not found"}})
 async def delete_yarn(
     yarn_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     yarn = await _get_owned_yarn(yarn_id, current_user, db)
     yarn.soft_delete()
@@ -469,9 +469,9 @@ async def delete_yarn(
 )
 async def upload_yarn_photo(
     yarn_id: uuid.UUID,
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     file: UploadFile = File(...),
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
 ) -> None:
     _validate_image(file)
     yarn = await _get_owned_yarn(yarn_id, current_user, db)
@@ -491,8 +491,8 @@ async def upload_yarn_photo(
 @router.get("/{yarn_id}/photo", responses={404: {"description": "No photo"}})
 async def get_yarn_photo(
     yarn_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Response:
     yarn = await _get_owned_yarn(yarn_id, current_user, db)
     if not yarn.photo_path or not storage.file_exists(yarn.photo_path):
@@ -505,8 +505,8 @@ async def get_yarn_photo(
 @router.delete("/{yarn_id}/photo", status_code=204, responses={404: {"description": "Yarn not found"}})
 async def delete_yarn_photo(
     yarn_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     yarn = await _get_owned_yarn(yarn_id, current_user, db)
     if yarn.photo_path:
@@ -529,8 +529,8 @@ async def delete_yarn_photo(
 async def add_skeins(
     yarn_id: uuid.UUID,
     body: AddSkeinsRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> list[SkeinSchema]:
     yarn = await _get_owned_yarn(yarn_id, current_user, db)
     if body.quantity < 1 or body.quantity > 100:
@@ -561,8 +561,8 @@ async def update_skein(
     yarn_id: uuid.UUID,
     skein_id: uuid.UUID,
     body: UpdateSkeinRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> SkeinSchema:
     yarn, skein = await _get_owned_skein(yarn_id, skein_id, current_user, db)
     for field, value in body.model_dump(exclude_none=True).items():
@@ -576,8 +576,8 @@ async def update_skein(
 async def delete_skein(
     yarn_id: uuid.UUID,
     skein_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     yarn, skein = await _get_owned_skein(yarn_id, skein_id, current_user, db)
     await db.delete(skein)
@@ -595,8 +595,8 @@ async def delete_skein(
 async def clone_yarn(
     yarn_id: uuid.UUID,
     body: CloneYarnRequest,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> YarnDetail:
     source = await _get_owned_yarn(yarn_id, current_user, db)
     clone = Yarn(
@@ -644,8 +644,8 @@ class YarnProjectRef(BaseModel):
 )
 async def get_yarn_projects(
     yarn_id: uuid.UUID,
-    current_user: User = Depends(get_effective_user),
-    db: AsyncSession = Depends(get_db),
+    current_user: Annotated[User, Depends(get_effective_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> list[YarnProjectRef]:
     yarn = await _get_owned_yarn(yarn_id, current_user, db)
     stmt = (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,7 +46,7 @@ import { useAuth } from "@/hooks/useAuth";
 
 const SentryRoutes = Sentry.withSentryReactRouterV6Routing(Routes);
 
-function AuthRoute({ children, requireAdmin = false, requireSuperuser = false }: { children: ReactNode; requireAdmin?: boolean; requireSuperuser?: boolean }) {
+function AuthRoute({ children, requireAdmin = false, requireSuperuser = false }: { readonly children: ReactNode; readonly requireAdmin?: boolean; readonly requireSuperuser?: boolean }) {
   return (
     <ProtectedRoute requireAdmin={requireAdmin} requireSuperuser={requireSuperuser}>
       <AppLayout>{children}</AppLayout>

--- a/frontend/src/api/yarn.ts
+++ b/frontend/src/api/yarn.ts
@@ -4,14 +4,14 @@ export function weightBothUnits(
   value: string,
   unit: "oz" | "g",
 ): { oz: number | undefined; g: number | undefined } {
-  const v = parseFloat(value);
-  if (!value || isNaN(v)) return { oz: undefined, g: undefined };
-  if (unit === "oz") return { oz: v, g: parseFloat((v * OZ_TO_G).toFixed(1)) };
-  return { oz: parseFloat((v / OZ_TO_G).toFixed(2)), g: v };
+  const v = Number.parseFloat(value);
+  if (!value || Number.isNaN(v)) return { oz: undefined, g: undefined };
+  if (unit === "oz") return { oz: v, g: Number.parseFloat((v * OZ_TO_G).toFixed(1)) };
+  return { oz: Number.parseFloat((v / OZ_TO_G).toFixed(2)), g: v };
 }
 
 export function displayWeight(oz: string | null, g: string | null): string | null {
-  if (oz) return `${oz} oz (${Math.round(parseFloat(oz) * OZ_TO_G)} g)`;
+  if (oz) return `${oz} oz (${Math.round(Number.parseFloat(oz) * OZ_TO_G)} g)`;
   if (g) return `${g} g`;
   return null;
 }

--- a/frontend/src/components/EulaContent.tsx
+++ b/frontend/src/components/EulaContent.tsx
@@ -1,5 +1,5 @@
 interface Props {
-  bodyHtml: string;
+  readonly bodyHtml: string;
 }
 
 export function EulaContent({ bodyHtml }: Props) {

--- a/frontend/src/components/EulaGate.tsx
+++ b/frontend/src/components/EulaGate.tsx
@@ -7,7 +7,7 @@ import { EulaContent } from "@/components/EulaContent";
 import type { ReactNode } from "react";
 
 interface Props {
-  children: ReactNode;
+  readonly children: ReactNode;
 }
 
 export function EulaGate({ children }: Props) {

--- a/frontend/src/components/FeedbackModal.tsx
+++ b/frontend/src/components/FeedbackModal.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/api/feedback";
 
 interface Props {
-  onClose: () => void;
+  readonly onClose: () => void;
 }
 
 const TYPE_PLACEHOLDERS: Record<SubmissionType, string> = {
@@ -258,7 +258,7 @@ export function FeedbackModal({ onClose }: Props) {
   );
 }
 
-function SuccessView({ record, onClose }: { record: FeedbackRecord; onClose: () => void }) {
+function SuccessView({ record, onClose }: { readonly record: FeedbackRecord; readonly onClose: () => void }) {
   const { user } = useAuth();
 
   const [pollDispatchStatus, setPollDispatchStatus] = useState<string>(record.dispatch_status);

--- a/frontend/src/components/LanguageSelector.tsx
+++ b/frontend/src/components/LanguageSelector.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { SUPPORTED_LANGUAGES } from "@/i18n/config";
 
 interface Props {
-  variant?: "public" | "app";
+  readonly variant?: "public" | "app";
 }
 
 export function LanguageSelector({ variant = "app" }: Props) {

--- a/frontend/src/components/SystemGate.tsx
+++ b/frontend/src/components/SystemGate.tsx
@@ -3,7 +3,7 @@ import { UninitializedPage } from "@/pages/UninitializedPage";
 
 type Status = "loading" | "initialized" | "uninitialized" | "unreachable";
 
-export function SystemGate({ children }: { children: React.ReactNode }) {
+export function SystemGate({ children }: { readonly children: React.ReactNode }) {
   const [status, setStatus] = useState<Status>("loading");
 
   useEffect(() => {

--- a/frontend/src/components/TieUpDiagram.tsx
+++ b/frontend/src/components/TieUpDiagram.tsx
@@ -1,8 +1,8 @@
 interface TieUpDiagramProps {
-  tieup: number[][];
-  numShafts: number;
-  numTreadles: number;
-  cellSize?: number;
+  readonly tieup: number[][];
+  readonly numShafts: number;
+  readonly numTreadles: number;
+  readonly cellSize?: number;
 }
 
 export function TieUpDiagram({ tieup, numShafts, numTreadles, cellSize = 18 }: TieUpDiagramProps) {

--- a/frontend/src/components/TrackerStylePreview.tsx
+++ b/frontend/src/components/TrackerStylePreview.tsx
@@ -8,7 +8,7 @@ const DEMO_WEFT = "#b45309";
 const DEMO_PICK = 7;
 const DEMO_TOTAL = 18;
 
-function DemoBox({ n, active, style }: { n: number; active: boolean; style: TrackerStyle }) {
+function DemoBox({ n, active, style }: { readonly n: number; readonly active: boolean; readonly style: TrackerStyle }) {
   const base = "rounded flex items-center justify-center font-bold text-[11px] border-2";
   if (style === "high_contrast") {
     return (
@@ -24,7 +24,7 @@ function DemoBox({ n, active, style }: { n: number; active: boolean; style: Trac
   );
 }
 
-function DemoPickCard({ compact, style }: { compact?: boolean; style: TrackerStyle }) {
+function DemoPickCard({ compact, style }: { readonly compact?: boolean; readonly style: TrackerStyle }) {
   const height = compact ? "h-10" : "h-16";
   const border = style === "high_contrast"
     ? compact ? "border border-foreground/30" : "border-2 border-foreground/50"
@@ -43,7 +43,7 @@ function DemoPickCard({ compact, style }: { compact?: boolean; style: TrackerSty
   );
 }
 
-export function TrackerStylePreview({ style }: { style: TrackerStyle }) {
+export function TrackerStylePreview({ style }: { readonly style: TrackerStyle }) {
   const isCompact = style === "compact";
   const isHighContrast = style === "high_contrast";
 
@@ -104,11 +104,11 @@ function LiveBox({
   colorMode,
   style,
 }: {
-  n: number;
-  active: boolean;
-  unused: boolean;
-  colorMode: ColorMode;
-  style: TrackerStyle;
+  readonly n: number;
+  readonly active: boolean;
+  readonly unused: boolean;
+  readonly colorMode: ColorMode;
+  readonly style: TrackerStyle;
 }) {
   const base = "rounded-md border-2 flex flex-col items-center justify-center font-bold overflow-hidden";
   const fontSize = "text-sm";
@@ -161,11 +161,11 @@ function LivePickCard({
   showWeftColor,
   shaftCount,
 }: {
-  compact?: boolean;
-  style: TrackerStyle;
-  colorMode: ColorMode;
-  showWeftColor: boolean;
-  shaftCount: number;
+  readonly compact?: boolean;
+  readonly style: TrackerStyle;
+  readonly colorMode: ColorMode;
+  readonly showWeftColor: boolean;
+  readonly shaftCount: number;
 }) {
   const height = compact ? "h-14" : "h-24";
   const border = style === "high_contrast"
@@ -208,13 +208,13 @@ export function TrackerLivePreview({
   showPickCards,
   hideUnusedShafts,
 }: {
-  style: TrackerStyle;
-  colorMode: string;
-  showProgress: boolean;
-  showDrawdown: boolean;
-  showWeftColor: boolean;
-  showPickCards: boolean;
-  hideUnusedShafts: boolean;
+  readonly style: TrackerStyle;
+  readonly colorMode: string;
+  readonly showProgress: boolean;
+  readonly showDrawdown: boolean;
+  readonly showWeftColor: boolean;
+  readonly showPickCards: boolean;
+  readonly hideUnusedShafts: boolean;
 }) {
   const isHighContrast = style === "high_contrast";
   const cm = (colorMode as ColorMode) ?? "strip";

--- a/frontend/src/components/VersionGate.tsx
+++ b/frontend/src/components/VersionGate.tsx
@@ -3,7 +3,7 @@ import { VersionErrorPage } from "@/pages/VersionErrorPage";
 
 type Status = "loading" | "ok" | "mismatch" | "unreachable";
 
-export function VersionGate({ children }: { children: React.ReactNode }) {
+export function VersionGate({ children }: { readonly children: React.ReactNode }) {
   const [status, setStatus] = useState<Status>("loading");
   const [backendVersion, setBackendVersion] = useState("");
   const [workerVersion, setWorkerVersion] = useState<string | undefined>();

--- a/frontend/src/components/WeftmarkLogo.tsx
+++ b/frontend/src/components/WeftmarkLogo.tsx
@@ -1,5 +1,5 @@
 interface Props {
-  className?: string;
+  readonly className?: string;
 }
 
 export function WeftmarkLogo({ className = "" }: Props) {

--- a/frontend/src/components/admin/CopyEmail.tsx
+++ b/frontend/src/components/admin/CopyEmail.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Copy, Check } from "lucide-react";
 
-export function CopyEmail({ email }: { email: string }) {
+export function CopyEmail({ email }: { readonly email: string }) {
   const [copied, setCopied] = useState(false);
 
   function handleCopy(e: React.MouseEvent) {

--- a/frontend/src/components/admin/UserDetailModal.tsx
+++ b/frontend/src/components/admin/UserDetailModal.tsx
@@ -23,8 +23,8 @@ export type UserDetailTarget =
   | { kind: "pending"; signup: PendingSignup };
 
 interface Props {
-  target: UserDetailTarget;
-  onClose: () => void;
+  readonly target: UserDetailTarget;
+  readonly onClose: () => void;
 }
 
 type Confirm =
@@ -32,7 +32,7 @@ type Confirm =
   | "dismiss-signup" | "ban-signup"
   | null;
 
-function InfoRow({ label, children }: { label: string; children: ReactNode }) {
+function InfoRow({ label, children }: { readonly label: string; readonly children: ReactNode }) {
   return (
     <div className="flex gap-4 text-sm">
       <span className="w-28 shrink-0 text-muted-foreground">{label}</span>
@@ -41,7 +41,7 @@ function InfoRow({ label, children }: { label: string; children: ReactNode }) {
   );
 }
 
-function Pill({ label, cls }: { label: string; cls: string }) {
+function Pill({ label, cls }: { readonly label: string; readonly cls: string }) {
   return (
     <span className={`inline-block rounded px-1.5 py-0.5 text-xs font-medium ${cls}`}>
       {label}
@@ -57,12 +57,12 @@ function ConfirmInline({
   onCancel,
   busy,
 }: {
-  message: string;
-  destructive?: boolean;
-  confirmLabel: string;
-  onConfirm: () => void;
-  onCancel: () => void;
-  busy: boolean;
+  readonly message: string;
+  readonly destructive?: boolean;
+  readonly confirmLabel: string;
+  readonly onConfirm: () => void;
+  readonly onCancel: () => void;
+  readonly busy: boolean;
 }) {
   return (
     <div className="flex w-full items-center gap-2 rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2">

--- a/frontend/src/components/auth/AuthCard.tsx
+++ b/frontend/src/components/auth/AuthCard.tsx
@@ -2,10 +2,10 @@ import type { ReactNode } from "react";
 import { WeftmarkLogo } from "@/components/WeftmarkLogo";
 
 interface Props {
-  children: ReactNode;
-  footer?: ReactNode;
+  readonly children: ReactNode;
+  readonly footer?: ReactNode;
   /** Skip the white card wrapper — Clerk pages use this so Clerk renders its own card naturally. */
-  naked?: boolean;
+  readonly naked?: boolean;
 }
 
 export function AuthCard({ children, footer, naked = false }: Props) {

--- a/frontend/src/components/collections/AddToCollectionModal.tsx
+++ b/frontend/src/components/collections/AddToCollectionModal.tsx
@@ -5,11 +5,11 @@ import { AppIcons } from "@/lib/icons";
 import { Button } from "@/components/ui/button";
 
 interface Props {
-  itemId: string;
-  itemType: "draft" | "project";
-  onAdd: (collectionId: string, itemId: string) => Promise<void>;
-  onRemove: (collectionId: string, itemId: string) => Promise<void>;
-  onClose: () => void;
+  readonly itemId: string;
+  readonly itemType: "draft" | "project";
+  readonly onAdd: (collectionId: string, itemId: string) => Promise<void>;
+  readonly onRemove: (collectionId: string, itemId: string) => Promise<void>;
+  readonly onClose: () => void;
 }
 
 export function AddToCollectionModal({ itemId, itemType, onAdd, onRemove, onClose }: Props) {

--- a/frontend/src/components/drafts/DraftCard.tsx
+++ b/frontend/src/components/drafts/DraftCard.tsx
@@ -13,9 +13,9 @@ interface ProjectCounts {
 }
 
 interface Props {
-  draft: Draft;
-  projectCounts?: ProjectCounts;
-  archived?: boolean;
+  readonly draft: Draft;
+  readonly projectCounts?: ProjectCounts;
+  readonly archived?: boolean;
 }
 
 export function DraftCard({ draft, projectCounts, archived }: Props) {

--- a/frontend/src/components/drafts/DraftPreviewModal.tsx
+++ b/frontend/src/components/drafts/DraftPreviewModal.tsx
@@ -4,11 +4,11 @@ import { Button } from "@/components/ui/button";
 import { ZoomablePreviewModal } from "@/components/ui/ZoomablePreviewModal";
 
 interface Props {
-  draftId: string;
-  draftName: string;
-  warpThreads?: number;
-  weftThreads?: number;
-  onClose: () => void;
+  readonly draftId: string;
+  readonly draftName: string;
+  readonly warpThreads?: number;
+  readonly weftThreads?: number;
+  readonly onClose: () => void;
 }
 
 // Drafts above this thread-area threshold get a load-confirmation gate.

--- a/frontend/src/components/drafts/UploadWifModal.tsx
+++ b/frontend/src/components/drafts/UploadWifModal.tsx
@@ -4,8 +4,8 @@ import { Button } from "@/components/ui/button";
 import { TagInput } from "@/components/ui/TagInput";
 
 interface Props {
-  onSuccess: () => void;
-  onClose: () => void;
+  readonly onSuccess: () => void;
+  readonly onClose: () => void;
 }
 
 export function UploadWifModal({ onSuccess, onClose }: Props) {

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -12,7 +12,7 @@ import type { ReactNode } from "react";
 const DETAIL_PATTERN = /^\/projects\/[^/]+/;
 
 interface Props {
-  children: ReactNode;
+  readonly children: ReactNode;
 }
 
 export function AppLayout({ children }: Props) {

--- a/frontend/src/components/layout/OnboardingChecklist.tsx
+++ b/frontend/src/components/layout/OnboardingChecklist.tsx
@@ -20,7 +20,7 @@ const TASKS: Task[] = [
   { key: "has_project",   label: "Create a project",       href: "/projects" },
 ];
 
-export function OnboardingChecklist({ collapsed }: { collapsed?: boolean }) {
+export function OnboardingChecklist({ collapsed }: { readonly collapsed?: boolean }) {
   const { user, refetch: refetchUser } = useAuth();
   const qc = useQueryClient();
   const [open, setOpen] = useState(false);

--- a/frontend/src/components/layout/ProtectedRoute.tsx
+++ b/frontend/src/components/layout/ProtectedRoute.tsx
@@ -4,9 +4,9 @@ import { useImpersonation } from "@/context/ImpersonationContext";
 import type { ReactNode } from "react";
 
 interface Props {
-  children: ReactNode;
-  requireAdmin?: boolean;
-  requireSuperuser?: boolean;
+  readonly children: ReactNode;
+  readonly requireAdmin?: boolean;
+  readonly requireSuperuser?: boolean;
 }
 
 export function ProtectedRoute({ children, requireAdmin = false, requireSuperuser = false }: Props) {

--- a/frontend/src/components/looms/AddVersionModal.tsx
+++ b/frontend/src/components/looms/AddVersionModal.tsx
@@ -5,10 +5,10 @@ import { useAuthContext } from "@/context/AuthContext";
 import { measurementSystemToUnit } from "@/lib/units";
 
 interface Props {
-  loomId: string;
-  loomType: LoomType;
-  onSuccess: () => void;
-  onClose: () => void;
+  readonly loomId: string;
+  readonly loomType: LoomType;
+  readonly onSuccess: () => void;
+  readonly onClose: () => void;
 }
 
 const today = () => new Date(Date.now() - new Date().getTimezoneOffset() * 60000).toISOString().slice(0, 10);
@@ -40,10 +40,10 @@ export function AddVersionModal({ loomId, loomType, onSuccess, onClose }: Props)
         name: versionName || undefined,
         effective_date: effectiveDate,
         description: description || undefined,
-        num_shafts: showsShafts(loomType) && numShafts ? parseInt(numShafts, 10) : undefined,
-        num_treadles: showsTreadles(loomType) && numTreadles !== "" ? parseInt(numTreadles, 10) : undefined,
-        num_heddles: showsHeddles(loomType) && numHeddles ? parseInt(numHeddles, 10) : undefined,
-        warp_waste_allowance: showsWarpWaste(loomType) && warpWaste ? parseFloat(warpWaste) : undefined,
+        num_shafts: showsShafts(loomType) && numShafts ? Number.parseInt(numShafts, 10) : undefined,
+        num_treadles: showsTreadles(loomType) && numTreadles !== "" ? Number.parseInt(numTreadles, 10) : undefined,
+        num_heddles: showsHeddles(loomType) && numHeddles ? Number.parseInt(numHeddles, 10) : undefined,
+        warp_waste_allowance: showsWarpWaste(loomType) && warpWaste ? Number.parseFloat(warpWaste) : undefined,
         warp_waste_unit: warpWasteUnit,
         weaving_width_unit: "cm",
       };

--- a/frontend/src/components/looms/CatalogRequestButton.tsx
+++ b/frontend/src/components/looms/CatalogRequestButton.tsx
@@ -34,7 +34,7 @@ function markSubmitted(loomId: string): void {
 // ---------- component ----------
 
 interface Props {
-  loom: LoomDetail;
+  readonly loom: LoomDetail;
 }
 
 export function CatalogRequestButton({ loom }: Props) {

--- a/frontend/src/components/looms/CloneVersionModal.tsx
+++ b/frontend/src/components/looms/CloneVersionModal.tsx
@@ -3,10 +3,10 @@ import { cloneVersion, type LoomVersion, type CloneVersionPayload } from "@/api/
 import { Button } from "@/components/ui/button";
 
 interface Props {
-  loomId: string;
-  source: LoomVersion;
-  onSuccess: (v: LoomVersion) => void;
-  onClose: () => void;
+  readonly loomId: string;
+  readonly source: LoomVersion;
+  readonly onSuccess: (v: LoomVersion) => void;
+  readonly onClose: () => void;
 }
 
 const today = () => new Date(Date.now() - new Date().getTimezoneOffset() * 60000).toISOString().slice(0, 10);

--- a/frontend/src/components/looms/EditLoomModal.tsx
+++ b/frontend/src/components/looms/EditLoomModal.tsx
@@ -5,9 +5,9 @@ import {
 import { Button } from "@/components/ui/button";
 
 interface Props {
-  loom: LoomDetail;
-  onSuccess: (updated: LoomDetail) => void;
-  onClose: () => void;
+  readonly loom: LoomDetail;
+  readonly onSuccess: (updated: LoomDetail) => void;
+  readonly onClose: () => void;
 }
 
 const LOOM_TYPES: LoomType[] = ["floor_loom", "table_loom", "rigid_heddle", "inkle", "dobby_floor_loom", "tapestry_loom", "rug_loom", "frame_loom", "other"];
@@ -37,7 +37,7 @@ export function EditLoomModal({ loom, onSuccess, onClose }: Props) {
         model_name: modelName,
         serial_number: serialNumber || undefined,
         purchase_date: purchaseDate || undefined,
-        purchase_price: purchasePrice ? parseFloat(String(purchasePrice)) : undefined,
+        purchase_price: purchasePrice ? Number.parseFloat(String(purchasePrice)) : undefined,
         vendor: vendor || undefined,
         notes: notes || undefined,
       };

--- a/frontend/src/components/looms/LinkToCatalogModal.tsx
+++ b/frontend/src/components/looms/LinkToCatalogModal.tsx
@@ -99,10 +99,10 @@ function deriveTreadles(
 // ---------- component ----------
 
 interface Props {
-  loom: LoomDetail;
-  version: LoomVersion;
-  onSuccess: () => void;
-  onClose: () => void;
+  readonly loom: LoomDetail;
+  readonly version: LoomVersion;
+  readonly onSuccess: () => void;
+  readonly onClose: () => void;
 }
 
 export function LinkToCatalogModal({ loom, version, onSuccess, onClose }: Props) {
@@ -202,7 +202,7 @@ export function LinkToCatalogModal({ loom, version, onSuccess, onClose }: Props)
 
     // Auto-match width to target version (convert units if needed)
     if (wOpts.length > 0 && version.weaving_width) {
-      const curVal = parseFloat(version.weaving_width);
+      const curVal = Number.parseFloat(version.weaving_width);
       const curUnit = version.weaving_width_unit as "cm" | "in";
       const targetUnit = wOpts[0].unit;
       const converted =
@@ -211,7 +211,7 @@ export function LinkToCatalogModal({ loom, version, onSuccess, onClose }: Props)
           : curUnit === "cm"
             ? curVal / 2.54
             : curVal * 2.54;
-      setSelectedWidthIdx(closestIdx(wOpts.map((o) => parseFloat(o.value)), converted));
+      setSelectedWidthIdx(closestIdx(wOpts.map((o) => Number.parseFloat(o.value)), converted));
     } else {
       setSelectedWidthIdx(0);
     }
@@ -277,12 +277,12 @@ export function LinkToCatalogModal({ loom, version, onSuccess, onClose }: Props)
               {
                 label: "Weaving width",
                 oldVal: cv.weaving_width
-                  ? `${parseFloat(cv.weaving_width)} ${cv.weaving_width_unit}`
+                  ? `${Number.parseFloat(cv.weaving_width)} ${cv.weaving_width_unit}`
                   : "—",
                 newVal: selectedWidthOpt.label,
                 changed:
                   !cv.weaving_width ||
-                  parseFloat(cv.weaving_width) !== parseFloat(selectedWidthOpt.value) ||
+                  Number.parseFloat(cv.weaving_width) !== Number.parseFloat(selectedWidthOpt.value) ||
                   cv.weaving_width_unit !== selectedWidthOpt.unit,
               },
             ]
@@ -313,7 +313,7 @@ export function LinkToCatalogModal({ loom, version, onSuccess, onClose }: Props)
           versionPayload.num_treadles = derivedTreadles;
         }
         if (selectedWidthOpt != null) {
-          versionPayload.weaving_width = parseFloat(selectedWidthOpt.value);
+          versionPayload.weaving_width = Number.parseFloat(selectedWidthOpt.value);
           versionPayload.weaving_width_unit = selectedWidthOpt.unit;
         }
         if (Object.keys(versionPayload).length > 0) {

--- a/frontend/src/components/looms/NewLoomModal.tsx
+++ b/frontend/src/components/looms/NewLoomModal.tsx
@@ -13,8 +13,8 @@ import { useAuthContext } from "@/context/AuthContext";
 import { measurementSystemToUnit } from "@/lib/units";
 
 interface Props {
-  onSuccess: () => void;
-  onClose: () => void;
+  readonly onSuccess: () => void;
+  readonly onClose: () => void;
 }
 
 const today = () =>
@@ -179,7 +179,7 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
       if (ref.treadle_count?.length) {
         setNumTreadles(String(ref.treadle_count[0]));
       } else if (showsTreadles(lt)) {
-        const s = parseInt(first, 10);
+        const s = Number.parseInt(first, 10);
         setNumTreadles(String(s + 2));
       }
     }
@@ -211,23 +211,23 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
   const handleShaftOptionChange = (val: string) => {
     setNumShafts(val);
     if (!treadlesManuallySet && treadleOptions && shaftOptions) {
-      const idx = shaftOptions.indexOf(parseInt(val, 10));
+      const idx = shaftOptions.indexOf(Number.parseInt(val, 10));
       if (idx !== -1 && treadleOptions[idx] != null) {
         setNumTreadles(String(treadleOptions[idx]));
         return;
       }
     }
     if (!treadlesManuallySet && showsTreadles(loomType)) {
-      const s = parseInt(val, 10);
-      if (!isNaN(s)) setNumTreadles(String(s + 2));
+      const s = Number.parseInt(val, 10);
+      if (!Number.isNaN(s)) setNumTreadles(String(s + 2));
     }
   };
 
   const handleShaftsManual = (val: string) => {
     setNumShafts(val);
     if (loomType === "floor_loom" && !treadlesManuallySet) {
-      const s = parseInt(val, 10);
-      if (!isNaN(s)) setNumTreadles(String(s + 2));
+      const s = Number.parseInt(val, 10);
+      if (!Number.isNaN(s)) setNumTreadles(String(s + 2));
     }
   };
 
@@ -236,8 +236,8 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
     setAcknowledged(false);
     setTreadlesManuallySet(false);
     if (newType === "floor_loom") {
-      const s = parseInt(numShafts, 10);
-      if (!isNaN(s)) setNumTreadles(String(s + 2));
+      const s = Number.parseInt(numShafts, 10);
+      if (!Number.isNaN(s)) setNumTreadles(String(s + 2));
     }
   };
 
@@ -255,16 +255,16 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
         notes: notes || undefined,
         effective_date: effectiveDate,
         num_shafts:
-          showsShafts(loomType) && numShafts ? parseInt(numShafts, 10) : undefined,
+          showsShafts(loomType) && numShafts ? Number.parseInt(numShafts, 10) : undefined,
         num_treadles:
           showsTreadles(loomType) && numTreadles !== ""
-            ? parseInt(numTreadles, 10)
+            ? Number.parseInt(numTreadles, 10)
             : undefined,
         num_heddles:
-          showsHeddles(loomType) && numHeddles ? parseInt(numHeddles, 10) : undefined,
-        weaving_width: weavingWidth ? parseFloat(weavingWidth) : undefined,
+          showsHeddles(loomType) && numHeddles ? Number.parseInt(numHeddles, 10) : undefined,
+        weaving_width: weavingWidth ? Number.parseFloat(weavingWidth) : undefined,
         weaving_width_unit: weavingWidthUnit,
-        warp_waste_allowance: warpWaste ? parseFloat(warpWaste) : undefined,
+        warp_waste_allowance: warpWaste ? Number.parseFloat(warpWaste) : undefined,
         warp_waste_unit: warpWasteUnit,
       };
       await createLoom(payload);

--- a/frontend/src/components/projects/AssignLoomModal.tsx
+++ b/frontend/src/components/projects/AssignLoomModal.tsx
@@ -5,15 +5,15 @@ import { listLooms, getLoom, SUPPORTED_LOOM_TYPES } from "@/api/looms";
 import { Button } from "@/components/ui/button";
 
 interface Props {
-  projectId: string;
-  activeProjects: ProjectSummary[];
-  projectType?: string;
-  draftNumTreadles?: number | null;
-  draftNumShafts?: number | null;
-  draftEffectiveNumTreadles?: number | null;
-  draftEffectiveNumShafts?: number | null;
-  onSuccess: () => void;
-  onClose: () => void;
+  readonly projectId: string;
+  readonly activeProjects: ProjectSummary[];
+  readonly projectType?: string;
+  readonly draftNumTreadles?: number | null;
+  readonly draftNumShafts?: number | null;
+  readonly draftEffectiveNumTreadles?: number | null;
+  readonly draftEffectiveNumShafts?: number | null;
+  readonly onSuccess: () => void;
+  readonly onClose: () => void;
 }
 
 const f = "w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring";

--- a/frontend/src/components/projects/CreateProjectModal.tsx
+++ b/frontend/src/components/projects/CreateProjectModal.tsx
@@ -9,18 +9,18 @@ import { useAuthContext } from "@/context/AuthContext";
 import { measurementSystemToUnit, convertLength, formatLength } from "@/lib/units";
 
 interface Props {
-  onSuccess: (id: string) => void;
-  onClose: () => void;
-  defaultDraftId?: string;
+  readonly onSuccess: (id: string) => void;
+  readonly onClose: () => void;
+  readonly defaultDraftId?: string;
 }
 
 const CM_PER_IN = 2.54;
 
 function convertLen(value: string, toUnit: "cm" | "in"): string {
-  const v = parseFloat(value);
-  if (!value || isNaN(v)) return value;
+  const v = Number.parseFloat(value);
+  if (!value || Number.isNaN(v)) return value;
   const result = toUnit === "in" ? v / CM_PER_IN : v * CM_PER_IN;
-  return parseFloat(result.toFixed(2)).toString();
+  return Number.parseFloat(result.toFixed(2)).toString();
 }
 
 const f = "w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
@@ -70,7 +70,7 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
     setPrevDraftId(selectedDraft?.id);
     if (selectedDraft?.warp_length_cm != null) {
       const val = convertLength(selectedDraft.warp_length_cm, "cm", lengthUnit);
-      setFinishedLength(parseFloat(val.toFixed(1)).toString());
+      setFinishedLength(Number.parseFloat(val.toFixed(1)).toString());
     } else {
       setFinishedLength("");
     }
@@ -133,8 +133,8 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
     selectedDraft.num_shafts !== selectedDraft.effective_num_shafts;
 
   const draftHasWarpLength = selectedDraft?.warp_length_cm != null;
-  const finishedLengthCm = finishedLength !== "" && !isNaN(parseFloat(finishedLength))
-    ? convertLength(parseFloat(finishedLength), lengthUnit, "cm")
+  const finishedLengthCm = finishedLength !== "" && !Number.isNaN(Number.parseFloat(finishedLength))
+    ? convertLength(Number.parseFloat(finishedLength), lengthUnit, "cm")
     : null;
   const warpLengthDefaultLabel = warpLengthDefaultCm != null
     ? formatLength(convertLength(warpLengthDefaultCm, "cm", lengthUnit), lengthUnit)
@@ -166,10 +166,10 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
     project_type: effectiveType as ProjectType,
     loom_id: loomId || undefined,
     loom_version_id: loomVersionId || undefined,
-    finished_length_per_item: finishedLength ? parseFloat(finishedLength) : undefined,
-    num_items: parseInt(numItems, 10) || 1,
-    waste_between_items: wasteBetween ? parseFloat(wasteBetween) : undefined,
-    warp_waste_allowance: warpWaste ? parseFloat(warpWaste) : undefined,
+    finished_length_per_item: finishedLength ? Number.parseFloat(finishedLength) : undefined,
+    num_items: Number.parseInt(numItems, 10) || 1,
+    waste_between_items: wasteBetween ? Number.parseFloat(wasteBetween) : undefined,
+    warp_waste_allowance: warpWaste ? Number.parseFloat(warpWaste) : undefined,
     length_unit: lengthUnit,
     tags: tags.length ? tags : undefined,
   });
@@ -401,7 +401,7 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
 
             {draftHasWarpLength && (
               <div className="grid grid-cols-2 gap-3 mt-3">
-                {parseInt(numItems, 10) > 1 && (
+                {Number.parseInt(numItems, 10) > 1 && (
                   <div>
                     <label className="mb-1 block text-sm font-medium">Waste between items</label>
                     <div className="flex gap-1">
@@ -410,7 +410,7 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
                     </div>
                   </div>
                 )}
-                <div className={parseInt(numItems, 10) <= 1 ? "col-span-2" : ""}>
+                <div className={Number.parseInt(numItems, 10) <= 1 ? "col-span-2" : ""}>
                   <label className="mb-1 block text-sm font-medium">Loom warp waste</label>
                   <div className="flex gap-1">
                     <input type="number" min={0} step="0.1" className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring" value={warpWaste || loomWasteInCurrentUnit(selectedVersion?.warp_waste_allowance ?? loomDetail?.versions.at(-1)?.warp_waste_allowance, selectedVersion?.warp_waste_unit ?? loomDetail?.versions.at(-1)?.warp_waste_unit ?? "cm")} onChange={(e) => setWarpWaste(e.target.value)} placeholder="30" />

--- a/frontend/src/components/projects/ProjectSummaryList.tsx
+++ b/frontend/src/components/projects/ProjectSummaryList.tsx
@@ -13,7 +13,7 @@ function fmtDate(iso: string): string {
   return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
 }
 
-function ProjectRow({ project }: { project: ProjectSummary }) {
+function ProjectRow({ project }: { readonly project: ProjectSummary }) {
   const isPlanning = project.status === "active" && !project.loom_id;
   const badgeKey = isPlanning ? "plan" : project.status;
   const badgeLabel = isPlanning ? "Plan" : PROJECT_STATUS_LABELS[project.status];
@@ -39,7 +39,7 @@ function ProjectRow({ project }: { project: ProjectSummary }) {
   );
 }
 
-function YearGroup({ year, items, defaultOpen }: { year: number; items: ProjectSummary[]; defaultOpen: boolean }) {
+function YearGroup({ year, items, defaultOpen }: { readonly year: number; readonly items: ProjectSummary[]; readonly defaultOpen: boolean }) {
   const [open, setOpen] = useState(defaultOpen);
   return (
     <div>
@@ -72,7 +72,7 @@ function groupByYear(items: ProjectSummary[], getDate: (p: ProjectSummary) => st
     .map(([year, items]) => ({ year, items }));
 }
 
-export function ProjectSummaryList({ projects }: { projects: ProjectSummary[] }) {
+export function ProjectSummaryList({ projects }: { readonly projects: ProjectSummary[] }) {
   const currentYear = new Date().getFullYear();
 
   const active = projects.filter((p) => p.status === "active" && !!p.loom_id);

--- a/frontend/src/components/projects/ShareModal.tsx
+++ b/frontend/src/components/projects/ShareModal.tsx
@@ -25,9 +25,9 @@ export function ShareModal({
   onUpdated,
   onClose,
 }: {
-  project: ProjectDetail;
-  onUpdated: (updated: ProjectDetail) => void;
-  onClose: () => void;
+  readonly project: ProjectDetail;
+  readonly onUpdated: (updated: ProjectDetail) => void;
+  readonly onClose: () => void;
 }) {
   const [expiryDays, setExpiryDays] = useState<string>("30");
   const [copied, setCopied] = useState(false);
@@ -45,9 +45,9 @@ export function ShareModal({
 
   const shareMutation = useMutation({
     mutationFn: () => {
-      const days = parseInt(expiryDays, 10);
+      const days = Number.parseInt(expiryDays, 10);
       const expires =
-        !isNaN(days) && days > 0
+        !Number.isNaN(days) && days > 0
           ? new Date(Date.now() + days * 86_400_000).toISOString()
           : null;
       return updateProjectShare(project.id, "link", expires);

--- a/frontend/src/components/projects/YarnPickerModal.tsx
+++ b/frontend/src/components/projects/YarnPickerModal.tsx
@@ -7,12 +7,12 @@ import { Button } from "@/components/ui/button";
 import { AuthedImage } from "@/components/ui/AuthedImage";
 
 interface Props {
-  colorHex: string;
-  currentYarnId: string | null;
-  onSelect: (yarnId: string, yarn: YarnSummary) => void;
-  onUnlink: () => void;
-  onClose: () => void;
-  isSaving: boolean;
+  readonly colorHex: string;
+  readonly currentYarnId: string | null;
+  readonly onSelect: (yarnId: string, yarn: YarnSummary) => void;
+  readonly onUnlink: () => void;
+  readonly onClose: () => void;
+  readonly isSaving: boolean;
 }
 
 export function YarnPickerModal({ colorHex, currentYarnId, onSelect, onUnlink, onClose, isSaving }: Props) {

--- a/frontend/src/components/ui/AuthedImage.tsx
+++ b/frontend/src/components/ui/AuthedImage.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from "react";
 import { getAuthToken } from "@/api/client";
 
 interface Props extends React.ImgHTMLAttributes<HTMLImageElement> {
-  src: string;
-  loadingContent?: React.ReactNode;
+  readonly src: string;
+  readonly loadingContent?: React.ReactNode;
 }
 
 export function AuthedImage({ src, loadingContent, ...props }: Props) {

--- a/frontend/src/components/ui/ColorPicker.tsx
+++ b/frontend/src/components/ui/ColorPicker.tsx
@@ -17,7 +17,7 @@ declare global {
 function hexToRgb(hex: string): [number, number, number] | null {
   const m = hex.match(/^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i);
   if (!m) return null;
-  return [parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16)];
+  return [Number.parseInt(m[1], 16), Number.parseInt(m[2], 16), Number.parseInt(m[3], 16)];
 }
 
 function rgbToHex(r: number, g: number, b: number): string {
@@ -134,10 +134,10 @@ const PICKER_HEIGHT = 360;
 const PICKER_WIDTH = 240;
 
 interface ColorPickerProps {
-  value: string;
-  onChange: (hex: string) => void;
-  size?: "sm" | "md";
-  className?: string;
+  readonly value: string;
+  readonly onChange: (hex: string) => void;
+  readonly size?: "sm" | "md";
+  readonly className?: string;
 }
 
 export function ColorPicker({ value, onChange, size = "md", className }: ColorPickerProps) {
@@ -225,7 +225,7 @@ export function ColorPicker({ value, onChange, size = "md", className }: ColorPi
     next[index] = raw;
     setRgbInput(next);
     const nums = next.map(Number);
-    if (next.every((v) => v !== "" && !isNaN(Number(v))) && nums.every((v) => v >= 0 && v <= 255)) {
+    if (next.every((v) => v !== "" && !Number.isNaN(Number(v))) && nums.every((v) => v >= 0 && v <= 255)) {
       const hex = rgbToHex(nums[0], nums[1], nums[2]);
       setHexInput(hex);
       const hsl = hexToHsl(hex);
@@ -240,7 +240,7 @@ export function ColorPicker({ value, onChange, size = "md", className }: ColorPi
     setHslInput(next);
     const [h, s, l] = next.map(Number);
     if (
-      next.every((v) => v !== "" && !isNaN(Number(v))) &&
+      next.every((v) => v !== "" && !Number.isNaN(Number(v))) &&
       h >= 0 && h <= 360 &&
       s >= 0 && s <= 100 &&
       l >= 0 && l <= 100

--- a/frontend/src/components/ui/SuperuserInspectionBanner.tsx
+++ b/frontend/src/components/ui/SuperuserInspectionBanner.tsx
@@ -1,5 +1,5 @@
 interface Props {
-  ownerEmail?: string;
+  readonly ownerEmail?: string;
 }
 
 export function SuperuserInspectionBanner({ ownerEmail }: Props) {

--- a/frontend/src/components/ui/TagChips.tsx
+++ b/frontend/src/components/ui/TagChips.tsx
@@ -1,7 +1,7 @@
 interface Props {
-  tags: string[];
-  max?: number;
-  className?: string;
+  readonly tags: string[];
+  readonly max?: number;
+  readonly className?: string;
 }
 
 function tagColor(tag: string): { background: string; color: string } {

--- a/frontend/src/components/ui/TagInput.tsx
+++ b/frontend/src/components/ui/TagInput.tsx
@@ -9,10 +9,10 @@ function tagColor(tag: string): { background: string; color: string } {
 }
 
 interface Props {
-  tags: string[];
-  onChange: (tags: string[]) => void;
-  placeholder?: string;
-  disabled?: boolean;
+  readonly tags: string[];
+  readonly onChange: (tags: string[]) => void;
+  readonly placeholder?: string;
+  readonly disabled?: boolean;
 }
 
 export function TagInput({ tags, onChange, placeholder = "Add a tag…", disabled = false }: Props) {

--- a/frontend/src/components/ui/ZoomablePreviewModal.tsx
+++ b/frontend/src/components/ui/ZoomablePreviewModal.tsx
@@ -4,13 +4,13 @@ import { AppIcons } from "@/lib/icons";
 import { Button } from "@/components/ui/button";
 
 interface Props {
-  src: string;
-  title: string;
-  onClose: () => void;
+  readonly src: string;
+  readonly title: string;
+  readonly onClose: () => void;
   /** When false, renders `gate` content instead of loading the image. */
-  gateConfirmed?: boolean;
+  readonly gateConfirmed?: boolean;
   /** Content shown when gateConfirmed is false (e.g. large-draft warning). */
-  gate?: React.ReactNode;
+  readonly gate?: React.ReactNode;
 }
 
 const ZOOM_STEP = 0.25;

--- a/frontend/src/components/yarn/AddFromRavelryModal.tsx
+++ b/frontend/src/components/yarn/AddFromRavelryModal.tsx
@@ -19,8 +19,8 @@ import { ColorPicker } from "@/components/ui/ColorPicker";
 import { Button } from "@/components/ui/button";
 
 interface Props {
-  onSuccess: () => void;
-  onClose: () => void;
+  readonly onSuccess: () => void;
+  readonly onClose: () => void;
 }
 
 type Step = "company" | "yarn" | "colorway";

--- a/frontend/src/components/yarn/AddYarnModal.tsx
+++ b/frontend/src/components/yarn/AddYarnModal.tsx
@@ -17,8 +17,8 @@ const WEIGHT_LABELS: Record<string, string> = {
 };
 
 interface Props {
-  onSuccess: () => void;
-  onClose: () => void;
+  readonly onSuccess: () => void;
+  readonly onClose: () => void;
 }
 
 export function AddYarnModal({ onSuccess, onClose }: Props) {
@@ -96,14 +96,14 @@ export function AddYarnModal({ onSuccess, onClose }: Props) {
         fiber_content: fiberContent.trim() || undefined,
         color_name: colorName.trim() || undefined,
         color_hex: hasColor ? colorHex : undefined,
-        unit_yardage: unitYardage ? parseFloat(unitYardage) : undefined,
+        unit_yardage: unitYardage ? Number.parseFloat(unitYardage) : undefined,
         unit_weight_oz: oz,
         unit_weight_g: g,
-        yards_per_pound: yardsPerPound ? parseFloat(yardsPerPound) : undefined,
-        sett_min: settMin ? parseInt(settMin, 10) : undefined,
-        sett_max: settMax ? parseInt(settMax, 10) : undefined,
+        yards_per_pound: yardsPerPound ? Number.parseFloat(yardsPerPound) : undefined,
+        sett_min: settMin ? Number.parseInt(settMin, 10) : undefined,
+        sett_max: settMax ? Number.parseInt(settMax, 10) : undefined,
         purchase_source: purchaseSource.trim() || undefined,
-        purchase_price: purchasePrice ? parseFloat(purchasePrice) : undefined,
+        purchase_price: purchasePrice ? Number.parseFloat(purchasePrice) : undefined,
         purchase_date: purchaseDate || undefined,
         notes: notes.trim() || undefined,
         machine_washable: machineWashable,

--- a/frontend/src/components/yarn/CloneYarnModal.tsx
+++ b/frontend/src/components/yarn/CloneYarnModal.tsx
@@ -4,9 +4,9 @@ import { Button } from "@/components/ui/button";
 import { ColorPicker } from "@/components/ui/ColorPicker";
 
 interface Props {
-  yarn: YarnDetail;
-  onSuccess: (newId: string) => void;
-  onClose: () => void;
+  readonly yarn: YarnDetail;
+  readonly onSuccess: (newId: string) => void;
+  readonly onClose: () => void;
 }
 
 export function CloneYarnModal({ yarn, onSuccess, onClose }: Props) {

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -38,7 +38,7 @@ interface AuthState {
 
 const AuthContext = createContext<AuthState | null>(null);
 
-export function AuthProvider({ children }: { children: ReactNode }) {
+export function AuthProvider({ children }: { readonly children: ReactNode }) {
   const { isLoaded, isSignedIn, getToken } = useClerkAuth();
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);

--- a/frontend/src/context/ImpersonationContext.tsx
+++ b/frontend/src/context/ImpersonationContext.tsx
@@ -21,7 +21,7 @@ function applyTheme(theme: string) {
   }
 }
 
-export function ImpersonationProvider({ children }: { children: ReactNode }) {
+export function ImpersonationProvider({ children }: { readonly children: ReactNode }) {
   const [impersonatedUser, setImpersonatedUser] = useState<User | null>(null);
   const startedAtRef = useRef<Date | null>(null);
   const realThemeRef = useRef<string>("system");

--- a/frontend/src/lib/colorName.ts
+++ b/frontend/src/lib/colorName.ts
@@ -52,17 +52,17 @@ const NAMED: [string, string][] = [
 ];
 
 const TABLE: [number, number, number, string][] = NAMED.map(([h, n]) => [
-  parseInt(h.slice(0, 2), 16),
-  parseInt(h.slice(2, 4), 16),
-  parseInt(h.slice(4, 6), 16),
+  Number.parseInt(h.slice(0, 2), 16),
+  Number.parseInt(h.slice(2, 4), 16),
+  Number.parseInt(h.slice(4, 6), 16),
   n,
 ]);
 
 export function nearestColorName(hex: string): string {
   const h = hex.replace("#", "");
-  const r = parseInt(h.slice(0, 2), 16);
-  const g = parseInt(h.slice(2, 4), 16);
-  const b = parseInt(h.slice(4, 6), 16);
+  const r = Number.parseInt(h.slice(0, 2), 16);
+  const g = Number.parseInt(h.slice(2, 4), 16);
+  const b = Number.parseInt(h.slice(4, 6), 16);
   let best = TABLE[0][3];
   let bestD = Infinity;
   for (const [tr, tg, tb, name] of TABLE) {

--- a/frontend/src/lib/units.ts
+++ b/frontend/src/lib/units.ts
@@ -21,8 +21,8 @@ export function displayLength(
   displayUnit: LengthUnit,
 ): string | null {
   if (value == null || value === "") return null;
-  const num = typeof value === "string" ? parseFloat(value) : value;
-  if (isNaN(num)) return null;
+  const num = typeof value === "string" ? Number.parseFloat(value) : value;
+  if (Number.isNaN(num)) return null;
   const converted = convertLength(num, storedUnit as LengthUnit, displayUnit);
   return formatLength(converted, displayUnit);
 }

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -159,7 +159,7 @@ const STATUS_PILL: Record<UserRow["status"], string> = {
   deleting: "bg-copper-subtle text-copper-on-subtle",
 };
 
-function StatusPill({ status }: { status: UserRow["status"] }) {
+function StatusPill({ status }: { readonly status: UserRow["status"] }) {
   return (
     <span className={`inline-block rounded px-1.5 py-0.5 text-xs font-medium ${STATUS_PILL[status]}`}>
       {status}
@@ -170,7 +170,7 @@ function StatusPill({ status }: { status: UserRow["status"] }) {
 function SortTh({
   label, k, sort, dir, onSort,
 }: {
-  label: string; k: SortKey; sort: SortKey; dir: "asc" | "desc"; onSort: (k: SortKey) => void;
+  readonly label: string; readonly k: SortKey; readonly sort: SortKey; readonly dir: "asc" | "desc"; readonly onSort: (k: SortKey) => void;
 }) {
   const active = sort === k;
   return (
@@ -601,11 +601,11 @@ function PendingSignupRow({
   onBan,
   isWorking,
 }: {
-  signup: PendingSignup;
-  onApprove: () => void;
-  onDismiss: () => void;
-  onBan: () => void;
-  isWorking: boolean;
+  readonly signup: PendingSignup;
+  readonly onApprove: () => void;
+  readonly onDismiss: () => void;
+  readonly onBan: () => void;
+  readonly isWorking: boolean;
 }) {
   const [confirming, setConfirming] = useState<"dismiss" | "ban" | null>(null);
 
@@ -653,7 +653,7 @@ function PendingSignupRow({
   );
 }
 
-function InviteRow({ invite, onRevoke }: { invite: InviteRecord; onRevoke?: () => void }) {
+function InviteRow({ invite, onRevoke }: { readonly invite: InviteRecord; readonly onRevoke?: () => void }) {
   const isPending = !invite.accepted_at && !invite.revoked_at && new Date(invite.expires_at) > new Date();
   const status = invite.accepted_at
     ? "accepted"
@@ -722,7 +722,7 @@ function StatsTab() {
   );
 }
 
-function StatTable({ title, rows }: { title: string; rows: { label: string; value: number | string }[] }) {
+function StatTable({ title, rows }: { readonly title: string; readonly rows: { label: string; value: number | string }[] }) {
   return (
     <div>
       <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">{title}</h2>
@@ -745,7 +745,7 @@ function StatTable({ title, rows }: { title: string; rows: { label: string; valu
 const MAX_HEALTH_POINTS = 60;
 const POLL_INTERVAL_MS = 3000;
 
-function Sparkline({ values, max, color }: { values: number[]; max: number; color: string }) {
+function Sparkline({ values, max, color }: { readonly values: number[]; readonly max: number; readonly color: string }) {
   const W = 300;
   const H = 48;
   if (values.length < 2) {
@@ -853,7 +853,7 @@ function HealthTab() {
 
 declare const __APP_VERSION__: string;
 
-function InfoTable({ rows }: { rows: { label: string; value: string }[] }) {
+function InfoTable({ rows }: { readonly rows: { label: string; value: string }[] }) {
   return (
     <div className="border rounded-lg divide-y overflow-hidden">
       {rows.map(({ label, value }) => (
@@ -963,11 +963,11 @@ function HealthChart({
   max,
   color,
 }: {
-  label: string;
-  current: string;
-  values: number[];
-  max: number;
-  color: string;
+  readonly label: string;
+  readonly current: string;
+  readonly values: number[];
+  readonly max: number;
+  readonly color: string;
 }) {
   return (
     <div className="border rounded-lg p-4 space-y-2">
@@ -986,7 +986,7 @@ function HealthChart({
 // Services tab
 // ---------------------------------------------------------------------------
 
-function StatusDot({ status, small }: { status: "ok" | "error"; small?: boolean }) {
+function StatusDot({ status, small }: { readonly status: "ok" | "error"; readonly small?: boolean }) {
   return (
     <span
       className={`inline-block rounded-full shrink-0 ${small ? "w-2 h-2" : "w-2.5 h-2.5"} ${
@@ -996,7 +996,7 @@ function StatusDot({ status, small }: { status: "ok" | "error"; small?: boolean 
   );
 }
 
-function CombinedServiceRow({ service, detail }: { service: ReadinessService; detail?: ServiceCheck }) {
+function CombinedServiceRow({ service, detail }: { readonly service: ReadinessService; readonly detail?: ServiceCheck }) {
   const [open, setOpen] = useState(false);
   const [webhookResult, setWebhookResult] = useState<WebhookProbeResult | null>(null);
   const [webhookTesting, setWebhookTesting] = useState(false);
@@ -1867,7 +1867,7 @@ function AuditLogTab() {
   );
 }
 
-function AuditLogRow({ entry }: { entry: AuditLogEntry }) {
+function AuditLogRow({ entry }: { readonly entry: AuditLogEntry }) {
   const [expanded, setExpanded] = useState(false);
   const hasDetails = entry.details && Object.keys(entry.details).length > 0;
 
@@ -1925,12 +1925,12 @@ const SHEDDING_OPTIONS = [
 ];
 
 function parseIntArray(s: string): number[] | undefined {
-  const parts = s.split(",").map((p) => p.trim()).filter(Boolean).map(Number).filter((n) => !isNaN(n));
+  const parts = s.split(",").map((p) => p.trim()).filter(Boolean).map(Number).filter((n) => !Number.isNaN(n));
   return parts.length > 0 ? parts : undefined;
 }
 
 function parseFloatArray(s: string): number[] | undefined {
-  const parts = s.split(",").map((p) => p.trim()).filter(Boolean).map(Number).filter((n) => !isNaN(n));
+  const parts = s.split(",").map((p) => p.trim()).filter(Boolean).map(Number).filter((n) => !Number.isNaN(n));
   return parts.length > 0 ? parts : undefined;
 }
 
@@ -2002,13 +2002,13 @@ function LoomRefFormModal({
   saving,
   error,
 }: {
-  title: string;
-  form: LoomRefForm;
-  onChange: (f: LoomRefForm) => void;
-  onSave: () => void;
-  onCancel: () => void;
-  saving: boolean;
-  error: string | null;
+  readonly title: string;
+  readonly form: LoomRefForm;
+  readonly onChange: (f: LoomRefForm) => void;
+  readonly onSave: () => void;
+  readonly onCancel: () => void;
+  readonly saving: boolean;
+  readonly error: string | null;
 }) {
   const inputCls = "w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
   const labelCls = "mb-1 block text-sm font-medium";

--- a/frontend/src/pages/CollectionDetailPage.tsx
+++ b/frontend/src/pages/CollectionDetailPage.tsx
@@ -22,7 +22,7 @@ import { AuthedImage } from "@/components/ui/AuthedImage";
 
 type SortKey = "name" | "added";
 
-function SortControl({ value, onChange }: { value: SortKey; onChange: (v: SortKey) => void }) {
+function SortControl({ value, onChange }: { readonly value: SortKey; readonly onChange: (v: SortKey) => void }) {
   const { t } = useTranslation();
   return (
     <div className="flex items-center gap-1 text-xs text-muted-foreground">
@@ -39,7 +39,7 @@ function SortControl({ value, onChange }: { value: SortKey; onChange: (v: SortKe
   );
 }
 
-function RemoveButton({ label, onConfirm }: { label: string; onConfirm: () => void }) {
+function RemoveButton({ label, onConfirm }: { readonly label: string; readonly onConfirm: () => void }) {
   const { t } = useTranslation();
   const [confirming, setConfirming] = useState(false);
   if (confirming) {
@@ -73,10 +73,10 @@ function AddDraftModal({
   onClose,
   onAdded,
 }: {
-  collectionId: string;
-  existingDraftIds: Set<string>;
-  onClose: () => void;
-  onAdded: () => void;
+  readonly collectionId: string;
+  readonly existingDraftIds: Set<string>;
+  readonly onClose: () => void;
+  readonly onAdded: () => void;
 }) {
   const { t } = useTranslation();
   const [query, setQuery] = useState("");
@@ -135,10 +135,10 @@ function AddProjectModal({
   onClose,
   onAdded,
 }: {
-  collectionId: string;
-  existingProjectIds: Set<string>;
-  onClose: () => void;
-  onAdded: () => void;
+  readonly collectionId: string;
+  readonly existingProjectIds: Set<string>;
+  readonly onClose: () => void;
+  readonly onAdded: () => void;
 }) {
   const { t } = useTranslation();
   const [query, setQuery] = useState("");

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -7,7 +7,7 @@ import { AppIcons } from "@/lib/icons";
 import { Button } from "@/components/ui/button";
 import { SkeletonCardGrid } from "@/components/ui/skeleton";
 
-function NewCollectionModal({ onClose, onSuccess }: { onClose: () => void; onSuccess: () => void }) {
+function NewCollectionModal({ onClose, onSuccess }: { readonly onClose: () => void; readonly onSuccess: () => void }) {
   const { t } = useTranslation();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -111,7 +111,7 @@ function NewCollectionModal({ onClose, onSuccess }: { onClose: () => void; onSuc
   );
 }
 
-function CollectionCard({ collection }: { collection: CollectionSummary }) {
+function CollectionCard({ collection }: { readonly collection: CollectionSummary }) {
   const { t } = useTranslation();
   return (
     <Link

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -67,12 +67,12 @@ function HeatmapGrid({
   onCellEnter,
   onCellLeave,
 }: {
-  weeks: Date[][];
-  rangeEnd: Date;
-  dayByDate: Map<string, ActivityDay>;
-  dowLabels: string[];
-  onCellEnter: (e: React.MouseEvent, dateStr: string) => void;
-  onCellLeave: () => void;
+  readonly weeks: Date[][];
+  readonly rangeEnd: Date;
+  readonly dayByDate: Map<string, ActivityDay>;
+  readonly dowLabels: string[];
+  readonly onCellEnter: (e: React.MouseEvent, dateStr: string) => void;
+  readonly onCellLeave: () => void;
 }) {
   const monthLabels: { label: string; col: number }[] = [];
   weeks.forEach((week, wi) => {

--- a/frontend/src/pages/DraftDetailPage.tsx
+++ b/frontend/src/pages/DraftDetailPage.tsx
@@ -349,8 +349,8 @@ export function DraftDetailPage() {
                       className="flex items-center gap-1.5 flex-wrap"
                       onSubmit={(e) => {
                         e.preventDefault();
-                        const v = parseFloat(warpLengthInput);
-                        if (!isNaN(v) && v > 0) {
+                        const v = Number.parseFloat(warpLengthInput);
+                        if (!Number.isNaN(v) && v > 0) {
                           warpLengthMutation.mutate({ length: v, unit: warpLengthUnit });
                         }
                       }}
@@ -412,7 +412,7 @@ export function DraftDetailPage() {
                             className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
                             onClick={() => {
                               const v = convertLength(draft.warp_length_cm!, "cm", displayUnit);
-                              setWarpLengthInput(parseFloat(v.toFixed(1)).toString());
+                              setWarpLengthInput(Number.parseFloat(v.toFixed(1)).toString());
                               setWarpLengthUnit(displayUnit);
                               setEditingWarpLength(true);
                             }}
@@ -467,8 +467,8 @@ export function DraftDetailPage() {
                         type="button"
                         className="text-xs text-accent underline underline-offset-2"
                         onClick={() => {
-                          const v = parseFloat(weavingWidthInput);
-                          if (!isNaN(v) && v > 0) weavingWidthMutation.mutate({ width: v, unit: weavingWidthUnit });
+                          const v = Number.parseFloat(weavingWidthInput);
+                          if (!Number.isNaN(v) && v > 0) weavingWidthMutation.mutate({ width: v, unit: weavingWidthUnit });
                         }}
                       >{t("common.save")}</button>
                       <button
@@ -529,8 +529,8 @@ export function DraftDetailPage() {
                         type="button"
                         className="text-xs text-accent underline underline-offset-2"
                         onClick={() => {
-                          const v = parseFloat(epiInput);
-                          if (!isNaN(v) && v > 0) epiMutation.mutate({ epi: v });
+                          const v = Number.parseFloat(epiInput);
+                          if (!Number.isNaN(v) && v > 0) epiMutation.mutate({ epi: v });
                         }}
                       >{t("common.save")}</button>
                       <button

--- a/frontend/src/pages/LoomCatalogPage.tsx
+++ b/frontend/src/pages/LoomCatalogPage.tsx
@@ -6,12 +6,12 @@ import { WeftmarkLogo } from "@/components/WeftmarkLogo";
 import { PublicFooter } from "@/components/PublicFooter";
 import { listLoomCatalog, type LoomReferenceSummary } from "@/api/looms";
 
-function ShaftBadge({ options }: { options: number[] | null }) {
+function ShaftBadge({ options }: { readonly options: number[] | null }) {
   if (!options || options.length === 0) return <span className="text-stone-400">—</span>;
   return <span>{options.map((n) => Math.round(n)).join(" / ")}</span>;
 }
 
-function WidthBadge({ loom }: { loom: LoomReferenceSummary }) {
+function WidthBadge({ loom }: { readonly loom: LoomReferenceSummary }) {
   const cm = loom.weaving_width_options_cm ?? [];
   const inches = loom.weaving_width_options_inches ?? [];
   if (inches.length === 0 && cm.length === 0) {
@@ -27,7 +27,7 @@ function WidthBadge({ loom }: { loom: LoomReferenceSummary }) {
   return <span>{parts.join(" / ")}</span>;
 }
 
-function LoomCard({ loom }: { loom: LoomReferenceSummary }) {
+function LoomCard({ loom }: { readonly loom: LoomReferenceSummary }) {
   const { t } = useTranslation();
   return (
     <div className="rounded-xl border border-stone-200 bg-white p-5 space-y-3 hover:border-amber-300 transition-colors">

--- a/frontend/src/pages/LoomDetailPage.tsx
+++ b/frontend/src/pages/LoomDetailPage.tsx
@@ -41,9 +41,9 @@ function ConfirmInline({
   onConfirm,
   onCancel,
 }: {
-  label: string;
-  onConfirm: () => void;
-  onCancel: () => void;
+  readonly label: string;
+  readonly onConfirm: () => void;
+  readonly onCancel: () => void;
 }) {
   const { t } = useTranslation();
   return (
@@ -69,7 +69,7 @@ function ConfirmInline({
 // Profile photo
 // ---------------------------------------------------------------------------
 
-function ProfilePhoto({ loom, onChanged }: { loom: LoomDetail; onChanged: () => void }) {
+function ProfilePhoto({ loom, onChanged }: { readonly loom: LoomDetail; readonly onChanged: () => void }) {
   const { t } = useTranslation();
   const { user } = useAuthContext();
   const isReadOnly = !!user?.is_superuser && loom.owner_id !== user.id;
@@ -191,7 +191,7 @@ function ProfilePhoto({ loom, onChanged }: { loom: LoomDetail; onChanged: () => 
 // Version photos
 // ---------------------------------------------------------------------------
 
-function VersionPhotos({ loom, version, onChanged }: { loom: LoomDetail; version: LoomVersion; onChanged: () => void }) {
+function VersionPhotos({ loom, version, onChanged }: { readonly loom: LoomDetail; readonly version: LoomVersion; readonly onChanged: () => void }) {
   const { t } = useTranslation();
   const fileRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
@@ -316,7 +316,7 @@ function VersionPhotos({ loom, version, onChanged }: { loom: LoomDetail; version
 // Version receipts
 // ---------------------------------------------------------------------------
 
-function VersionReceipts({ loom, version, onChanged }: { loom: LoomDetail; version: LoomVersion; onChanged: () => void }) {
+function VersionReceipts({ loom, version, onChanged }: { readonly loom: LoomDetail; readonly version: LoomVersion; readonly onChanged: () => void }) {
   const { t } = useTranslation();
   const fileRef = useRef<HTMLInputElement>(null);
   const [description, setDescription] = useState("");
@@ -402,7 +402,7 @@ function VersionReceipts({ loom, version, onChanged }: { loom: LoomDetail; versi
 // Accessories
 // ---------------------------------------------------------------------------
 
-function VersionAccessories({ loom, version, onChanged }: { loom: LoomDetail; version: LoomVersion; onChanged: () => void }) {
+function VersionAccessories({ loom, version, onChanged }: { readonly loom: LoomDetail; readonly version: LoomVersion; readonly onChanged: () => void }) {
   const { t } = useTranslation();
   const [input, setInput] = useState("");
   const [saving, setSaving] = useState(false);
@@ -483,7 +483,7 @@ function VersionAccessories({ loom, version, onChanged }: { loom: LoomDetail; ve
 // Reed inventory
 // ---------------------------------------------------------------------------
 
-function ReedsPanel({ loom, onChanged }: { loom: LoomDetail; onChanged: () => void }) {
+function ReedsPanel({ loom, onChanged }: { readonly loom: LoomDetail; readonly onChanged: () => void }) {
   const { t } = useTranslation();
   const [dentsInput, setDentsInput] = useState("");
   const [widthInput, setWidthInput] = useState("");
@@ -494,8 +494,8 @@ function ReedsPanel({ loom, onChanged }: { loom: LoomDetail; onChanged: () => vo
 
   const handleAdd = async (e: React.FormEvent) => {
     e.preventDefault();
-    const dents = parseFloat(dentsInput);
-    if (!dentsInput || isNaN(dents) || dents <= 0) {
+    const dents = Number.parseFloat(dentsInput);
+    if (!dentsInput || Number.isNaN(dents) || dents <= 0) {
       setError(t("loomDetailPage.dentsRequired"));
       return;
     }
@@ -504,7 +504,7 @@ function ReedsPanel({ loom, onChanged }: { loom: LoomDetail; onChanged: () => vo
     try {
       await addReed(loom.id, {
         dents_per_inch: dents,
-        ...(widthInput ? { width_cm: parseFloat(widthInput) } : {}),
+        ...(widthInput ? { width_cm: Number.parseFloat(widthInput) } : {}),
         ...(labelInput.trim() ? { label: labelInput.trim() } : {}),
       });
       setDentsInput("");
@@ -530,7 +530,7 @@ function ReedsPanel({ loom, onChanged }: { loom: LoomDetail; onChanged: () => vo
   };
 
   const duplicate = dentsInput
-    ? loom.reeds.some((r) => r.dents_per_inch === parseFloat(dentsInput))
+    ? loom.reeds.some((r) => r.dents_per_inch === Number.parseFloat(dentsInput))
     : false;
 
   return (
@@ -610,7 +610,7 @@ function ReedsPanel({ loom, onChanged }: { loom: LoomDetail; onChanged: () => vo
       </form>
       {duplicate && (
         <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
-          {t("loomDetailPage.duplicateReed", { dpi: parseFloat(dentsInput) })}
+          {t("loomDetailPage.duplicateReed", { dpi: Number.parseFloat(dentsInput) })}
         </p>
       )}
       {error && <p className="mt-1 text-xs text-destructive">{error}</p>}
@@ -626,11 +626,11 @@ function ReedsPanel({ loom, onChanged }: { loom: LoomDetail; onChanged: () => vo
 function VersionCard({
   loom, version, isCurrent, onChanged, onClone,
 }: {
-  loom: LoomDetail;
-  version: LoomVersion;
-  isCurrent: boolean;
-  onChanged: () => void;
-  onClone: (v: LoomVersion) => void;
+  readonly loom: LoomDetail;
+  readonly version: LoomVersion;
+  readonly isCurrent: boolean;
+  readonly onChanged: () => void;
+  readonly onClone: (v: LoomVersion) => void;
 }) {
   const { t } = useTranslation();
   const { user } = useAuthContext();
@@ -656,7 +656,7 @@ function VersionCard({
     (version.warp_waste_allowance ? version.warp_waste_unit : displayUnit) as LengthUnit
   );
   const [editWaste, setEditWaste] = useState(
-    version.warp_waste_allowance ? parseFloat(version.warp_waste_allowance).toFixed(1) : ""
+    version.warp_waste_allowance ? Number.parseFloat(version.warp_waste_allowance).toFixed(1) : ""
   );
   const [saving, setSaving] = useState(false);
   const [editError, setEditError] = useState<string | null>(null);
@@ -667,7 +667,7 @@ function VersionCard({
     setSaving(true);
     setEditError(null);
     try {
-      const waste = editWaste.trim() ? parseFloat(editWaste) : undefined;
+      const waste = editWaste.trim() ? Number.parseFloat(editWaste) : undefined;
       await updateVersion(loom.id, version.id, {
         name: editName.trim() || undefined,
         description: editDesc.trim() || undefined,
@@ -685,7 +685,7 @@ function VersionCard({
   const handleEditCancel = () => {
     setEditName(version.name ?? "");
     setEditDesc(version.description ?? "");
-    setEditWaste(version.warp_waste_allowance ? parseFloat(version.warp_waste_allowance).toFixed(1) : "");
+    setEditWaste(version.warp_waste_allowance ? Number.parseFloat(version.warp_waste_allowance).toFixed(1) : "");
     setEditWasteUnit((version.warp_waste_allowance ? version.warp_waste_unit : displayUnit) as LengthUnit);
     setEditError(null);
     setEditing(false);
@@ -693,8 +693,8 @@ function VersionCard({
 
   function handleWasteUnitChange(newUnit: LengthUnit) {
     if (editWaste) {
-      const val = parseFloat(editWaste);
-      if (!isNaN(val)) setEditWaste(convertLength(val, editWasteUnit, newUnit).toFixed(1));
+      const val = Number.parseFloat(editWaste);
+      if (!Number.isNaN(val)) setEditWaste(convertLength(val, editWasteUnit, newUnit).toFixed(1));
     }
     setEditWasteUnit(newUnit);
   }

--- a/frontend/src/pages/LoomsPage.tsx
+++ b/frontend/src/pages/LoomsPage.tsx
@@ -16,7 +16,7 @@ interface LoomProjectCounts {
   abandoned: number;
 }
 
-function LoomCard({ loom, projectCounts, retired }: { loom: Loom; projectCounts?: LoomProjectCounts; retired?: boolean }) {
+function LoomCard({ loom, projectCounts, retired }: { readonly loom: Loom; readonly projectCounts?: LoomProjectCounts; readonly retired?: boolean }) {
   const { t } = useTranslation();
   const v = loom.current_version;
   return (

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -32,9 +32,9 @@ import { SuperuserInspectionBanner } from "@/components/ui/SuperuserInspectionBa
 // ---------------------------------------------------------------------------
 
 function contrastColor(hex: string): string {
-  const r = parseInt(hex.slice(1, 3), 16) / 255;
-  const g = parseInt(hex.slice(3, 5), 16) / 255;
-  const b = parseInt(hex.slice(5, 7), 16) / 255;
+  const r = Number.parseInt(hex.slice(1, 3), 16) / 255;
+  const g = Number.parseInt(hex.slice(3, 5), 16) / 255;
+  const b = Number.parseInt(hex.slice(5, 7), 16) / 255;
   const lin = (c: number) => c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
   const L = 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
   return L > 0.179 ? "#000000" : "#ffffff";
@@ -51,9 +51,9 @@ function CollapsibleSection({
   children,
   defaultOpen = false,
 }: {
-  title: string;
-  children: React.ReactNode;
-  defaultOpen?: boolean;
+  readonly title: string;
+  readonly children: React.ReactNode;
+  readonly defaultOpen?: boolean;
 }) {
   const [open, setOpen] = useState(defaultOpen);
   return (
@@ -84,7 +84,7 @@ function fmtDuration(ms: number): string {
   return `${totalSec}s`;
 }
 
-function SessionMetricsPanel({ metrics }: { metrics: ProjectMetrics }) {
+function SessionMetricsPanel({ metrics }: { readonly metrics: ProjectMetrics }) {
   const { t } = useTranslation();
   const [elapsed, setElapsed] = useState(0);
 
@@ -138,11 +138,11 @@ function DesignPreviewModal({
   draftName,
   onClose,
 }: {
-  projectId: string;
-  hasDrawdownPreview: boolean;
-  colorReplacements: Record<string, string> | null;
-  draftName: string;
-  onClose: () => void;
+  readonly projectId: string;
+  readonly hasDrawdownPreview: boolean;
+  readonly colorReplacements: Record<string, string> | null;
+  readonly draftName: string;
+  readonly onClose: () => void;
 }) {
   const src = hasDrawdownPreview
     ? projectDrawdownPreviewUrl(projectId)
@@ -170,12 +170,12 @@ function PickDisplay({
   showWeftColor,
   compact = false,
 }: {
-  pick: PickRow;
-  totalCount: number;
-  projectType: string;
-  colorMode: ColorMode;
-  showWeftColor: boolean;
-  compact?: boolean;
+  readonly pick: PickRow;
+  readonly totalCount: number;
+  readonly projectType: string;
+  readonly colorMode: ColorMode;
+  readonly showWeftColor: boolean;
+  readonly compact?: boolean;
 }) {
   const { t } = useTranslation();
   const count = Math.max(totalCount, 1);
@@ -299,11 +299,11 @@ function WeavingPatternView({
   picks,
   maxActive,
 }: {
-  projectId: string;
-  currentPickIndex: number;
-  totalPicks: number;
-  picks: PickRow[];
-  maxActive: number;
+  readonly projectId: string;
+  readonly currentPickIndex: number;
+  readonly totalPicks: number;
+  readonly picks: PickRow[];
+  readonly maxActive: number;
 }) {
   const { t } = useTranslation();
   const containerH = useAdaptivePatternHeight();
@@ -328,7 +328,7 @@ function WeavingPatternView({
         try {
           const saved = localStorage.getItem(lsColKey);
           if (saved !== null && scrollRef.current) {
-            scrollRef.current.scrollLeft = parseInt(saved, 10) || 0;
+            scrollRef.current.scrollLeft = Number.parseInt(saved, 10) || 0;
           }
         } catch { /* localStorage unavailable */ }
       } catch (err) {
@@ -494,9 +494,9 @@ function AbandonedDrawdownView({
   currentPick,
   totalPicks,
 }: {
-  draftId: string;
-  currentPick: number;
-  totalPicks: number;
+  readonly draftId: string;
+  readonly currentPick: number;
+  readonly totalPicks: number;
 }) {
   const { t } = useTranslation();
   const [imgSrc, setImgSrc] = useState<string | null>(null);
@@ -587,12 +587,12 @@ function StepControls({
   stepping,
   jumpDisabled = false,
 }: {
-  currentPick: number;
-  total: number;
-  onStep: (dir: "advance" | "reverse") => void;
-  onJump: (pick: number) => void;
-  stepping: boolean;
-  jumpDisabled?: boolean;
+  readonly currentPick: number;
+  readonly total: number;
+  readonly onStep: (dir: "advance" | "reverse") => void;
+  readonly onJump: (pick: number) => void;
+  readonly stepping: boolean;
+  readonly jumpDisabled?: boolean;
 }) {
   const { t } = useTranslation();
   const atStart = currentPick <= 1;
@@ -664,17 +664,17 @@ function JumpToPick({
   onJump,
   disabled,
 }: {
-  total: number;
-  onJump: (pick: number) => void;
-  disabled: boolean;
+  readonly total: number;
+  readonly onJump: (pick: number) => void;
+  readonly disabled: boolean;
 }) {
   const { t } = useTranslation();
   const [value, setValue] = useState("");
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    const n = parseInt(value, 10);
-    if (!isNaN(n)) {
+    const n = Number.parseInt(value, 10);
+    if (!Number.isNaN(n)) {
       onJump(Math.max(1, Math.min(n, total + 1)));
       setValue("");
     }
@@ -712,7 +712,7 @@ function JumpToPick({
 // Progress bar
 // ---------------------------------------------------------------------------
 
-function ProgressBar({ current, total }: { current: number; total: number }) {
+function ProgressBar({ current, total }: { readonly current: number; readonly total: number }) {
   const { t } = useTranslation();
   const pct = total > 0 ? Math.round((Math.min(current - 1, total) / total) * 100) : 0;
   return (
@@ -739,11 +739,11 @@ function PhotoGrid({
   onDeleted,
   readOnly = false,
 }: {
-  projectId: string;
-  photos: ProjectPhoto[];
-  onUploaded: (p: ProjectPhoto) => void;
-  onDeleted: (id: string) => void;
-  readOnly?: boolean;
+  readonly projectId: string;
+  readonly photos: ProjectPhoto[];
+  readonly onUploaded: (p: ProjectPhoto) => void;
+  readonly onDeleted: (id: string) => void;
+  readonly readOnly?: boolean;
 }) {
   const { t } = useTranslation();
   const inputRef = useRef<HTMLInputElement>(null);
@@ -887,9 +887,9 @@ function CompletedSummary({
   siblings,
   onPhotosChange,
 }: {
-  project: import("@/api/projects").ProjectDetail;
-  siblings: ProjectSummary[];
-  onPhotosChange: (photos: ProjectPhoto[]) => void;
+  readonly project: import("@/api/projects").ProjectDetail;
+  readonly siblings: ProjectSummary[];
+  readonly onPhotosChange: (photos: ProjectPhoto[]) => void;
 }) {
   const { t } = useTranslation();
   const { user } = useAuthContext();

--- a/frontend/src/pages/ProjectLandingPage.tsx
+++ b/frontend/src/pages/ProjectLandingPage.tsx
@@ -81,7 +81,7 @@ function useAuthedSvg(url: string | null): { svg: string | null; loading: boolea
 // Zoom percentage input — lets the user type a zoom value directly.
 // ---------------------------------------------------------------------------
 
-function ZoomInput({ zoom, onCommit }: { zoom: number; onCommit: (z: number) => void }) {
+function ZoomInput({ zoom, onCommit }: { readonly zoom: number; readonly onCommit: (z: number) => void }) {
   const [editing, setEditing] = useState(false);
   const [raw, setRaw] = useState("");
 
@@ -93,8 +93,8 @@ function ZoomInput({ zoom, onCommit }: { zoom: number; onCommit: (z: number) => 
 
   function commit(input: string) {
     setEditing(false);
-    const n = parseInt(input, 10);
-    if (!isNaN(n)) {
+    const n = Number.parseInt(input, 10);
+    if (!Number.isNaN(n)) {
       onCommit(Math.max(0.05, Math.min(8, n / 100)));
     }
   }
@@ -124,9 +124,9 @@ function ZoomInput({ zoom, onCommit }: { zoom: number; onCommit: (z: number) => 
 // ---------------------------------------------------------------------------
 
 function DrawdownModal({ svgUrl, title = "Design preview", onClose }: {
-  svgUrl: string;
-  title?: string;
-  onClose: () => void;
+  readonly svgUrl: string;
+  readonly title?: string;
+  readonly onClose: () => void;
 }) {
   const { t } = useTranslation();
   const [zoom, setZoom] = useState(1);
@@ -223,12 +223,12 @@ function DrawdownModal({ svgUrl, title = "Design preview", onClose }: {
       const w = svgEl.getAttribute("width");
       const h = svgEl.getAttribute("height");
       if (w && h) {
-        svgSizeRef.current = { w: parseFloat(w), h: parseFloat(h) };
+        svgSizeRef.current = { w: Number.parseFloat(w), h: Number.parseFloat(h) };
       } else {
         const vb = svgEl.getAttribute("viewBox");
         if (vb) {
           const parts = vb.trim().split(/\s+/);
-          if (parts.length >= 4) svgSizeRef.current = { w: parseFloat(parts[2]), h: parseFloat(parts[3]) };
+          if (parts.length >= 4) svgSizeRef.current = { w: Number.parseFloat(parts[2]), h: Number.parseFloat(parts[3]) };
         }
       }
     }
@@ -361,9 +361,9 @@ function DrawdownModal({ svgUrl, title = "Design preview", onClose }: {
 // ---------------------------------------------------------------------------
 
 function TieUpModal({ projectId, draftName, onClose }: {
-  projectId: string;
-  draftName: string;
-  onClose: () => void;
+  readonly projectId: string;
+  readonly draftName: string;
+  readonly onClose: () => void;
 }) {
   const { t } = useTranslation();
   const { data: plan, isLoading } = useQuery({
@@ -455,16 +455,16 @@ function ColorPaletteSection({
   locked,
   yarnColors,
 }: {
-  projectId: string;
-  wifColors: { index: number; hex: string }[];
-  warpStats: { hex: string; count: number; percentage: number }[] | null;
-  weftStats: { hex: string; count: number; percentage: number }[] | null;
-  colorReplacements: Record<string, string> | null;
-  warpLengthCm: number | null;
-  onSave: (replacements: Record<string, string>, yarnLinks: Record<string, string | null>) => void;
-  isSaving: boolean;
-  locked?: boolean;
-  yarnColors: ProjectYarnColor[];
+  readonly projectId: string;
+  readonly wifColors: { index: number; hex: string }[];
+  readonly warpStats: { hex: string; count: number; percentage: number }[] | null;
+  readonly weftStats: { hex: string; count: number; percentage: number }[] | null;
+  readonly colorReplacements: Record<string, string> | null;
+  readonly warpLengthCm: number | null;
+  readonly onSave: (replacements: Record<string, string>, yarnLinks: Record<string, string | null>) => void;
+  readonly isSaving: boolean;
+  readonly locked?: boolean;
+  readonly yarnColors: ProjectYarnColor[];
 }) {
   const { t } = useTranslation();
   const { user } = useAuthContext();
@@ -786,9 +786,9 @@ function WarpSetupSection({
   displayUnit,
   onUpdated,
 }: {
-  project: ProjectDetail;
-  displayUnit: LengthUnit;
-  onUpdated: (p: ProjectDetail) => void;
+  readonly project: ProjectDetail;
+  readonly displayUnit: LengthUnit;
+  readonly onUpdated: (p: ProjectDetail) => void;
 }) {
   // Per-field unit defaults: prefer the original source unit over the user's global preference.
   // Length / item + waste-between: use the draft WIF warp_length_unit if available.
@@ -805,12 +805,12 @@ function WarpSetupSection({
   // Ground-truth loom waste in cm; changes only when backend data refreshes.
   const loomWasteDefaultCm = useMemo((): number | null => {
     if (project.warp_waste_allowance) {
-      const n = parseFloat(project.warp_waste_allowance);
-      if (!isNaN(n)) return convertLength(n, (project.length_unit as LengthUnit) ?? "cm", "cm");
+      const n = Number.parseFloat(project.warp_waste_allowance);
+      if (!Number.isNaN(n)) return convertLength(n, (project.length_unit as LengthUnit) ?? "cm", "cm");
     }
     if (project.loom_warp_waste_allowance) {
-      const n = parseFloat(project.loom_warp_waste_allowance);
-      if (!isNaN(n)) return convertLength(n, (project.loom_warp_waste_unit as LengthUnit) ?? "cm", "cm");
+      const n = Number.parseFloat(project.loom_warp_waste_allowance);
+      if (!Number.isNaN(n)) return convertLength(n, (project.loom_warp_waste_unit as LengthUnit) ?? "cm", "cm");
     }
     return null;
   }, [project.warp_waste_allowance, project.loom_warp_waste_allowance, project.loom_warp_waste_unit, project.length_unit]);
@@ -818,8 +818,8 @@ function WarpSetupSection({
   // Helpers to convert a stored project value (in project.length_unit) to a target unit via cm.
   function fromStored(raw: string | null, target: LengthUnit): string {
     if (!raw) return "";
-    const n = parseFloat(raw);
-    if (isNaN(n)) return "";
+    const n = Number.parseFloat(raw);
+    if (Number.isNaN(n)) return "";
     const cm = convertLength(n, (project.length_unit as LengthUnit) ?? "cm", "cm");
     return convertLength(cm, "cm", target).toFixed(1);
   }
@@ -859,17 +859,17 @@ function WarpSetupSection({
 
   // Unit-change handlers auto-convert current field values to the new unit.
   function handleItemUnitChange(newUnit: LengthUnit) {
-    const conv = (v: string) => { const n = parseFloat(v); return isNaN(n) ? v : convertLength(n, itemUnit, newUnit).toFixed(1); };
+    const conv = (v: string) => { const n = Number.parseFloat(v); return Number.isNaN(n) ? v : convertLength(n, itemUnit, newUnit).toFixed(1); };
     if (lengthPerItem) setLengthPerItem(conv(lengthPerItem));
     if (wasteBetween) setWasteBetween(conv(wasteBetween));
     setItemUnit(newUnit);
   }
   function handleWasteUnitChange(newUnit: LengthUnit) {
-    if (loomWaste) { const n = parseFloat(loomWaste); if (!isNaN(n)) setLoomWaste(convertLength(n, wasteUnit, newUnit).toFixed(1)); }
+    if (loomWaste) { const n = Number.parseFloat(loomWaste); if (!Number.isNaN(n)) setLoomWaste(convertLength(n, wasteUnit, newUnit).toFixed(1)); }
     setWasteUnit(newUnit);
   }
 
-  const numItems = Math.max(1, parseInt(items, 10) || 1);
+  const numItems = Math.max(1, Number.parseInt(items, 10) || 1);
 
   // "Origin" values for dirty detection — computed in current field units so a unit change alone isn't dirty.
   const origLength = (() => {
@@ -888,7 +888,7 @@ function WarpSetupSection({
 
   const mutation = useMutation({
     mutationFn: () => {
-      const toCm = (v: string, u: LengthUnit) => convertLength(parseFloat(v), u, "cm");
+      const toCm = (v: string, u: LengthUnit) => convertLength(Number.parseFloat(v), u, "cm");
       return updateProjectWarpSetup(project.id, {
         num_items: numItems,
         finished_length_per_item: lengthPerItem ? toCm(lengthPerItem, itemUnit) : null,
@@ -988,8 +988,8 @@ function ReedSelector({
   project,
   onUpdated,
 }: {
-  project: ProjectDetail;
-  onUpdated: (p: ProjectDetail) => void;
+  readonly project: ProjectDetail;
+  readonly onUpdated: (p: ProjectDetail) => void;
 }) {
   const { t } = useTranslation();
   const locked = project.status !== "created";
@@ -1036,18 +1036,18 @@ function ReedSelector({
 
   function handleSelect(val: string) {
     setSelectValue(val);
-    if (val !== "custom" && val !== "") mutation.mutate(parseFloat(val));
+    if (val !== "custom" && val !== "") mutation.mutate(Number.parseFloat(val));
     else if (val === "") mutation.mutate(null);
   }
 
   function handleCustomSave() {
-    const n = parseFloat(customInput);
-    if (!isNaN(n) && n > 0) mutation.mutate(n);
+    const n = Number.parseFloat(customInput);
+    if (!Number.isNaN(n) && n > 0) mutation.mutate(n);
   }
 
   const effectiveDents = isCustom
-    ? parseFloat(customInput)
-    : selectValue !== "" ? parseFloat(selectValue) : null;
+    ? Number.parseFloat(customInput)
+    : selectValue !== "" ? Number.parseFloat(selectValue) : null;
   const effectiveDentsInt = effectiveDents != null ? Math.round(effectiveDents) : null;
 
   const isCleanMultiple =
@@ -1223,9 +1223,9 @@ function NotesSection({
   initialNotes,
   onUpdated,
 }: {
-  projectId: string;
-  initialNotes: string | null;
-  onUpdated: (updated: ProjectDetail) => void;
+  readonly projectId: string;
+  readonly initialNotes: string | null;
+  readonly onUpdated: (updated: ProjectDetail) => void;
 }) {
   const { t } = useTranslation();
   const [editing, setEditing] = useState(false);

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -42,8 +42,8 @@ function groupByYear(
 }
 
 function ProjectCard({ project, onAssign }: {
-  project: ProjectSummary;
-  onAssign?: (id: string) => void;
+  readonly project: ProjectSummary;
+  readonly onAssign?: (id: string) => void;
 }) {
   const { t } = useTranslation();
   const [showPreview, setShowPreview] = useState(false);
@@ -185,10 +185,10 @@ function YearGroup({
   defaultExpanded,
   onAssign,
 }: {
-  year: number;
-  items: ProjectSummary[];
-  defaultExpanded: boolean;
-  onAssign?: (id: string) => void;
+  readonly year: number;
+  readonly items: ProjectSummary[];
+  readonly defaultExpanded: boolean;
+  readonly onAssign?: (id: string) => void;
 }) {
   const [open, setOpen] = useState(defaultExpanded);
   return (

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -854,7 +854,7 @@ function FeedbackHistorySection() {
   );
 }
 
-function Section({ title, description, children }: { title: string; description?: string; children: ReactNode }) {
+function Section({ title, description, children }: { readonly title: string; readonly description?: string; readonly children: ReactNode }) {
   return (
     <div className="space-y-5">
       <div className="border-b pb-2 space-y-0.5">
@@ -866,7 +866,7 @@ function Section({ title, description, children }: { title: string; description?
   );
 }
 
-function Field({ label, children }: { label: string; children: ReactNode }) {
+function Field({ label, children }: { readonly label: string; readonly children: ReactNode }) {
   return (
     <div className="space-y-2">
       <label className="text-sm font-medium">{label}</label>

--- a/frontend/src/pages/SharedProjectPage.tsx
+++ b/frontend/src/pages/SharedProjectPage.tsx
@@ -17,7 +17,7 @@ import { PublicFooter } from "@/components/PublicFooter";
 // Status badge
 // ---------------------------------------------------------------------------
 
-function StatusBadge({ status }: { status: string }) {
+function StatusBadge({ status }: { readonly status: string }) {
   const colors: Record<string, string> = {
     created: "bg-blue-100 text-blue-700",
     active: "bg-green-100 text-green-800",
@@ -36,7 +36,7 @@ function StatusBadge({ status }: { status: string }) {
 // Progress bar
 // ---------------------------------------------------------------------------
 
-function ProgressBar({ current, total }: { current: number; total: number }) {
+function ProgressBar({ current, total }: { readonly current: number; readonly total: number }) {
   const { t } = useTranslation();
   const done = Math.max(0, current - 1);
   const pct = Math.min(100, Math.round((done / Math.max(total, 1)) * 100));
@@ -67,11 +67,11 @@ function DrawdownWithHaze({
   totalPicks,
   isActive,
 }: {
-  previewUrl: string;
-  svgUrl: string;
-  currentPick: number;
-  totalPicks: number;
-  isActive: boolean;
+  readonly previewUrl: string;
+  readonly svgUrl: string;
+  readonly currentPick: number;
+  readonly totalPicks: number;
+  readonly isActive: boolean;
 }) {
   const { t } = useTranslation();
   const [showHaze, setShowHaze] = useState(true);
@@ -149,10 +149,10 @@ function ColorPaletteTable({
   weftStats,
   colorReplacements,
 }: {
-  wifColors: WifColor[];
-  warpStats: ColorStat[] | null;
-  weftStats: ColorStat[] | null;
-  colorReplacements: Record<string, string> | null;
+  readonly wifColors: WifColor[];
+  readonly warpStats: ColorStat[] | null;
+  readonly weftStats: ColorStat[] | null;
+  readonly colorReplacements: Record<string, string> | null;
 }) {
   const { t } = useTranslation();
   const bothPresent = warpStats !== null && weftStats !== null;
@@ -217,7 +217,7 @@ function ColorPaletteTable({
 // Info row
 // ---------------------------------------------------------------------------
 
-function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
+function InfoRow({ label, value }: { readonly label: string; readonly value: React.ReactNode }) {
   return (
     <div className="flex justify-between gap-4 py-2 border-b border-stone-100 last:border-0">
       <span className="text-sm text-stone-500 shrink-0">{label}</span>

--- a/frontend/src/pages/SuperuserPage.tsx
+++ b/frontend/src/pages/SuperuserPage.tsx
@@ -498,7 +498,7 @@ function StorageAuditTab() {
   );
 }
 
-function CveFindingsTable({ title, findings }: { title: string; findings: CveFinding[] }) {
+function CveFindingsTable({ title, findings }: { readonly title: string; readonly findings: CveFinding[] }) {
   if (findings.length === 0) return null;
   return (
     <div className="space-y-2">
@@ -626,7 +626,7 @@ function CveScanTab() {
   );
 }
 
-function WorkerCard({ worker, apiVersion }: { worker: WorkerInfo; apiVersion: string }) {
+function WorkerCard({ worker, apiVersion }: { readonly worker: WorkerInfo; readonly apiVersion: string }) {
   const isOnline = worker.status === "online";
   const hasActive = worker.active_tasks.length > 0;
   const hasReserved = worker.reserved_tasks.length > 0;
@@ -826,7 +826,7 @@ function shortName(name: string): string {
   return parts.length >= 2 ? parts.slice(-2).join(".") : name;
 }
 
-function TaskHistoryRow({ item, onRevoke }: { item: TaskHistoryItem; onRevoke: (id: string) => void }) {
+function TaskHistoryRow({ item, onRevoke }: { readonly item: TaskHistoryItem; readonly onRevoke: (id: string) => void }) {
   const [expanded, setExpanded] = useState(false);
   const cancellable = item.state === "queued" || item.state === "running";
   return (
@@ -960,7 +960,7 @@ const DELETION_STATE_STYLE: Record<string, string> = {
   complete: "border-green-500/40 bg-green-500/10 text-green-700 dark:text-green-300",
 };
 
-function DeletionStateBadge({ state }: { state: string }) {
+function DeletionStateBadge({ state }: { readonly state: string }) {
   return (
     <span className={`text-xs px-2 py-0.5 rounded border font-medium ${DELETION_STATE_STYLE[state] ?? "border-border text-muted-foreground"}`}>
       {state}
@@ -1296,7 +1296,7 @@ const CRON_PRESETS = [
   { label: "Custom", value: "custom" },
 ];
 
-function ScheduledTaskCard({ task, onSaved }: { task: ScheduledTask; onSaved: () => void }) {
+function ScheduledTaskCard({ task, onSaved }: { readonly task: ScheduledTask; readonly onSaved: () => void }) {
   const [enabled, setEnabled] = useState(task.enabled);
   const [preset, setPreset] = useState<string>(() => {
     const match = CRON_PRESETS.find((p) => p.value === task.cron && p.value !== "custom");
@@ -1435,7 +1435,7 @@ function ScheduledTasksTab() {
 // Data Exports tab
 // ---------------------------------------------------------------------------
 
-function ExportStatusBadge({ status }: { status: AdminExportRecord["status"] }) {
+function ExportStatusBadge({ status }: { readonly status: AdminExportRecord["status"] }) {
   const cls =
     status === "complete"
       ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300"
@@ -1447,7 +1447,7 @@ function ExportStatusBadge({ status }: { status: AdminExportRecord["status"] }) 
   );
 }
 
-function ExportRow({ record, onDeleted }: { record: AdminExportRecord; onDeleted: () => void }) {
+function ExportRow({ record, onDeleted }: { readonly record: AdminExportRecord; readonly onDeleted: () => void }) {
   const [confirming, setConfirming] = useState(false);
   const mutation = useMutation({
     mutationFn: () => deleteExport(record.id),
@@ -2094,7 +2094,7 @@ function ConfigSection() {
   );
 }
 
-function NeonUsageBars({ daily }: { daily: { date: string; compute_seconds: number }[] }) {
+function NeonUsageBars({ daily }: { readonly daily: { date: string; compute_seconds: number }[] }) {
   if (daily.length === 0) return null;
   const maxDaily = Math.max(1, ...daily.map((d) => d.compute_seconds));
   return (

--- a/frontend/src/pages/VersionErrorPage.tsx
+++ b/frontend/src/pages/VersionErrorPage.tsx
@@ -1,9 +1,9 @@
 import { useTranslation } from "react-i18next";
 
 interface Props {
-  frontendVersion: string;
-  backendVersion: string;
-  workerVersion?: string;
+  readonly frontendVersion: string;
+  readonly backendVersion: string;
+  readonly workerVersion?: string;
 }
 
 export function VersionErrorPage({ frontendVersion, backendVersion, workerVersion }: Props) {

--- a/frontend/src/pages/WarpingPlanPage.tsx
+++ b/frontend/src/pages/WarpingPlanPage.tsx
@@ -19,9 +19,9 @@ const TABS: { id: ReportTab; key: string }[] = [
 
 function approximateColorName(hex: string): string {
   if (!hex || hex.length < 7) return "";
-  const r = parseInt(hex.slice(1, 3), 16) / 255;
-  const g = parseInt(hex.slice(3, 5), 16) / 255;
-  const b = parseInt(hex.slice(5, 7), 16) / 255;
+  const r = Number.parseInt(hex.slice(1, 3), 16) / 255;
+  const g = Number.parseInt(hex.slice(3, 5), 16) / 255;
+  const b = Number.parseInt(hex.slice(5, 7), 16) / 255;
   const max = Math.max(r, g, b);
   const min = Math.min(r, g, b);
   const delta = max - min;
@@ -89,16 +89,16 @@ interface WarpSetup {
 
 function computeWarpSetup(project: ProjectDetail): WarpSetup {
   const displayUnit = (project.length_unit as LengthUnit) || "cm";
-  const itemLengthCm = project.finished_length_per_item != null ? parseFloat(project.finished_length_per_item) : null;
-  const wasteBetweenCm = project.waste_between_items != null ? parseFloat(project.waste_between_items) : null;
+  const itemLengthCm = project.finished_length_per_item != null ? Number.parseFloat(project.finished_length_per_item) : null;
+  const wasteBetweenCm = project.waste_between_items != null ? Number.parseFloat(project.waste_between_items) : null;
   const numItems = project.num_items || 1;
 
   let warpWasteCm: number | null = null;
   if (project.warp_waste_allowance != null) {
-    warpWasteCm = parseFloat(project.warp_waste_allowance);
+    warpWasteCm = Number.parseFloat(project.warp_waste_allowance);
   } else if (project.loom_warp_waste_allowance != null && project.loom_warp_waste_unit) {
     warpWasteCm = convertLength(
-      parseFloat(project.loom_warp_waste_allowance),
+      Number.parseFloat(project.loom_warp_waste_allowance),
       project.loom_warp_waste_unit as LengthUnit,
       "cm",
     );
@@ -130,9 +130,9 @@ function MissingParamsBanner({
   projectId,
   loomId,
 }: {
-  setup: WarpSetup;
-  projectId: string;
-  loomId: string | null;
+  readonly setup: WarpSetup;
+  readonly projectId: string;
+  readonly loomId: string | null;
 }) {
   const { t } = useTranslation();
   const items: React.ReactNode[] = [];
@@ -230,7 +230,7 @@ function MissingParamsBanner({
   );
 }
 
-function Swatch({ hex }: { hex: string | null }) {
+function Swatch({ hex }: { readonly hex: string | null }) {
   if (!hex) return <span className="inline-block h-4 w-4 rounded border border-border bg-muted" />;
   return (
     <span
@@ -241,7 +241,7 @@ function Swatch({ hex }: { hex: string | null }) {
   );
 }
 
-function SummarySection({ plan }: { plan: WarpingPlan }) {
+function SummarySection({ plan }: { readonly plan: WarpingPlan }) {
   const { t } = useTranslation();
   const warpLengthM = plan.warp_length_cm != null ? (plan.warp_length_cm / 100).toFixed(2) : null;
   return (
@@ -288,7 +288,7 @@ function SummarySection({ plan }: { plan: WarpingPlan }) {
   );
 }
 
-function WarpColorSummary({ rows }: { rows: ColorStat[] }) {
+function WarpColorSummary({ rows }: { readonly rows: ColorStat[] }) {
   const { t } = useTranslation();
   if (rows.length === 0) return null;
   return (
@@ -324,8 +324,8 @@ function WindingSection({
   plan,
   project,
 }: {
-  plan: WarpingPlan;
-  project?: ProjectDetail;
+  readonly plan: WarpingPlan;
+  readonly project?: ProjectDetail;
 }) {
   const { t } = useTranslation();
   const setup = project ? computeWarpSetup(project) : null;
@@ -459,7 +459,7 @@ function WindingSection({
   );
 }
 
-function TieUpSection({ plan }: { plan: WarpingPlan }) {
+function TieUpSection({ plan }: { readonly plan: WarpingPlan }) {
   const { t } = useTranslation();
   if (!plan.has_tieup || !plan.tieup || !plan.tieup_num_shafts || !plan.tieup_num_treadles) {
     return (
@@ -487,7 +487,7 @@ function TieUpSection({ plan }: { plan: WarpingPlan }) {
   );
 }
 
-function ThreadingSection({ plan }: { plan: WarpingPlan }) {
+function ThreadingSection({ plan }: { readonly plan: WarpingPlan }) {
   const { t } = useTranslation();
   if (!plan.has_threading || !plan.threading || plan.threading.length === 0) {
     return (

--- a/frontend/src/pages/YarnDetailPage.tsx
+++ b/frontend/src/pages/YarnDetailPage.tsx
@@ -7,7 +7,7 @@ import { formatColorwayLabel, getRavelryStatus, getRavelryYarnDetail, pushYarnTo
 import { Button } from "@/components/ui/button";
 import { ColorPicker } from "@/components/ui/ColorPicker";
 
-function DevJsonModal({ data, onClose }: { data: unknown; onClose: () => void }) {
+function DevJsonModal({ data, onClose }: { readonly data: unknown; readonly onClose: () => void }) {
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
@@ -52,9 +52,9 @@ function EditColorwayModal({
   onClose,
   onSaved,
 }: {
-  yarn: { id: string; color_name: string | null; ravelry_yarn_id: number | null };
-  onClose: () => void;
-  onSaved: () => void;
+  readonly yarn: { id: string; color_name: string | null; ravelry_yarn_id: number | null };
+  readonly onClose: () => void;
+  readonly onSaved: () => void;
 }) {
   const { t } = useTranslation();
   const [tab, setTab] = useState<"rename" | "link">("rename");
@@ -230,7 +230,7 @@ function EditColorwayModal({
 // Color picker section
 // ---------------------------------------------------------------------------
 
-function ColorSection({ yarn, onSaved }: { yarn: { id: string; color_hex: string | null; ravelry_stash_id: number | null }; onSaved: () => void }) {
+function ColorSection({ yarn, onSaved }: { readonly yarn: { id: string; color_hex: string | null; ravelry_stash_id: number | null }; readonly onSaved: () => void }) {
   const { t } = useTranslation();
   const [colorHex, setColorHex] = useState(yarn.color_hex ?? "#888888");
   const [saving, setSaving] = useState(false);
@@ -273,9 +273,9 @@ function ColorSection({ yarn, onSaved }: { yarn: { id: string; color_hex: string
 // ---------------------------------------------------------------------------
 
 function RavelrySection({ ry, companyUrl, permalink }: {
-  ry: RavelryYarnApiDetail;
-  companyUrl: string | null;
-  permalink: string | null;
+  readonly ry: RavelryYarnApiDetail;
+  readonly companyUrl: string | null;
+  readonly permalink: string | null;
 }) {
   const { t } = useTranslation();
 

--- a/frontend/src/pages/YarnPage.tsx
+++ b/frontend/src/pages/YarnPage.tsx
@@ -112,7 +112,7 @@ function applyFilters(yarns: YarnSummary[], f: YarnFilters): YarnSummary[] {
 
 // ─── shared photo cell ────────────────────────────────────────────────────────
 
-function YarnPhoto({ yarn, className }: { yarn: YarnSummary; className: string }) {
+function YarnPhoto({ yarn, className }: { readonly yarn: YarnSummary; readonly className: string }) {
   const ravelryUrl =
     yarn.ravelry_colorway_thumbnail_url ??
     yarn.ravelry_colorway_photo_url ??
@@ -140,7 +140,7 @@ function isStashPushEligible(yarn: YarnSummary) {
   return yarn.ravelry_yarn_id !== null && yarn.ravelry_stash_id === null && !yarn.out_of_stash && !yarn.archived;
 }
 
-function YarnCard({ yarn, connected }: { yarn: YarnSummary; connected: boolean }) {
+function YarnCard({ yarn, connected }: { readonly yarn: YarnSummary; readonly connected: boolean }) {
   const { t } = useTranslation();
   const skeinLabel =
     yarn.skein_count === 0
@@ -214,7 +214,7 @@ function YarnCard({ yarn, connected }: { yarn: YarnSummary; connected: boolean }
 
 // ─── grid view ────────────────────────────────────────────────────────────────
 
-function YarnGridTile({ yarn, connected }: { yarn: YarnSummary; connected: boolean }) {
+function YarnGridTile({ yarn, connected }: { readonly yarn: YarnSummary; readonly connected: boolean }) {
   const { t } = useTranslation();
   const skeinLabel =
     yarn.skein_count === 0
@@ -260,11 +260,11 @@ function YarnGridTile({ yarn, connected }: { yarn: YarnSummary; connected: boole
 function SortHeader({
   label, currentSort, ascKey, descKey, onSort,
 }: {
-  label: string;
-  currentSort: SortKey;
-  ascKey: SortKey;
-  descKey?: SortKey;
-  onSort: (key: SortKey) => void;
+  readonly label: string;
+  readonly currentSort: SortKey;
+  readonly ascKey: SortKey;
+  readonly descKey?: SortKey;
+  readonly onSort: (key: SortKey) => void;
 }) {
   const isActive = currentSort === ascKey || currentSort === descKey;
   const isAsc = currentSort === ascKey;
@@ -284,9 +284,9 @@ function SortHeader({
 function YarnTable({
   yarns, sort, onSort,
 }: {
-  yarns: YarnSummary[];
-  sort: SortKey;
-  onSort: (key: SortKey) => void;
+  readonly yarns: YarnSummary[];
+  readonly sort: SortKey;
+  readonly onSort: (key: SortKey) => void;
 }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -384,9 +384,9 @@ function YarnTable({
 function FilterPopover({
   allYarns, filters, onChange,
 }: {
-  allYarns: YarnSummary[];
-  filters: YarnFilters;
-  onChange: (f: YarnFilters) => void;
+  readonly allYarns: YarnSummary[];
+  readonly filters: YarnFilters;
+  readonly onChange: (f: YarnFilters) => void;
 }) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);


### PR DESCRIPTION
## Summary
Three mechanical SonarCloud sweeps combined per request, 601 findings total.

**`python:S8410`** (347, backend) — every remaining `param: Type = Depends(...)` converted to `Annotated[Type, Depends(...)]`. AST-driven (Python `ast` module, offset-based source splicing) rather than regex, specifically to handle correct **parameter reordering**: an `Annotated`-wrapped dependency has no trailing default, so where a `Depends()` param originally followed a real-default param (e.g. `verify_s3: bool = False`), it's now reordered before it — otherwise Python raises a `SyntaxError` (non-default argument follows default argument). Reordering is safe: FastAPI resolves route parameters by keyword injection, never positionally, and this test suite only calls routes through the `AsyncClient` HTTP fixtures. `deps.py`/`rate_limiter.py` also use `Depends()` but aren't flagged by this rule (not path-operation functions) — confirmed untouched against the actual SonarCloud finding set. `projects.py` was already fully converted in an earlier pass.

**`typescript:S6759`** (136, frontend) — every destructured component props type marked `readonly` on each member. AST-driven via the TypeScript compiler API to correctly resolve both inline object-literal prop types and named `interface`/`type` references back to their declaration (avoids missing or double-editing a shared props interface).

**`typescript:S7773`** (118, frontend) — `parseInt`/`parseFloat` → `Number.parseInt`/`Number.parseFloat` (93 of 118, pure aliases, safe mechanical sweep) + `isNaN` → `Number.isNaN` (25 of 118, individually reviewed since these differ in coercion behavior on non-number inputs — every flagged call site's argument was already the result of `Number()`/`Number.parseFloat()`/`Number.parseInt()`, so behavior-identical in every case).

Two commits: backend (S8410) and frontend (S6759+S7773 combined — their fixes interleave within several of the same files).

Closes #1055, #1056, #1057. Part of #1047.

## Test plan
- [x] `ruff` / `mypy` clean on all 15 backend files; app imports with all 176 routes unchanged
- [x] `eslint` / `tsc --noEmit` clean across the full frontend after both frontend sweeps
- [x] Zero remaining `= Depends(`, bare `parseInt`/`parseFloat`/`isNaN`, or un-`readonly` props in any touched file (verified via grep/re-scan)
- [x] `test_admin.py` run showed failures under concurrent local DB load; isolated re-run of the same failing tests (no concurrent process) confirmed they pass — consistent with the DB-contention pattern already documented in this session, not a real regression
- [ ] Full local suite not re-run end-to-end given the ~2-4hr local runtime established earlier this session — CI's single clean run is the authoritative check here

🤖 Generated with [Claude Code](https://claude.com/claude-code)