### PR TITLE
refactor: dedupe groupByYear between ProjectsPage and ProjectSummaryList (#1053)

### DIFF
--- a/frontend/src/components/projects/ProjectSummaryList.tsx
+++ b/frontend/src/components/projects/ProjectSummaryList.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { PROJECT_TYPE_LABELS, PROJECT_STATUS_LABELS, type ProjectSummary } from "@/api/projects";
+import { groupByYear } from "@/lib/utils";
 
 const STATUS_COLORS: Record<string, string> = {
   active: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
@@ -57,19 +58,6 @@ function YearGroup({ year, items, defaultOpen }: { readonly year: number; readon
       )}
     </div>
   );
-}
-
-function groupByYear(items: ProjectSummary[], getDate: (p: ProjectSummary) => string | null) {
-  const map = new Map<number, ProjectSummary[]>();
-  for (const item of items) {
-    const d = getDate(item);
-    const year = d ? new Date(d).getFullYear() : new Date().getFullYear();
-    if (!map.has(year)) map.set(year, []);
-    map.get(year)!.push(item);
-  }
-  return Array.from(map.entries())
-    .sort(([a], [b]) => b - a)
-    .map(([year, items]) => ({ year, items }));
 }
 
 export function ProjectSummaryList({ projects }: { readonly projects: ProjectSummary[] }) {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -15,3 +15,16 @@ export function formatUptime(seconds: number): string {
   parts.push(`${m} minute${m !== 1 ? "s" : ""}`);
   return parts.join(", ");
 }
+
+export function groupByYear<T>(items: T[], getDate: (item: T) => string | null): Array<{ year: number; items: T[] }> {
+  const map = new Map<number, T[]>();
+  for (const item of items) {
+    const d = getDate(item);
+    const year = d ? new Date(d).getFullYear() : new Date().getFullYear();
+    if (!map.has(year)) map.set(year, []);
+    map.get(year)!.push(item);
+  }
+  return Array.from(map.entries())
+    .sort(([a], [b]) => b - a)
+    .map(([year, items]) => ({ year, items }));
+}

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -4,6 +4,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { listProjects, projectDrawdownPreviewUrl, PROJECT_TYPE_LABELS, PROJECT_STATUS_LABELS, type ProjectSummary } from "@/api/projects";
 import { AppIcons } from "@/lib/icons";
+import { groupByYear } from "@/lib/utils";
 import { previewUrl } from "@/api/drafts";
 import { AuthedImage } from "@/components/ui/AuthedImage";
 import { CreateProjectModal } from "@/components/projects/CreateProjectModal";
@@ -23,22 +24,6 @@ const STATUS_COLORS: Record<string, string> = {
 
 function fmtDate(iso: string): string {
   return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" });
-}
-
-function groupByYear(
-  items: ProjectSummary[],
-  getDate: (p: ProjectSummary) => string | null,
-): Array<{ year: number; items: ProjectSummary[] }> {
-  const map = new Map<number, ProjectSummary[]>();
-  for (const item of items) {
-    const d = getDate(item);
-    const year = d ? new Date(d).getFullYear() : new Date().getFullYear();
-    if (!map.has(year)) map.set(year, []);
-    map.get(year)!.push(item);
-  }
-  return Array.from(map.entries())
-    .sort(([a], [b]) => b - a)
-    .map(([year, items]) => ({ year, items }));
 }
 
 function ProjectCard({ project, onAssign }: {


### PR DESCRIPTION
## Summary
- Second slice of #1053 — extracts \`groupByYear()\` (byte-identical between \`ProjectsPage.tsx\` and \`ProjectSummaryList.tsx\`, only difference was an explicit return-type annotation on one copy) into \`lib/utils.ts\` as a generic \`<T>\` version. Fixes the 11-line duplicate block SonarCloud flagged between them.
- The function never actually depended on \`ProjectSummary\` specifically — genericized to \`<T>\` with a \`getDate: (item: T) => string | null\` extractor, same behavior.
- \`STATUS_COLORS\`/\`fmtDate\`/\`ProjectRow\`-vs-\`ProjectCard\` were deliberately left alone — they differ enough between the two files (different status keys, different date formats, different card layouts) to not be part of this specific duplicate finding.
- 6 of 8 duplicate-block pairs remain after this one, per #1053's own tracking table.
- Part of #1053, #1047.

## Test plan
- [x] \`eslint\` / \`tsc --noEmit\` clean
- [x] Docker frontend + backend build succeeds
- [x] Full \`rbd\` cycle — all containers healthy, backend \`/api/health\` returns 200
- [x] Confirmed \`ProjectSummary\` type still used elsewhere in both files (no orphaned import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)