### PR TITLE
chore: replace unused local variables with _ (S1481, #1066)

### DIFF
--- a/backend/app/routers/looms.py
+++ b/backend/app/routers/looms.py
@@ -707,7 +707,7 @@ async def upload_version_photo(
     file: UploadFile = File(...),
 ) -> LoomVersionPhotoSchema:
     _validate_image(file)
-    loom, version = await _get_owned_version(loom_id, version_id, current_user, db)
+    _, version = await _get_owned_version(loom_id, version_id, current_user, db)
     if len(version.photos) >= MAX_VERSION_PHOTOS:
         raise HTTPException(status_code=400, detail=f"Maximum {MAX_VERSION_PHOTOS} photos per configuration")
     data = await file.read()
@@ -744,7 +744,7 @@ async def get_version_photo(
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Response:
-    loom, version = await _get_owned_version(loom_id, version_id, current_user, db, allow_superuser=True)
+    _, version = await _get_owned_version(loom_id, version_id, current_user, db, allow_superuser=True)
     photo = next((p for p in version.photos if p.id == photo_id), None)
     if photo is None or not storage.file_exists(photo.path):
         raise HTTPException(status_code=404, detail="Photo not found")
@@ -765,7 +765,7 @@ async def delete_version_photo(
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
-    loom, version = await _get_owned_version(loom_id, version_id, current_user, db)
+    _, version = await _get_owned_version(loom_id, version_id, current_user, db)
     photo = next((p for p in version.photos if p.id == photo_id), None)
     if photo is None:
         raise HTTPException(status_code=404, detail="Photo not found")
@@ -793,7 +793,7 @@ async def upload_version_receipt(
     description: str | None = None,
 ) -> LoomVersionReceiptSchema:
     _validate_receipt(file)
-    loom, version = await _get_owned_version(loom_id, version_id, current_user, db)
+    _, _ = await _get_owned_version(loom_id, version_id, current_user, db)
     data = await file.read()
     if len(data) > MAX_FILE_SIZE:
         raise HTTPException(status_code=400, detail=_FILE_TOO_LARGE)
@@ -823,7 +823,7 @@ async def get_version_receipt(
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Response:
-    loom, version = await _get_owned_version(loom_id, version_id, current_user, db, allow_superuser=True)
+    _, version = await _get_owned_version(loom_id, version_id, current_user, db, allow_superuser=True)
     receipt = next((r for r in version.receipts if r.id == receipt_id), None)
     if receipt is None or not storage.file_exists(receipt.path):
         raise HTTPException(status_code=404, detail="Receipt not found")
@@ -850,7 +850,7 @@ async def delete_version_receipt(
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
-    loom, version = await _get_owned_version(loom_id, version_id, current_user, db)
+    _, version = await _get_owned_version(loom_id, version_id, current_user, db)
     receipt = next((r for r in version.receipts if r.id == receipt_id), None)
     if receipt is None:
         raise HTTPException(status_code=404, detail="Receipt not found")
@@ -875,7 +875,7 @@ async def update_version(
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> LoomVersionSchema:
-    loom, version = await _get_owned_version(loom_id, version_id, current_user, db)
+    _, version = await _get_owned_version(loom_id, version_id, current_user, db)
     for field, value in body.model_dump(exclude_none=True).items():
         setattr(version, field, value)
     await db.commit()
@@ -950,7 +950,7 @@ async def add_accessory(
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> LoomVersionAccessorySchema:
-    loom, version = await _get_owned_version(loom_id, version_id, current_user, db)
+    _, _ = await _get_owned_version(loom_id, version_id, current_user, db)
     acc = LoomVersionAccessory(loom_version_id=version_id, name=body.name.strip())
     db.add(acc)
     await db.commit()
@@ -970,7 +970,7 @@ async def delete_accessory(
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
-    loom, version = await _get_owned_version(loom_id, version_id, current_user, db)
+    _, version = await _get_owned_version(loom_id, version_id, current_user, db)
     acc = next((a for a in version.accessories if a.id == accessory_id), None)
     if acc is None:
         raise HTTPException(status_code=404, detail="Accessory not found")

--- a/backend/app/routers/yarn.py
+++ b/backend/app/routers/yarn.py
@@ -561,7 +561,7 @@ async def update_skein(
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> SkeinSchema:
-    yarn, skein = await _get_owned_skein(yarn_id, skein_id, current_user, db)
+    _, skein = await _get_owned_skein(yarn_id, skein_id, current_user, db)
     for field, value in body.model_dump(exclude_none=True).items():
         setattr(skein, field, value)
     await db.commit()
@@ -576,7 +576,7 @@ async def delete_skein(
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
-    yarn, skein = await _get_owned_skein(yarn_id, skein_id, current_user, db)
+    _, skein = await _get_owned_skein(yarn_id, skein_id, current_user, db)
     await db.delete(skein)
     await db.commit()
 

--- a/backend/app/services/smtp_health.py
+++ b/backend/app/services/smtp_health.py
@@ -32,7 +32,7 @@ _in_backoff: bool = False
 async def _tcp_probe(host: str, port: int) -> tuple[bool, str]:
     """Open a bare TCP connection to host:port and immediately close it."""
     try:
-        reader, writer = await asyncio.wait_for(
+        _, writer = await asyncio.wait_for(
             asyncio.open_connection(host, port),
             timeout=TCP_TIMEOUT_S,
         )

--- a/backend/app/weaving/_render.py
+++ b/backend/app/weaving/_render.py
@@ -358,7 +358,7 @@ class SVGRenderer:
         doc.append(_SVG.g(*grp))
 
     def paint_fill_marker(self, doc, box) -> None:
-        startx, starty, endx, endy = box
+        startx, starty, _, _ = box
         doc.append(
             _SVG.rect(
                 x=startx + 2,


### PR DESCRIPTION
## Summary
- 16 findings across 4 files. All tuple-unpack assignments where one (or both) sides are never referenced afterward:
  - \`backend/app/routers/looms.py\` (11): \`loom, version = await _get_owned_version(...)\` where \`loom\` (and in 2 cases, also \`version\`) is discarded — the call is kept purely for its ownership-check side effect (raises 404 if not found/not owned).
  - \`backend/app/routers/yarn.py\` (2): same pattern, \`yarn, skein = await _get_owned_skein(...)\`.
  - \`backend/app/weaving/_render.py\` (2): \`paint_fill_marker\`'s \`startx, starty, endx, endy = box\` only ever uses \`startx\`/\`starty\`.
  - \`backend/app/services/smtp_health.py\` (1): the TCP probe's \`reader, writer = await asyncio.open_connection(...)\` only needs to close \`writer\`.
- Pure rename to \`_\`, zero behavior change.
- **Note on line numbers**: SonarCloud's cached findings for \`looms.py\`/\`yarn.py\` were stale (line-shifted by the intervening S8410/S8409/S9011 PRs) — re-derived the current, correct locations via direct static analysis of each \`_get_owned_*\` call site's function body rather than trusting the old scan data.
- Part of #1047.

## Test plan
- [x] \`ruff\` / \`mypy\` clean on all 4 touched files
- [x] App imports with all 176 routes unchanged
- [ ] Local pytest run for the touched test files not completed end-to-end (stopped after 20+ min per the established local-runtime pattern this session) — this change is provably behavior-preserving (renaming a variable that is, by definition, never read cannot alter program behavior), and CI's clean run is the authoritative check

🤖 Generated with [Claude Code](https://claude.com/claude-code)