### PR TITLE
chore: convert remaining Query/Body/File defaults to Annotated (S8410 remainder, #1075)

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1778,7 +1778,7 @@ async def backfill_clerk_user(
     clerk_user_id: str,
     admin: Annotated[User, Depends(require_superuser)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    body: BackfillRequest = Body(default_factory=BackfillRequest),
+    body: Annotated[BackfillRequest, Body(default_factory=BackfillRequest)],
 ) -> BackfillResponse:
     existing = await db.scalar(select(User).where(User.clerk_user_id == clerk_user_id, User.deleted_at.is_(None)))
     if existing:

--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -222,8 +222,8 @@ async def create_draft(
 async def list_drafts(
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    include_archived: bool = Query(False),
-    tags: list[str] | None = Query(None),
+    include_archived: Annotated[bool, Query()] = False,
+    tags: Annotated[list[str] | None, Query()] = None,
 ) -> list[DraftSummary]:
     q = select(Draft).where(Draft.owner_id == current_user.id, Draft.deleted_at.is_(None))
     if not include_archived:
@@ -343,9 +343,9 @@ async def get_drawdown(
     draft_id: uuid.UUID,
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    start_row: int | None = Query(None, ge=0),
-    row_count: int | None = Query(None, ge=1),
-    hide_unused_shafts_treadles: bool = Query(False),
+    start_row: Annotated[int | None, Query(ge=0)] = None,
+    row_count: Annotated[int | None, Query(ge=1)] = None,
+    hide_unused_shafts_treadles: Annotated[bool, Query()] = False,
 ) -> Response:
     draft = await _get_owned_draft(draft_id, current_user, db, allow_superuser=True)
 
@@ -572,7 +572,7 @@ async def delete_draft(
     draft_id: uuid.UUID,
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    force: bool = Query(False),
+    force: Annotated[bool, Query()] = False,
 ) -> None:
     from app.models.project import Project
 

--- a/backend/app/routers/feedback.py
+++ b/backend/app/routers/feedback.py
@@ -206,8 +206,8 @@ async def get_feedback_status(
 async def list_feedback(
     db: Annotated[AsyncSession, Depends(get_db)],
     _admin: Annotated[User, Depends(require_admin)],
-    page: int = Query(1, ge=1),
-    page_size: int = Query(25, ge=1, le=100),
+    page: Annotated[int, Query(ge=1)] = 1,
+    page_size: Annotated[int, Query(ge=1, le=100)] = 25,
     submission_type: str | None = None,
     dispatch_status: str | None = None,
     include_deleted: bool = False,

--- a/backend/app/routers/loom_catalog.py
+++ b/backend/app/routers/loom_catalog.py
@@ -211,11 +211,11 @@ public_router = APIRouter(prefix="/api/loom-catalog", tags=["loom-catalog"])
 @public_router.get("")
 async def list_loom_catalog(
     db: Annotated[AsyncSession, Depends(get_db)],
-    q: str | None = Query(None, description="Search brand, model, or series"),
-    category: str | None = Query(None),
-    min_shafts: int | None = Query(None),
-    foldable: bool | None = Query(None),
-    origin_country: str | None = Query(None),
+    q: Annotated[str | None, Query(description="Search brand, model, or series")] = None,
+    category: Annotated[str | None, Query()] = None,
+    min_shafts: Annotated[int | None, Query()] = None,
+    foldable: Annotated[bool | None, Query()] = None,
+    origin_country: Annotated[str | None, Query()] = None,
 ) -> list[LoomReferenceSummary]:
     stmt = select(LoomReference).order_by(LoomReference.brand, LoomReference.model_name)
 
@@ -247,8 +247,8 @@ async def list_loom_catalog(
 @public_router.get("/search")
 async def search_loom_catalog(
     db: Annotated[AsyncSession, Depends(get_db)],
-    q: str = Query(..., min_length=1),
-    limit: int = Query(20, le=50),
+    q: Annotated[str, Query(min_length=1)],
+    limit: Annotated[int, Query(le=50)] = 20,
 ) -> list[LoomReferenceSummary]:
     """Typeahead search — returns summaries matching brand or model name."""
     ql = q.lower()
@@ -290,7 +290,7 @@ admin_catalog_router = APIRouter(prefix="/api/admin/loom-catalog", tags=["admin"
 async def admin_list_loom_catalog(
     db: Annotated[AsyncSession, Depends(get_db)],
     _admin: Annotated[User, Depends(require_admin)],
-    q: str | None = Query(None),
+    q: Annotated[str | None, Query()] = None,
 ) -> list[LoomReferenceSchema]:
     stmt = select(LoomReference).order_by(LoomReference.brand, LoomReference.model_name)
     if q:

--- a/backend/app/routers/looms.py
+++ b/backend/app/routers/looms.py
@@ -478,7 +478,7 @@ async def create_loom(
 async def list_looms(
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    include_retired: bool = Query(False),
+    include_retired: Annotated[bool, Query()] = False,
 ) -> list[LoomSummary]:
     q = (
         select(Loom)
@@ -539,7 +539,7 @@ async def delete_loom(
     loom_id: uuid.UUID,
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    force: bool = Query(False),
+    force: Annotated[bool, Query()] = False,
 ) -> None:
     from app.models.project import Project
 
@@ -606,7 +606,7 @@ async def upload_loom_photo(
     loom_id: uuid.UUID,
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    file: UploadFile = File(...),
+    file: Annotated[UploadFile, File()],
 ) -> None:
     _validate_image(file)
     loom = await _get_owned_loom(loom_id, current_user, db)
@@ -704,7 +704,7 @@ async def upload_version_photo(
     version_id: uuid.UUID,
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    file: UploadFile = File(...),
+    file: Annotated[UploadFile, File()],
 ) -> LoomVersionPhotoSchema:
     _validate_image(file)
     _, version = await _get_owned_version(loom_id, version_id, current_user, db)
@@ -789,7 +789,7 @@ async def upload_version_receipt(
     version_id: uuid.UUID,
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    file: UploadFile = File(...),
+    file: Annotated[UploadFile, File()],
     description: str | None = None,
 ) -> LoomVersionReceiptSchema:
     _validate_receipt(file)

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -635,9 +635,9 @@ async def create_project(
 async def list_projects(
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    draft_id: uuid.UUID | None = Query(None),
-    loom_id: uuid.UUID | None = Query(None),
-    tags: list[str] | None = Query(None),
+    draft_id: Annotated[uuid.UUID | None, Query()] = None,
+    loom_id: Annotated[uuid.UUID | None, Query()] = None,
+    tags: Annotated[list[str] | None, Query()] = None,
 ) -> list[ProjectSummary]:
     q = select(Project).where(Project.owner_id == current_user.id, Project.deleted_at.is_(None))
     if draft_id is not None:
@@ -659,10 +659,10 @@ async def get_project_drawdown(
     project_id: uuid.UUID,
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    start_row: int | None = Query(None, ge=0),
-    row_count: int | None = Query(None, ge=1),
-    start_col: int | None = Query(None, ge=0),
-    col_count: int | None = Query(None, ge=1),
+    start_row: Annotated[int | None, Query(ge=0)] = None,
+    row_count: Annotated[int | None, Query(ge=1)] = None,
+    start_col: Annotated[int | None, Query(ge=0)] = None,
+    col_count: Annotated[int | None, Query(ge=1)] = None,
 ) -> Response:
     from app.config import get_settings
     from app.services import rendering
@@ -779,8 +779,8 @@ async def get_project_drawdown_svg(
     project_id: uuid.UUID,
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    cell_px: int = Query(20, ge=1, le=30),
-    color_replacements: str | None = Query(None),
+    cell_px: Annotated[int, Query(ge=1, le=30)] = 20,
+    color_replacements: Annotated[str | None, Query()] = None,
 ) -> Response:
     import json
 
@@ -842,7 +842,7 @@ async def get_project_drawdown_preview(
     project_id: uuid.UUID,
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    color_replacements: str | None = Query(None),
+    color_replacements: Annotated[str | None, Query()] = None,
 ) -> Response:
     """Full draft PNG (threading + tieup + drawdown), optionally with colour replacements applied."""
     import json
@@ -926,7 +926,7 @@ async def get_project_drawdown_data(
     project_id: uuid.UUID,
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    cell_px: int = Query(20, ge=4, le=30),
+    cell_px: Annotated[int, Query(ge=4, le=30)] = 20,
 ) -> Response:
     from app.services import rendering
     from app.services.storage import afile_exists, aread_file
@@ -1483,7 +1483,7 @@ async def complete_project(
     project_id: uuid.UUID,
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    force: bool = Query(False, description="Complete even if not all picks are logged"),
+    force: Annotated[bool, Query(description="Complete even if not all picks are logged")] = False,
 ) -> ProjectDetail:
     project = await _get_owned_project(project_id, current_user, db)
     if project.status not in ("created", "active"):
@@ -1686,7 +1686,7 @@ async def upload_project_photo(
     project_id: uuid.UUID,
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    file: UploadFile = File(...),
+    file: Annotated[UploadFile, File()],
 ) -> ProjectPhotoSchema:
     project = await _get_owned_project(project_id, current_user, db)
 

--- a/backend/app/routers/ravelry.py
+++ b/backend/app/routers/ravelry.py
@@ -97,10 +97,10 @@ async def authorize(
 @router.get("/callback")
 async def oauth_callback(
     db: Annotated[AsyncSession, Depends(get_db)],
-    state: str = Query(...),
-    code: str | None = Query(None),
-    error: str | None = Query(None),
-    error_description: str | None = Query(None),
+    state: Annotated[str, Query()],
+    code: Annotated[str | None, Query()] = None,
+    error: Annotated[str | None, Query()] = None,
+    error_description: Annotated[str | None, Query()] = None,
 ) -> RedirectResponse:
     """Ravelry redirects here after the user approves or denies access.
 
@@ -185,7 +185,7 @@ async def yarn_detail(
 )
 async def popular_companies(
     _current_user: Annotated[User, Depends(get_current_user)],
-    limit: int = Query(10, ge=1, le=20),
+    limit: Annotated[int, Query(ge=1, le=20)] = 10,
 ) -> list[RavelryCompany]:
     """Return popular yarn companies (uses dev read-only key, sort=best)."""
     try:
@@ -199,9 +199,9 @@ async def popular_companies(
 @router.get("/popular/yarns", responses={502: {"description": "Ravelry request failed"}})
 async def popular_yarns(
     _current_user: Annotated[User, Depends(get_current_user)],
-    company_id: int = Query(...),
-    company_name: str = Query(...),
-    limit: int = Query(8, ge=1, le=20),
+    company_id: Annotated[int, Query()],
+    company_name: Annotated[str, Query()],
+    limit: Annotated[int, Query(ge=1, le=20)] = 8,
 ) -> list[RavelryYarnResult]:
     """Return popular yarns for a company (uses dev read-only key, seeded by company name)."""
     try:
@@ -215,7 +215,7 @@ async def popular_yarns(
 @router.get("/search/companies", responses={502: {"description": "Ravelry search failed"}})
 async def search_companies(
     _current_user: Annotated[User, Depends(get_current_user)],
-    q: str = Query(..., min_length=1),
+    q: Annotated[str, Query(min_length=1)],
 ) -> list[RavelryCompany]:
     """Search Ravelry yarn companies by name (uses dev read-only key)."""
     try:
@@ -229,8 +229,8 @@ async def search_companies(
 @router.get("/search/yarns", responses={502: {"description": "Ravelry search failed"}})
 async def search_yarns(
     _current_user: Annotated[User, Depends(get_current_user)],
-    q: str = Query(..., min_length=1),
-    company_id: int | None = Query(None),
+    q: Annotated[str, Query(min_length=1)],
+    company_id: Annotated[int | None, Query()] = None,
 ) -> list[RavelryYarnResult]:
     """Search Ravelry yarns, optionally filtered by company (uses dev read-only key)."""
     try:

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -470,7 +470,7 @@ async def get_onboarding_status(
 async def get_activity_heatmap(
     current_user: Annotated[User, Depends(get_current_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    year: int | None = Query(default=None),
+    year: Annotated[int | None, Query()] = None,
 ) -> ActivityHeatmapResponse:
     from collections import defaultdict
 

--- a/backend/app/routers/yarn.py
+++ b/backend/app/routers/yarn.py
@@ -380,7 +380,7 @@ async def create_yarn(
 async def list_yarn(
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    include_archived: bool = Query(False),
+    include_archived: Annotated[bool, Query()] = False,
 ) -> list[YarnSummary]:
     filters = [Yarn.owner_id == current_user.id, Yarn.deleted_at.is_(None)]
     if not include_archived:
@@ -471,7 +471,7 @@ async def upload_yarn_photo(
     yarn_id: uuid.UUID,
     current_user: Annotated[User, Depends(get_effective_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    file: UploadFile = File(...),
+    file: Annotated[UploadFile, File()],
 ) -> None:
     _validate_image(file)
     yarn = await _get_owned_yarn(yarn_id, current_user, db)


### PR DESCRIPTION
## Summary
- Step 1 of the #1047 game plan. Fixes 49 remaining \`python:S8410\` findings across 9 files — the rule also flags \`Query()\`/\`Body()\`/\`File()\` markers used in the legacy default-argument style, which #1055's \`Depends()\`-only sweep didn't cover.
- AST-driven, handling the extra complexity these markers have over \`Depends()\`:
  - The marker's own default value (first positional arg, or \`default=\` keyword) moves *outside* \`Annotated[...]\` to become the parameter's real default.
  - \`...\` (Ellipsis) means required — dropped entirely, no external default.
  - \`default_factory=\` is FastAPI/Pydantic's own factory mechanism and stays *inside* the marker unchanged, also with no external default.
  - Same parameter-reordering as #1055 applied wherever a converted required param would otherwise follow one that keeps a real default.
- Closes #1075. Part of #1047.

## Test plan
- [x] \`ruff\` / \`mypy\` clean on all 9 files; app imports with all 176 routes unchanged
- [x] **Dumped \`app.openapi()\` before and after the change and diffed byte-for-byte — identical.** Confirms every default, requiredness flag, and validation constraint (\`ge\`/\`le\`/\`min_length\`/etc.) survived the conversion exactly, across all the tricky cases (\`default_factory\`, Ellipsis-required, extra validation kwargs).
- [ ] Local pytest run for the 9 touched routers' test files started but not confirmed complete in time for this PR — given the byte-identical OpenAPI schema comparison already proves the API contract is unchanged, and CI's clean run is the authoritative check anyway

🤖 Generated with [Claude Code](https://claude.com/claude-code)