### PR TITLE
test: pytest.raises tightening + monkeypatch fixture sweep (#1065, #1076)

### DIFF
--- a/backend/tests/routers/test_health.py
+++ b/backend/tests/routers/test_health.py
@@ -12,7 +12,7 @@ from app.version import VERSION
 
 
 @pytest.fixture(autouse=True)
-def reset_health_state():
+def reset_health_state(monkeypatch):
     """Restore module-level caches and task between tests."""
     original_detailed = health_module._detailed_cache
     original_readiness = health_module._readiness_cache
@@ -27,15 +27,15 @@ def reset_health_state():
     # Cancel any task created during the test before restoring
     if health_module._detailed_task is not None and health_module._detailed_task is not original_task:
         health_module._detailed_task.cancel()
-    health_module._detailed_cache = original_detailed
-    health_module._readiness_cache = original_readiness
-    health_module._detailed_task = original_task
-    health_module._open_health_event_id = original_open_event
-    health_module._last_alert_status = original_last_alert
-    health_module._superuser_email_cache = original_email_cache
-    health_module._consecutive_failures = original_failures
-    health_module._last_postgres_result = original_pg_result
-    health_module._last_postgres_probe_at = original_pg_probe_at
+    monkeypatch.setattr(health_module, "_detailed_cache", original_detailed)
+    monkeypatch.setattr(health_module, "_readiness_cache", original_readiness)
+    monkeypatch.setattr(health_module, "_detailed_task", original_task)
+    monkeypatch.setattr(health_module, "_open_health_event_id", original_open_event)
+    monkeypatch.setattr(health_module, "_last_alert_status", original_last_alert)
+    monkeypatch.setattr(health_module, "_superuser_email_cache", original_email_cache)
+    monkeypatch.setattr(health_module, "_consecutive_failures", original_failures)
+    monkeypatch.setattr(health_module, "_last_postgres_result", original_pg_result)
+    monkeypatch.setattr(health_module, "_last_postgres_probe_at", original_pg_probe_at)
 
 
 class TestHealth:
@@ -59,37 +59,45 @@ class TestHealth:
 
 
 class TestHealthReady:
-    async def test_returns_503_when_cache_empty(self, client: AsyncClient):
-        health_module._readiness_cache = None
+    async def test_returns_503_when_cache_empty(self, client: AsyncClient, monkeypatch):
+        monkeypatch.setattr(health_module, "_readiness_cache", None)
         resp = await client.get("/api/health/ready")
         assert resp.status_code == 503
         assert resp.json()["status"] == "starting"
 
-    async def test_returns_200_when_ok(self, client: AsyncClient):
-        health_module._readiness_cache = ReadinessResponse(status="ok", services=[])
+    async def test_returns_200_when_ok(self, client: AsyncClient, monkeypatch):
+        monkeypatch.setattr(health_module, "_readiness_cache", ReadinessResponse(status="ok", services=[]))
         resp = await client.get("/api/health/ready")
         assert resp.status_code == 200
 
-    async def test_returns_503_when_error(self, client: AsyncClient):
-        health_module._readiness_cache = ReadinessResponse(
-            status="error",
-            services=[ReadinessService(name="postgres", ok=False, critical=True)],
+    async def test_returns_503_when_error(self, client: AsyncClient, monkeypatch):
+        monkeypatch.setattr(
+            health_module,
+            "_readiness_cache",
+            ReadinessResponse(
+                status="error",
+                services=[ReadinessService(name="postgres", ok=False, critical=True)],
+            ),
         )
         resp = await client.get("/api/health/ready")
         assert resp.status_code == 503
 
-    async def test_returns_200_when_degraded(self, client: AsyncClient):
-        health_module._readiness_cache = ReadinessResponse(
-            status="degraded",
-            services=[ReadinessService(name="SMTP", ok=False, critical=False)],
+    async def test_returns_200_when_degraded(self, client: AsyncClient, monkeypatch):
+        monkeypatch.setattr(
+            health_module,
+            "_readiness_cache",
+            ReadinessResponse(
+                status="degraded",
+                services=[ReadinessService(name="SMTP", ok=False, critical=False)],
+            ),
         )
         resp = await client.get("/api/health/ready")
         assert resp.status_code == 200
 
 
 class TestHealthDetailed:
-    async def test_returns_200_with_starting_when_cache_empty(self, client: AsyncClient):
-        health_module._detailed_cache = None
+    async def test_returns_200_with_starting_when_cache_empty(self, client: AsyncClient, monkeypatch):
+        monkeypatch.setattr(health_module, "_detailed_cache", None)
         resp = await client.get("/api/health/detailed")
         assert resp.status_code == 200
         body = resp.json()
@@ -97,48 +105,64 @@ class TestHealthDetailed:
         assert "next_check_at" in body
         assert body["next_check_at"] is not None
 
-    async def test_returns_200_when_cache_populated(self, client: AsyncClient):
-        health_module._detailed_cache = ReadinessResponse(
-            status="ok",
-            services=[ReadinessService(name="PostgreSQL", ok=True, critical=True)],
-            checked_at="2026-01-01T00:00:00+00:00",
+    async def test_returns_200_when_cache_populated(self, client: AsyncClient, monkeypatch):
+        monkeypatch.setattr(
+            health_module,
+            "_detailed_cache",
+            ReadinessResponse(
+                status="ok",
+                services=[ReadinessService(name="PostgreSQL", ok=True, critical=True)],
+                checked_at="2026-01-01T00:00:00+00:00",
+            ),
         )
         resp = await client.get("/api/health/detailed")
         assert resp.status_code == 200
 
-    async def test_returns_cached_status(self, client: AsyncClient):
-        health_module._detailed_cache = ReadinessResponse(
-            status="degraded",
-            services=[ReadinessService(name="Clerk Webhook", ok=False, critical=False, message="timeout")],
-            checked_at="2026-01-01T00:00:00+00:00",
+    async def test_returns_cached_status(self, client: AsyncClient, monkeypatch):
+        monkeypatch.setattr(
+            health_module,
+            "_detailed_cache",
+            ReadinessResponse(
+                status="degraded",
+                services=[ReadinessService(name="Clerk Webhook", ok=False, critical=False, message="timeout")],
+                checked_at="2026-01-01T00:00:00+00:00",
+            ),
         )
         body = (await client.get("/api/health/detailed")).json()
         assert body["status"] == "degraded"
         assert body["checked_at"] == "2026-01-01T00:00:00+00:00"
 
-    async def test_response_includes_services(self, client: AsyncClient):
-        health_module._detailed_cache = ReadinessResponse(
-            status="ok",
-            services=[
-                ReadinessService(name="PostgreSQL", ok=True, critical=True),
-                ReadinessService(name="Clerk Webhook", ok=True, critical=False),
-            ],
-            checked_at="2026-01-01T00:00:00+00:00",
+    async def test_response_includes_services(self, client: AsyncClient, monkeypatch):
+        monkeypatch.setattr(
+            health_module,
+            "_detailed_cache",
+            ReadinessResponse(
+                status="ok",
+                services=[
+                    ReadinessService(name="PostgreSQL", ok=True, critical=True),
+                    ReadinessService(name="Clerk Webhook", ok=True, critical=False),
+                ],
+                checked_at="2026-01-01T00:00:00+00:00",
+            ),
         )
         body = (await client.get("/api/health/detailed")).json()
         names = [s["name"] for s in body["services"]]
         assert "PostgreSQL" in names
         assert "Clerk Webhook" in names
 
-    async def test_detailed_returns_200_even_when_degraded(self, client: AsyncClient):
-        health_module._detailed_cache = ReadinessResponse(status="degraded", services=[])
+    async def test_detailed_returns_200_even_when_degraded(self, client: AsyncClient, monkeypatch):
+        monkeypatch.setattr(health_module, "_detailed_cache", ReadinessResponse(status="degraded", services=[]))
         resp = await client.get("/api/health/detailed")
         assert resp.status_code == 200
 
-    async def test_detailed_returns_200_even_when_error(self, client: AsyncClient):
-        health_module._detailed_cache = ReadinessResponse(
-            status="error",
-            services=[ReadinessService(name="PostgreSQL", ok=False, critical=True)],
+    async def test_detailed_returns_200_even_when_error(self, client: AsyncClient, monkeypatch):
+        monkeypatch.setattr(
+            health_module,
+            "_detailed_cache",
+            ReadinessResponse(
+                status="error",
+                services=[ReadinessService(name="PostgreSQL", ok=False, critical=True)],
+            ),
         )
         resp = await client.get("/api/health/detailed")
         assert resp.status_code == 200
@@ -150,17 +174,17 @@ class TestDetailedRefreshLifecycle:
             pass
 
         monkeypatch.setattr(health_module, "_detailed_refresh_loop", idle)
-        health_module._detailed_task = None
+        monkeypatch.setattr(health_module, "_detailed_task", None)
         health_module.start_detailed_refresh()
         assert health_module._detailed_task is not None
 
-    async def test_stop_cancels_task(self):
-        health_module._detailed_task = asyncio.create_task(asyncio.sleep(100))
+    async def test_stop_cancels_task(self, monkeypatch):
+        monkeypatch.setattr(health_module, "_detailed_task", asyncio.create_task(asyncio.sleep(100)))
         health_module.stop_detailed_refresh()
         assert health_module._detailed_task is None
 
-    async def test_stop_noop_when_no_task(self):
-        health_module._detailed_task = None
+    async def test_stop_noop_when_no_task(self, monkeypatch):
+        monkeypatch.setattr(health_module, "_detailed_task", None)
         health_module.stop_detailed_refresh()
         assert health_module._detailed_task is None
 
@@ -256,14 +280,14 @@ class TestBuildReadinessFromResults:
 
 
 class TestSetReadiness:
-    def test_sets_cache(self):
-        health_module._readiness_cache = None
+    def test_sets_cache(self, monkeypatch):
+        monkeypatch.setattr(health_module, "_readiness_cache", None)
         r = ReadinessResponse(status="ok", services=[])
         set_readiness(r)
         assert health_module._readiness_cache is r
 
-    def test_overwrites_existing(self):
-        health_module._readiness_cache = ReadinessResponse(status="error", services=[])
+    def test_overwrites_existing(self, monkeypatch):
+        monkeypatch.setattr(health_module, "_readiness_cache", ReadinessResponse(status="error", services=[]))
         r = ReadinessResponse(status="ok", services=[])
         set_readiness(r)
         assert health_module._readiness_cache.status == "ok"
@@ -331,10 +355,10 @@ class TestGetWorkerVersion:
 
 
 class TestRefreshSuperuserEmailCache:
-    async def test_populates_cache(self, db_session, superuser_user):
+    async def test_populates_cache(self, db_session, superuser_user, monkeypatch):
         from app.routers.health import _refresh_superuser_email_cache
 
-        health_module._superuser_email_cache = []
+        monkeypatch.setattr(health_module, "_superuser_email_cache", [])
 
         ctx = MagicMock()
         ctx.__aenter__ = AsyncMock(return_value=db_session)
@@ -369,10 +393,10 @@ class TestDispatchHealthAlert:
 
         mock_email.assert_not_called()
 
-    async def test_no_op_when_email_cache_empty(self):
+    async def test_no_op_when_email_cache_empty(self, monkeypatch):
         from app.routers.health import _dispatch_health_alert
 
-        health_module._superuser_email_cache = []
+        monkeypatch.setattr(health_module, "_superuser_email_cache", [])
         result = ReadinessResponse(status="error", services=[])
 
         with patch("app.routers.health.get_settings") as mock_settings:
@@ -382,10 +406,10 @@ class TestDispatchHealthAlert:
             mock_settings.return_value.frontend_url = "http://localhost"
             await _dispatch_health_alert(result, is_recovery=False)
 
-    async def test_swallows_email_exception(self):
+    async def test_swallows_email_exception(self, monkeypatch):
         from app.routers.health import _dispatch_health_alert
 
-        health_module._superuser_email_cache = ["admin@test.com"]
+        monkeypatch.setattr(health_module, "_superuser_email_cache", ["admin@test.com"])
         result = ReadinessResponse(status="error", services=[])
 
         with patch("app.routers.health.get_settings") as mock_settings:
@@ -400,10 +424,10 @@ class TestDispatchHealthAlert:
             ):
                 await _dispatch_health_alert(result, is_recovery=False)  # must not raise
 
-    async def test_calls_recovery_email_when_is_recovery(self):
+    async def test_calls_recovery_email_when_is_recovery(self, monkeypatch):
         from app.routers.health import _dispatch_health_alert
 
-        health_module._superuser_email_cache = ["admin@test.com"]
+        monkeypatch.setattr(health_module, "_superuser_email_cache", ["admin@test.com"])
         result = ReadinessResponse(status="ok", services=[])
 
         with patch("app.routers.health.get_settings") as mock_settings:
@@ -523,12 +547,12 @@ class TestRunDetailedProbes:
         assert result.status == "error"
         assert result.services[0].ok is False
 
-    async def test_skips_postgres_probe_when_recently_checked(self):
+    async def test_skips_postgres_probe_when_recently_checked(self, monkeypatch):
         from app.routers.health import _run_detailed_probes
 
         cached_result = MagicMock(service="PostgreSQL", status="ok", message="Cached", checks=[])
-        health_module._last_postgres_result = cached_result
-        health_module._last_postgres_probe_at = datetime.now(timezone.utc)
+        monkeypatch.setattr(health_module, "_last_postgres_result", cached_result)
+        monkeypatch.setattr(health_module, "_last_postgres_probe_at", datetime.now(timezone.utc))
 
         other_result = MagicMock(service="S3", status="ok", message="ok", checks=[])
 
@@ -557,12 +581,18 @@ class TestRunDetailedProbes:
         assert pg_service.ok is True
         assert pg_service.message == "Cached"
 
-    async def test_probes_postgres_when_interval_elapsed(self):
+    async def test_probes_postgres_when_interval_elapsed(self, monkeypatch):
         from app.routers.health import POSTGRES_PROBE_INTERVAL_S, _run_detailed_probes
 
-        health_module._last_postgres_result = MagicMock(service="PostgreSQL", status="ok", message="Stale", checks=[])
-        health_module._last_postgres_probe_at = datetime.now(timezone.utc) - timedelta(
-            seconds=POSTGRES_PROBE_INTERVAL_S + 1
+        monkeypatch.setattr(
+            health_module,
+            "_last_postgres_result",
+            MagicMock(service="PostgreSQL", status="ok", message="Stale", checks=[]),
+        )
+        monkeypatch.setattr(
+            health_module,
+            "_last_postgres_probe_at",
+            datetime.now(timezone.utc) - timedelta(seconds=POSTGRES_PROBE_INTERVAL_S + 1),
         )
 
         fresh_result = MagicMock(service="PostgreSQL", status="ok", message="Fresh", checks=[])
@@ -608,10 +638,10 @@ class TestRecordHealthTransitionDBPaths:
         ctx.__aexit__ = AsyncMock(return_value=False)
         return ctx
 
-    async def test_opens_event_when_going_to_error(self):
+    async def test_opens_event_when_going_to_error(self, monkeypatch):
         from app.routers.health import _record_health_transition
 
-        health_module._open_health_event_id = None
+        monkeypatch.setattr(health_module, "_open_health_event_id", None)
         result = ReadinessResponse(
             status="error",
             services=[ReadinessService(name="PG", ok=False, critical=True)],
@@ -633,10 +663,10 @@ class TestRecordHealthTransitionDBPaths:
         mock_write.assert_called_once()
         assert health_module._open_health_event_id == mock_evt.id
 
-    async def test_opens_event_when_going_to_degraded(self):
+    async def test_opens_event_when_going_to_degraded(self, monkeypatch):
         from app.routers.health import _record_health_transition
 
-        health_module._open_health_event_id = None
+        monkeypatch.setattr(health_module, "_open_health_event_id", None)
         result = ReadinessResponse(
             status="degraded",
             services=[ReadinessService(name="S3", ok=False, critical=False)],
@@ -655,11 +685,11 @@ class TestRecordHealthTransitionDBPaths:
 
         assert health_module._open_health_event_id == mock_evt.id
 
-    async def test_closes_event_on_recovery(self):
+    async def test_closes_event_on_recovery(self, monkeypatch):
         from app.routers.health import _record_health_transition
 
         event_id = uuid.uuid4()
-        health_module._open_health_event_id = event_id
+        monkeypatch.setattr(health_module, "_open_health_event_id", event_id)
         result = ReadinessResponse(status="ok", services=[])
 
         mock_evt = MagicMock()
@@ -676,10 +706,10 @@ class TestRecordHealthTransitionDBPaths:
         mock_close.assert_called_once()
         assert health_module._open_health_event_id is None
 
-    async def test_recovery_clears_id_even_when_event_not_found(self):
+    async def test_recovery_clears_id_even_when_event_not_found(self, monkeypatch):
         from app.routers.health import _record_health_transition
 
-        health_module._open_health_event_id = uuid.uuid4()
+        monkeypatch.setattr(health_module, "_open_health_event_id", uuid.uuid4())
         result = ReadinessResponse(status="ok", services=[])
 
         mock_db = AsyncMock()
@@ -693,10 +723,10 @@ class TestRecordHealthTransitionDBPaths:
         mock_close.assert_not_called()
         assert health_module._open_health_event_id is None
 
-    async def test_already_closed_event_not_closed_again(self):
+    async def test_already_closed_event_not_closed_again(self, monkeypatch):
         from app.routers.health import _record_health_transition
 
-        health_module._open_health_event_id = uuid.uuid4()
+        monkeypatch.setattr(health_module, "_open_health_event_id", uuid.uuid4())
         result = ReadinessResponse(status="ok", services=[])
 
         mock_evt = MagicMock()
@@ -719,10 +749,10 @@ class TestRecordHealthTransitionDBPaths:
 
 
 class TestStartStopDetailedRefresh:
-    def test_start_creates_background_task(self):
+    def test_start_creates_background_task(self, monkeypatch):
         from app.routers.health import start_detailed_refresh
 
-        health_module._detailed_task = None
+        monkeypatch.setattr(health_module, "_detailed_task", None)
         mock_task = MagicMock()
         with patch("app.routers.health.asyncio") as mock_asyncio:
             mock_asyncio.create_task.return_value = mock_task
@@ -731,42 +761,42 @@ class TestStartStopDetailedRefresh:
         mock_asyncio.create_task.assert_called_once()
         assert health_module._detailed_task is mock_task
 
-    def test_start_sets_initial_status(self):
+    def test_start_sets_initial_status(self, monkeypatch):
         from app.routers.health import start_detailed_refresh
 
-        health_module._last_alert_status = None
+        monkeypatch.setattr(health_module, "_last_alert_status", None)
         with patch("app.routers.health.asyncio") as mock_asyncio:
             mock_asyncio.create_task.return_value = MagicMock()
             start_detailed_refresh(initial_status="ok")
 
         assert health_module._last_alert_status == "ok"
 
-    def test_start_without_initial_status_leaves_it_unchanged(self):
+    def test_start_without_initial_status_leaves_it_unchanged(self, monkeypatch):
         from app.routers.health import start_detailed_refresh
 
-        health_module._last_alert_status = "degraded"
+        monkeypatch.setattr(health_module, "_last_alert_status", "degraded")
         with patch("app.routers.health.asyncio") as mock_asyncio:
             mock_asyncio.create_task.return_value = MagicMock()
             start_detailed_refresh()
 
         assert health_module._last_alert_status == "degraded"
 
-    def test_stop_cancels_task_and_clears_reference(self):
+    def test_stop_cancels_task_and_clears_reference(self, monkeypatch):
         from app.routers.health import stop_detailed_refresh
 
         mock_task = MagicMock()
         mock_task.cancel = MagicMock()
-        health_module._detailed_task = mock_task
+        monkeypatch.setattr(health_module, "_detailed_task", mock_task)
 
         stop_detailed_refresh()
 
         mock_task.cancel.assert_called_once()
         assert health_module._detailed_task is None
 
-    def test_stop_noop_when_no_task(self):
+    def test_stop_noop_when_no_task(self, monkeypatch):
         from app.routers.health import stop_detailed_refresh
 
-        health_module._detailed_task = None
+        monkeypatch.setattr(health_module, "_detailed_task", None)
         stop_detailed_refresh()  # must not raise
 
 
@@ -788,15 +818,15 @@ class TestDetailedRefreshLoop:
 
         return fake_sleep
 
-    async def test_ok_result_resets_failure_counter_and_updates_cache(self):
+    async def test_ok_result_resets_failure_counter_and_updates_cache(self, monkeypatch):
         from app.routers.health import _detailed_refresh_loop
 
         result = ReadinessResponse(
             status="ok",
             services=[ReadinessService(name="PostgreSQL", ok=True, critical=True)],
         )
-        health_module._consecutive_failures = 5
-        health_module._last_alert_status = None
+        monkeypatch.setattr(health_module, "_consecutive_failures", 5)
+        monkeypatch.setattr(health_module, "_last_alert_status", None)
 
         with patch("app.routers.health.asyncio.sleep", side_effect=self._make_fake_sleep()):
             with patch("app.routers.health._run_detailed_probes", new_callable=AsyncMock, return_value=result):
@@ -809,14 +839,14 @@ class TestDetailedRefreshLoop:
         assert health_module._detailed_cache is result
         assert health_module._last_alert_status == "ok"
 
-    async def test_first_non_ok_increments_counter_but_does_not_surface(self):
+    async def test_first_non_ok_increments_counter_but_does_not_surface(self, monkeypatch):
         from app.routers.health import _detailed_refresh_loop
 
         result = ReadinessResponse(
             status="error",
             services=[ReadinessService(name="PostgreSQL", ok=False, critical=True)],
         )
-        health_module._consecutive_failures = 0
+        monkeypatch.setattr(health_module, "_consecutive_failures", 0)
 
         # On first non-ok the loop does an extra sleep(_FAILURE_RETRY_GAP_S) then `continue`,
         # so the end-of-loop sleep is never reached — CancelledError comes from call 2.
@@ -830,7 +860,7 @@ class TestDetailedRefreshLoop:
         assert health_module._consecutive_failures == 1
         mock_record.assert_not_called()  # not surfaced yet
 
-    async def test_confirmed_failure_surfaces_and_updates_cache(self):
+    async def test_confirmed_failure_surfaces_and_updates_cache(self, monkeypatch):
         from app.routers.health import _detailed_refresh_loop
 
         result = ReadinessResponse(
@@ -838,8 +868,8 @@ class TestDetailedRefreshLoop:
             services=[ReadinessService(name="PostgreSQL", ok=False, critical=True)],
         )
         # Already at the threshold — next non-ok gets surfaced
-        health_module._consecutive_failures = 3
-        health_module._last_alert_status = None
+        monkeypatch.setattr(health_module, "_consecutive_failures", 3)
+        monkeypatch.setattr(health_module, "_last_alert_status", None)
 
         with patch("app.routers.health.asyncio.sleep", side_effect=self._make_fake_sleep()):
             with patch("app.routers.health._run_detailed_probes", new_callable=AsyncMock, return_value=result):
@@ -851,15 +881,15 @@ class TestDetailedRefreshLoop:
         mock_record.assert_called_once()
         assert health_module._detailed_cache is result
 
-    async def test_status_change_triggers_alert_task(self):
+    async def test_status_change_triggers_alert_task(self, monkeypatch):
         from app.routers.health import _detailed_refresh_loop
 
         result = ReadinessResponse(
             status="error",
             services=[ReadinessService(name="PostgreSQL", ok=False, critical=True)],
         )
-        health_module._consecutive_failures = 3
-        health_module._last_alert_status = "ok"  # transition from ok → error
+        monkeypatch.setattr(health_module, "_consecutive_failures", 3)
+        monkeypatch.setattr(health_module, "_last_alert_status", "ok")  # transition from ok → error
 
         with patch("app.routers.health.asyncio.sleep", side_effect=self._make_fake_sleep()):
             with patch("app.routers.health._run_detailed_probes", new_callable=AsyncMock, return_value=result):
@@ -872,12 +902,12 @@ class TestDetailedRefreshLoop:
         mock_fire_and_forget.assert_called_once()
         assert health_module._last_alert_status == "error"
 
-    async def test_recovery_triggers_alert_task(self):
+    async def test_recovery_triggers_alert_task(self, monkeypatch):
         from app.routers.health import _detailed_refresh_loop
 
         result = ReadinessResponse(status="ok", services=[])
-        health_module._consecutive_failures = 0
-        health_module._last_alert_status = "error"  # transition from error → ok
+        monkeypatch.setattr(health_module, "_consecutive_failures", 0)
+        monkeypatch.setattr(health_module, "_last_alert_status", "error")  # transition from error → ok
 
         with patch("app.routers.health.asyncio.sleep", side_effect=self._make_fake_sleep()):
             with patch("app.routers.health._run_detailed_probes", new_callable=AsyncMock, return_value=result):

--- a/backend/tests/services/test_business_metrics.py
+++ b/backend/tests/services/test_business_metrics.py
@@ -174,8 +174,8 @@ _SESSION_CREATED_DATA = {
 
 class TestLoginsCounter:
     @pytest.mark.asyncio
-    async def test_user_login_increments_counter(self, patched_metrics):
-        auth_router.logins_total = bm.logins_total
+    async def test_user_login_increments_counter(self, patched_metrics, monkeypatch):
+        monkeypatch.setattr(auth_router, "logins_total", bm.logins_total)
         await auth_router._handle_session_created(_SESSION_CREATED_DATA)
 
         points = _get_data_points(patched_metrics, "weftmark.user.logins")
@@ -184,8 +184,8 @@ class TestLoginsCounter:
         assert points[0].attributes == {"role": "user"}
 
     @pytest.mark.asyncio
-    async def test_admin_login_uses_admin_role_attribute(self, patched_metrics):
-        auth_router.logins_total = bm.logins_total
+    async def test_admin_login_uses_admin_role_attribute(self, patched_metrics, monkeypatch):
+        monkeypatch.setattr(auth_router, "logins_total", bm.logins_total)
         data = {**_SESSION_CREATED_DATA, "user": {"id": "user_test123", "public_metadata": {"is_admin": True}}}
         await auth_router._handle_session_created(data)
 
@@ -194,8 +194,8 @@ class TestLoginsCounter:
         assert points[0].attributes == {"role": "admin"}
 
     @pytest.mark.asyncio
-    async def test_missing_public_metadata_defaults_to_user(self, patched_metrics):
-        auth_router.logins_total = bm.logins_total
+    async def test_missing_public_metadata_defaults_to_user(self, patched_metrics, monkeypatch):
+        monkeypatch.setattr(auth_router, "logins_total", bm.logins_total)
         data = {**_SESSION_CREATED_DATA, "user": {"id": "user_test123"}}
         await auth_router._handle_session_created(data)
 
@@ -203,8 +203,8 @@ class TestLoginsCounter:
         assert points[0].attributes == {"role": "user"}
 
     @pytest.mark.asyncio
-    async def test_multiple_logins_accumulate_by_role(self, patched_metrics):
-        auth_router.logins_total = bm.logins_total
+    async def test_multiple_logins_accumulate_by_role(self, patched_metrics, monkeypatch):
+        monkeypatch.setattr(auth_router, "logins_total", bm.logins_total)
         admin_data = {**_SESSION_CREATED_DATA, "user": {"id": "u1", "public_metadata": {"is_admin": True}}}
         await auth_router._handle_session_created(_SESSION_CREATED_DATA)
         await auth_router._handle_session_created(_SESSION_CREATED_DATA)
@@ -222,16 +222,16 @@ _GEO_COUNTRY_ONLY = {"country_iso": "DE", "subdivision": "", "city": ""}
 
 class TestLoginsGeoAttributes:
     @pytest.mark.asyncio
-    async def test_no_request_emits_no_geo(self, patched_metrics):
-        auth_router.logins_total = bm.logins_total
+    async def test_no_request_emits_no_geo(self, patched_metrics, monkeypatch):
+        monkeypatch.setattr(auth_router, "logins_total", bm.logins_total)
         await auth_router._handle_session_created(_SESSION_CREATED_DATA)
 
         points = _get_data_points(patched_metrics, "weftmark.user.logins")
         assert points[0].attributes == {"role": "user"}
 
     @pytest.mark.asyncio
-    async def test_mmdb_provides_full_geo(self, patched_metrics):
-        auth_router.logins_total = bm.logins_total
+    async def test_mmdb_provides_full_geo(self, patched_metrics, monkeypatch):
+        monkeypatch.setattr(auth_router, "logins_total", bm.logins_total)
         req = _mock_request({"CF-Connecting-IP": "203.0.113.42", "CF-IPCountry": "US"})
 
         with patch("app.services.geo.get_geo", return_value=_GEO_FULL):
@@ -244,8 +244,8 @@ class TestLoginsGeoAttributes:
         assert attrs["city"] == "Denver"
 
     @pytest.mark.asyncio
-    async def test_mmdb_absent_falls_back_to_cf_ipcountry(self, patched_metrics):
-        auth_router.logins_total = bm.logins_total
+    async def test_mmdb_absent_falls_back_to_cf_ipcountry(self, patched_metrics, monkeypatch):
+        monkeypatch.setattr(auth_router, "logins_total", bm.logins_total)
         req = _mock_request({"CF-Connecting-IP": "203.0.113.42", "CF-IPCountry": "GB"})
 
         with patch("app.services.geo.get_geo", return_value={}):
@@ -258,8 +258,8 @@ class TestLoginsGeoAttributes:
         assert "city" not in attrs
 
     @pytest.mark.asyncio
-    async def test_no_ip_no_mmdb_uses_cf_ipcountry(self, patched_metrics):
-        auth_router.logins_total = bm.logins_total
+    async def test_no_ip_no_mmdb_uses_cf_ipcountry(self, patched_metrics, monkeypatch):
+        monkeypatch.setattr(auth_router, "logins_total", bm.logins_total)
         req = _mock_request({"CF-IPCountry": "FR"})
 
         await auth_router._handle_session_created(_SESSION_CREATED_DATA, req)
@@ -268,8 +268,8 @@ class TestLoginsGeoAttributes:
         assert points[0].attributes == {"role": "user", "country": "FR"}
 
     @pytest.mark.asyncio
-    async def test_empty_cf_ipcountry_omits_country_attribute(self, patched_metrics):
-        auth_router.logins_total = bm.logins_total
+    async def test_empty_cf_ipcountry_omits_country_attribute(self, patched_metrics, monkeypatch):
+        monkeypatch.setattr(auth_router, "logins_total", bm.logins_total)
         req = _mock_request({"CF-IPCountry": ""})
 
         await auth_router._handle_session_created(_SESSION_CREATED_DATA, req)
@@ -278,8 +278,8 @@ class TestLoginsGeoAttributes:
         assert "country" not in points[0].attributes
 
     @pytest.mark.asyncio
-    async def test_mmdb_country_iso_takes_precedence_over_cf_header(self, patched_metrics):
-        auth_router.logins_total = bm.logins_total
+    async def test_mmdb_country_iso_takes_precedence_over_cf_header(self, patched_metrics, monkeypatch):
+        monkeypatch.setattr(auth_router, "logins_total", bm.logins_total)
         # CF says CA, MMDB says US — MMDB wins
         req = _mock_request({"CF-Connecting-IP": "203.0.113.42", "CF-IPCountry": "CA"})
 
@@ -290,8 +290,8 @@ class TestLoginsGeoAttributes:
         assert points[0].attributes["country"] == "US"
 
     @pytest.mark.asyncio
-    async def test_mmdb_empty_subdivision_and_city_omitted(self, patched_metrics):
-        auth_router.logins_total = bm.logins_total
+    async def test_mmdb_empty_subdivision_and_city_omitted(self, patched_metrics, monkeypatch):
+        monkeypatch.setattr(auth_router, "logins_total", bm.logins_total)
         req = _mock_request({"CF-Connecting-IP": "203.0.113.42", "CF-IPCountry": "DE"})
 
         with patch("app.services.geo.get_geo", return_value=_GEO_COUNTRY_ONLY):
@@ -317,8 +317,8 @@ _SESSION_ENDED_DATA = {
 
 class TestSessionsEndedCounter:
     @pytest.mark.asyncio
-    async def test_user_session_ended_increments_counter(self, patched_metrics):
-        auth_router.sessions_ended_total = bm.sessions_ended_total
+    async def test_user_session_ended_increments_counter(self, patched_metrics, monkeypatch):
+        monkeypatch.setattr(auth_router, "sessions_ended_total", bm.sessions_ended_total)
         await auth_router._handle_session_ended(_SESSION_ENDED_DATA)
 
         points = _get_data_points(patched_metrics, "weftmark.user.sessions_ended")
@@ -327,8 +327,8 @@ class TestSessionsEndedCounter:
         assert points[0].attributes == {"role": "user"}
 
     @pytest.mark.asyncio
-    async def test_admin_session_ended_uses_admin_role_attribute(self, patched_metrics):
-        auth_router.sessions_ended_total = bm.sessions_ended_total
+    async def test_admin_session_ended_uses_admin_role_attribute(self, patched_metrics, monkeypatch):
+        monkeypatch.setattr(auth_router, "sessions_ended_total", bm.sessions_ended_total)
         data = {**_SESSION_ENDED_DATA, "user": {"id": "user_test123", "public_metadata": {"is_admin": True}}}
         await auth_router._handle_session_ended(data)
 
@@ -337,8 +337,8 @@ class TestSessionsEndedCounter:
         assert points[0].attributes == {"role": "admin"}
 
     @pytest.mark.asyncio
-    async def test_missing_public_metadata_defaults_to_user(self, patched_metrics):
-        auth_router.sessions_ended_total = bm.sessions_ended_total
+    async def test_missing_public_metadata_defaults_to_user(self, patched_metrics, monkeypatch):
+        monkeypatch.setattr(auth_router, "sessions_ended_total", bm.sessions_ended_total)
         data = {**_SESSION_ENDED_DATA, "user": {"id": "user_test123"}}
         await auth_router._handle_session_ended(data)
 
@@ -346,8 +346,8 @@ class TestSessionsEndedCounter:
         assert points[0].attributes == {"role": "user"}
 
     @pytest.mark.asyncio
-    async def test_multiple_sessions_ended_accumulate_by_role(self, patched_metrics):
-        auth_router.sessions_ended_total = bm.sessions_ended_total
+    async def test_multiple_sessions_ended_accumulate_by_role(self, patched_metrics, monkeypatch):
+        monkeypatch.setattr(auth_router, "sessions_ended_total", bm.sessions_ended_total)
         admin_data = {**_SESSION_ENDED_DATA, "user": {"id": "u1", "public_metadata": {"is_admin": True}}}
         await auth_router._handle_session_ended(_SESSION_ENDED_DATA)
         await auth_router._handle_session_ended(_SESSION_ENDED_DATA)

--- a/backend/tests/services/test_clerk.py
+++ b/backend/tests/services/test_clerk.py
@@ -218,7 +218,7 @@ class TestBanClerkUser:
         response.raise_for_status.side_effect = Exception("403 Forbidden")
         ctx, client = _mock_client("post", response)
         with patch("httpx.AsyncClient", return_value=ctx):
-            with pytest.raises(Exception):
+            with pytest.raises(Exception, match="403 Forbidden"):
                 await ban_clerk_user("user_abc")
 
 

--- a/backend/tests/services/test_clerk_auth.py
+++ b/backend/tests/services/test_clerk_auth.py
@@ -26,7 +26,7 @@ class TestJwksUrlFromPublishableKey:
         assert url == "https://clerk.prod.example.com/.well-known/jwks.json"
 
     def test_raises_on_malformed_key(self):
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             jwks_url_from_publishable_key("not_a_valid_key")
 
     def test_raises_on_too_few_parts(self):

--- a/backend/tests/services/test_clerk_webhook_probe.py
+++ b/backend/tests/services/test_clerk_webhook_probe.py
@@ -25,13 +25,13 @@ def _mock_settings(
 
 
 @pytest.fixture(autouse=True)
-def reset_probe_state():
+def reset_probe_state(monkeypatch):
     """Ensure module-level asyncio state is clean between tests."""
-    probe_module._pending_event = None
-    probe_module._probe_lock = None
+    monkeypatch.setattr(probe_module, "_pending_event", None)
+    monkeypatch.setattr(probe_module, "_probe_lock", None)
     yield
-    probe_module._pending_event = None
-    probe_module._probe_lock = None
+    monkeypatch.setattr(probe_module, "_pending_event", None)
+    monkeypatch.setattr(probe_module, "_probe_lock", None)
 
 
 # ---------------------------------------------------------------------------
@@ -40,13 +40,13 @@ def reset_probe_state():
 
 
 class TestSignalProbe:
-    def test_noop_when_no_pending_event(self):
-        probe_module._pending_event = None
+    def test_noop_when_no_pending_event(self, monkeypatch):
+        monkeypatch.setattr(probe_module, "_pending_event", None)
         signal_probe()  # must not raise
 
-    def test_sets_event_when_pending(self):
+    def test_sets_event_when_pending(self, monkeypatch):
         event = asyncio.Event()
-        probe_module._pending_event = event
+        monkeypatch.setattr(probe_module, "_pending_event", event)
         signal_probe()
         assert event.is_set()
 

--- a/backend/tests/services/test_images.py
+++ b/backend/tests/services/test_images.py
@@ -41,8 +41,9 @@ class TestValidateImageFormat:
             validate_image_format(b"this is not an image")
 
     def test_unsupported_format_raises(self):
+        gif_bytes = _make_gif_bytes()
         with pytest.raises(ValueError, match="Unsupported image format: GIF"):
-            validate_image_format(_make_gif_bytes())
+            validate_image_format(gif_bytes)
 
     def test_empty_bytes_raise(self):
         with pytest.raises(ValueError, match="Could not decode image"):

--- a/backend/tests/services/test_rendering.py
+++ b/backend/tests/services/test_rendering.py
@@ -11,6 +11,7 @@ A full PyWeaving-compatible WIF requires: [WIF] with Date, [CONTENTS],
 """
 
 import sys
+from configparser import MissingSectionHeaderError
 from pathlib import Path
 
 import pytest
@@ -206,7 +207,7 @@ class TestLoadDraft:
         assert draft.rising_shed is True
 
     def test_invalid_wif_raises(self):
-        with pytest.raises(Exception):
+        with pytest.raises(MissingSectionHeaderError):
             load_draft(b"this is not a wif file at all")
 
     @pytest.mark.skipif(
@@ -217,7 +218,7 @@ class TestLoadDraft:
         bytes raise UnicodeDecodeError.  Callers must normalise encoding first
         (wif_parser handles this; rendering does not)."""
         latin1_wif = MINIMAL_WIF.decode().replace("TestSuite", "Caf\xe9Loom").encode("latin-1")
-        with pytest.raises(Exception):
+        with pytest.raises(UnicodeDecodeError):
             load_draft(latin1_wif)
 
 

--- a/backend/tests/services/test_smtp_health.py
+++ b/backend/tests/services/test_smtp_health.py
@@ -99,14 +99,14 @@ class TestCircuitBreaker:
         assert ok is False
         assert "cached" in msg
 
-    async def test_backoff_retries_after_window(self):
+    async def test_backoff_retries_after_window(self, monkeypatch):
         # First call — fail, enter backoff
         with patch("asyncio.open_connection", side_effect=OSError("refused")):
             await smtp_health.check("smtp.example.com", 587)
 
         # Wind the clock past BACKOFF_SECONDS
         past = datetime.now(timezone.utc) - timedelta(seconds=smtp_health.BACKOFF_SECONDS + 1)
-        smtp_health._last_checked_at = past
+        monkeypatch.setattr(smtp_health, "_last_checked_at", past)
 
         # Second call — should attempt a fresh probe (and succeed this time)
         mock_reader = MagicMock()
@@ -119,7 +119,7 @@ class TestCircuitBreaker:
         assert ok is True
         assert "cached" not in msg
 
-    async def test_success_resets_backoff(self):
+    async def test_success_resets_backoff(self, monkeypatch):
         # Enter backoff
         with patch("asyncio.open_connection", side_effect=OSError("refused")):
             await smtp_health.check("smtp.example.com", 587)
@@ -127,7 +127,11 @@ class TestCircuitBreaker:
         assert smtp_health._in_backoff is True
 
         # Expire backoff window and probe successfully
-        smtp_health._last_checked_at = datetime.now(timezone.utc) - timedelta(seconds=smtp_health.BACKOFF_SECONDS + 1)
+        monkeypatch.setattr(
+            smtp_health,
+            "_last_checked_at",
+            datetime.now(timezone.utc) - timedelta(seconds=smtp_health.BACKOFF_SECONDS + 1),
+        )
         mock_reader = MagicMock()
         mock_writer = MagicMock()
         mock_writer.wait_closed = AsyncMock()

--- a/backend/tests/tasks/test_deletion_task.py
+++ b/backend/tests/tasks/test_deletion_task.py
@@ -240,8 +240,9 @@ class TestDeleteUserErrorPaths:
             new_callable=AsyncMock,
             side_effect=SoftTimeLimitExceeded(),
         ):
+            task = _task_mock()
             with pytest.raises(SoftTimeLimitExceeded):
-                await _delete_user(_task_mock(), user.id)
+                await _delete_user(task, user.id)
 
         await db_session.refresh(user)
         assert user.deletion_state == "stalled"
@@ -305,8 +306,9 @@ class TestDeleteUserErrorPaths:
             patch("app.services.email.send_deletion_completed_admin", new_callable=AsyncMock),
             patch("app.services.email.send_deletion_stalled_superuser", new_callable=AsyncMock) as mock_stall_email,
         ):
+            task = _task_mock()
             with pytest.raises(SoftTimeLimitExceeded):
-                await _delete_user(_task_mock(), user.id)
+                await _delete_user(task, user.id)
 
         mock_stall_email.assert_called_once()
         assert superuser.email in mock_stall_email.call_args[0][0]

--- a/backend/tests/tasks/test_dispatch.py
+++ b/backend/tests/tasks/test_dispatch.py
@@ -195,8 +195,9 @@ class TestDispatchFailure:
                 new=AsyncMock(side_effect=RuntimeError("API error")),
             ),
         ):
+            feedback_id = str(row.id)
             with pytest.raises(RuntimeError):
-                await _dispatch(task, str(row.id))
+                await _dispatch(task, feedback_id)
 
         await db_session.refresh(row)
         assert row.dispatch_status == "failed"
@@ -215,8 +216,9 @@ class TestDispatchFailure:
                 new=AsyncMock(side_effect=RuntimeError("API error")),
             ),
         ):
+            feedback_id = str(row.id)
             with pytest.raises(RuntimeError):
-                await _dispatch(task, str(row.id))
+                await _dispatch(task, feedback_id)
 
         await db_session.refresh(row)
         assert row.dispatch_error is not None
@@ -235,8 +237,9 @@ class TestDispatchFailure:
                 new=AsyncMock(side_effect=RuntimeError("API error")),
             ),
         ):
+            feedback_id = str(row.id)
             with pytest.raises(RuntimeError):
-                await _dispatch(task, str(row.id))
+                await _dispatch(task, feedback_id)
 
         task.retry.assert_called_once()
 

--- a/backend/tests/tasks/test_email_task.py
+++ b/backend/tests/tasks/test_email_task.py
@@ -330,6 +330,7 @@ class TestRetryOnFailure:
             raise ConnectionError("SMTP timeout")
 
         with patch("app.tasks.email_task._do_smtp", _fail):
+            queued_at = _queued_at(10)
             with pytest.raises(Exception, match="retry sentinel"):
                 send_email.run.__func__(
                     task,
@@ -337,7 +338,7 @@ class TestRetryOnFailure:
                     subject="s",
                     txt="t",
                     html=_BASE_HTML,
-                    queued_at=_queued_at(10),
+                    queued_at=queued_at,
                 )
         task.retry.assert_called_once()
 
@@ -357,14 +358,15 @@ class TestRetryOnFailure:
             raise ConnectionError("timeout")
 
         with patch("app.tasks.email_task._do_smtp", _fail):
-            with pytest.raises(Exception):
+            queued_at = _queued_at(10)
+            with pytest.raises(Exception, match="retry sentinel"):
                 send_email.run.__func__(
                     task,
                     to=["r@t.com"],
                     subject="s",
                     txt="t",
                     html=_BASE_HTML,
-                    queued_at=_queued_at(10),
+                    queued_at=queued_at,
                 )
         # retries=2 → countdown = min(60 * 2**2, 1800) = min(240, 1800) = 240
         assert countdowns[0] == 240
@@ -385,13 +387,14 @@ class TestRetryOnFailure:
             raise ConnectionError("timeout")
 
         with patch("app.tasks.email_task._do_smtp", _fail):
-            with pytest.raises(Exception):
+            queued_at = _queued_at(10)
+            with pytest.raises(Exception, match="retry sentinel"):
                 send_email.run.__func__(
                     task,
                     to=["r@t.com"],
                     subject="s",
                     txt="t",
                     html=_BASE_HTML,
-                    queued_at=_queued_at(10),
+                    queued_at=queued_at,
                 )
         assert countdowns[0] == 1800

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -51,8 +51,9 @@ def _make_engine():
 async def test_seed_aborts_when_not_dev(tmp_path):
     settings = _make_settings(app_env="prod")
     with patch("app.cli.get_settings", return_value=settings), patch("app.cli._BACKEND_DIR", tmp_path):
+        config_path = str(tmp_path / "seed.json")
         with pytest.raises(SystemExit) as exc_info:
-            await cmd_seed(str(tmp_path / "seed.json"), 5)
+            await cmd_seed(config_path, 5)
     assert exc_info.value.code == 1
 
 
@@ -64,8 +65,9 @@ async def test_seed_aborts_when_not_dev(tmp_path):
 async def test_seed_aborts_when_seed_disabled(tmp_path):
     settings = _make_settings(seed_enabled=False)
     with patch("app.cli.get_settings", return_value=settings), patch("app.cli._BACKEND_DIR", tmp_path):
+        config_path = str(tmp_path / "seed.json")
         with pytest.raises(SystemExit) as exc_info:
-            await cmd_seed(str(tmp_path / "seed.json"), 5)
+            await cmd_seed(config_path, 5)
     assert exc_info.value.code == 1
 
 
@@ -77,8 +79,9 @@ async def test_seed_aborts_when_seed_disabled(tmp_path):
 async def test_seed_aborts_when_no_clerk_key(tmp_path):
     settings = _make_settings(clerk_secret_key="")
     with patch("app.cli.get_settings", return_value=settings), patch("app.cli._BACKEND_DIR", tmp_path):
+        config_path = str(tmp_path / "seed.json")
         with pytest.raises(SystemExit) as exc_info:
-            await cmd_seed(str(tmp_path / "seed.json"), 5)
+            await cmd_seed(config_path, 5)
     assert exc_info.value.code == 1
 
 
@@ -94,8 +97,9 @@ async def test_seed_aborts_when_clerk_unreachable(tmp_path):
         patch("app.cli._clerk_list_users", AsyncMock(side_effect=Exception("connection refused"))),
         patch("app.cli._BACKEND_DIR", tmp_path),
     ):
+        config_path = str(tmp_path / "seed.json")
         with pytest.raises(SystemExit) as exc_info:
-            await cmd_seed(str(tmp_path / "seed.json"), 5)
+            await cmd_seed(config_path, 5)
     assert exc_info.value.code == 1
 
 
@@ -117,8 +121,9 @@ async def test_seed_proceeds_when_clerk_has_users(tmp_path):
         patch("app.cli._BACKEND_DIR", tmp_path),
     ):
         # Should exit on missing config, not on Clerk having users
+        config_path = str(tmp_path / "nonexistent.json")
         with pytest.raises(SystemExit) as exc_info:
-            await cmd_seed(str(tmp_path / "nonexistent.json"), 5)
+            await cmd_seed(config_path, 5)
     assert exc_info.value.code == 1
 
 
@@ -142,8 +147,9 @@ async def test_seed_aborts_when_db_unreachable(tmp_path):
         patch("app.cli.async_sessionmaker", return_value=factory),
         patch("app.cli._BACKEND_DIR", tmp_path),
     ):
+        config_path = str(tmp_path / "seed.json")
         with pytest.raises(SystemExit) as exc_info:
-            await cmd_seed(str(tmp_path / "seed.json"), 5)
+            await cmd_seed(config_path, 5)
     assert exc_info.value.code == 1
 
 
@@ -170,8 +176,9 @@ async def test_seed_aborts_when_config_outside_backend_dir(tmp_path):
         patch("app.cli.async_sessionmaker", return_value=factory),
         patch("app.cli._BACKEND_DIR", allowed_dir),
     ):
+        config_path = str(escaping_config)
         with pytest.raises(SystemExit) as exc_info:
-            await cmd_seed(str(escaping_config), 5)
+            await cmd_seed(config_path, 5)
     assert exc_info.value.code == 1
 
 
@@ -186,8 +193,9 @@ async def test_seed_aborts_when_config_missing(tmp_path):
         patch("app.cli.async_sessionmaker", return_value=factory),
         patch("app.cli._BACKEND_DIR", tmp_path),
     ):
+        config_path = str(tmp_path / "nonexistent.json")
         with pytest.raises(SystemExit) as exc_info:
-            await cmd_seed(str(tmp_path / "nonexistent.json"), 5)
+            await cmd_seed(config_path, 5)
     assert exc_info.value.code == 1
 
 
@@ -209,8 +217,9 @@ async def test_seed_aborts_when_no_users_in_config(tmp_path):
         patch("app.cli.async_sessionmaker", return_value=factory),
         patch("app.cli._BACKEND_DIR", tmp_path),
     ):
+        config_path = str(config)
         with pytest.raises(SystemExit) as exc_info:
-            await cmd_seed(str(config), 5)
+            await cmd_seed(config_path, 5)
     assert exc_info.value.code == 1
 
 
@@ -269,8 +278,9 @@ async def test_seed_aborts_when_clerk_delete_fails(tmp_path):
         patch("app.cli.async_sessionmaker", return_value=factory),
         patch("app.cli._BACKEND_DIR", tmp_path),
     ):
+        config_path = str(config)
         with pytest.raises(SystemExit) as exc_info:
-            await cmd_seed(str(config), 5)
+            await cmd_seed(config_path, 5)
     assert exc_info.value.code == 1
 
 


### PR DESCRIPTION
## Summary
Step 2 of the #1047 game plan — backend test-quality sweep, 86 findings combined into one branch since both are test-file-only changes needing real test runs (not just lint) to verify.

**S5778 + S5958 (25 findings, #1065)** — \`pytest.raises\` blocks either wrapped more than one invocation (mostly a nested call in the tested function's own arguments — \`str(path)\`, \`_task_mock()\`, \`_queued_at(10)\`, etc. — hoisted to a variable before the block) or asserted too broadly (bare \`Exception\`, no message check — narrowed to the actual exception type, verified empirically against the real code rather than guessed, or given a \`match=\` where the raised type is genuinely just \`Exception\` by a mock's own design).

**S8997 (61+ findings, #1076)** — tests manually mutating module-level globals directly instead of using \`monkeypatch.setattr()\`, across 4 files (\`test_health.py\`, \`test_business_metrics.py\`, \`test_smtp_health.py\`, \`test_clerk_webhook_probe.py\`). Converted every matching instance per file rather than just the subset SonarCloud's new-code window flagged, to avoid leaving files half-converted. AST-driven, including correctly handling the zero-argument \`autouse\` fixture case (inserting \`monkeypatch\` as the sole parameter rather than appending after an existing one — an earlier draft of the script got this wrong and left \`monkeypatch\` referenced-but-undefined; caught before commit).

Two commits, one per issue. Closes #1065, #1076. Part of #1047.

## Test plan
- [x] \`ruff\` / \`mypy\` clean on all 12 touched files (2 pre-existing mypy findings, confirmed unrelated via stash-and-rerun on the unmodified files)
- [x] Full local pytest run across all 12 files: **271 passed, 0 failed**, 46 skipped (DB-dependent, expected)
- [x] All "coroutine never awaited" warnings confirmed pre-existing (stash-and-rerun comparison against unmodified files gave identical results)
- [x] Zero remaining unconverted instances of either pattern (grep-verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)