### PR TITLE
refactor: extract shared DeleteConflictPanel (#1053)

### DIFF
--- a/e2e/tests/delete-conflict.spec.ts
+++ b/e2e/tests/delete-conflict.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "../fixtures";
+
+// Runs under the "authenticated" project.
+// Both eqauser's seeded draft and seeded loom are linked to the seeded
+// "EQA Fixture Project", so attempting to delete either always hits the
+// 409 conflict path. We only ever cancel out of the confirm-force-delete
+// state -- never actually force-delete -- so the fixture project survives
+// for other tests / runs.
+const SEEDED_DRAFT_ID = "86e64447-378d-4ac5-9a06-644bb0a24351";
+const SEEDED_LOOM_ID = "c45670c9-5341-4902-a654-0d2ab34e380b";
+// The panel renders each blocking project as "· <name>" list items; matching
+// that exact bullet form avoids colliding with the project name shown
+// elsewhere on the page (e.g. the related-projects list).
+const FIXTURE_PROJECT_BULLET = "· EQA Fixture Project";
+
+test.describe("Delete-conflict panel (#1053, shared DeleteConflictPanel)", () => {
+  test("draft delete shows the conflict panel naming the blocking project, and cancel dismisses it", async ({ page }) => {
+    await page.goto(`/drafts/${SEEDED_DRAFT_ID}`);
+    await expect(page.locator("body")).not.toContainText("Loading…");
+
+    await page.getByRole("button", { name: /danger zone/i }).click();
+    await page.getByRole("button", { name: /^delete draft$/i }).click();
+    await page.getByRole("button", { name: /^confirm delete$/i }).click();
+
+    await expect(page.getByText(/used by 1 active project/i)).toBeVisible();
+    await expect(page.getByText(FIXTURE_PROJECT_BULLET)).toBeVisible();
+
+    await page.getByRole("button", { name: /force delete/i }).click();
+    await expect(page.getByRole("button", { name: /^confirm force delete$/i })).toBeVisible();
+
+    await page.getByRole("button", { name: /^cancel$/i }).click();
+    await expect(page.getByText(/used by 1 active project/i)).not.toBeVisible();
+
+    // Fixture must survive: reload and confirm the draft is still there.
+    await page.reload();
+    await expect(page.locator("body")).not.toContainText("Loading…");
+    await expect(page).toHaveURL(new RegExp(SEEDED_DRAFT_ID));
+  });
+
+  test("loom delete shows the conflict panel naming the blocking project, and cancel dismisses it", async ({ page }) => {
+    await page.goto(`/looms/${SEEDED_LOOM_ID}`);
+    await expect(page.locator("body")).not.toContainText("Loading…");
+
+    await page.getByRole("button", { name: /danger zone/i }).click();
+    await page.getByRole("button", { name: /^delete loom$/i }).click();
+    await page.getByRole("button", { name: /^confirm delete$/i }).click();
+
+    await expect(page.getByText(/used by 1 active project/i)).toBeVisible();
+    await expect(page.getByText(FIXTURE_PROJECT_BULLET)).toBeVisible();
+
+    await page.getByRole("button", { name: /force delete/i }).click();
+    await expect(page.getByRole("button", { name: /^confirm force delete$/i })).toBeVisible();
+
+    await page.getByRole("button", { name: /^cancel$/i }).click();
+    await expect(page.getByText(/used by 1 active project/i)).not.toBeVisible();
+
+    // Fixture must survive: reload and confirm the loom is still there.
+    await page.reload();
+    await expect(page.locator("body")).not.toContainText("Loading…");
+    await expect(page).toHaveURL(new RegExp(SEEDED_LOOM_ID));
+  });
+});

--- a/frontend/src/components/DeleteConflictPanel.tsx
+++ b/frontend/src/components/DeleteConflictPanel.tsx
@@ -1,0 +1,57 @@
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import type { DeleteConflict } from "@/api/drafts";
+
+interface DeleteConflictPanelProps {
+  readonly conflict: DeleteConflict;
+  readonly usedByMessage: string;
+  readonly conflictNote: string;
+  readonly confirmForceDelete: boolean;
+  readonly onRequestForceDelete: () => void;
+  readonly forceDeleteLabel: string;
+  readonly triggerButtonClassName?: string;
+  readonly onConfirmForceDelete: () => void;
+  readonly confirmForceDeleteLabel: string;
+  readonly busy: boolean;
+  readonly busyLabel?: string;
+  readonly onCancel: () => void;
+}
+
+export function DeleteConflictPanel({
+  conflict,
+  usedByMessage,
+  conflictNote,
+  confirmForceDelete,
+  onRequestForceDelete,
+  forceDeleteLabel,
+  triggerButtonClassName,
+  onConfirmForceDelete,
+  confirmForceDeleteLabel,
+  busy,
+  busyLabel,
+  onCancel,
+}: DeleteConflictPanelProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm text-destructive font-medium">{usedByMessage}</p>
+      <ul className="text-xs text-muted-foreground space-y-0.5 pl-3">
+        {conflict.projects.map((p) => <li key={p.id}>· {p.name}</li>)}
+      </ul>
+      <p className="text-xs text-muted-foreground">{conflictNote}</p>
+      {!confirmForceDelete ? (
+        <Button variant="outline" size="sm" className={triggerButtonClassName} onClick={onRequestForceDelete}>
+          {forceDeleteLabel}
+        </Button>
+      ) : (
+        <div className="flex gap-2">
+          <Button variant="destructive" size="sm" onClick={onConfirmForceDelete} disabled={busy}>
+            {busy && busyLabel ? busyLabel : confirmForceDeleteLabel}
+          </Button>
+          <Button variant="outline" size="sm" onClick={onCancel}>{t("common.cancel")}</Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/DraftDetailPage.tsx
+++ b/frontend/src/pages/DraftDetailPage.tsx
@@ -12,6 +12,7 @@ import { listProjects } from "@/api/projects";
 import { ProjectSummaryList } from "@/components/projects/ProjectSummaryList";
 import { CreateProjectModal } from "@/components/projects/CreateProjectModal";
 import { DraftPreviewModal } from "@/components/drafts/DraftPreviewModal";
+import { DeleteConflictPanel } from "@/components/DeleteConflictPanel";
 import { Button } from "@/components/ui/button";
 import { AuthedImage } from "@/components/ui/AuthedImage";
 import { useAuthContext } from "@/context/AuthContext";
@@ -940,41 +941,19 @@ export function DraftDetailPage() {
 
                 {/* 409 conflict */}
                 {deleteConflict && (
-                  <div className="space-y-2">
-                    <p className="text-sm text-destructive font-medium">
-                      {t("draftDetailPage.usedByConflict", { count: deleteConflict.projects.length })}
-                    </p>
-                    <ul className="text-xs text-muted-foreground space-y-0.5 pl-3">
-                      {deleteConflict.projects.map((p) => <li key={p.id}>· {p.name}</li>)}
-                    </ul>
-                    <p className="text-xs text-muted-foreground">
-                      {t("draftDetailPage.conflictNote")}
-                    </p>
-                    {!confirmForceDelete ? (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="text-destructive hover:text-destructive"
-                        onClick={() => setConfirmForceDelete(true)}
-                      >
-                        {t("draftDetailPage.forceDelete", { count: deleteConflict.projects.length })}
-                      </Button>
-                    ) : (
-                      <div className="flex gap-2">
-                        <Button
-                          variant="destructive"
-                          size="sm"
-                          onClick={() => deleteMutation.mutate(true)}
-                          disabled={deleteMutation.isPending}
-                        >
-                          {t("draftDetailPage.confirmForceDelete")}
-                        </Button>
-                        <Button variant="outline" size="sm" onClick={() => { setDeleteConflict(null); setConfirmForceDelete(false); }}>
-                          {t("common.cancel")}
-                        </Button>
-                      </div>
-                    )}
-                  </div>
+                  <DeleteConflictPanel
+                    conflict={deleteConflict}
+                    usedByMessage={t("draftDetailPage.usedByConflict", { count: deleteConflict.projects.length })}
+                    conflictNote={t("draftDetailPage.conflictNote")}
+                    confirmForceDelete={confirmForceDelete}
+                    onRequestForceDelete={() => setConfirmForceDelete(true)}
+                    forceDeleteLabel={t("draftDetailPage.forceDelete", { count: deleteConflict.projects.length })}
+                    triggerButtonClassName="text-destructive hover:text-destructive"
+                    onConfirmForceDelete={() => deleteMutation.mutate(true)}
+                    confirmForceDeleteLabel={t("draftDetailPage.confirmForceDelete")}
+                    busy={deleteMutation.isPending}
+                    onCancel={() => { setDeleteConflict(null); setConfirmForceDelete(false); }}
+                  />
                 )}
               </div>
             </div>

--- a/frontend/src/pages/LoomDetailPage.tsx
+++ b/frontend/src/pages/LoomDetailPage.tsx
@@ -18,6 +18,7 @@ import {
   LOOM_TYPE_LABELS, SUPPORTED_LOOM_TYPES,
 } from "@/api/looms";
 import { type DeleteConflict } from "@/api/drafts";
+import { DeleteConflictPanel } from "@/components/DeleteConflictPanel";
 import { AddVersionModal } from "@/components/looms/AddVersionModal";
 import { EditLoomModal } from "@/components/looms/EditLoomModal";
 import { CloneVersionModal } from "@/components/looms/CloneVersionModal";
@@ -1094,34 +1095,20 @@ export function LoomDetailPage() {
 
                   {/* 409 conflict */}
                   {deleteConflict && (
-                    <div className="space-y-2">
-                      <p className="text-sm text-destructive font-medium">
-                        {t("loomDetailPage.usedByConflict", { count: deleteConflict.projects.length })}
-                      </p>
-                      <ul className="text-xs text-muted-foreground space-y-0.5 pl-3">
-                        {deleteConflict.projects.map((p) => <li key={p.id}>· {p.name}</li>)}
-                      </ul>
-                      <p className="text-xs text-muted-foreground">
-                        {t("loomDetailPage.conflictUnlinkNote")}
-                      </p>
-                      {!confirmForceDelete ? (
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="border-destructive/50 text-destructive hover:bg-destructive/10"
-                          onClick={() => setConfirmForceDelete(true)}
-                        >
-                          {t("loomDetailPage.forceDelete", { count: deleteConflict.projects.length })}
-                        </Button>
-                      ) : (
-                        <div className="flex gap-2">
-                          <Button size="sm" onClick={() => handleDelete(true)} disabled={deleting} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
-                            {deleting ? t("loomDetailPage.deleting") : t("loomDetailPage.confirmForceDelete")}
-                          </Button>
-                          <Button variant="outline" size="sm" onClick={() => { setDeleteConflict(null); setConfirmForceDelete(false); }}>{t("common.cancel")}</Button>
-                        </div>
-                      )}
-                    </div>
+                    <DeleteConflictPanel
+                      conflict={deleteConflict}
+                      usedByMessage={t("loomDetailPage.usedByConflict", { count: deleteConflict.projects.length })}
+                      conflictNote={t("loomDetailPage.conflictUnlinkNote")}
+                      confirmForceDelete={confirmForceDelete}
+                      onRequestForceDelete={() => setConfirmForceDelete(true)}
+                      forceDeleteLabel={t("loomDetailPage.forceDelete", { count: deleteConflict.projects.length })}
+                      triggerButtonClassName="border-destructive/50 text-destructive hover:bg-destructive/10"
+                      onConfirmForceDelete={() => handleDelete(true)}
+                      confirmForceDeleteLabel={t("loomDetailPage.confirmForceDelete")}
+                      busy={deleting}
+                      busyLabel={t("loomDetailPage.deleting")}
+                      onCancel={() => { setDeleteConflict(null); setConfirmForceDelete(false); }}
+                    />
                   )}
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Extracts the shared "409 conflict → force delete" UI (`DeleteConflictPanel`) used by `LoomDetailPage` and `DraftDetailPage`, resolving the 18-line SonarCloud duplicate block (5th of 8 pairs tracked in #1053).
- Preserves all existing per-page behavior exactly: loom's custom trigger-button styling and "Deleting…" busy-label swap, draft's plain trigger styling and static label — passed through as props, not unified away.
- No visual/behavioral change on the happy path; the confirm-force-delete button now consistently uses the `destructive` Button variant on both pages (previously Loom hand-rolled the identical classes inline — verified byte-for-byte identical to the `destructive` variant CSS).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] Full Docker rebuild (frontend + backend + worker + worker2), health check confirms `0.212.18` healthy
- [x] New e2e coverage (`e2e/tests/delete-conflict.spec.ts`) drives the actual 409 path on both pages against the seeded `EQA Fixture Project` fixture (linked to eqauser's seeded draft + loom), asserting the conflict panel renders with the correct blocking-project name, then cancels out non-destructively (fixture data untouched) — 4/4 passed
- [x] Full existing e2e suite (30 non-skipped tests) — no regressions

Part of #1053 (5 of 8 duplicate-block pairs now resolved across this and prior PRs). 3 remain: `AdminPage.tsx`↔`SuperuserPage.tsx` + `AdminPage.tsx` internal, `CollectionDetailPage.tsx` internal, `ProjectsPage.tsx`↔`ProjectSummaryList.tsx` + `ProjectsPage.tsx`↔`DraftsPage.tsx`, `AddFromRavelryModal.tsx`↔`YarnDetailPage.tsx` — not closing #1053 yet.