### PR TITLE
refactor: extract shared TagFilterBar (#1053)

### DIFF
--- a/e2e/tests/tag-filter.spec.ts
+++ b/e2e/tests/tag-filter.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "../fixtures";
+
+// Runs under the "authenticated" project.
+// Exercises the shared TagFilterBar extracted from DraftsPage/ProjectsPage
+// (#1053). eqauser's seeded fixtures have no tags by default, so this test
+// tags the seeded draft via a direct authenticated API call (using the
+// browser's own Clerk session token), drives the real filter UI, then
+// restores the draft to its original tagless state in a `finally` so the
+// fixture is left exactly as found.
+const SEEDED_DRAFT_ID = "86e64447-378d-4ac5-9a06-644bb0a24351";
+const TEST_TAG = "e2e-tag-filter";
+
+async function patchDraftTags(page: import("@playwright/test").Page, tags: string[]) {
+  await page.waitForFunction(() => Boolean((window as unknown as { Clerk?: { session?: unknown } }).Clerk?.session));
+  return page.evaluate(
+    async ({ draftId, tags: t }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const token = await (window as any).Clerk.session.getToken();
+      const res = await fetch(`/api/drafts/${draftId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ tags: t }),
+      });
+      if (!res.ok) throw new Error(`PATCH tags failed: ${res.status}`);
+    },
+    { draftId: SEEDED_DRAFT_ID, tags },
+  );
+}
+
+test.describe("Tag filter bar (#1053, shared TagFilterBar)", () => {
+  test("clicking a tag filters drafts, and clear removes the filter", async ({ page }) => {
+    await page.goto("/drafts");
+    await expect(page.locator("body")).not.toContainText("Loading…");
+
+    await patchDraftTags(page, [TEST_TAG]);
+    try {
+      await page.reload();
+      await expect(page.locator("body")).not.toContainText("Loading…");
+      await page.getByTestId("draft-card").first().waitFor({ state: "visible", timeout: 10_000 });
+
+      const unfilteredCount = await page.getByTestId("draft-card").count();
+      expect(unfilteredCount).toBeGreaterThan(1);
+
+      const tagButton = page.getByRole("button", { name: TEST_TAG, exact: true });
+      await expect(tagButton).toBeVisible();
+      await tagButton.click();
+
+      await expect(page.getByTestId("draft-card")).toHaveCount(1);
+
+      const clearButton = page.getByRole("button", { name: "Clear", exact: true });
+      await expect(clearButton).toBeVisible();
+      await clearButton.click();
+      await expect(clearButton).not.toBeVisible();
+      await expect(page.getByTestId("draft-card")).toHaveCount(unfilteredCount);
+    } finally {
+      await patchDraftTags(page, []);
+    }
+  });
+});

--- a/frontend/src/components/TagFilterBar.tsx
+++ b/frontend/src/components/TagFilterBar.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from "react";
+
+interface TagFilterBarProps {
+  readonly tags: string[];
+  readonly activeTag: string | null;
+  readonly onToggle: (tag: string) => void;
+  readonly onClear: () => void;
+  readonly clearLabel: string;
+  readonly className?: string;
+  readonly clearIcon: ReactNode;
+}
+
+export function TagFilterBar({ tags, activeTag, onToggle, onClear, clearLabel, className, clearIcon }: TagFilterBarProps) {
+  if (tags.length === 0) return null;
+
+  return (
+    <div className={`flex flex-wrap gap-1.5${className ? ` ${className}` : ""}`}>
+      {tags.map((tag) => (
+        <button
+          key={tag}
+          type="button"
+          onClick={() => onToggle(tag)}
+          className={`rounded-full px-2.5 py-0.5 text-xs transition-colors ${
+            activeTag === tag
+              ? "bg-accent text-accent-foreground"
+              : "bg-muted text-muted-foreground hover:bg-accent/20"
+          }`}
+        >
+          {tag}
+        </button>
+      ))}
+      {activeTag && (
+        <button
+          type="button"
+          onClick={onClear}
+          className="rounded-full px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
+        >
+          {clearIcon} {clearLabel}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/DraftsPage.tsx
+++ b/frontend/src/pages/DraftsPage.tsx
@@ -8,6 +8,7 @@ import { UploadWifModal } from "@/components/drafts/UploadWifModal";
 import { Button } from "@/components/ui/button";
 import { AppIcons } from "@/lib/icons";
 import { SkeletonCardGrid } from "@/components/ui/skeleton";
+import { TagFilterBar } from "@/components/TagFilterBar";
 
 export function DraftsPage() {
   const { t } = useTranslation();
@@ -64,31 +65,15 @@ export function DraftsPage() {
         <Button onClick={() => setShowUpload(true)}>{t("draftsPage.newButton")}</Button>
       </div>
 
-      {allTags.length > 0 && (
-        <div className="flex flex-wrap gap-1.5 mb-5">
-          {allTags.map((tag) => (
-            <button
-              key={tag}
-              onClick={() => setActiveTagFilter(activeTagFilter === tag ? null : tag)}
-              className={`rounded-full px-2.5 py-0.5 text-xs transition-colors ${
-                activeTagFilter === tag
-                  ? "bg-accent text-accent-foreground"
-                  : "bg-muted text-muted-foreground hover:bg-accent/20"
-              }`}
-            >
-              {tag}
-            </button>
-          ))}
-          {activeTagFilter && (
-            <button
-              onClick={() => setActiveTagFilter(null)}
-              className="rounded-full px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
-            >
-              <AppIcons.Close className="h-3 w-3" /> {t("draftsPage.clearFilter")}
-            </button>
-          )}
-        </div>
-      )}
+      <TagFilterBar
+        tags={allTags}
+        activeTag={activeTagFilter}
+        onToggle={(tag) => setActiveTagFilter(activeTagFilter === tag ? null : tag)}
+        onClear={() => setActiveTagFilter(null)}
+        clearLabel={t("draftsPage.clearFilter")}
+        clearIcon={<AppIcons.Close className="h-3 w-3" />}
+        className="mb-5"
+      />
 
       {isLoading && <SkeletonCardGrid count={4} cardClassName="h-[130px]" />}
       {error && <p className="text-sm text-destructive">{t("draftsPage.loadError")}</p>}

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { TagChips } from "@/components/ui/TagChips";
 import { Link } from "react-router-dom";
 import { SkeletonCardGrid } from "@/components/ui/skeleton";
+import { TagFilterBar } from "@/components/TagFilterBar";
 
 const STATUS_COLORS: Record<string, string> = {
   created: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
@@ -145,6 +146,7 @@ function ProjectCard({ project, onAssign }: {
             onKeyDown={(e) => { e.stopPropagation(); if (e.key === "Escape") setShowPreview(false); }}
           >
             <button
+              type="button"
               onClick={() => setShowPreview(false)}
               className="absolute -top-9 right-0 text-white/70 hover:text-white text-sm"
             >
@@ -242,31 +244,14 @@ export function ProjectsPage() {
         <Button size="sm" onClick={() => setShowCreate(true)}>{t("projectsPage.newButton")}</Button>
       </div>
 
-      {allTags.length > 0 && (
-        <div className="flex flex-wrap gap-1.5">
-          {allTags.map((tag) => (
-            <button
-              key={tag}
-              onClick={() => setActiveTagFilter(activeTagFilter === tag ? null : tag)}
-              className={`rounded-full px-2.5 py-0.5 text-xs transition-colors ${
-                activeTagFilter === tag
-                  ? "bg-accent text-accent-foreground"
-                  : "bg-muted text-muted-foreground hover:bg-accent/20"
-              }`}
-            >
-              {tag}
-            </button>
-          ))}
-          {activeTagFilter && (
-            <button
-              onClick={() => setActiveTagFilter(null)}
-              className="rounded-full px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
-            >
-              <AppIcons.Close className="h-3 w-3" /> {t("projectsPage.clearFilter")}
-            </button>
-          )}
-        </div>
-      )}
+      <TagFilterBar
+        tags={allTags}
+        activeTag={activeTagFilter}
+        onToggle={(tag) => setActiveTagFilter(activeTagFilter === tag ? null : tag)}
+        onClear={() => setActiveTagFilter(null)}
+        clearLabel={t("projectsPage.clearFilter")}
+        clearIcon={<AppIcons.Close className="h-3 w-3" />}
+      />
 
       {isLoading && <SkeletonCardGrid count={4} cardClassName="h-[160px]" gridClassName="grid gap-3 sm:grid-cols-2" />}
       {error && <p className="text-sm text-destructive">{t("projectsPage.loadError")}</p>}


### PR DESCRIPTION
## Summary
- Extracts a shared `TagFilterBar` component consolidating the 23-line tag-filter-chips block duplicated between `ProjectsPage` and `DraftsPage` (7th of 8 #1053 slices).
- Preserves per-page differences exactly: `DraftsPage`'s extra `mb-5` bottom margin is passed via `className`, and each page keeps its own i18n key for the "Clear" label.
- Adds a missing `type="button"` on `ProjectsPage.tsx`'s preview-close button while in the file (S9011).
- Checked the `ProjectsPage.tsx`↔`ProjectSummaryList.tsx` pair also noted in #1053: SonarCloud no longer reports any duplication there (diverged since #1052's baseline scan, same as the `AdminPage`↔`SuperuserPage` pair resolved in #1081). Nothing to extract.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] Full Docker rebuild (frontend + backend + worker + worker2), health check confirms `0.212.20` healthy
- [x] New e2e coverage (`e2e/tests/tag-filter.spec.ts`) tags the seeded eqauser draft via a real authenticated API call, drives the actual filter click on `/drafts` (card count 5→1→5), and restores the draft to its original tagless state in a `finally` — verified restored via direct DB check after the run
- [x] Full existing e2e suite (32 non-skipped tests) — no regressions

Part of #1053 (7 of 8 tracked slices now resolved; `ProjectsPage`↔`ProjectSummaryList` turned out to be stale/already-resolved, see above). 1 slice remains: `AddFromRavelryModal.tsx`↔`YarnDetailPage.tsx` — not closing #1053 yet.