### PR TITLE
refactor: extract shared ColorwayGrid + finish S9011 (#1053)

### DIFF
--- a/frontend/src/components/yarn/AddFromRavelryModal.tsx
+++ b/frontend/src/components/yarn/AddFromRavelryModal.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/api/ravelry";
 import { listYarn } from "@/api/yarn";
 import { ColorPicker } from "@/components/ui/ColorPicker";
+import { ColorwayGrid } from "@/components/yarn/ColorwayGrid";
 import { Button } from "@/components/ui/button";
 
 interface Props {
@@ -301,7 +302,7 @@ export function AddFromRavelryModal({ onSuccess, onClose }: Props) {
               {step === "colorway" && t("addFromRavelryModal.stepColorway", { yarn: selectedYarn?.name })}
             </p>
           </div>
-          <button onClick={onClose} className="text-muted-foreground hover:text-foreground text-lg leading-none">✕</button>
+          <button type="button" onClick={onClose} className="text-muted-foreground hover:text-foreground text-lg leading-none">✕</button>
         </div>
 
         <div className={`px-5 py-4 space-y-3 ${step !== "colorway" ? "max-h-[60vh] overflow-y-auto" : ""}`}>
@@ -331,6 +332,7 @@ export function AddFromRavelryModal({ onSuccess, onClose }: Props) {
                       {inventoryBrands.map((brand) => (
                         <li key={`inv-${brand}`}>
                           <button
+                            type="button"
                             className="w-full text-left rounded-md px-3 py-2 text-sm hover:bg-accent/10 transition-colors text-card-foreground"
                             onClick={() => pickInventoryBrand(brand)}
                           >
@@ -341,6 +343,7 @@ export function AddFromRavelryModal({ onSuccess, onClose }: Props) {
                       {popularFill.map((c) => (
                         <li key={`pop-${c.id}`}>
                           <button
+                            type="button"
                             className="w-full text-left rounded-md px-3 py-2 text-sm hover:bg-accent/10 transition-colors text-muted-foreground"
                             onClick={() => pickCompany(c)}
                           >
@@ -363,6 +366,7 @@ export function AddFromRavelryModal({ onSuccess, onClose }: Props) {
                     {companies.map((c) => (
                       <li key={c.id}>
                         <button
+                          type="button"
                           className="w-full text-left rounded-md px-3 py-2 text-sm hover:bg-accent/10 transition-colors text-card-foreground"
                           onClick={() => pickCompany(c)}
                         >
@@ -401,6 +405,7 @@ export function AddFromRavelryModal({ onSuccess, onClose }: Props) {
                       {inventoryYarnLines.map((name) => (
                         <li key={`inv-${name}`}>
                           <button
+                            type="button"
                             className="w-full text-left rounded-md px-3 py-2 text-sm hover:bg-accent/10 transition-colors text-card-foreground"
                             onClick={() => pickInventoryYarnLine(name)}
                           >
@@ -411,6 +416,7 @@ export function AddFromRavelryModal({ onSuccess, onClose }: Props) {
                       {popularYarnsFill.map((y) => (
                         <li key={`pop-${y.id}`}>
                           <button
+                            type="button"
                             className="w-full text-left flex items-center gap-3 rounded-md px-3 py-2 hover:bg-accent/10 transition-colors"
                             onClick={() => pickYarn(y)}
                           >
@@ -439,6 +445,7 @@ export function AddFromRavelryModal({ onSuccess, onClose }: Props) {
                     {sortedYarns.map((y) => (
                       <li key={y.id}>
                         <button
+                          type="button"
                           className="w-full text-left flex items-center gap-3 rounded-md px-3 py-2 hover:bg-accent/10 transition-colors"
                           onClick={() => pickYarn(y)}
                         >
@@ -487,6 +494,7 @@ export function AddFromRavelryModal({ onSuccess, onClose }: Props) {
                     {inventoryColorways.map((name) => (
                       <button
                         key={name}
+                        type="button"
                         className={`rounded-full border px-2.5 py-0.5 text-xs transition-colors ${
                           colorName === name
                             ? "border-ring bg-accent/10 text-accent"
@@ -516,29 +524,17 @@ export function AddFromRavelryModal({ onSuccess, onClose }: Props) {
                     onChange={(e) => setColorwayFilter(e.target.value)}
                   />
                   {colorwayFilter && (
-                    <button className={clearBtnCls} onClick={() => setColorwayFilter("")}>✕</button>
+                    <button type="button" className={clearBtnCls} onClick={() => setColorwayFilter("")}>✕</button>
                   )}
                 </div>
               )}
               {!colorwaysLoading && filteredColorways.length > 0 && (
-                <div className="grid grid-cols-3 gap-1.5 max-h-44 overflow-y-auto">
-                  {filteredColorways.map((cw) => (
-                    <button
-                      key={cw.id}
-                      className={`text-left rounded-md border p-1.5 text-xs transition-colors ${
-                        selectedColorway?.id === cw.id
-                          ? "border-ring bg-accent/10 text-accent"
-                          : "border-border hover:border-ring text-card-foreground"
-                      }`}
-                      onClick={() => pickColorway(cw)}
-                    >
-                      {cw.photos?.[0]?.square_url && (
-                        <img src={cw.photos[0].square_url} alt={cw.name} className="h-10 w-full rounded object-cover mb-1" />
-                      )}
-                      <span className="truncate block leading-tight">{formatColorwayLabel(cw)}</span>
-                    </button>
-                  ))}
-                </div>
+                <ColorwayGrid
+                  colorways={filteredColorways}
+                  selectedColorway={selectedColorway}
+                  onPick={pickColorway}
+                  className="grid grid-cols-3 gap-1.5 max-h-44 overflow-y-auto"
+                />
               )}
 
               {/* Color hex */}

--- a/frontend/src/components/yarn/ColorwayGrid.tsx
+++ b/frontend/src/components/yarn/ColorwayGrid.tsx
@@ -1,0 +1,32 @@
+import { formatColorwayLabel, type RavelryColorway } from "@/api/ravelry";
+
+interface ColorwayGridProps {
+  readonly colorways: readonly RavelryColorway[];
+  readonly selectedColorway: RavelryColorway | null;
+  readonly onPick: (cw: RavelryColorway) => void;
+  readonly className?: string;
+}
+
+export function ColorwayGrid({ colorways, selectedColorway, onPick, className = "grid grid-cols-3 gap-1.5" }: ColorwayGridProps) {
+  return (
+    <div className={className}>
+      {colorways.map((cw) => (
+        <button
+          key={cw.id}
+          type="button"
+          className={`text-left rounded-md border p-1.5 text-xs transition-colors ${
+            selectedColorway?.id === cw.id
+              ? "border-ring bg-accent/10 text-accent"
+              : "border-border hover:border-ring text-card-foreground"
+          }`}
+          onClick={() => onPick(cw)}
+        >
+          {cw.photos?.[0]?.square_url && (
+            <img src={cw.photos[0].square_url} alt={cw.name} className="h-10 w-full rounded object-cover mb-1" />
+          )}
+          <span className="truncate block leading-tight">{formatColorwayLabel(cw)}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/pages/YarnDetailPage.tsx
+++ b/frontend/src/pages/YarnDetailPage.tsx
@@ -6,6 +6,7 @@ import { getYarn, updateYarn, patchYarnColorway, getYarnProjects, type YarnProje
 import { formatColorwayLabel, getRavelryStatus, getRavelryYarnDetail, pushYarnToStash, type RavelryColorway, type RavelryYarnApiDetail } from "@/api/ravelry";
 import { Button } from "@/components/ui/button";
 import { ColorPicker } from "@/components/ui/ColorPicker";
+import { ColorwayGrid } from "@/components/yarn/ColorwayGrid";
 
 function DevJsonModal({ data, onClose }: { readonly data: unknown; readonly onClose: () => void }) {
   return (
@@ -21,7 +22,7 @@ function DevJsonModal({ data, onClose }: { readonly data: unknown; readonly onCl
       >
         <div className="flex items-center justify-between px-4 py-3 border-b border-border">
           <span className="text-xs font-mono font-semibold text-accent">DEV — raw data</span>
-          <button onClick={onClose} className="text-muted-foreground hover:text-foreground text-lg leading-none">×</button>
+          <button type="button" onClick={onClose} className="text-muted-foreground hover:text-foreground text-lg leading-none">×</button>
         </div>
         <pre className="p-4 text-xs font-mono text-card-foreground whitespace-pre-wrap break-all">
           {JSON.stringify(data, null, 2)}
@@ -137,7 +138,7 @@ function EditColorwayModal({
       >
         <div className="flex items-center justify-between px-5 py-4 border-b border-border">
           <h2 id="edit-colorway-title" className="text-sm font-semibold">{t("yarnDetailPage.editColorwayTitle")}</h2>
-          <button onClick={onClose} className="text-muted-foreground hover:text-foreground text-lg leading-none">×</button>
+          <button type="button" onClick={onClose} className="text-muted-foreground hover:text-foreground text-lg leading-none">×</button>
         </div>
 
         {yarn.ravelry_yarn_id && (
@@ -145,6 +146,7 @@ function EditColorwayModal({
             {(["rename", "link"] as const).map((t_) => (
               <button
                 key={t_}
+                type="button"
                 onClick={() => handleTabChange(t_)}
                 className={`flex-1 px-4 py-2.5 text-xs font-medium transition-colors ${
                   tab === t_
@@ -171,7 +173,7 @@ function EditColorwayModal({
                     onChange={(e) => setColorwayFilter(e.target.value)}
                   />
                   {colorwayFilter && (
-                    <button className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground text-xs" onClick={() => setColorwayFilter("")}>✕</button>
+                    <button type="button" className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground text-xs" onClick={() => setColorwayFilter("")}>✕</button>
                   )}
                 </div>
               )}
@@ -179,24 +181,7 @@ function EditColorwayModal({
                 <p className="text-xs text-muted-foreground">{t("yarnDetailPage.noColorways")}</p>
               )}
               {filteredColorways.length > 0 && (
-                <div className="grid grid-cols-3 gap-1.5">
-                  {filteredColorways.map((cw) => (
-                    <button
-                      key={cw.id}
-                      className={`text-left rounded-md border p-1.5 text-xs transition-colors ${
-                        selectedColorway?.id === cw.id
-                          ? "border-ring bg-accent/10 text-accent"
-                          : "border-border hover:border-ring text-card-foreground"
-                      }`}
-                      onClick={() => pickColorway(cw)}
-                    >
-                      {cw.photos?.[0]?.square_url && (
-                        <img src={cw.photos[0].square_url} alt={cw.name} className="h-10 w-full rounded object-cover mb-1" />
-                      )}
-                      <span className="truncate block leading-tight">{formatColorwayLabel(cw)}</span>
-                    </button>
-                  ))}
-                </div>
+                <ColorwayGrid colorways={filteredColorways} selectedColorway={selectedColorway} onPick={pickColorway} />
               )}
             </>
           )}
@@ -512,6 +497,7 @@ export function YarnDetailPage() {
           {/* Tags row */}
           <div className="flex flex-wrap gap-1.5 pt-0.5 items-center">
             <button
+              type="button"
               onClick={() => setShowEditColorway(true)}
               title={t("yarnDetailPage.editColorway")}
               className="flex items-center gap-1 rounded-full bg-muted text-muted-foreground px-2.5 py-0.5 text-xs hover:bg-accent/20 hover:text-foreground transition-colors"
@@ -548,6 +534,7 @@ export function YarnDetailPage() {
             )}
             {ravelryStatus?.connected && yarn.ravelry_yarn_id !== null && yarn.ravelry_stash_id === null && !yarn.out_of_stash && !yarn.archived && (
               <button
+                type="button"
                 onClick={() => pushMutation.mutate()}
                 disabled={pushMutation.isPending}
                 className="rounded-full bg-muted text-muted-foreground px-2.5 py-0.5 text-xs hover:bg-muted/80 disabled:opacity-50 transition-colors"
@@ -589,6 +576,7 @@ export function YarnDetailPage() {
           {isDevEnv && (
             <div className="mt-3 pt-3 border-t border-border flex flex-wrap gap-4">
               <button
+                type="button"
                 onClick={() => setShowDebug(true)}
                 className="text-xs font-mono text-accent hover:text-accent/80"
               >
@@ -596,6 +584,7 @@ export function YarnDetailPage() {
               </button>
               {yarn.ravelry_yarn_id && (
                 <button
+                  type="button"
                   onClick={async () => {
                     setRavelryLoading(true);
                     try {


### PR DESCRIPTION
## Summary
- Extracts a shared `ColorwayGrid` component consolidating the 18-line colorway-picker grid duplicated between `AddFromRavelryModal` (new-yarn-from-Ravelry flow) and `YarnDetailPage` (link-existing-yarn-to-Ravelry flow) — the 8th and final #1053 slice.
- Preserves the one real difference between call sites: `AddFromRavelryModal`'s grid has `max-h-44 overflow-y-auto` (it sits in a longer scrolling modal step) while `YarnDetailPage`'s doesn't — passed through as an optional `className` override.
- Finishes the S9011 sweep for both files (adds `type="button"` to all remaining untyped raw `<button>` elements — 8 in `YarnDetailPage.tsx`, 9 in `AddFromRavelryModal.tsx`). Both were reverted out of #1052 for the same duplication reason.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] Full Docker rebuild (frontend + backend + worker + worker2), health check confirms `0.212.21` healthy
- [x] Full existing e2e suite (32 non-skipped tests, including `dashboard.spec.ts`'s "Add yarn modal opens" which mounts `AddFromRavelryModal` for real) — no regressions
- [ ] **Could not browser-drive the colorway grid itself** — reaching it requires a live Ravelry OAuth connection, and no test account in this environment has one configured (`eqauser.ravelry_username` is `null`, no Ravelry test fixtures/mocking exist in the e2e suite). Verified instead via: byte-for-byte manual diff of the extracted JSX against both original call sites (props map 1:1, no logic changes), `tsc`/`eslint` clean, and the smoke test confirming the modal housing the grid still mounts without error.

Closes #1053 — all 8 tracked duplicate-block pairs now resolved (5 fixed via extraction across PRs #1079–#1082 and this PR; 3 — `AdminPage`↔`SuperuserPage`, `ProjectsPage`↔`ProjectSummaryList`, and the original `CollectionDetailPage` pairing — turned out to already be resolved by the time each was reached, confirmed via live SonarCloud duplication checks).