### PR TITLE
chore: SonarCloud long-tail TypeScript sweep (#1067)

### DIFF
--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -235,7 +235,7 @@ export const getAuditLog = (params: { page?: number; page_size?: number; event_t
   if (params.event_type) qs.set("event_type", params.event_type);
   if (params.q) qs.set("q", params.q);
   const query = qs.toString();
-  return api.get<AuditLogPage>(`/api/admin/audit-log${query ? `?${query}` : ""}`);
+  return api.get<AuditLogPage>(`/api/admin/audit-log${query ? "?" + query : ""}`);
 };
 
 export interface ReconcileClerkOnlyUser {
@@ -472,7 +472,7 @@ export const getServerEvents = (params: { page?: number; page_size?: number; eve
   if (params.page_size) qs.set("page_size", String(params.page_size));
   if (params.event_type) qs.set("event_type", params.event_type);
   const query = qs.toString();
-  return api.get<ServerEventPage>(`/api/admin/server-events${query ? `?${query}` : ""}`);
+  return api.get<ServerEventPage>(`/api/admin/server-events${query ? "?" + query : ""}`);
 };
 
 export type CredentialResource = "smtp" | "s3" | "clerk" | "postgres" | "app";

--- a/frontend/src/api/feedback.ts
+++ b/frontend/src/api/feedback.ts
@@ -70,7 +70,7 @@ export const listAdminFeedback = (params: {
   if (params.dispatch_status) qs.set("dispatch_status", params.dispatch_status);
   if (params.include_deleted) qs.set("include_deleted", "true");
   const query = qs.toString();
-  return api.get<FeedbackPage>(`/api/admin/feedback${query ? `?${query}` : ""}`);
+  return api.get<FeedbackPage>(`/api/admin/feedback${query ? "?" + query : ""}`);
 };
 
 export const getAdminFeedbackDetail = (id: string) =>

--- a/frontend/src/api/looms.ts
+++ b/frontend/src/api/looms.ts
@@ -210,14 +210,6 @@ export function updateLoom(id: string, payload: UpdateLoomPayload): Promise<Loom
   });
 }
 
-export function updateLoomVersion(loomId: string, versionId: string, payload: UpdateVersionPayload): Promise<LoomVersion> {
-  return req(`/api/looms/${loomId}/versions/${versionId}`, {
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload),
-  });
-}
-
 export function addLoomVersion(id: string, payload: AddVersionPayload): Promise<LoomVersion> {
   return req(`/api/looms/${id}/versions`, {
     method: "POST",

--- a/frontend/src/components/DevBanner.tsx
+++ b/frontend/src/components/DevBanner.tsx
@@ -37,7 +37,7 @@ export function DevBanner() {
     <div
       className={`w-full text-center text-xs font-semibold py-1.5 px-4 select-none overflow-hidden${colorStyle ? "" : " bg-amber-400 text-amber-950"}`}
       style={{
-        ...(colorStyle ?? {}),
+        ...colorStyle,
         maxHeight: visible ? "3rem" : "0",
         opacity: visible ? 1 : 0,
         transition: "max-height 0.5s ease, opacity 0.5s ease",

--- a/frontend/src/components/TagFilterBar.tsx
+++ b/frontend/src/components/TagFilterBar.tsx
@@ -14,7 +14,7 @@ export function TagFilterBar({ tags, activeTag, onToggle, onClear, clearLabel, c
   if (tags.length === 0) return null;
 
   return (
-    <div className={`flex flex-wrap gap-1.5${className ? ` ${className}` : ""}`}>
+    <div className={`flex flex-wrap gap-1.5${className ? " " + className : ""}`}>
       {tags.map((tag) => (
         <button
           key={tag}

--- a/frontend/src/components/TrackerStylePreview.tsx
+++ b/frontend/src/components/TrackerStylePreview.tsx
@@ -2,7 +2,7 @@ export type TrackerStyle = "default" | "compact" | "high_contrast";
 
 // ── Static style-picker preview (small, used in the card selector) ──────────
 
-const DEMO_ACTIVE = [1, 3];
+const DEMO_ACTIVE = new Set([1, 3]);
 const DEMO_SHAFTS = 4;
 const DEMO_WEFT = "#b45309";
 const DEMO_PICK = 7;
@@ -35,7 +35,7 @@ function DemoPickCard({ compact, style }: { readonly compact?: boolean; readonly
     <div className={`rounded-lg ${bg} ${border} ${height} px-2 py-1.5 flex items-stretch gap-2`}>
       <div className="flex-1 grid gap-0.5" style={{ gridTemplateColumns: `repeat(${DEMO_SHAFTS}, 1fr)` }}>
         {Array.from({ length: DEMO_SHAFTS }, (_, i) => i + 1).map((n) => (
-          <DemoBox key={n} n={n} active={DEMO_ACTIVE.includes(n)} style={style} />
+          <DemoBox key={n} n={n} active={DEMO_ACTIVE.has(n)} style={style} />
         ))}
       </div>
       {!compact && <div className="w-4 shrink-0 rounded" style={{ backgroundColor: DEMO_WEFT }} />}
@@ -89,7 +89,7 @@ export function TrackerStylePreview({ style }: { readonly style: TrackerStyle })
 
 const LIVE_SHAFTS_ALL = 8;   // total shafts on the loom
 const LIVE_SHAFTS_USED = 4;  // shafts actually used by the design (trailing 4 are "unused")
-const LIVE_ACTIVE = [1, 3];
+const LIVE_ACTIVE = new Set([1, 3]);
 const LIVE_WEFT = "#b45309";
 const LIVE_PICK = 12;
 const LIVE_TOTAL = 32;
@@ -180,7 +180,7 @@ function LivePickCard({
           <LiveBox
             key={n}
             n={n}
-            active={!compact && LIVE_ACTIVE.includes(n)}
+            active={!compact && LIVE_ACTIVE.has(n)}
             unused={n > LIVE_SHAFTS_USED}
             colorMode={compact ? "theme" : colorMode}
             style={style}

--- a/frontend/src/components/admin/CveBanner.tsx
+++ b/frontend/src/components/admin/CveBanner.tsx
@@ -12,7 +12,7 @@ export function CveBanner() {
     staleTime: 5 * 60_000,
   });
 
-  if (dismissed || !data || data.finding_count == null || data.finding_count === 0) return null;
+  if (dismissed || data?.finding_count == null || data.finding_count === 0) return null;
 
   return (
     <div className="flex items-center justify-between gap-3 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm">

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -26,7 +26,6 @@ interface Props {
 }
 
 interface NavGroupSectionProps {
-  readonly group: NavGroup;
   readonly icon: LucideIcon;
   readonly label: string;
   readonly expanded: boolean;
@@ -262,7 +261,6 @@ function SidebarBottomNav({ user, desktopCollapsed, onClose, onFeedbackClick }: 
   return (
     <div className={`shrink-0 border-t border-border px-3 py-3 space-y-0.5 ${desktopCollapsed ? "lg:px-2" : ""}`}>
       <NavGroupSection
-        group="settings"
         icon={SettingsIcon}
         label={t("nav.settings")}
         expanded={expandedGroup === "settings"}
@@ -275,7 +273,6 @@ function SidebarBottomNav({ user, desktopCollapsed, onClose, onFeedbackClick }: 
 
       {user?.is_admin && (
         <NavGroupSection
-          group="admin"
           icon={AdminIcon}
           label={t("nav.admin")}
           expanded={expandedGroup === "admin"}
@@ -289,7 +286,6 @@ function SidebarBottomNav({ user, desktopCollapsed, onClose, onFeedbackClick }: 
 
       {user?.is_superuser && (
         <NavGroupSection
-          group="superuser"
           icon={SuperuserIcon}
           label={t("nav.superuser")}
           expanded={expandedGroup === "superuser"}

--- a/frontend/src/components/looms/NewLoomModal.tsx
+++ b/frontend/src/components/looms/NewLoomModal.tsx
@@ -406,8 +406,8 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
                       type="checkbox"
                       checked={acknowledged}
                       onChange={(e) => setAcknowledged(e.target.checked)}
-                    />
-                    I understand this loom cannot be used for project tracking
+                    />{/*
+                    */}I understand this loom cannot be used for project tracking
                   </label>
                 </div>
               )}
@@ -548,8 +548,8 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
                       type="checkbox"
                       checked={acknowledged}
                       onChange={(e) => setAcknowledged(e.target.checked)}
-                    />
-                    I understand this loom cannot be used for project tracking
+                    />{/*
+                    */}I understand this loom cannot be used for project tracking
                   </label>
                 </div>
               )}

--- a/frontend/src/components/projects/ShareModal.tsx
+++ b/frontend/src/components/projects/ShareModal.tsx
@@ -15,7 +15,7 @@ export async function copyToClipboard(text: string): Promise<boolean> {
     document.body.appendChild(ta);
     ta.select();
     const ok = document.execCommand("copy");
-    document.body.removeChild(ta);
+    ta.remove();
     return ok;
   }
 }

--- a/frontend/src/components/ui/ColorPicker.tsx
+++ b/frontend/src/components/ui/ColorPicker.tsx
@@ -15,7 +15,7 @@ declare global {
 // ---------------------------------------------------------------------------
 
 function hexToRgb(hex: string): [number, number, number] | null {
-  const m = hex.match(/^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i);
+  const m = /^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
   if (!m) return null;
   return [Number.parseInt(m[1], 16), Number.parseInt(m[2], 16), Number.parseInt(m[3], 16)];
 }
@@ -50,12 +50,12 @@ function hslToHex(h: number, s: number, l: number): string {
   const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
   const m = ll - c / 2;
   let rv = 0, gv = 0, bv = 0;
-  if (h < 60) { rv = c; gv = x; bv = 0; }
-  else if (h < 120) { rv = x; gv = c; bv = 0; }
-  else if (h < 180) { rv = 0; gv = c; bv = x; }
-  else if (h < 240) { rv = 0; gv = x; bv = c; }
-  else if (h < 300) { rv = x; gv = 0; bv = c; }
-  else { rv = c; gv = 0; bv = x; }
+  if (h < 60) { rv = c; gv = x; }
+  else if (h < 120) { rv = x; gv = c; }
+  else if (h < 180) { gv = c; bv = x; }
+  else if (h < 240) { gv = x; bv = c; }
+  else if (h < 300) { rv = x; bv = c; }
+  else { rv = c; bv = x; }
   return rgbToHex(Math.round((rv + m) * 255), Math.round((gv + m) * 255), Math.round((bv + m) * 255));
 }
 

--- a/frontend/src/components/ui/TagChips.tsx
+++ b/frontend/src/components/ui/TagChips.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 function tagColor(tag: string): { background: string; color: string } {
   let h = 0;
-  for (let i = 0; i < tag.length; i++) h = (h * 31 + tag.charCodeAt(i)) >>> 0;
+  for (let i = 0; i < tag.length; i++) h = (h * 31 + (tag.codePointAt(i) ?? 0)) >>> 0;
   const hue = h % 360;
   return {
     background: `hsl(${hue}, 60%, 88%)`,

--- a/frontend/src/components/ui/TagInput.tsx
+++ b/frontend/src/components/ui/TagInput.tsx
@@ -3,7 +3,7 @@ import { AppIcons } from "@/lib/icons";
 
 function tagColor(tag: string): { background: string; color: string } {
   let h = 0;
-  for (let i = 0; i < tag.length; i++) h = (h * 31 + tag.charCodeAt(i)) >>> 0;
+  for (let i = 0; i < tag.length; i++) h = (h * 31 + (tag.codePointAt(i) ?? 0)) >>> 0;
   const hue = h % 360;
   return { background: `hsl(${hue}, 60%, 88%)`, color: `hsl(${hue}, 55%, 30%)` };
 }

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,7 +1,12 @@
-import { createContext, startTransition, useCallback, useContext, useEffect, useState, type ReactNode } from "react";
+import { createContext, startTransition, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
 import { useAuth as useClerkAuth } from "@clerk/clerk-react";
 import { api, configureApiClient } from "@/api/client";
-import { getHealthReady } from "@/api/health";
+import { getHealthReady, type ReadinessResponse } from "@/api/health";
+
+function isClerkWebhookDegraded(h: ReadinessResponse): boolean {
+  const wh = h.services.find((s) => s.name === "Clerk Webhook");
+  return !!wh && !wh.ok;
+}
 
 export interface User {
   id: string;
@@ -59,10 +64,7 @@ export function AuthProvider({ children }: { readonly children: ReactNode }) {
         // so we can show an informative banner rather than a generic error.
         if (isSignedIn) {
           getHealthReady()
-            .then((h) => {
-              const wh = h.services.find((s) => s.name === "Clerk Webhook");
-              setWebhookDegraded(!!wh && !wh.ok);
-            })
+            .then((h) => setWebhookDegraded(isClerkWebhookDegraded(h)))
             .catch(() => {});
         }
       })
@@ -96,10 +98,13 @@ export function AuthProvider({ children }: { readonly children: ReactNode }) {
     document.documentElement.classList.toggle("dark", theme === "dark");
   }, [user?.theme]);
 
+  const value = useMemo<AuthState>(
+    () => ({ user, isLoading, isAuthenticated: user !== null, webhookDegraded, refetch: fetchUser }),
+    [user, isLoading, webhookDegraded, fetchUser],
+  );
+
   return (
-    <AuthContext.Provider
-      value={{ user, isLoading, isAuthenticated: user !== null, webhookDegraded, refetch: fetchUser }}
-    >
+    <AuthContext.Provider value={value}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/context/ImpersonationContext.tsx
+++ b/frontend/src/context/ImpersonationContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useRef, useState, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useMemo, useRef, useState, type ReactNode } from "react";
 import { setImpersonationTarget } from "@/api/client";
 import { startImpersonationSession, endImpersonationSession } from "@/api/impersonation";
 import type { User } from "@/context/AuthContext";
@@ -50,15 +50,18 @@ export function ImpersonationProvider({ children }: { readonly children: ReactNo
     }
   }, [impersonatedUser]);
 
+  const value = useMemo<ImpersonationState>(
+    () => ({
+      isImpersonating: impersonatedUser !== null,
+      impersonatedUser,
+      startImpersonation,
+      endImpersonation,
+    }),
+    [impersonatedUser, startImpersonation, endImpersonation],
+  );
+
   return (
-    <ImpersonationContext.Provider
-      value={{
-        isImpersonating: impersonatedUser !== null,
-        impersonatedUser,
-        startImpersonation,
-        endImpersonation,
-      }}
-    >
+    <ImpersonationContext.Provider value={value}>
       {children}
     </ImpersonationContext.Provider>
   );

--- a/frontend/src/lib/image-utils.ts
+++ b/frontend/src/lib/image-utils.ts
@@ -1,5 +1,20 @@
 const MAX_DIM = 2048;
 
+function canvasToJpegBlob(canvas: HTMLCanvasElement, quality: number): Promise<Blob | null> {
+  return new Promise((resolve) => canvas.toBlob(resolve, "image/jpeg", quality));
+}
+
+// Recompresses at progressively lower quality until under maxBytes, or quality bottoms out.
+async function shrinkToJpeg(canvas: HTMLCanvasElement, maxBytes: number): Promise<Blob> {
+  let quality = 0.85;
+  for (;;) {
+    const blob = await canvasToJpegBlob(canvas, quality);
+    if (!blob) throw new Error("Resize failed");
+    if (blob.size <= maxBytes || quality <= 0.3) return blob;
+    quality = Math.round((quality - 0.1) * 10) / 10;
+  }
+}
+
 export async function resizeImageToFile(
   file: File,
   maxBytes: number,
@@ -30,22 +45,9 @@ export async function resizeImageToFile(
 
       const baseName = file.name.replace(/\.[^.]+$/, "");
 
-      const tryQuality = (quality: number) => {
-        canvas.toBlob(
-          (blob) => {
-            if (!blob) { reject(new Error("Resize failed")); return; }
-            if (blob.size <= maxBytes || quality <= 0.3) {
-              resolve(new File([blob], `${baseName}.jpg`, { type: "image/jpeg" }));
-            } else {
-              tryQuality(Math.round((quality - 0.1) * 10) / 10);
-            }
-          },
-          "image/jpeg",
-          quality,
-        );
-      };
-
-      tryQuality(0.85);
+      shrinkToJpeg(canvas, maxBytes)
+        .then((blob) => resolve(new File([blob], `${baseName}.jpg`, { type: "image/jpeg" })))
+        .catch(reject);
     };
 
     img.onerror = () => { URL.revokeObjectURL(url); reject(new Error("Could not load image")); };

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -77,8 +77,8 @@ export function AboutPage() {
                 className="text-amber-800 underline hover:text-amber-900 transition-colors"
               >
                 GitHub
-              </a>
-              .
+              </a>{/*
+              */}.
             </p>
           </div>
         </div>

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -745,6 +745,16 @@ function StatTable({ title, rows }: { readonly title: string; readonly rows: { l
 // ---------------------------------------------------------------------------
 
 const MAX_HEALTH_POINTS = 60;
+
+function appendHealthPoint(prev: AdminHealth[], d: AdminHealth): AdminHealth[] {
+  return [...prev.slice(-(MAX_HEALTH_POINTS - 1)), d];
+}
+
+function pollHealthOnce(setHistory: React.Dispatch<React.SetStateAction<AdminHealth[]>>) {
+  getAdminHealth()
+    .then((d) => setHistory((prev) => appendHealthPoint(prev, d)))
+    .catch(() => {});
+}
 const POLL_INTERVAL_MS = 3000;
 
 function Sparkline({ values, max, color }: { readonly values: number[]; readonly max: number; readonly color: string }) {
@@ -782,11 +792,7 @@ function HealthTab() {
   const latest = history[history.length - 1] ?? null;
 
   useEffect(() => {
-    const fetch = () => {
-      getAdminHealth()
-        .then((d) => setHistory((prev) => [...prev.slice(-(MAX_HEALTH_POINTS - 1)), d]))
-        .catch(() => {});
-    };
+    const fetch = () => pollHealthOnce(setHistory);
     fetch();
     pollingRef.current = setInterval(fetch, POLL_INTERVAL_MS);
     return () => {
@@ -1312,7 +1318,7 @@ function ServerEventsPanel() {
       {isLoading && <p className="text-xs text-muted-foreground">Loading…</p>}
       {isError && <p className="text-xs text-destructive">Failed to load server events.</p>}
 
-      {data && data.items.length === 0 && (
+      {data?.items.length === 0 && (
         <p className="text-xs text-muted-foreground">No events recorded yet.</p>
       )}
 
@@ -1451,6 +1457,12 @@ function SlugsTab() {
   );
 }
 
+function formatDwell(ms: number | null) {
+  if (ms == null) return "—";
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
 function StepLogSection() {
   const [projectId, setProjectId] = useState("");
   const [submittedId, setSubmittedId] = useState<string | null>(null);
@@ -1467,12 +1479,6 @@ function StepLogSection() {
     if (trimmed) setSubmittedId(trimmed);
   }
 
-  function formatDwell(ms: number | null) {
-    if (ms == null) return "—";
-    if (ms < 1000) return `${ms}ms`;
-    return `${(ms / 1000).toFixed(1)}s`;
-  }
-
   return (
     <div className="space-y-3 mt-8">
       <h2 className="text-base font-semibold">Project step log</h2>
@@ -1487,7 +1493,7 @@ function StepLogSection() {
       </form>
       {isLoading && <div className="text-sm text-muted-foreground">Loading…</div>}
       {isError && <div className="text-sm text-destructive">Failed to load steps.</div>}
-      {steps && steps.length === 0 && (
+      {steps?.length === 0 && (
         <div className="text-sm text-muted-foreground">No steps recorded for this project.</div>
       )}
       {steps && steps.length > 0 && (
@@ -1598,14 +1604,14 @@ function FeedbackTab() {
             ))}
           </select>
           <label className="flex items-center gap-1.5 cursor-pointer text-muted-foreground">
-            <input type="checkbox" checked={includeDeleted} onChange={(e) => setIncludeDeleted(e.target.checked)} />
-            Show deleted
+            <input type="checkbox" checked={includeDeleted} onChange={(e) => setIncludeDeleted(e.target.checked)} />{/*
+            */}Show deleted
           </label>
         </div>
       </div>
 
       {isLoading && <div className="text-sm text-muted-foreground py-8 text-center">Loading…</div>}
-      {data && data.items.length === 0 && (
+      {data?.items.length === 0 && (
         <div className="text-sm text-muted-foreground py-8 text-center">No submissions found.</div>
       )}
       {data && data.items.length > 0 && (
@@ -1691,7 +1697,7 @@ function FeedbackTab() {
               <div className="text-xs text-muted-foreground space-y-1">
                 <p className="font-medium text-foreground">Diagnostics</p>
                 {Object.entries(detail.diagnostics).map(([k, v]) =>
-                  v ? <p key={k}><span className="font-mono">{k}:</span> {String(v)}</p> : null
+                  v ? <p key={k}><span className="font-mono">{k}:</span> {typeof v === "object" ? JSON.stringify(v) : String(v)}</p> : null
                 )}
               </div>
             )}
@@ -1837,7 +1843,7 @@ function AuditLogTab() {
       {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
       {isError && <p className="text-sm text-destructive">Failed to load audit log.</p>}
 
-      {data && data.items.length === 0 && (
+      {data?.items.length === 0 && (
         <p className="text-sm text-muted-foreground">No events found.</p>
       )}
 
@@ -2049,7 +2055,7 @@ function LoomRefFormModal({
             <label className={labelCls}>Shedding mechanism</label>
             <select className={inputCls} value={form.shedding_mechanism} onChange={(e) => onChange({ ...form, shedding_mechanism: e.target.value })}>
               <option value="">—</option>
-              {SHEDDING_OPTIONS.map((o) => <option key={o} value={o}>{o.replace(/_/g, " ")}</option>)}
+              {SHEDDING_OPTIONS.map((o) => <option key={o} value={o}>{o.replaceAll("_", " ")}</option>)}
             </select>
           </div>
           <div>

--- a/frontend/src/pages/CollectionDetailPage.tsx
+++ b/frontend/src/pages/CollectionDetailPage.tsx
@@ -13,9 +13,8 @@ import {
   type DraftMember,
   type ProjectMember,
 } from "@/api/collections";
-import { listDrafts } from "@/api/drafts";
+import { listDrafts, previewUrl } from "@/api/drafts";
 import { listProjects } from "@/api/projects";
-import { previewUrl } from "@/api/drafts";
 import { AppIcons } from "@/lib/icons";
 import { Button } from "@/components/ui/button";
 import { AuthedImage } from "@/components/ui/AuthedImage";

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -22,6 +22,10 @@ function NewCollectionModal({ onClose, onSuccess }: { readonly onClose: () => vo
     setTagInput("");
   }
 
+  function removeTag(tag: string) {
+    setTags((prev) => prev.filter((x) => x !== tag));
+  }
+
   function handleTagKey(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === "Enter" || e.key === ",") {
       e.preventDefault();
@@ -85,7 +89,7 @@ function NewCollectionModal({ onClose, onSuccess }: { readonly onClose: () => vo
               {tags.map((tag) => (
                 <span key={tag} className="flex items-center gap-1 rounded bg-muted px-2 py-0.5 text-xs">
                   {tag}
-                  <button type="button" onClick={() => setTags((prev) => prev.filter((x) => x !== tag))} className="text-muted-foreground hover:text-foreground">×</button>
+                  <button type="button" onClick={() => removeTag(tag)} className="text-muted-foreground hover:text-foreground">×</button>
                 </span>
               ))}
             </div>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -85,10 +85,10 @@ function HeatmapGrid({
     <div className="overflow-x-auto pb-1">
       <div className="inline-flex flex-col gap-[3px]" style={{ minWidth: "max-content" }}>
         <div className="flex gap-[3px]" style={{ paddingLeft: "22px" }}>
-          {weeks.map((_, wi) => {
+          {weeks.map((week, wi) => {
             const label = monthLabels.find((m) => m.col === wi);
             return (
-              <div key={wi} className="w-[10px] text-[9px] text-muted-foreground leading-none overflow-visible whitespace-nowrap">
+              <div key={toDateStr(week[0])} className="w-[10px] text-[9px] text-muted-foreground leading-none overflow-visible whitespace-nowrap">
                 {label ? label.label : ""}
               </div>
             );
@@ -99,14 +99,15 @@ function HeatmapGrid({
             <span className="w-[18px] text-[9px] text-muted-foreground text-right shrink-0 leading-none">
               {dow % 2 === 1 ? dowLabels[dow] : ""}
             </span>
-            {weeks.map((week, wi) => {
+            {weeks.map((week) => {
+              const weekKey = toDateStr(week[0]);
               const day = week[dow];
-              if (!day || day > rangeEnd) return <div key={wi} className="w-[10px] h-[10px] rounded-[2px] opacity-0" />;
+              if (!day || day > rangeEnd) return <div key={weekKey} className="w-[10px] h-[10px] rounded-[2px] opacity-0" />;
               const dateStr = toDateStr(day);
               const count = dayByDate.get(dateStr)?.count ?? 0;
               return (
                 <div
-                  key={wi}
+                  key={weekKey}
                   className={`w-[10px] h-[10px] rounded-[2px] ${intensityClass(count)} ${count > 0 ? "cursor-pointer" : "cursor-default"}`}
                   onMouseEnter={(e) => onCellEnter(e, dateStr)}
                   onMouseLeave={onCellLeave}

--- a/frontend/src/pages/DraftDetailPage.tsx
+++ b/frontend/src/pages/DraftDetailPage.tsx
@@ -254,16 +254,16 @@ export function DraftDetailPage() {
         {draft.lint_errors.length > 0 && (
           <div className="rounded-md bg-destructive/10 p-4 space-y-1">
             <p className="text-sm font-medium text-destructive">{t("draftDetailPage.lintErrors")}</p>
-            {draft.lint_errors.map((e, i) => (
-              <p key={i} className="text-sm text-destructive">{e}</p>
+            {draft.lint_errors.map((e) => (
+              <p key={e} className="text-sm text-destructive">{e}</p>
             ))}
           </div>
         )}
         {draft.lint_warnings.length > 0 && (
           <div className="rounded-md bg-muted p-4 space-y-1">
             <p className="text-sm font-medium">{t("draftDetailPage.lintWarnings")}</p>
-            {draft.lint_warnings.map((w, i) => (
-              <p key={i} className="text-sm text-muted-foreground">{w}</p>
+            {draft.lint_warnings.map((w) => (
+              <p key={w} className="text-sm text-muted-foreground">{w}</p>
             ))}
           </div>
         )}

--- a/frontend/src/pages/LoomCatalogPage.tsx
+++ b/frontend/src/pages/LoomCatalogPage.tsx
@@ -60,7 +60,7 @@ function LoomCard({ loom }: { readonly loom: LoomReferenceSummary }) {
         {loom.shedding_mechanism && (
           <>
             <span className="text-stone-500">{t("loomCatalogPage.shedding")}</span>
-            <span>{loom.shedding_mechanism.replace(/_/g, " ")}</span>
+            <span>{loom.shedding_mechanism.replaceAll("_", " ")}</span>
           </>
         )}
         {loom.foldable !== null && (

--- a/frontend/src/pages/PrivacyPage.tsx
+++ b/frontend/src/pages/PrivacyPage.tsx
@@ -39,8 +39,8 @@ export function PrivacyPage() {
                 className="text-amber-800 underline hover:text-amber-900 transition-colors"
               >
                 admin@weftmark.com
-              </a>
-              .
+              </a>{/*
+              */}.
             </p>
             <p className="text-stone-600 leading-relaxed">
               WeftMark is intended for users aged 18 or older. We do not knowingly collect personal
@@ -197,8 +197,8 @@ export function PrivacyPage() {
                 className="text-amber-800 underline hover:text-amber-900 transition-colors"
               >
                 admin@weftmark.com
-              </a>
-              . We will respond within 30 days.
+              </a>{/*
+              */}. We will respond within 30 days.
             </p>
           </section>
 

--- a/frontend/src/pages/ProjectLandingPage.tsx
+++ b/frontend/src/pages/ProjectLandingPage.tsx
@@ -66,7 +66,10 @@ function useAuthedSvg(url: string | null): { svg: string | null; loading: boolea
       const token = await getAuthToken();
       const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
       const res = await fetch(fetchUrl, { headers, credentials: "include" });
-      if (!res.ok || cancelled) { if (!cancelled) dispatch({ type: "error" }); return; }
+      if (!res.ok || cancelled) {
+        if (!cancelled) { dispatch({ type: "error" }); }
+        return;
+      }
       const text = await res.text();
       if (!cancelled) dispatch({ type: "done", svg: text });
     }

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { listProjects, projectDrawdownPreviewUrl, PROJECT_TYPE_LABELS, PROJECT_STATUS_LABELS, type ProjectSummary } from "@/api/projects";
@@ -11,7 +11,6 @@ import { CreateProjectModal } from "@/components/projects/CreateProjectModal";
 import { AssignLoomModal } from "@/components/projects/AssignLoomModal";
 import { Button } from "@/components/ui/button";
 import { TagChips } from "@/components/ui/TagChips";
-import { Link } from "react-router-dom";
 import { SkeletonCardGrid } from "@/components/ui/skeleton";
 import { TagFilterBar } from "@/components/TagFilterBar";
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -126,13 +126,13 @@ export function SettingsPage() {
     }
   }
 
-  function handleConsentToggle(value: boolean) {
-    if (!value && dataConsent) {
+  function handleConsentToggle() {
+    if (dataConsent) {
       // Turning off — warn about sharing impact
       setShowConsentWarning(true);
     } else {
-      setDataConsent(value);
-      save({ ai_training_consent: value });
+      setDataConsent(true);
+      save({ ai_training_consent: true });
     }
   }
 
@@ -428,7 +428,7 @@ export function SettingsPage() {
                     <button type="button"
                       role="switch"
                       aria-checked={!dataConsent}
-                      onClick={() => handleConsentToggle(!dataConsent)}
+                      onClick={handleConsentToggle}
                       className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
                         !dataConsent ? "bg-primary" : "bg-input"
                       }`}

--- a/frontend/src/pages/SuperuserPage.tsx
+++ b/frontend/src/pages/SuperuserPage.tsx
@@ -51,14 +51,14 @@ import {
   type ConfigTestResult,
   type ConfigTestOption,
   type ConfigFieldState,
+  listAdminUsers,
+  type AdminUser,
 } from "@/api/admin";
 import { EulaContent } from "@/components/EulaContent";
 import { CveBanner } from "@/components/admin/CveBanner";
 import { CopyEmail } from "@/components/admin/CopyEmail";
 import { formatBytes } from "@/lib/image-utils";
 import { formatUptime } from "@/lib/utils";
-import { listAdminUsers } from "@/api/admin";
-import type { AdminUser } from "@/api/admin";
 
 declare const __FRONTEND_DEPS__: Record<string, string>;
 
@@ -275,8 +275,8 @@ function EulaTab() {
             {lintResult.issues.length === 0 ? (
               <p className="text-xs text-green-600 font-medium">✓ No issues found</p>
             ) : (
-              lintResult.issues.map((issue, i) => (
-                <p key={i} className={`text-xs ${issue.level === "error" ? "text-destructive" : "text-yellow-600"}`}>
+              lintResult.issues.map((issue) => (
+                <p key={`${issue.level}-${issue.message}`} className={`text-xs ${issue.level === "error" ? "text-destructive" : "text-yellow-600"}`}>
                   {issue.level === "error" ? "✗" : "⚠"} {issue.message}
                 </p>
               ))
@@ -899,7 +899,7 @@ function TaskHistoryTable() {
 
       {isLoading && <p className="text-xs text-muted-foreground">Loading…</p>}
 
-      {data && data.items.length === 0 && (
+      {data?.items.length === 0 && (
         <p className="text-xs text-muted-foreground">No task history yet. Dispatch a task to see it here.</p>
       )}
 
@@ -1035,7 +1035,7 @@ function MaintenanceTab() {
     queryFn: getSoftDeleteQueue,
   });
 
-  const nothingEligible = queue != null && queue.ready_to_purge.total === 0;
+  const nothingEligible = queue?.ready_to_purge.total === 0;
 
   function triggerPurge() {
     setPurging(true);
@@ -1201,8 +1201,8 @@ function ReconcileTab() {
           {/* In Clerk, not in DB */}
           <div className="space-y-2">
             <h3 className="text-sm font-medium">
-              In Clerk, not in DB
-              <span className="ml-2 text-xs font-normal text-muted-foreground">
+              In Clerk, not in DB{/*
+              */}<span className="ml-2 text-xs font-normal text-muted-foreground">
                 ({report.clerk_only.length} {report.clerk_only.length === 1 ? "user" : "users"})
               </span>
             </h3>
@@ -1252,8 +1252,8 @@ function ReconcileTab() {
           {/* In DB, not in Clerk */}
           <div className="space-y-2">
             <h3 className="text-sm font-medium">
-              In DB, not in Clerk
-              <span className="ml-2 text-xs font-normal text-muted-foreground">
+              In DB, not in Clerk{/*
+              */}<span className="ml-2 text-xs font-normal text-muted-foreground">
                 ({report.db_only.length} {report.db_only.length === 1 ? "user" : "users"})
               </span>
             </h3>
@@ -1416,7 +1416,7 @@ function ScheduledTasksTab() {
         <h1 className="text-lg font-semibold">Scheduled Tasks</h1>
         <p className="text-sm text-muted-foreground">Configure recurring background tasks. Schedules are stored in Postgres and survive restarts; the scheduler tick runs every 60 seconds via Celery Beat.</p>
       </div>
-      {data && data.length === 0 && (
+      {data?.length === 0 && (
         <p className="text-sm text-muted-foreground">No scheduled tasks configured.</p>
       )}
       {data?.map((task) => (
@@ -1537,7 +1537,7 @@ function ExportsTab() {
       {isLoading && <p className="text-sm text-muted-foreground py-8 text-center">Loading…</p>}
       {error && <p className="text-sm text-destructive">Failed to load exports.</p>}
 
-      {!isLoading && data && data.length === 0 && (
+      {!isLoading && data?.length === 0 && (
         <p className="text-sm text-muted-foreground py-8 text-center">No export requests found.</p>
       )}
 

--- a/frontend/src/pages/TermsPage.tsx
+++ b/frontend/src/pages/TermsPage.tsx
@@ -52,8 +52,8 @@ export function TermsPage() {
               {t("termsPage.error")}{" "}
               <a href="mailto:admin@weftmark.com" className="underline">
                 admin@weftmark.com
-              </a>
-              .
+              </a>{/*
+              */}.
             </p>
           )}
 

--- a/frontend/src/pages/YarnDetailPage.tsx
+++ b/frontend/src/pages/YarnDetailPage.tsx
@@ -300,8 +300,8 @@ function RavelrySection({ ry, companyUrl, permalink }: {
       {/* Multi-fiber breakdown */}
       {fibers.length > 1 && (
         <ul className="space-y-1">
-          {fibers.map((f, i) => (
-            <li key={i} className="text-sm text-muted-foreground flex gap-2">
+          {fibers.map((f) => (
+            <li key={f.fiber_category.name} className="text-sm text-muted-foreground flex gap-2">
               <span className="text-card-foreground font-medium w-12 text-right shrink-0">
                 {f.percentage != null ? `${f.percentage}%` : "—"}
               </span>
@@ -314,8 +314,8 @@ function RavelrySection({ ry, companyUrl, permalink }: {
       {/* Attribute bullets */}
       {attributes.length > 0 && (
         <ul className="space-y-1 text-sm text-muted-foreground list-none">
-          {attributes.map((attr, i) => (
-            <li key={i} className="flex items-start gap-2">
+          {attributes.map((attr) => (
+            <li key={attr} className="flex items-start gap-2">
               <span className="text-accent mt-0.5">•</span>
               <span>{attr}</span>
             </li>

--- a/frontend/src/pages/YarnPage.tsx
+++ b/frontend/src/pages/YarnPage.tsx
@@ -550,8 +550,8 @@ export function YarnPage() {
   const [bannerDismissed, setBannerDismissed] = useState(
     () => localStorage.getItem(BANNER_KEY) === "1"
   );
-  const [prefs, setPrefsState] = useState<YarnPrefs>(loadPrefs);
-  const { view, sort, filters } = prefs;
+  const [prefsState, setPrefsState] = useState<YarnPrefs>(loadPrefs);
+  const { view, sort, filters } = prefsState;
 
   function setPrefs(update: Partial<YarnPrefs>) {
     setPrefsState((prev) => {


### PR DESCRIPTION
## Summary
First half of #1067's long-tail cleanup (39 rules, 104 findings) — the TypeScript-side rules. 31 files, all mechanical or narrowly-scoped fixes:

- **S6772** (ambiguous JSX whitespace, 9): explicit `{/* */}` no-space markers where margin/gap utilities already provide the visual spacing
- **S6582** (optional chaining, 9)
- **S6479** (array index as key, 8/9): switched to stable content-derived keys (date strings, tag/message text, category names). 1 deferred — see below.
- **S3863** (merge duplicate imports, 6)
- **S2004** (functions nested >4 deep, 4): extracted top-level helpers. `image-utils.ts`'s recursive quality-reduction retry became a `while`-loop + promisified `canvas.toBlob` — real restructuring, not just a rename, verified via `looms.spec.ts` e2e (still 3/3 passing against the real resize flow).
- **S4624** (nested template literals, 4)
- **S4144** (duplicate function impl, 1): `looms.ts` had two byte-identical functions (`updateLoomVersion` / `updateVersion`); the former was dead code (zero call sites) and got removed.
- **S6594, S4165, S7781, S7776, S7758, S6767, S6754, S6551, S7721, S7762, S7744, S2681, S2301, S6481** (1-2 each): see diff for specifics. Notably `ColorPicker.tsx`'s `S4165` (6 flagged "redundant assignments") turned out to be a genuinely harmless redundancy in a hue-to-RGB conversion, not a bug — verified against the standard HSL algorithm before simplifying.

## Deferred as Won't Fix (SonarCloud dashboard, with justification)
Forcing these "fixes" would trade real behavior for a lint pass:
- **`WarpingPlanPage.tsx` array-index key** — the index *is* the row's displayed identity (`position N`); colors can legitimately repeat across rows, so no content-derived key is actually more correct.
- **`ShareModal.tsx` `execCommand`** — only reached as the clipboard-copy fallback once the modern Clipboard API has already failed; there's no non-deprecated replacement for that exact fallback case.
- **`YarnDetailPage.tsx` + `LanguageSelector.tsx` ARIA roles** (`S6819`) — deliberate custom modal / rich-option dropdown (flag+label rendering) where the suggested native-tag replacement (`<dialog>`, `<select>`) is a real UX regression and needs live interaction testing to redo safely — same caution the issue itself calls out for `S1082`/`S1077`.

## Not in this PR
- `S1082` / `S1077` (accessibility, explicitly flagged in #1067 as needing real interaction testing) — deferred to #1062/#1064.
- All Python-side long-tail rules — separate PR to follow.

## Test plan
- [x] `tsc --noEmit` clean (full repo)
- [x] `eslint` clean (full repo)
- [x] Full Docker rebuild (frontend + backend + worker + worker2), health check confirms `0.212.22` healthy
- [x] Full e2e suite (32 non-skipped tests) — no regressions, including all 3 `looms.spec.ts` resize tests exercising the rewritten `image-utils.ts`

Part of #1067 (TypeScript half). Not closing #1067 yet — Python-side rules remain.