### PR TITLE
chore: extract nested ternaries to statements/helpers (S3358)

### DIFF
--- a/frontend/src/components/FeedbackModal.tsx
+++ b/frontend/src/components/FeedbackModal.tsx
@@ -129,16 +129,16 @@ export function FeedbackModal({ onClose }: Props) {
           </button>
         </div>
 
-        {submitted ? (
-          <SuccessView record={submitted} onClose={onClose} />
-        ) : !user ? (
+        {submitted && <SuccessView record={submitted} onClose={onClose} />}
+        {!submitted && !user && (
           <div className="space-y-4">
             <p className="text-sm text-muted-foreground">Please sign in to submit feedback.</p>
             <div className="flex justify-end">
               <Button type="button" variant="outline" onClick={onClose}>Close</Button>
             </div>
           </div>
-        ) : (
+        )}
+        {!submitted && user && (
           <form onSubmit={handleSubmit} className="space-y-4">
             {/* Type selector */}
             <div>
@@ -303,12 +303,13 @@ function SuccessView({ record, onClose }: { readonly record: FeedbackRecord; rea
         Thank you — your {typeLabel} was received.
       </p>
 
-      {pollDispatchStatus === "pending" && !timedOut ? (
+      {pollDispatchStatus === "pending" && !timedOut && (
         <div className="flex items-center gap-2 rounded-md bg-muted px-3 py-2 text-sm text-muted-foreground">
           <AppIcons.Spinner className="h-4 w-4 animate-spin shrink-0" />
           <span>Creating your GitHub Discussion thread…</span>
         </div>
-      ) : pollDispatchStatus === "sent" && pollDiscussionUrl ? (
+      )}
+      {!(pollDispatchStatus === "pending" && !timedOut) && pollDispatchStatus === "sent" && pollDiscussionUrl && (
         <div className="space-y-2">
           <p className="text-sm text-muted-foreground">
             A discussion thread has been created. You can follow progress and attach screenshots there:
@@ -323,7 +324,8 @@ function SuccessView({ record, onClose }: { readonly record: FeedbackRecord; rea
             View on GitHub
           </a>
         </div>
-      ) : (
+      )}
+      {!(pollDispatchStatus === "pending" && !timedOut) && !(pollDispatchStatus === "sent" && pollDiscussionUrl) && (
         <p className="text-sm text-muted-foreground">
           Your submission is stored and will be reviewed by the team.
           {(pollDispatchStatus === "skipped" || timedOut) &&

--- a/frontend/src/components/TrackerStylePreview.tsx
+++ b/frontend/src/components/TrackerStylePreview.tsx
@@ -24,11 +24,14 @@ function DemoBox({ n, active, style }: { readonly n: number; readonly active: bo
   );
 }
 
+function demoCardBorder(style: TrackerStyle, compact: boolean | undefined): string {
+  if (style === "high_contrast") return compact ? "border border-foreground/30" : "border-2 border-foreground/50";
+  return compact ? "border border-primary/20" : "border-2 border-primary/30";
+}
+
 function DemoPickCard({ compact, style }: { readonly compact?: boolean; readonly style: TrackerStyle }) {
   const height = compact ? "h-10" : "h-16";
-  const border = style === "high_contrast"
-    ? compact ? "border border-foreground/30" : "border-2 border-foreground/50"
-    : compact ? "border border-primary/20" : "border-2 border-primary/30";
+  const border = demoCardBorder(style, compact);
   const bg = style === "high_contrast" ? "bg-muted/60" : "bg-primary/5 dark:bg-primary/10";
 
   return (
@@ -70,10 +73,12 @@ export function TrackerStylePreview({ style }: { readonly style: TrackerStyle })
             {Array.from({ length: 4 }, (_, row) =>
               Array.from({ length: 4 }, (__, col) => {
                 const lit = (row + col) % 2 === 0;
+                let dotColor = "bg-muted-foreground/15";
+                if (lit) dotColor = isHighContrast ? "bg-foreground/70" : "bg-primary/60";
                 return (
                   <div
                     key={`${row}-${col}`}
-                    className={`h-2 rounded-sm ${lit ? (isHighContrast ? "bg-foreground/70" : "bg-primary/60") : "bg-muted-foreground/15"}`}
+                    className={`h-2 rounded-sm ${dotColor}`}
                   />
                 );
               })
@@ -154,6 +159,11 @@ function LiveBox({
   );
 }
 
+function liveCardBorder(style: TrackerStyle, compact: boolean | undefined): string {
+  if (style === "high_contrast") return compact ? "border border-foreground/30" : "border-2 border-foreground/40";
+  return compact ? "border border-primary/20" : "border-2 border-primary/30";
+}
+
 function LivePickCard({
   compact,
   style,
@@ -168,9 +178,7 @@ function LivePickCard({
   readonly shaftCount: number;
 }) {
   const height = compact ? "h-14" : "h-24";
-  const border = style === "high_contrast"
-    ? compact ? "border border-foreground/30" : "border-2 border-foreground/40"
-    : compact ? "border border-primary/20" : "border-2 border-primary/30";
+  const border = liveCardBorder(style, compact);
   const bg = style === "high_contrast" ? "bg-muted/60" : "bg-primary/5 dark:bg-primary/10";
 
   return (
@@ -283,16 +291,13 @@ export function TrackerLivePreview({
                   const shaftNum = col + 1;
                   const isUnused = shaftNum > LIVE_SHAFTS_USED;
                   const lit = !isUnused && (row + col) % 2 === 0;
+                  let cellColor = "bg-muted-foreground/15";
+                  if (isUnused) cellColor = "bg-muted-foreground/8 border border-dashed border-border/30";
+                  else if (lit) cellColor = isHighContrast ? "bg-foreground/80" : "bg-primary/70";
                   return (
                     <div
                       key={`${row}-${col}`}
-                      className={`h-3 rounded-sm ${
-                        isUnused
-                          ? "bg-muted-foreground/8 border border-dashed border-border/30"
-                          : lit
-                            ? (isHighContrast ? "bg-foreground/80" : "bg-primary/70")
-                            : "bg-muted-foreground/15"
-                      }`}
+                      className={`h-3 rounded-sm ${cellColor}`}
                     />
                   );
                 })

--- a/frontend/src/components/admin/UserDetailModal.tsx
+++ b/frontend/src/components/admin/UserDetailModal.tsx
@@ -263,6 +263,55 @@ export function UserDetailModal({ target, onClose }: Props) {
 
   const u = target.user;
 
+  const deactivateBtnClass = u.is_active
+    ? "border-amber-400 text-amber-700 hover:bg-amber-50 hover:text-amber-800"
+    : "bg-green-600 hover:bg-green-700";
+
+  let elevateControls: ReactNode = null;
+  if (confirming === "elevate") {
+    elevateControls = (
+      <ConfirmInline
+        message={`Make ${u.display_name} a superuser?`}
+        confirmLabel="Make superuser"
+        onConfirm={() => handleElevate(false)}
+        onCancel={() => setConfirming(null)}
+        busy={busy}
+      />
+    );
+  } else if (confirming === "elevate-force" && elevateContent) {
+    elevateControls = (
+      <ConfirmInline
+        message={`This user has ${[
+          elevateContent.projects && `${elevateContent.projects} projects`,
+          elevateContent.looms && `${elevateContent.looms} looms`,
+          elevateContent.drafts && `${elevateContent.drafts} drafts`,
+          elevateContent.yarn && `${elevateContent.yarn} yarn`,
+        ]
+          .filter(Boolean)
+          .join(", ")} — all content will be permanently deleted.`}
+        destructive
+        confirmLabel="Delete content & elevate"
+        onConfirm={() => handleElevate(true)}
+        onCancel={() => {
+          setConfirming(null);
+          setElevateContent(null);
+        }}
+        busy={busy}
+      />
+    );
+  } else {
+    elevateControls = (
+      <Button
+        size="sm"
+        variant="default"
+        disabled={busy || u.clerk_banned}
+        onClick={() => setConfirming("elevate")}
+      >
+        Make superuser
+      </Button>
+    );
+  }
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
       <div className="w-full max-w-lg rounded-lg border bg-background shadow-lg flex flex-col max-h-[90vh]">
@@ -313,7 +362,9 @@ export function UserDetailModal({ target, onClose }: Props) {
                   const used = u.counts.storage_bytes;
                   const quota = u.counts.storage_quota_bytes;
                   const pct = Math.min(Math.round((used / quota) * 100), 100);
-                  const barColor = pct >= 90 ? "bg-red-500" : pct >= 75 ? "bg-amber-500" : "bg-primary";
+                  let barColor = "bg-primary";
+                  if (pct >= 90) barColor = "bg-red-500";
+                  else if (pct >= 75) barColor = "bg-amber-500";
                   return (
                     <>
                       <div className="flex justify-between mb-1">
@@ -384,45 +435,7 @@ export function UserDetailModal({ target, onClose }: Props) {
                   )}
 
                   {/* Elevate to superuser */}
-                  {u.is_admin && (
-                    confirming === "elevate" ? (
-                      <ConfirmInline
-                        message={`Make ${u.display_name} a superuser?`}
-                        confirmLabel="Make superuser"
-                        onConfirm={() => handleElevate(false)}
-                        onCancel={() => setConfirming(null)}
-                        busy={busy}
-                      />
-                    ) : confirming === "elevate-force" && elevateContent ? (
-                      <ConfirmInline
-                        message={`This user has ${[
-                          elevateContent.projects && `${elevateContent.projects} projects`,
-                          elevateContent.looms && `${elevateContent.looms} looms`,
-                          elevateContent.drafts && `${elevateContent.drafts} drafts`,
-                          elevateContent.yarn && `${elevateContent.yarn} yarn`,
-                        ]
-                          .filter(Boolean)
-                          .join(", ")} — all content will be permanently deleted.`}
-                        destructive
-                        confirmLabel="Delete content & elevate"
-                        onConfirm={() => handleElevate(true)}
-                        onCancel={() => {
-                          setConfirming(null);
-                          setElevateContent(null);
-                        }}
-                        busy={busy}
-                      />
-                    ) : (
-                      <Button
-                        size="sm"
-                        variant="default"
-                        disabled={busy || u.clerk_banned}
-                        onClick={() => setConfirming("elevate")}
-                      >
-                        Make superuser
-                      </Button>
-                    )
-                  )}
+                  {u.is_admin && elevateControls}
                 </div>
               )}
 
@@ -447,11 +460,7 @@ export function UserDetailModal({ target, onClose }: Props) {
                       <Button
                         size="sm"
                         variant={u.is_active ? "outline" : "default"}
-                        className={
-                          u.is_active
-                            ? "border-amber-400 text-amber-700 hover:bg-amber-50 hover:text-amber-800"
-                            : "bg-green-600 hover:bg-green-700"
-                        }
+                        className={deactivateBtnClass}
                         disabled={busy || (u.is_active && u.is_admin)}
                         title={
                           u.is_active && u.is_admin

--- a/frontend/src/components/looms/LinkToCatalogModal.tsx
+++ b/frontend/src/components/looms/LinkToCatalogModal.tsx
@@ -205,12 +205,8 @@ export function LinkToCatalogModal({ loom, version, onSuccess, onClose }: Props)
       const curVal = Number.parseFloat(version.weaving_width);
       const curUnit = version.weaving_width_unit as "cm" | "in";
       const targetUnit = wOpts[0].unit;
-      const converted =
-        curUnit === targetUnit
-          ? curVal
-          : curUnit === "cm"
-            ? curVal / 2.54
-            : curVal * 2.54;
+      let converted = curVal;
+      if (curUnit !== targetUnit) converted = curUnit === "cm" ? curVal / 2.54 : curVal * 2.54;
       setSelectedWidthIdx(closestIdx(wOpts.map((o) => Number.parseFloat(o.value)), converted));
     } else {
       setSelectedWidthIdx(0);

--- a/frontend/src/components/looms/NewLoomModal.tsx
+++ b/frontend/src/components/looms/NewLoomModal.tsx
@@ -127,7 +127,9 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
   const treadleOptions = selectedRef?.treadle_count ?? null;
   const widthOptions = selectedRef ? buildWidthOptions(selectedRef) : [];
 
-  const mode = selectedRef ? "catalog" : manualMode ? "manual" : "searching";
+  let mode: "catalog" | "manual" | "searching" = "searching";
+  if (selectedRef) mode = "catalog";
+  else if (manualMode) mode = "manual";
   const showForm = mode === "catalog" || mode === "manual";
   const isUnsupported = !SUPPORTED_LOOM_TYPES.has(loomType);
 

--- a/frontend/src/components/projects/CreateProjectModal.tsx
+++ b/frontend/src/components/projects/CreateProjectModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { createProject, completeProject, abandonProject, listProjects, ApiError, PROJECT_TYPE_LABELS, type ProjectType, type ProjectSummary } from "@/api/projects";
 import { listDrafts } from "@/api/drafts";
@@ -218,6 +218,43 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
 
   const canSubmit = name.trim() && draftId && !!effectiveType && !loading;
 
+  let projectTypeSection: ReactNode = null;
+  if (filteredTypes.length === 0) {
+    projectTypeSection = (
+      <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2.5 text-sm">
+        {selectedLoom && availableTypes.length > 0 ? (
+          <>
+            <p className="font-medium text-destructive">Loom and draft are incompatible</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              This WIF supports {availableTypes.map(t => PROJECT_TYPE_LABELS[t]).join(" and ")}, but the selected loom does not.
+              {availableTypes.includes("lift") && !selectedLoom.supports_lift_tracking && " The loom does not support lift tracking."}
+              {availableTypes.includes("treadle") && !selectedLoom.supports_treadle_tracking && " The loom does not support treadle tracking."}
+              {" "}Try a different loom or go to the draft page to generate a lift plan.
+            </p>
+          </>
+        ) : (
+          <>
+            <p className="font-medium text-destructive">No project types available</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              This WIF has no treadling or lift plan data. Go to the draft page to generate a lift plan if the file has tieup and treadling sections.
+            </p>
+          </>
+        )}
+      </div>
+    );
+  } else if (filteredTypes.length === 1) {
+    projectTypeSection = <p className="text-sm py-2">{PROJECT_TYPE_LABELS[filteredTypes[0]]}</p>;
+  } else {
+    projectTypeSection = (
+      <select className={f} value={effectiveType} onChange={(e) => setProjectType(e.target.value as ProjectType)} required>
+        <option value="">Select type…</option>
+        {filteredTypes.map((t) => (
+          <option key={t} value={t}>{PROJECT_TYPE_LABELS[t]}</option>
+        ))}
+      </select>
+    );
+  }
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
       <div className="w-full max-w-lg rounded-lg border bg-background shadow-lg flex flex-col max-h-[90vh]">
@@ -315,37 +352,7 @@ export function CreateProjectModal({ onSuccess, onClose, defaultDraftId }: Props
           {selectedDraft && (
             <div>
               <label className="mb-1 block text-sm font-medium">Project type <span className="text-destructive">*</span></label>
-              {filteredTypes.length === 0 ? (
-                <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2.5 text-sm">
-                  {selectedLoom && availableTypes.length > 0 ? (
-                    <>
-                      <p className="font-medium text-destructive">Loom and draft are incompatible</p>
-                      <p className="mt-0.5 text-xs text-muted-foreground">
-                        This WIF supports {availableTypes.map(t => PROJECT_TYPE_LABELS[t]).join(" and ")}, but the selected loom does not.
-                        {availableTypes.includes("lift") && !selectedLoom.supports_lift_tracking && " The loom does not support lift tracking."}
-                        {availableTypes.includes("treadle") && !selectedLoom.supports_treadle_tracking && " The loom does not support treadle tracking."}
-                        {" "}Try a different loom or go to the draft page to generate a lift plan.
-                      </p>
-                    </>
-                  ) : (
-                    <>
-                      <p className="font-medium text-destructive">No project types available</p>
-                      <p className="mt-0.5 text-xs text-muted-foreground">
-                        This WIF has no treadling or lift plan data. Go to the draft page to generate a lift plan if the file has tieup and treadling sections.
-                      </p>
-                    </>
-                  )}
-                </div>
-              ) : filteredTypes.length === 1 ? (
-                <p className="text-sm py-2">{PROJECT_TYPE_LABELS[filteredTypes[0]]}</p>
-              ) : (
-                <select className={f} value={effectiveType} onChange={(e) => setProjectType(e.target.value as ProjectType)} required>
-                  <option value="">Select type…</option>
-                  {filteredTypes.map((t) => (
-                    <option key={t} value={t}>{PROJECT_TYPE_LABELS[t]}</option>
-                  ))}
-                </select>
-              )}
+              {projectTypeSection}
             </div>
           )}
 

--- a/frontend/src/components/projects/ProjectSummaryList.tsx
+++ b/frontend/src/components/projects/ProjectSummaryList.tsx
@@ -18,11 +18,9 @@ function ProjectRow({ project }: { readonly project: ProjectSummary }) {
   const isPlanning = project.status === "active" && !project.loom_id;
   const badgeKey = isPlanning ? "plan" : project.status;
   const badgeLabel = isPlanning ? "Plan" : PROJECT_STATUS_LABELS[project.status];
-  const endDate = project.status === "completed"
-    ? project.completed_at
-    : project.status === "abandoned"
-      ? project.abandoned_at
-      : null;
+  let endDate: string | null = null;
+  if (project.status === "completed") endDate = project.completed_at;
+  else if (project.status === "abandoned") endDate = project.abandoned_at;
 
   return (
     <Link

--- a/frontend/src/components/projects/YarnPickerModal.tsx
+++ b/frontend/src/components/projects/YarnPickerModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { listYarn, yarnPhotoUrl, type YarnSummary } from "@/api/yarn";
@@ -82,6 +82,33 @@ export function YarnPickerModal({ colorHex, currentYarnId, onSelect, onUnlink, o
           )}
           {filtered.map((yarn) => {
             const isCurrent = yarn.id === currentYarnId;
+
+            let swatch: ReactNode;
+            if (yarn.has_photo) {
+              swatch = (
+                <AuthedImage
+                  src={yarnPhotoUrl(yarn.id)}
+                  alt=""
+                  className="h-full w-full object-cover"
+                />
+              );
+            } else if (yarn.ravelry_colorway_thumbnail_url) {
+              swatch = (
+                <img
+                  src={yarn.ravelry_colorway_thumbnail_url}
+                  alt=""
+                  className="h-full w-full object-cover"
+                />
+              );
+            } else {
+              swatch = (
+                <span
+                  className="block h-full w-full"
+                  style={{ background: yarn.color_hex ?? "#e5e7eb" }}
+                />
+              );
+            }
+
             return (
               <button type="button"
                 key={yarn.id}
@@ -95,24 +122,7 @@ export function YarnPickerModal({ colorHex, currentYarnId, onSelect, onUnlink, o
               >
                 {/* Yarn photo / color swatch */}
                 <div className="h-8 w-8 rounded border border-border flex-shrink-0 overflow-hidden">
-                  {yarn.has_photo ? (
-                    <AuthedImage
-                      src={yarnPhotoUrl(yarn.id)}
-                      alt=""
-                      className="h-full w-full object-cover"
-                    />
-                  ) : yarn.ravelry_colorway_thumbnail_url ? (
-                    <img
-                      src={yarn.ravelry_colorway_thumbnail_url}
-                      alt=""
-                      className="h-full w-full object-cover"
-                    />
-                  ) : (
-                    <span
-                      className="block h-full w-full"
-                      style={{ background: yarn.color_hex ?? "#e5e7eb" }}
-                    />
-                  )}
+                  {swatch}
                 </div>
 
                 {/* Name + color */}

--- a/frontend/src/components/yarn/AddFromRavelryModal.tsx
+++ b/frontend/src/components/yarn/AddFromRavelryModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
@@ -281,6 +281,86 @@ export function AddFromRavelryModal({ onSuccess, onClose }: Props) {
   const inputCls = "w-full rounded-md border border-input bg-background px-3 py-2 pr-8 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring";
   const clearBtnCls = "absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground leading-none p-0.5";
 
+  let companyPrefillContent: ReactNode = null;
+  if (inventoryBrands.length > 0 || popularFill.length > 0) {
+    companyPrefillContent = (
+      <>
+        {inventoryBrands.length > 0 && (
+          <p className="text-xs text-muted-foreground">{t("addFromRavelryModal.fromInventoryLabel")}</p>
+        )}
+        <ul className="space-y-1">
+          {inventoryBrands.map((brand) => (
+            <li key={`inv-${brand}`}>
+              <button
+                type="button"
+                className="w-full text-left rounded-md px-3 py-2 text-sm hover:bg-accent/10 transition-colors text-card-foreground"
+                onClick={() => pickInventoryBrand(brand)}
+              >
+                {brand}
+              </button>
+            </li>
+          ))}
+          {popularFill.map((c) => (
+            <li key={`pop-${c.id}`}>
+              <button
+                type="button"
+                className="w-full text-left rounded-md px-3 py-2 text-sm hover:bg-accent/10 transition-colors text-muted-foreground"
+                onClick={() => pickCompany(c)}
+              >
+                {c.name}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </>
+    );
+  } else if (popularFetching) {
+    companyPrefillContent = <p className="text-xs text-muted-foreground">{t("common.loading")}</p>;
+  }
+
+  let yarnPrefillContent: ReactNode = null;
+  if (inventoryYarnLines.length > 0 || popularYarnsFill.length > 0) {
+    yarnPrefillContent = (
+      <>
+        {inventoryYarnLines.length > 0 && (
+          <p className="text-xs text-muted-foreground">{t("addFromRavelryModal.fromInventoryLabel")}</p>
+        )}
+        <ul className="space-y-1">
+          {inventoryYarnLines.map((name) => (
+            <li key={`inv-${name}`}>
+              <button
+                type="button"
+                className="w-full text-left rounded-md px-3 py-2 text-sm hover:bg-accent/10 transition-colors text-card-foreground"
+                onClick={() => pickInventoryYarnLine(name)}
+              >
+                {name}
+              </button>
+            </li>
+          ))}
+          {popularYarnsFill.map((y) => (
+            <li key={`pop-${y.id}`}>
+              <button
+                type="button"
+                className="w-full text-left flex items-center gap-3 rounded-md px-3 py-2 hover:bg-accent/10 transition-colors"
+                onClick={() => pickYarn(y)}
+              >
+                {y.photo_url && (
+                  <img src={y.photo_url} alt={y.name} className="h-10 w-10 rounded object-cover shrink-0" />
+                )}
+                <div className="min-w-0">
+                  <p className="text-sm text-muted-foreground truncate">{y.name}</p>
+                  <p className="text-xs text-muted-foreground">{y.weight_name ?? ""}</p>
+                </div>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </>
+    );
+  } else if (popularYarnsFetching) {
+    yarnPrefillContent = <p className="text-xs text-muted-foreground">{t("common.loading")}</p>;
+  }
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-16 px-4"
@@ -322,41 +402,7 @@ export function AddFromRavelryModal({ onSuccess, onClose }: Props) {
                   <button type="button" className={clearBtnCls} aria-label={t("common.clear")} onClick={() => setCompanyQuery("")}>✕</button>
                 )}
               </div>
-              {!companyQuery.trim() ? (
-                inventoryBrands.length > 0 || popularFill.length > 0 ? (
-                  <>
-                    {inventoryBrands.length > 0 && (
-                      <p className="text-xs text-muted-foreground">{t("addFromRavelryModal.fromInventoryLabel")}</p>
-                    )}
-                    <ul className="space-y-1">
-                      {inventoryBrands.map((brand) => (
-                        <li key={`inv-${brand}`}>
-                          <button
-                            type="button"
-                            className="w-full text-left rounded-md px-3 py-2 text-sm hover:bg-accent/10 transition-colors text-card-foreground"
-                            onClick={() => pickInventoryBrand(brand)}
-                          >
-                            {brand}
-                          </button>
-                        </li>
-                      ))}
-                      {popularFill.map((c) => (
-                        <li key={`pop-${c.id}`}>
-                          <button
-                            type="button"
-                            className="w-full text-left rounded-md px-3 py-2 text-sm hover:bg-accent/10 transition-colors text-muted-foreground"
-                            onClick={() => pickCompany(c)}
-                          >
-                            {c.name}
-                          </button>
-                        </li>
-                      ))}
-                    </ul>
-                  </>
-                ) : popularFetching ? (
-                  <p className="text-xs text-muted-foreground">{t("common.loading")}</p>
-                ) : null
-              ) : (
+              {!companyQuery.trim() ? companyPrefillContent : (
                 <>
                   {companyLoading && <p className="text-xs text-muted-foreground">{t("common.loading")}</p>}
                   {!companyLoading && companies.length === 0 && (
@@ -395,47 +441,7 @@ export function AddFromRavelryModal({ onSuccess, onClose }: Props) {
                   <button type="button" className={clearBtnCls} aria-label={t("common.clear")} onClick={() => setYarnQuery("")}>✕</button>
                 )}
               </div>
-              {!yarnQuery.trim() ? (
-                inventoryYarnLines.length > 0 || popularYarnsFill.length > 0 ? (
-                  <>
-                    {inventoryYarnLines.length > 0 && (
-                      <p className="text-xs text-muted-foreground">{t("addFromRavelryModal.fromInventoryLabel")}</p>
-                    )}
-                    <ul className="space-y-1">
-                      {inventoryYarnLines.map((name) => (
-                        <li key={`inv-${name}`}>
-                          <button
-                            type="button"
-                            className="w-full text-left rounded-md px-3 py-2 text-sm hover:bg-accent/10 transition-colors text-card-foreground"
-                            onClick={() => pickInventoryYarnLine(name)}
-                          >
-                            {name}
-                          </button>
-                        </li>
-                      ))}
-                      {popularYarnsFill.map((y) => (
-                        <li key={`pop-${y.id}`}>
-                          <button
-                            type="button"
-                            className="w-full text-left flex items-center gap-3 rounded-md px-3 py-2 hover:bg-accent/10 transition-colors"
-                            onClick={() => pickYarn(y)}
-                          >
-                            {y.photo_url && (
-                              <img src={y.photo_url} alt={y.name} className="h-10 w-10 rounded object-cover shrink-0" />
-                            )}
-                            <div className="min-w-0">
-                              <p className="text-sm text-muted-foreground truncate">{y.name}</p>
-                              <p className="text-xs text-muted-foreground">{y.weight_name ?? ""}</p>
-                            </div>
-                          </button>
-                        </li>
-                      ))}
-                    </ul>
-                  </>
-                ) : popularYarnsFetching ? (
-                  <p className="text-xs text-muted-foreground">{t("common.loading")}</p>
-                ) : null
-              ) : (
+              {!yarnQuery.trim() ? yarnPrefillContent : (
                 <>
                   {yarnLoading && <p className="text-xs text-muted-foreground">{t("common.loading")}</p>}
                   {!yarnLoading && yarns.length === 0 && (

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -173,12 +173,14 @@ function SortTh({
   readonly label: string; readonly k: SortKey; readonly sort: SortKey; readonly dir: "asc" | "desc"; readonly onSort: (k: SortKey) => void;
 }) {
   const active = sort === k;
+  let arrow = "";
+  if (active) arrow = dir === "asc" ? " ↑" : " ↓";
   return (
     <th
       className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground cursor-pointer select-none hover:text-foreground whitespace-nowrap"
       onClick={() => onSort(k)}
     >
-      {label}{active ? (dir === "asc" ? " ↑" : " ↓") : ""}
+      {label}{arrow}
     </th>
   );
 }
@@ -280,6 +282,8 @@ function UsersTab() {
   if (usersLoading || pendingLoading)
     return <p className="text-sm text-muted-foreground">Loading…</p>;
 
+  const userWord = `user${rows.length !== 1 ? "s" : ""}`;
+
   return (
     <div className="space-y-6">
       <div className="space-y-1 pb-2 border-b">
@@ -322,7 +326,7 @@ function UsersTab() {
 
       <p className="text-xs text-muted-foreground">
         {sorted.length === rows.length
-          ? `${rows.length} user${rows.length !== 1 ? "s" : ""}`
+          ? `${rows.length} ${userWord}`
           : `${sorted.length} of ${rows.length} users`}
       </p>
 
@@ -611,6 +615,43 @@ function PendingSignupRow({
 }) {
   const [confirming, setConfirming] = useState<"dismiss" | "ban" | null>(null);
 
+  let actions: React.ReactNode;
+  if (confirming === "dismiss") {
+    actions = (
+      <>
+        <span className="text-xs text-muted-foreground font-medium">Dismiss?</span>
+        <Button size="sm" variant="outline" disabled={isWorking} onClick={() => { setConfirming(null); onDismiss(); }}>
+          Confirm
+        </Button>
+        <Button size="sm" variant="outline" onClick={() => setConfirming(null)}>Cancel</Button>
+      </>
+    );
+  } else if (confirming === "ban") {
+    actions = (
+      <>
+        <span className="text-xs text-destructive font-medium">Ban?</span>
+        <Button size="sm" variant="destructive" disabled={isWorking} onClick={() => { setConfirming(null); onBan(); }}>
+          Confirm
+        </Button>
+        <Button size="sm" variant="outline" onClick={() => setConfirming(null)}>Cancel</Button>
+      </>
+    );
+  } else {
+    actions = (
+      <>
+        <Button size="sm" disabled={isWorking} onClick={onApprove} className="bg-green-600 hover:bg-green-700 text-white">
+          Approve
+        </Button>
+        <Button size="sm" variant="outline" disabled={isWorking} onClick={() => setConfirming("dismiss")}>
+          Dismiss
+        </Button>
+        <Button size="sm" variant="destructive" disabled={isWorking} onClick={() => setConfirming("ban")}>
+          Ban
+        </Button>
+      </>
+    );
+  }
+
   return (
     <div className="flex items-center justify-between px-4 py-3 bg-background gap-4">
       <div className="min-w-0">
@@ -621,35 +662,7 @@ function PendingSignupRow({
         </p>
       </div>
       <div className="flex items-center gap-2 shrink-0">
-        {confirming === "dismiss" ? (
-          <>
-            <span className="text-xs text-muted-foreground font-medium">Dismiss?</span>
-            <Button size="sm" variant="outline" disabled={isWorking} onClick={() => { setConfirming(null); onDismiss(); }}>
-              Confirm
-            </Button>
-            <Button size="sm" variant="outline" onClick={() => setConfirming(null)}>Cancel</Button>
-          </>
-        ) : confirming === "ban" ? (
-          <>
-            <span className="text-xs text-destructive font-medium">Ban?</span>
-            <Button size="sm" variant="destructive" disabled={isWorking} onClick={() => { setConfirming(null); onBan(); }}>
-              Confirm
-            </Button>
-            <Button size="sm" variant="outline" onClick={() => setConfirming(null)}>Cancel</Button>
-          </>
-        ) : (
-          <>
-            <Button size="sm" disabled={isWorking} onClick={onApprove} className="bg-green-600 hover:bg-green-700 text-white">
-              Approve
-            </Button>
-            <Button size="sm" variant="outline" disabled={isWorking} onClick={() => setConfirming("dismiss")}>
-              Dismiss
-            </Button>
-            <Button size="sm" variant="destructive" disabled={isWorking} onClick={() => setConfirming("ban")}>
-              Ban
-            </Button>
-          </>
-        )}
+        {actions}
       </div>
     </div>
   );
@@ -657,13 +670,11 @@ function PendingSignupRow({
 
 function InviteRow({ invite, onRevoke }: { readonly invite: InviteRecord; readonly onRevoke?: () => void }) {
   const isPending = !invite.accepted_at && !invite.revoked_at && new Date(invite.expires_at) > new Date();
-  const status = invite.accepted_at
-    ? "accepted"
-    : invite.revoked_at
-    ? "revoked"
-    : new Date(invite.expires_at) <= new Date()
-    ? "expired"
-    : "pending";
+  let status: "accepted" | "revoked" | "expired" | "pending";
+  if (invite.accepted_at) status = "accepted";
+  else if (invite.revoked_at) status = "revoked";
+  else if (new Date(invite.expires_at) <= new Date()) status = "expired";
+  else status = "pending";
 
   return (
     <div className="flex items-center justify-between px-4 py-3 bg-background gap-4">
@@ -1203,7 +1214,7 @@ function ServicesTab() {
           </span>
         </div>
         <Button size="sm" variant="outline" disabled={diagFetching} onClick={() => runDiag()}>
-          {diagFetching ? "Running…" : diagTime ? `Re-run · ${diagTime}` : "Running…"}
+          {diagFetching || !diagTime ? "Running…" : `Re-run · ${diagTime}`}
         </Button>
       </div>
 
@@ -1404,6 +1415,7 @@ function SlugsTab() {
           <tbody>
             {slugs.map((row: AdminSlugRecord) => {
               const expired = row.share_expires_at ? new Date(row.share_expires_at) <= new Date() : false;
+              const expiryClass = expired ? "text-destructive" : "";
               return (
                 <tr key={row.slug} className="border-b border-border last:border-0 hover:bg-muted/20">
                   <td className="px-3 py-2.5 font-mono text-xs text-muted-foreground">
@@ -1422,7 +1434,7 @@ function SlugsTab() {
                   <td className="px-3 py-2.5 text-xs capitalize">{row.project_status}</td>
                   <td className="px-3 py-2.5 text-xs">
                     {row.share_expires_at ? (
-                      <span className={expired ? "text-destructive" : ""}>
+                      <span className={expiryClass}>
                         {new Date(row.share_expires_at).toLocaleDateString()}
                         {expired && " (expired)"}
                       </span>
@@ -1578,6 +1590,9 @@ function FeedbackTab() {
     },
   });
 
+  const recoverLabel = recoverMutation.isPending ? "Recovering…" : "Recover";
+  const deleteLabel = deleteMutation.isPending ? "Deleting…" : "Delete";
+
   const STATUS_COLORS: Record<string, string> = {
     sent: "text-green-600 dark:text-green-400",
     failed: "text-destructive",
@@ -1696,9 +1711,11 @@ function FeedbackTab() {
             {detail.diagnostics && Object.keys(detail.diagnostics).length > 0 && (
               <div className="text-xs text-muted-foreground space-y-1">
                 <p className="font-medium text-foreground">Diagnostics</p>
-                {Object.entries(detail.diagnostics).map(([k, v]) =>
-                  v ? <p key={k}><span className="font-mono">{k}:</span> {typeof v === "object" ? JSON.stringify(v) : String(v)}</p> : null
-                )}
+                {Object.entries(detail.diagnostics).map(([k, v]) => {
+                  if (!v) return null;
+                  const display = typeof v === "object" ? JSON.stringify(v) : String(v);
+                  return <p key={k}><span className="font-mono">{k}:</span> {display}</p>;
+                })}
               </div>
             )}
 
@@ -1734,7 +1751,7 @@ function FeedbackTab() {
                   disabled={recoverMutation.isPending}
                   onClick={() => recoverMutation.mutate(detail.id)}
                 >
-                  {recoverMutation.isPending ? "Recovering…" : "Recover"}
+                  {recoverLabel}
                 </Button>
               ) : (
                 <Button
@@ -1746,7 +1763,7 @@ function FeedbackTab() {
                     if (confirm("Soft-delete this submission?")) deleteMutation.mutate(detail.id);
                   }}
                 >
-                  {deleteMutation.isPending ? "Deleting…" : "Delete"}
+                  {deleteLabel}
                 </Button>
               )}
               <Button variant="outline" size="sm" onClick={() => setDetail(null)}>Close</Button>
@@ -1878,6 +1895,8 @@ function AuditLogTab() {
 function AuditLogRow({ entry }: { readonly entry: AuditLogEntry }) {
   const [expanded, setExpanded] = useState(false);
   const hasDetails = entry.details && Object.keys(entry.details).length > 0;
+  let toggleLabel = "—";
+  if (hasDetails) toggleLabel = expanded ? "▲ hide" : "▼ show";
 
   return (
     <>
@@ -1896,7 +1915,7 @@ function AuditLogRow({ entry }: { readonly entry: AuditLogEntry }) {
         <td className="px-3 py-2 text-muted-foreground">{entry.actor_email ? <CopyEmail email={entry.actor_email} /> : <span className="italic">system</span>}</td>
         <td className="px-3 py-2 text-muted-foreground">{entry.target_email ? <CopyEmail email={entry.target_email} /> : "—"}</td>
         <td className="px-3 py-2 text-muted-foreground text-xs">
-          {hasDetails ? (expanded ? "▲ hide" : "▼ show") : "—"}
+          {toggleLabel}
         </td>
       </tr>
       {expanded && hasDetails && (
@@ -1946,6 +1965,11 @@ function formatArray(arr: number[] | null | undefined): string {
   return arr ? arr.join(", ") : "";
 }
 
+function formatFoldable(foldable: boolean | null): string {
+  if (foldable === null) return "—";
+  return foldable ? "Yes" : "No";
+}
+
 interface LoomRefForm {
   brand: string;
   model_name: string;
@@ -1970,6 +1994,9 @@ function emptyForm(): LoomRefForm {
 }
 
 function formFromRef(ref: LoomReferenceDetail): LoomRefForm {
+  let foldable: "" | "true" | "false" = "";
+  if (ref.foldable !== null) foldable = ref.foldable ? "true" : "false";
+
   return {
     brand: ref.brand,
     model_name: ref.model_name,
@@ -1980,7 +2007,7 @@ function formFromRef(ref: LoomReferenceDetail): LoomRefForm {
     treadle_count: formatArray(ref.treadle_count),
     weaving_width_options_inches: formatArray(ref.weaving_width_options_inches),
     weaving_width_options_cm: formatArray(ref.weaving_width_options_cm),
-    foldable: ref.foldable === null ? "" : ref.foldable ? "true" : "false",
+    foldable,
     origin_country: ref.origin_country ?? "",
   };
 }
@@ -2179,32 +2206,18 @@ function LoomDatabaseTab() {
     }
   }
 
-  return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div className="space-y-1 pb-2 border-b flex-1 mr-4">
-          <h1 className="text-lg font-semibold">Loom Database</h1>
-          <p className="text-sm text-muted-foreground">Admin-maintained catalog of commercially available looms, used for typeahead in loom creation.</p>
-        </div>
-        <Button size="sm" onClick={openAdd}>Add loom</Button>
-      </div>
-
-      <input
-        type="search"
-        placeholder="Search brand or model…"
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        className="w-full max-w-xs rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-      />
-
-      {isLoading ? (
-        <p className="text-sm text-muted-foreground">Loading…</p>
-      ) : refs.length === 0 ? (
-        <p className="text-sm text-muted-foreground py-4 text-center">
-          {debouncedSearch ? "No looms match that search." : "No looms in the catalog yet."}
-        </p>
-      ) : (
-        <div className="rounded-md border border-border overflow-x-auto">
+  let tableSection: React.ReactNode;
+  if (isLoading) {
+    tableSection = <p className="text-sm text-muted-foreground">Loading…</p>;
+  } else if (refs.length === 0) {
+    tableSection = (
+      <p className="text-sm text-muted-foreground py-4 text-center">
+        {debouncedSearch ? "No looms match that search." : "No looms in the catalog yet."}
+      </p>
+    );
+  } else {
+    tableSection = (
+      <div className="rounded-md border border-border overflow-x-auto">
           <table className="w-full text-sm min-w-[700px]">
             <thead className="bg-muted/50">
               <tr>
@@ -2235,7 +2248,7 @@ function LoomDatabaseTab() {
                     {ref.weaving_width_options_inches ? ref.weaving_width_options_inches.join(", ") : "—"}
                   </td>
                   <td className="px-3 py-2.5 text-xs text-muted-foreground">
-                    {ref.foldable === null ? "—" : ref.foldable ? "Yes" : "No"}
+                    {formatFoldable(ref.foldable)}
                   </td>
                   <td className="px-3 py-2.5 text-xs text-muted-foreground">{ref.origin_country ?? "—"}</td>
                   <td className="px-3 py-2.5 text-right whitespace-nowrap">
@@ -2251,7 +2264,28 @@ function LoomDatabaseTab() {
             </tbody>
           </table>
         </div>
-      )}
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="space-y-1 pb-2 border-b flex-1 mr-4">
+          <h1 className="text-lg font-semibold">Loom Database</h1>
+          <p className="text-sm text-muted-foreground">Admin-maintained catalog of commercially available looms, used for typeahead in loom creation.</p>
+        </div>
+        <Button size="sm" onClick={openAdd}>Add loom</Button>
+      </div>
+
+      <input
+        type="search"
+        placeholder="Search brand or model…"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className="w-full max-w-xs rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+      />
+
+      {tableSection}
 
       {refs.length > 0 && (
         <p className="text-xs text-muted-foreground">{refs.length} {refs.length === 1 ? "entry" : "entries"}</p>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,11 +1,11 @@
 import { useAuth } from "@/hooks/useAuth";
 import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { listProjects, PROJECT_TYPE_LABELS } from "@/api/projects";
 import { listDrafts } from "@/api/drafts";
-import { listLooms } from "@/api/looms";
+import { listLooms, type Loom } from "@/api/looms";
 import { listCollections } from "@/api/collections";
 import { getActivityHeatmap, type ActivityDay } from "@/api/users";
 import { AppIcons } from "@/lib/icons";
@@ -298,6 +298,12 @@ function ActivityHeatmap() {
   );
 }
 
+function LoomTrackingIcon({ loom }: { readonly loom: Pick<Loom, "supports_lift_tracking" | "supports_treadle_tracking"> }) {
+  if (loom.supports_lift_tracking) return <AppIcons.Lift className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />;
+  if (loom.supports_treadle_tracking) return <AppIcons.Treadle className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />;
+  return <AppIcons.Equipment className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />;
+}
+
 export function DashboardPage() {
   const { t } = useTranslation();
   const { user } = useAuth();
@@ -325,6 +331,128 @@ export function DashboardPage() {
   const activeProjects = projects.filter((a) => (a.status === "active" || a.status === "created") && !!a.loom_id);
   const planningProjects = projects.filter((a) => (a.status === "active" || a.status === "created") && !a.loom_id);
   const completedCount = projects.filter((a) => a.status === "completed").length;
+
+  let draftsSection: ReactNode;
+  if (draftsLoading) {
+    draftsSection = <SkeletonCardGrid count={3} cardClassName="h-[72px]" gridClassName="grid grid-cols-2 sm:grid-cols-3 gap-3" />;
+  } else if (drafts.length === 0) {
+    draftsSection = (
+      <div className="rounded-lg border border-dashed p-6 text-center">
+        <p className="text-sm text-muted-foreground">{t("dashboard.drafts.empty")}</p>
+        <Link to="/drafts" className="mt-2 inline-block text-sm text-foreground underline underline-offset-2">
+          {t("dashboard.drafts.uploadFirst")}
+        </Link>
+      </div>
+    );
+  } else {
+    draftsSection = (
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+        {drafts.slice(0, 3).map((draft) => (
+          <Link
+            key={draft.id}
+            to="/drafts"
+            className="rounded-lg border p-4 hover:border-ring transition-colors flex items-start gap-3"
+          >
+            <div className="shrink-0 mt-0.5">
+              <AppIcons.Draft className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
+            </div>
+            <div className="min-w-0">
+              <p className="text-sm font-medium truncate">{draft.name}</p>
+              <p className="mt-0.5 text-xs text-muted-foreground truncate">{draft.wif_filename}</p>
+            </div>
+          </Link>
+        ))}
+        {drafts.length > 3 && (
+          <Link
+            to="/drafts"
+            className="rounded-lg border border-dashed p-4 flex items-center justify-center hover:border-ring transition-colors"
+          >
+            <span className="text-xs text-muted-foreground">{t("dashboard.moreItems", { count: drafts.length - 3 })}</span>
+          </Link>
+        )}
+      </div>
+    );
+  }
+
+  let collectionsSection: ReactNode;
+  if (collectionsLoading) {
+    collectionsSection = <SkeletonCardGrid count={3} cardClassName="h-[80px]" gridClassName="grid gap-3 sm:grid-cols-3" />;
+  } else if (collections.length === 0) {
+    collectionsSection = (
+      <div className="rounded-lg border border-dashed p-6 text-center">
+        <p className="text-sm text-muted-foreground">{t("dashboard.collectionSection.empty")}</p>
+        <Link to="/collections" className="mt-2 inline-block text-sm text-foreground underline underline-offset-2">{t("dashboard.collectionSection.createFirst")}</Link>
+      </div>
+    );
+  } else {
+    collectionsSection = (
+      <div className="grid gap-3 sm:grid-cols-3">
+        {collections.slice(0, 3).map((c) => (
+          <Link key={c.id} to={`/collections/${c.id}`} className="rounded-lg border p-4 hover:border-ring transition-colors">
+            <div className="flex items-start gap-2">
+              <AppIcons.Collections className="h-4 w-4 shrink-0 mt-0.5 text-muted-foreground" strokeWidth={1.75} />
+              <div className="min-w-0">
+                <p className="text-sm font-medium truncate">{c.name}</p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  {t("dashboard.collectionSection.itemSummary", {
+                    drafts: t("dashboard.collectionSection.draftCount", { count: c.draft_count }),
+                    projects: t("dashboard.collectionSection.projectCount", { count: c.project_count }),
+                  })}
+                </p>
+              </div>
+            </div>
+          </Link>
+        ))}
+        {collections.length > 3 && (
+          <Link to="/collections" className="rounded-lg border border-dashed p-4 flex items-center justify-center text-xs text-muted-foreground hover:border-ring transition-colors">
+            {t("dashboard.moreItems", { count: collections.length - 3 })}
+          </Link>
+        )}
+      </div>
+    );
+  }
+
+  let equipmentSection: ReactNode;
+  if (loomsLoading) {
+    equipmentSection = <SkeletonCardGrid count={3} cardClassName="h-[72px]" gridClassName="grid grid-cols-2 sm:grid-cols-3 gap-3" />;
+  } else if (looms.length === 0) {
+    equipmentSection = (
+      <div className="rounded-lg border border-dashed p-6 text-center">
+        <p className="text-sm text-muted-foreground">{t("dashboard.equipment.empty")}</p>
+        <Link to="/looms" className="mt-2 inline-block text-sm text-foreground underline underline-offset-2">
+          {t("dashboard.equipment.addFirst")}
+        </Link>
+      </div>
+    );
+  } else {
+    equipmentSection = (
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+        {looms.slice(0, 3).map((loom) => (
+          <Link
+            key={loom.id}
+            to="/looms"
+            className="rounded-lg border p-4 hover:border-ring transition-colors flex items-start gap-3"
+          >
+            <div className="shrink-0 mt-0.5">
+              <LoomTrackingIcon loom={loom} />
+            </div>
+            <div className="min-w-0">
+              <p className="text-sm font-medium truncate">{loom.model_name}</p>
+              <p className="mt-0.5 text-xs text-muted-foreground truncate">{loom.manufacturer}</p>
+            </div>
+          </Link>
+        ))}
+        {looms.length > 3 && (
+          <Link
+            to="/looms"
+            className="rounded-lg border border-dashed p-4 flex items-center justify-center hover:border-ring transition-colors"
+          >
+            <span className="text-xs text-muted-foreground">{t("dashboard.moreItems", { count: looms.length - 3 })}</span>
+          </Link>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className="p-6 max-w-3xl mx-auto w-full space-y-8">
@@ -460,42 +588,7 @@ export function DashboardPage() {
             {t("dashboard.viewAll")}
           </Link>
         </div>
-        {draftsLoading ? (
-          <SkeletonCardGrid count={3} cardClassName="h-[72px]" gridClassName="grid grid-cols-2 sm:grid-cols-3 gap-3" />
-        ) : drafts.length === 0 ? (
-          <div className="rounded-lg border border-dashed p-6 text-center">
-            <p className="text-sm text-muted-foreground">{t("dashboard.drafts.empty")}</p>
-            <Link to="/drafts" className="mt-2 inline-block text-sm text-foreground underline underline-offset-2">
-              {t("dashboard.drafts.uploadFirst")}
-            </Link>
-          </div>
-        ) : (
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-            {drafts.slice(0, 3).map((draft) => (
-              <Link
-                key={draft.id}
-                to="/drafts"
-                className="rounded-lg border p-4 hover:border-ring transition-colors flex items-start gap-3"
-              >
-                <div className="shrink-0 mt-0.5">
-                  <AppIcons.Draft className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
-                </div>
-                <div className="min-w-0">
-                  <p className="text-sm font-medium truncate">{draft.name}</p>
-                  <p className="mt-0.5 text-xs text-muted-foreground truncate">{draft.wif_filename}</p>
-                </div>
-              </Link>
-            ))}
-            {drafts.length > 3 && (
-              <Link
-                to="/drafts"
-                className="rounded-lg border border-dashed p-4 flex items-center justify-center hover:border-ring transition-colors"
-              >
-                <span className="text-xs text-muted-foreground">{t("dashboard.moreItems", { count: drafts.length - 3 })}</span>
-              </Link>
-            )}
-          </div>
-        )}
+        {draftsSection}
       </section>
 
       {/* Collections */}
@@ -504,38 +597,7 @@ export function DashboardPage() {
           <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">{t("dashboard.collectionSection.heading")}</h2>
           <Link to="/collections" className="text-xs text-muted-foreground hover:text-foreground">{t("dashboard.viewAll")}</Link>
         </div>
-        {collectionsLoading ? (
-          <SkeletonCardGrid count={3} cardClassName="h-[80px]" gridClassName="grid gap-3 sm:grid-cols-3" />
-        ) : collections.length === 0 ? (
-          <div className="rounded-lg border border-dashed p-6 text-center">
-            <p className="text-sm text-muted-foreground">{t("dashboard.collectionSection.empty")}</p>
-            <Link to="/collections" className="mt-2 inline-block text-sm text-foreground underline underline-offset-2">{t("dashboard.collectionSection.createFirst")}</Link>
-          </div>
-        ) : (
-          <div className="grid gap-3 sm:grid-cols-3">
-            {collections.slice(0, 3).map((c) => (
-              <Link key={c.id} to={`/collections/${c.id}`} className="rounded-lg border p-4 hover:border-ring transition-colors">
-                <div className="flex items-start gap-2">
-                  <AppIcons.Collections className="h-4 w-4 shrink-0 mt-0.5 text-muted-foreground" strokeWidth={1.75} />
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium truncate">{c.name}</p>
-                    <p className="text-xs text-muted-foreground mt-0.5">
-                      {t("dashboard.collectionSection.itemSummary", {
-                        drafts: t("dashboard.collectionSection.draftCount", { count: c.draft_count }),
-                        projects: t("dashboard.collectionSection.projectCount", { count: c.project_count }),
-                      })}
-                    </p>
-                  </div>
-                </div>
-              </Link>
-            ))}
-            {collections.length > 3 && (
-              <Link to="/collections" className="rounded-lg border border-dashed p-4 flex items-center justify-center text-xs text-muted-foreground hover:border-ring transition-colors">
-                {t("dashboard.moreItems", { count: collections.length - 3 })}
-              </Link>
-            )}
-          </div>
-        )}
+        {collectionsSection}
       </section>
 
       {/* Equipment */}
@@ -546,46 +608,7 @@ export function DashboardPage() {
             {t("dashboard.viewAll")}
           </Link>
         </div>
-        {loomsLoading ? (
-          <SkeletonCardGrid count={3} cardClassName="h-[72px]" gridClassName="grid grid-cols-2 sm:grid-cols-3 gap-3" />
-        ) : looms.length === 0 ? (
-          <div className="rounded-lg border border-dashed p-6 text-center">
-            <p className="text-sm text-muted-foreground">{t("dashboard.equipment.empty")}</p>
-            <Link to="/looms" className="mt-2 inline-block text-sm text-foreground underline underline-offset-2">
-              {t("dashboard.equipment.addFirst")}
-            </Link>
-          </div>
-        ) : (
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-            {looms.slice(0, 3).map((loom) => (
-              <Link
-                key={loom.id}
-                to="/looms"
-                className="rounded-lg border p-4 hover:border-ring transition-colors flex items-start gap-3"
-              >
-                <div className="shrink-0 mt-0.5">
-                  {loom.supports_lift_tracking
-                    ? <AppIcons.Lift className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
-                    : loom.supports_treadle_tracking
-                      ? <AppIcons.Treadle className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
-                      : <AppIcons.Equipment className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />}
-                </div>
-                <div className="min-w-0">
-                  <p className="text-sm font-medium truncate">{loom.model_name}</p>
-                  <p className="mt-0.5 text-xs text-muted-foreground truncate">{loom.manufacturer}</p>
-                </div>
-              </Link>
-            ))}
-            {looms.length > 3 && (
-              <Link
-                to="/looms"
-                className="rounded-lg border border-dashed p-4 flex items-center justify-center hover:border-ring transition-colors"
-              >
-                <span className="text-xs text-muted-foreground">{t("dashboard.moreItems", { count: looms.length - 3 })}</span>
-              </Link>
-            )}
-          </div>
-        )}
+        {equipmentSection}
       </section>
 
       {/* Activity heatmap */}
@@ -605,7 +628,9 @@ export function DashboardPage() {
               const usedMB = user.storage_used_bytes / (1024 * 1024);
               const quotaMB = user.storage_quota_bytes / (1024 * 1024);
               const pct = Math.min(Math.round((user.storage_used_bytes / user.storage_quota_bytes) * 100), 100);
-              const barColor = pct >= 90 ? "bg-red-500" : pct >= 75 ? "bg-amber-500" : "bg-primary";
+              let barColor = "bg-primary";
+              if (pct >= 90) barColor = "bg-red-500";
+              else if (pct >= 75) barColor = "bg-amber-500";
               const usedLabel = usedMB < 1 ? `${Math.round(usedMB * 1024)} KB` : `${usedMB.toFixed(1)} MB`;
               return (
                 <>

--- a/frontend/src/pages/LoomCatalogPage.tsx
+++ b/frontend/src/pages/LoomCatalogPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useRef, useMemo, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
@@ -144,6 +144,32 @@ export function LoomCatalogPage() {
   const selectClass =
     "rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400";
 
+  let listContent: ReactNode;
+  if (isLoading) {
+    listContent = <div className="text-center py-16 text-stone-400">{t("loomCatalogPage.loading")}</div>;
+  } else if (looms.length === 0) {
+    listContent = (
+      <div className="text-center py-16 text-stone-400">
+        {hasFilters ? t("loomCatalogPage.noFilters") : t("loomCatalogPage.empty")}
+      </div>
+    );
+  } else {
+    listContent = (
+      <div className="space-y-8">
+        {Object.entries(grouped).map(([brand, entries]) => (
+          <section key={brand}>
+            <h2 className="text-lg font-semibold text-stone-700 mb-3">{brand}</h2>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {entries.map((loom) => (
+                <LoomCard key={loom.id} loom={loom} />
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+    );
+  }
+
   return (
     <div className="flex min-h-screen flex-col bg-stone-50 text-stone-900">
       <header className="border-b border-stone-200 bg-stone-50 px-6 py-4">
@@ -239,26 +265,7 @@ export function LoomCatalogPage() {
             )}
           </div>
 
-          {isLoading ? (
-            <div className="text-center py-16 text-stone-400">{t("loomCatalogPage.loading")}</div>
-          ) : looms.length === 0 ? (
-            <div className="text-center py-16 text-stone-400">
-              {hasFilters ? t("loomCatalogPage.noFilters") : t("loomCatalogPage.empty")}
-            </div>
-          ) : (
-            <div className="space-y-8">
-              {Object.entries(grouped).map(([brand, entries]) => (
-                <section key={brand}>
-                  <h2 className="text-lg font-semibold text-stone-700 mb-3">{brand}</h2>
-                  <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                    {entries.map((loom) => (
-                      <LoomCard key={loom.id} loom={loom} />
-                    ))}
-                  </div>
-                </section>
-              ))}
-            </div>
-          )}
+          {listContent}
         </div>
       </main>
 

--- a/frontend/src/pages/LoomDetailPage.tsx
+++ b/frontend/src/pages/LoomDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useRef, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { AppIcons } from "@/lib/icons";
@@ -179,6 +179,8 @@ function ProfilePhoto({ loom, onChanged }: { readonly loom: LoomDetail; readonly
   };
 
   const busy = uploading || deleting;
+  let uploadLabel = loom.has_photo ? t("loomDetailPage.replacePhoto") : t("loomDetailPage.uploadPhoto");
+  if (uploading) uploadLabel = t("loomDetailPage.uploading");
 
   return (
     <div className="flex items-start gap-4">
@@ -198,7 +200,7 @@ function ProfilePhoto({ loom, onChanged }: { readonly loom: LoomDetail; readonly
           <>
             <input ref={fileRef} type="file" accept="image/jpeg,image/png,image/webp,image/gif" className="hidden" onChange={handleFileSelected} />
             <Button size="sm" variant="outline" onClick={() => fileRef.current?.click()} disabled={busy || !!pendingFile}>
-              {uploading ? t("loomDetailPage.uploading") : loom.has_photo ? t("loomDetailPage.replacePhoto") : t("loomDetailPage.uploadPhoto")}
+              {uploadLabel}
             </Button>
             {loom.has_photo && !confirmRemove && (
               <Button size="sm" variant="outline" onClick={() => setConfirmRemove(true)} disabled={busy || !!pendingFile}>
@@ -954,6 +956,24 @@ export function LoomDetailPage() {
   const currentVersionId = loom.current_version?.id;
   const isReadOnly = !!user?.is_superuser && loom.owner_id !== user.id;
 
+  let deleteLoomControls: ReactNode = null;
+  if (!confirmDelete && !deleteConflict) {
+    deleteLoomControls = (
+      <Button variant="outline" size="sm" className="shrink-0 border-destructive/50 text-destructive hover:bg-destructive/10" onClick={() => setConfirmDelete(true)}>
+        {t("loomDetailPage.deleteLoomButton")}
+      </Button>
+    );
+  } else if (confirmDelete) {
+    deleteLoomControls = (
+      <div className="flex shrink-0 items-center gap-2">
+        <Button variant="outline" size="sm" onClick={() => setConfirmDelete(false)} disabled={deleting}>{t("common.cancel")}</Button>
+        <Button size="sm" onClick={() => handleDelete(false)} disabled={deleting} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
+          {deleting ? t("loomDetailPage.deleting") : t("loomDetailPage.confirmDelete")}
+        </Button>
+      </div>
+    );
+  }
+
   return (
     <div className="max-w-3xl mx-auto w-full">
       {isReadOnly && <SuperuserInspectionBanner />}
@@ -1079,18 +1099,7 @@ export function LoomDetailPage() {
                       <p className="text-sm font-medium">{t("loomDetailPage.deleteLoom")}</p>
                       <p className="mt-0.5 text-xs text-muted-foreground">{t("loomDetailPage.deleteNote")}</p>
                     </div>
-                    {!confirmDelete && !deleteConflict ? (
-                      <Button variant="outline" size="sm" className="shrink-0 border-destructive/50 text-destructive hover:bg-destructive/10" onClick={() => setConfirmDelete(true)}>
-                        {t("loomDetailPage.deleteLoomButton")}
-                      </Button>
-                    ) : confirmDelete ? (
-                      <div className="flex shrink-0 items-center gap-2">
-                        <Button variant="outline" size="sm" onClick={() => setConfirmDelete(false)} disabled={deleting}>{t("common.cancel")}</Button>
-                        <Button size="sm" onClick={() => handleDelete(false)} disabled={deleting} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
-                          {deleting ? t("loomDetailPage.deleting") : t("loomDetailPage.confirmDelete")}
-                        </Button>
-                      </div>
-                    ) : null}
+                    {deleteLoomControls}
                   </div>
 
                   {/* 409 conflict */}

--- a/frontend/src/pages/LoomsPage.tsx
+++ b/frontend/src/pages/LoomsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
@@ -19,6 +19,12 @@ interface LoomProjectCounts {
 function LoomCard({ loom, projectCounts, retired }: { readonly loom: Loom; readonly projectCounts?: LoomProjectCounts; readonly retired?: boolean }) {
   const { t } = useTranslation();
   const v = loom.current_version;
+
+  let typeIcon: ReactNode;
+  if (loom.supports_lift_tracking) typeIcon = <AppIcons.Lift className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />;
+  else if (loom.supports_treadle_tracking) typeIcon = <AppIcons.Treadle className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />;
+  else typeIcon = <AppIcons.Equipment className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />;
+
   return (
     <Link
       to={`/looms/${loom.id}`}
@@ -37,11 +43,7 @@ function LoomCard({ loom, projectCounts, retired }: { readonly loom: Loom; reado
       <div className="flex items-start justify-between gap-2">
         <div className="flex items-start gap-3">
           <div className="shrink-0 mt-0.5">
-            {loom.supports_lift_tracking
-              ? <AppIcons.Lift className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
-              : loom.supports_treadle_tracking
-                ? <AppIcons.Treadle className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
-                : <AppIcons.Equipment className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />}
+            {typeIcon}
           </div>
           <div>
             <p className="font-medium">{loom.manufacturer} {loom.model_name}</p>

--- a/frontend/src/pages/ProjectLandingPage.tsx
+++ b/frontend/src/pages/ProjectLandingPage.tsx
@@ -1,5 +1,5 @@
 import DOMPurify from "dompurify";
-import { useCallback, useEffect, useLayoutEffect, useReducer, useRef, useState, useMemo } from "react";
+import { useCallback, useEffect, useLayoutEffect, useReducer, useRef, useState, useMemo, type ReactNode } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -668,6 +668,18 @@ function ColorPaletteSection({
                     const displayName = hasPending
                       ? (pendingEntry?.yarn.name ?? null)
                       : (serverLinked?.yarn_name ?? null);
+                    let linkLabel: ReactNode;
+                    if (isUnlinkPending && serverLinked) {
+                      linkLabel = <span className="truncate max-w-[100px] text-muted-foreground line-through">{serverLinked.yarn_name}</span>;
+                    } else if (displayName) {
+                      linkLabel = (
+                        <span className={`truncate max-w-[100px] ${hasPending ? "text-accent" : "text-card-foreground"}`}>
+                          {displayName}
+                        </span>
+                      );
+                    } else {
+                      linkLabel = <span className="text-muted-foreground">{t("projectLandingPage.linkYarn")}</span>;
+                    }
                     return (
                       <td className="px-3 py-2">
                         <button type="button"
@@ -678,15 +690,7 @@ function ColorPaletteSection({
                           title={displayName ?? t("projectLandingPage.linkYarn")}
                         >
                           <AppIcons.Yarn className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
-                          {isUnlinkPending && serverLinked ? (
-                            <span className="truncate max-w-[100px] text-muted-foreground line-through">{serverLinked.yarn_name}</span>
-                          ) : displayName ? (
-                            <span className={`truncate max-w-[100px] ${hasPending ? "text-accent" : "text-card-foreground"}`}>
-                              {displayName}
-                            </span>
-                          ) : (
-                            <span className="text-muted-foreground">{t("projectLandingPage.linkYarn")}</span>
-                          )}
+                          {linkLabel}
                           {hasPending && <span className="text-[10px] text-accent">•</span>}
                         </button>
                       </td>
@@ -1048,9 +1052,9 @@ function ReedSelector({
     if (!Number.isNaN(n) && n > 0) mutation.mutate(n);
   }
 
-  const effectiveDents = isCustom
-    ? Number.parseFloat(customInput)
-    : selectValue !== "" ? Number.parseFloat(selectValue) : null;
+  let effectiveDents: number | null = null;
+  if (isCustom) effectiveDents = Number.parseFloat(customInput);
+  else if (selectValue !== "") effectiveDents = Number.parseFloat(selectValue);
   const effectiveDentsInt = effectiveDents != null ? Math.round(effectiveDents) : null;
 
   const isCleanMultiple =
@@ -1411,6 +1415,23 @@ export function ProjectLandingPage() {
   const m = project.draft_wif_measurements;
   const warpLengthCm = project.draft_warp_length_cm;
 
+  let settOrSpacing: ReactNode = null;
+  if (project.draft_epi_override != null) {
+    settOrSpacing = (
+      <>
+        <dt className="text-muted-foreground">{t("projectLandingPage.sett")}</dt>
+        <dd>{project.draft_epi_override} {t("projectLandingPage.epiUnit")}</dd>
+      </>
+    );
+  } else if (m?.warp_spacing != null) {
+    settOrSpacing = (
+      <>
+        <dt className="text-muted-foreground">{t("projectLandingPage.warpSpacing")}</dt>
+        <dd>{displayLength(m.warp_spacing, "cm", displayUnit)}</dd>
+      </>
+    );
+  }
+
   return (
     <div className="h-full overflow-y-auto">
     <div className="mx-auto max-w-3xl px-4 py-6 space-y-6">
@@ -1559,17 +1580,7 @@ export function ProjectLandingPage() {
               <dd>{displayLength(project.draft_weaving_width_override_cm, "cm", displayUnit)}</dd>
             </>
           )}
-          {project.draft_epi_override != null ? (
-            <>
-              <dt className="text-muted-foreground">{t("projectLandingPage.sett")}</dt>
-              <dd>{project.draft_epi_override} {t("projectLandingPage.epiUnit")}</dd>
-            </>
-          ) : m?.warp_spacing != null ? (
-            <>
-              <dt className="text-muted-foreground">{t("projectLandingPage.warpSpacing")}</dt>
-              <dd>{displayLength(m.warp_spacing, "cm", displayUnit)}</dd>
-            </>
-          ) : null}
+          {settOrSpacing}
           {warpLengthCm != null && (
             <>
               <dt className="text-muted-foreground">{t("projectLandingPage.warpLength")}</dt>

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, type ReactNode } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
@@ -36,11 +36,14 @@ function ProjectCard({ project, onAssign }: {
   const badgeKey = isPlanning ? "plan" : project.status;
   const badgeLabel = isPlanning ? t("projectsPage.planBadge") : PROJECT_STATUS_LABELS[project.status];
 
-  const endDate = project.status === "completed"
-    ? project.completed_at
-    : project.status === "abandoned"
-      ? project.abandoned_at
-      : null;
+  let endDate: string | null = null;
+  if (project.status === "completed") endDate = project.completed_at;
+  else if (project.status === "abandoned") endDate = project.abandoned_at;
+
+  let typeIcon: ReactNode;
+  if (isPlanning) typeIcon = <AppIcons.Planning className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />;
+  else if (project.project_type === "treadle") typeIcon = <AppIcons.Treadle className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />;
+  else typeIcon = <AppIcons.Lift className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />;
 
   const pct = project.total_picks > 0
     ? Math.round((Math.min(project.current_pick - 1, project.total_picks) / project.total_picks) * 100)
@@ -61,11 +64,7 @@ function ProjectCard({ project, onAssign }: {
       <Link to={`/projects/${project.id}`} className="block p-4">
         <div className="flex gap-3">
           <div className="shrink-0 mt-0.5">
-            {isPlanning
-              ? <AppIcons.Planning className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
-              : project.project_type === "treadle"
-                ? <AppIcons.Treadle className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />
-                : <AppIcons.Lift className="h-6 w-6 text-muted-foreground" strokeWidth={1.75} />}
+            {typeIcon}
           </div>
           <div className="flex-1 min-w-0">
             <div className="flex items-start justify-between gap-2">

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -778,13 +778,13 @@ function FeedbackHistorySection() {
     queryFn: listMyFeedback,
   });
 
-  return (
-    <Section title={t("settings.sections.feedbackHistory")} description={t("settings.feedbackHistory.description")}>
-      {isLoading ? (
-        <p className="text-sm text-muted-foreground">{t("common.loading")}</p>
-      ) : submissions.length === 0 ? (
-        <p className="text-sm text-muted-foreground">{t("settings.feedbackHistory.noSubmissions")}</p>
-      ) : (
+  let feedbackHistoryContent: ReactNode;
+  if (isLoading) {
+    feedbackHistoryContent = <p className="text-sm text-muted-foreground">{t("common.loading")}</p>;
+  } else if (submissions.length === 0) {
+    feedbackHistoryContent = <p className="text-sm text-muted-foreground">{t("settings.feedbackHistory.noSubmissions")}</p>;
+  } else {
+    feedbackHistoryContent = (
         <div className="divide-y divide-border rounded-lg border">
           {submissions.map((s: FeedbackRecord) => (
             <div key={s.id} className="px-4 py-3 space-y-1">
@@ -849,7 +849,12 @@ function FeedbackHistorySection() {
             </div>
           ))}
         </div>
-      )}
+    );
+  }
+
+  return (
+    <Section title={t("settings.sections.feedbackHistory")} description={t("settings.feedbackHistory.description")}>
+      {feedbackHistoryContent}
     </Section>
   );
 }

--- a/frontend/src/pages/SuperuserPage.tsx
+++ b/frontend/src/pages/SuperuserPage.tsx
@@ -403,6 +403,52 @@ function StorageAuditTab() {
 
   const allSelected = !!result && selected.size === result.orphaned_files.length && result.orphaned_files.length > 0;
 
+  let orphanedSection: React.ReactNode = null;
+  if (result) {
+    orphanedSection = result.orphaned_files.length === 0 ? (
+      <p className="text-sm text-muted-foreground">No orphaned files found.</p>
+    ) : (
+      <div className="rounded-md border overflow-auto max-h-96">
+        <table className="w-full text-xs">
+          <thead className="bg-muted sticky top-0">
+            <tr>
+              <th className="p-2 text-left w-8">
+                <input
+                  type="checkbox"
+                  checked={allSelected}
+                  onChange={toggleAll}
+                  className="cursor-pointer"
+                />
+              </th>
+              <th className="p-2 text-left font-medium">Key</th>
+              <th className="p-2 text-right font-medium">Size</th>
+              <th className="p-2 text-right font-medium">Last Modified</th>
+            </tr>
+          </thead>
+          <tbody>
+            {result.orphaned_files.map((f) => (
+              <tr key={f.key} className="border-t hover:bg-muted/50">
+                <td className="p-2">
+                  <input
+                    type="checkbox"
+                    checked={selected.has(f.key)}
+                    onChange={() => toggleSelect(f.key)}
+                    className="cursor-pointer"
+                  />
+                </td>
+                <td className="p-2 font-mono break-all">{f.key}</td>
+                <td className="p-2 text-right whitespace-nowrap">{formatBytes(f.size)}</td>
+                <td className="p-2 text-right whitespace-nowrap text-muted-foreground">
+                  {new Date(f.last_modified).toLocaleDateString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-4">
       <div className="space-y-1 pb-2 border-b">
@@ -448,48 +494,7 @@ function StorageAuditTab() {
                 <span><span className="font-medium text-amber-600 dark:text-amber-400">{result.orphaned_count}</span> orphaned</span>
               </div>
 
-              {result.orphaned_files.length === 0 ? (
-                <p className="text-sm text-muted-foreground">No orphaned files found.</p>
-              ) : (
-                <div className="rounded-md border overflow-auto max-h-96">
-                  <table className="w-full text-xs">
-                    <thead className="bg-muted sticky top-0">
-                      <tr>
-                        <th className="p-2 text-left w-8">
-                          <input
-                            type="checkbox"
-                            checked={allSelected}
-                            onChange={toggleAll}
-                            className="cursor-pointer"
-                          />
-                        </th>
-                        <th className="p-2 text-left font-medium">Key</th>
-                        <th className="p-2 text-right font-medium">Size</th>
-                        <th className="p-2 text-right font-medium">Last Modified</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {result.orphaned_files.map((f) => (
-                        <tr key={f.key} className="border-t hover:bg-muted/50">
-                          <td className="p-2">
-                            <input
-                              type="checkbox"
-                              checked={selected.has(f.key)}
-                              onChange={() => toggleSelect(f.key)}
-                              className="cursor-pointer"
-                            />
-                          </td>
-                          <td className="p-2 font-mono break-all">{f.key}</td>
-                          <td className="p-2 text-right whitespace-nowrap">{formatBytes(f.size)}</td>
-                          <td className="p-2 text-right whitespace-nowrap text-muted-foreground">
-                            {new Date(f.last_modified).toLocaleDateString()}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              )}
+              {orphanedSection}
             </>
           )}
         </div>
@@ -631,6 +636,11 @@ function WorkerCard({ worker, apiVersion }: { readonly worker: WorkerInfo; reado
   const hasActive = worker.active_tasks.length > 0;
   const hasReserved = worker.reserved_tasks.length > 0;
   const versionMismatch = isOnline && worker.version != null && worker.version !== apiVersion;
+  let concurrencyClass = "border-border text-muted-foreground";
+  if (worker.concurrency !== null) {
+    if (worker.active_tasks.length >= worker.concurrency) concurrencyClass = "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300";
+    else if (worker.active_tasks.length > 0) concurrencyClass = "border-blue-500/30 text-blue-600 dark:text-blue-400";
+  }
 
   return (
     <div className={`border rounded-lg overflow-hidden ${versionMismatch ? "border-amber-500/50" : ""}`}>
@@ -647,13 +657,7 @@ function WorkerCard({ worker, apiVersion }: { readonly worker: WorkerInfo; reado
           </span>
         )}
         {isOnline && worker.concurrency !== null && (
-          <span className={`text-xs px-2 py-0.5 rounded border tabular-nums ${
-            worker.active_tasks.length >= worker.concurrency
-              ? "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300"
-              : worker.active_tasks.length > 0
-              ? "border-blue-500/30 text-blue-600 dark:text-blue-400"
-              : "border-border text-muted-foreground"
-          }`}>
+          <span className={`text-xs px-2 py-0.5 rounded border tabular-nums ${concurrencyClass}`}>
             {worker.active_tasks.length}/{worker.concurrency} slots
           </span>
         )}
@@ -829,6 +833,8 @@ function shortName(name: string): string {
 function TaskHistoryRow({ item, onRevoke }: { readonly item: TaskHistoryItem; readonly onRevoke: (id: string) => void }) {
   const [expanded, setExpanded] = useState(false);
   const cancellable = item.state === "queued" || item.state === "running";
+  let errorToggle = "—";
+  if (item.error) errorToggle = expanded ? "▲" : "▼ error";
   return (
     <>
       <tr
@@ -844,7 +850,7 @@ function TaskHistoryRow({ item, onRevoke }: { readonly item: TaskHistoryItem; re
         <td className="px-3 py-2 tabular-nums text-right">{fmtSec(item.wait_seconds)}</td>
         <td className="px-3 py-2 tabular-nums text-right">{fmtSec(item.run_seconds)}</td>
         <td className="px-3 py-2 tabular-nums text-right whitespace-nowrap">{fmtTime(item.completed_at)}</td>
-        <td className="px-3 py-2 text-muted-foreground">{item.error ? (expanded ? "▲" : "▼ error") : "—"}</td>
+        <td className="px-3 py-2 text-muted-foreground">{errorToggle}</td>
         <td className="px-3 py-2" onClick={(e) => e.stopPropagation()}>
           {cancellable && (
             <button type="button"
@@ -1183,6 +1189,10 @@ function ReconcileTab() {
     }
   }
 
+  let reconcileLabel = "Run reconciliation";
+  if (loading) reconcileLabel = "Running…";
+  else if (ran) reconcileLabel = "Re-run reconciliation";
+
   return (
     <div className="space-y-6">
       <div className="space-y-1 pb-2 border-b">
@@ -1191,7 +1201,7 @@ function ReconcileTab() {
       </div>
 
       <Button onClick={runReconcile} disabled={loading} size="sm">
-        {loading ? "Running…" : ran ? "Re-run reconciliation" : "Run reconciliation"}
+        {reconcileLabel}
       </Button>
 
       {error && <p className="text-sm text-destructive">{error}</p>}
@@ -1435,13 +1445,14 @@ function ScheduledTasksTab() {
 // Data Exports tab
 // ---------------------------------------------------------------------------
 
+const EXPORT_STATUS_CLASS: Record<string, string> = {
+  complete: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+  failed: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
+};
+const EXPORT_STATUS_DEFAULT_CLASS = "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300";
+
 function ExportStatusBadge({ status }: { readonly status: AdminExportRecord["status"] }) {
-  const cls =
-    status === "complete"
-      ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300"
-      : status === "failed"
-        ? "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300"
-        : "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300";
+  const cls = EXPORT_STATUS_CLASS[status] ?? EXPORT_STATUS_DEFAULT_CLASS;
   return (
     <span className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${cls}`}>{status}</span>
   );
@@ -1576,6 +1587,20 @@ function credentialStatus(daysRemaining: number | null): { label: string; cls: s
   if (daysRemaining <= 7) return { label: "Critical", cls: "bg-destructive/10 text-destructive" };
   if (daysRemaining <= 30) return { label: "Warning", cls: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300" };
   return { label: "OK", cls: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300" };
+}
+
+function ExpiresCell({ expiresOn, daysRemaining }: { readonly expiresOn: string | null; readonly daysRemaining: number | null }) {
+  if (!expiresOn) return <span className="text-muted-foreground">Never</span>;
+  let daysLabel = "";
+  if (daysRemaining !== null) daysLabel = daysRemaining < 0 ? `${Math.abs(daysRemaining)}d ago` : `${daysRemaining}d`;
+  return (
+    <>
+      {new Date(expiresOn).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })}
+      {daysRemaining !== null && (
+        <span className="ml-1.5 text-xs text-muted-foreground">({daysLabel})</span>
+      )}
+    </>
+  );
 }
 
 const GROUP_CONFIG: Record<string, { label: string; fields: string[]; testService: string | null }> = {
@@ -2119,6 +2144,36 @@ function NeonUsageBars({ daily }: { readonly daily: { date: string; compute_seco
   );
 }
 
+function ProjectUsageSection({ project }: {
+  readonly project: { configured: boolean; error: string | null; total_compute_seconds: number; daily: { date: string; compute_seconds: number }[] };
+}) {
+  if (!project.configured) {
+    return (
+      <div className="border rounded-lg px-4 py-2 bg-background text-sm text-muted-foreground">
+        neon_project_id isn't set — showing account-wide usage above only.
+      </div>
+    );
+  }
+  if (project.error) {
+    return (
+      <div className="border rounded-lg px-4 py-2 bg-background text-sm text-destructive">
+        {project.error}
+      </div>
+    );
+  }
+  return (
+    <div className="border rounded-lg overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-2 bg-background border-b">
+        <span className="text-sm">Total compute time</span>
+        <span className="text-xs font-mono text-muted-foreground">
+          {(project.total_compute_seconds / 3600).toFixed(1)} hours
+        </span>
+      </div>
+      <NeonUsageBars daily={project.daily} />
+    </div>
+  );
+}
+
 function NeonDashboardTab() {
   const { data, isLoading } = useQuery({
     queryKey: ["admin", "neon-dashboard"],
@@ -2208,25 +2263,7 @@ function NeonDashboardTab() {
             <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
               Configured project (last 30 days)
             </h3>
-            {!data.project.configured ? (
-              <div className="border rounded-lg px-4 py-2 bg-background text-sm text-muted-foreground">
-                neon_project_id isn't set — showing account-wide usage above only.
-              </div>
-            ) : data.project.error ? (
-              <div className="border rounded-lg px-4 py-2 bg-background text-sm text-destructive">
-                {data.project.error}
-              </div>
-            ) : (
-              <div className="border rounded-lg overflow-hidden">
-                <div className="flex items-center justify-between px-4 py-2 bg-background border-b">
-                  <span className="text-sm">Total compute time</span>
-                  <span className="text-xs font-mono text-muted-foreground">
-                    {(data.project.total_compute_seconds / 3600).toFixed(1)} hours
-                  </span>
-                </div>
-                <NeonUsageBars daily={data.project.daily} />
-              </div>
-            )}
+            <ProjectUsageSection project={data.project} />
           </div>
         </div>
       )}
@@ -2314,6 +2351,50 @@ function CredentialsTab() {
     return a.days_remaining - b.days_remaining;
   });
 
+  let tableSection: React.ReactNode;
+  if (isLoading) {
+    tableSection = <p className="text-sm text-muted-foreground">Loading…</p>;
+  } else if (sorted.length === 0) {
+    tableSection = <p className="text-sm text-muted-foreground">No credentials tracked yet.</p>;
+  } else {
+    tableSection = (
+      <div className="rounded-md border border-border overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-muted">
+            <tr>
+              <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">Name</th>
+              <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">Service</th>
+              <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">Expires</th>
+              <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">Status</th>
+              <th className="px-3 py-2" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {sorted.map((c) => {
+              const { label, cls } = credentialStatus(c.days_remaining);
+              return (
+                <tr key={c.id} className="hover:bg-muted/50">
+                  <td className="px-3 py-2.5 font-medium">{c.name}</td>
+                  <td className="px-3 py-2.5 text-muted-foreground">{RESOURCE_LABELS[c.resource]}</td>
+                  <td className="px-3 py-2.5 text-muted-foreground">
+                    <ExpiresCell expiresOn={c.expires_on} daysRemaining={c.days_remaining} />
+                  </td>
+                  <td className="px-3 py-2.5">
+                    <span className={`inline-block rounded px-1.5 py-0.5 text-xs font-medium ${cls}`}>{label}</span>
+                  </td>
+                  <td className="px-3 py-2.5 text-right">
+                    <button type="button" className="text-xs text-muted-foreground hover:text-foreground mr-3" onClick={() => openEdit(c)}>Edit</button>
+                    <button type="button" className="text-xs text-destructive hover:text-destructive/80" onClick={() => setDeleteTarget(c)}>Delete</button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -2324,55 +2405,7 @@ function CredentialsTab() {
         <Button size="sm" onClick={openAdd}>Add credential</Button>
       </div>
 
-      {isLoading ? (
-        <p className="text-sm text-muted-foreground">Loading…</p>
-      ) : sorted.length === 0 ? (
-        <p className="text-sm text-muted-foreground">No credentials tracked yet.</p>
-      ) : (
-        <div className="rounded-md border border-border overflow-hidden">
-          <table className="w-full text-sm">
-            <thead className="bg-muted">
-              <tr>
-                <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">Name</th>
-                <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">Service</th>
-                <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">Expires</th>
-                <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">Status</th>
-                <th className="px-3 py-2" />
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {sorted.map((c) => {
-                const { label, cls } = credentialStatus(c.days_remaining);
-                return (
-                  <tr key={c.id} className="hover:bg-muted/50">
-                    <td className="px-3 py-2.5 font-medium">{c.name}</td>
-                    <td className="px-3 py-2.5 text-muted-foreground">{RESOURCE_LABELS[c.resource]}</td>
-                    <td className="px-3 py-2.5 text-muted-foreground">
-                      {c.expires_on
-                        ? <>
-                            {new Date(c.expires_on).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })}
-                            {c.days_remaining !== null && (
-                              <span className="ml-1.5 text-xs text-muted-foreground">
-                                ({c.days_remaining < 0 ? `${Math.abs(c.days_remaining)}d ago` : `${c.days_remaining}d`})
-                              </span>
-                            )}
-                          </>
-                        : <span className="text-muted-foreground">Never</span>}
-                    </td>
-                    <td className="px-3 py-2.5">
-                      <span className={`inline-block rounded px-1.5 py-0.5 text-xs font-medium ${cls}`}>{label}</span>
-                    </td>
-                    <td className="px-3 py-2.5 text-right">
-                      <button type="button" className="text-xs text-muted-foreground hover:text-foreground mr-3" onClick={() => openEdit(c)}>Edit</button>
-                      <button type="button" className="text-xs text-destructive hover:text-destructive/80" onClick={() => setDeleteTarget(c)}>Delete</button>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      )}
+      {tableSection}
 
       <ConfigSection />
 

--- a/frontend/src/pages/WarpingPlanPage.tsx
+++ b/frontend/src/pages/WarpingPlanPage.tsx
@@ -52,11 +52,11 @@ function approximateColorName(hex: string): string {
     return "Tan";
   }
 
-  const prefix =
-    l < 0.18 ? "Very Dark " :
-    l < 0.32 ? "Dark " :
-    l > 0.78 ? "Pale " :
-    l > 0.63 ? "Light " : "";
+  let prefix = "";
+  if (l < 0.18) prefix = "Very Dark ";
+  else if (l < 0.32) prefix = "Dark ";
+  else if (l > 0.78) prefix = "Pale ";
+  else if (l > 0.63) prefix = "Light ";
 
   let name: string;
   if (h < 12 || h >= 348) name = "Red";

--- a/frontend/src/pages/YarnDetailPage.tsx
+++ b/frontend/src/pages/YarnDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams, Link } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -451,6 +451,30 @@ export function YarnDetailPage() {
     heroPhoto?.medium_url ?? heroPhoto?.small_url ?? heroPhoto?.square_url ??
     yarn.ravelry_photo_url;
 
+  let heroContent: ReactNode;
+  if (heroPhotoUrl) {
+    heroContent = (
+      <img
+        src={heroPhotoUrl}
+        alt={`${yarn.brand} ${yarn.name}`}
+        className="h-36 w-36 rounded-xl object-cover border border-border shrink-0"
+      />
+    );
+  } else if (yarn.color_hex) {
+    heroContent = (
+      <div
+        className="h-36 w-36 rounded-xl border border-border shrink-0"
+        style={{ backgroundColor: yarn.color_hex }}
+      />
+    );
+  } else {
+    heroContent = (
+      <div className="h-36 w-36 rounded-xl border border-dashed border-border flex items-center justify-center text-xs text-muted-foreground shrink-0">
+        {t("yarnDetailPage.noPhoto")}
+      </div>
+    );
+  }
+
   return (
     <div className="p-6 max-w-2xl mx-auto w-full space-y-6">
 
@@ -473,22 +497,7 @@ export function YarnDetailPage() {
 
       {/* Hero: photo + title block */}
       <div className="flex gap-5 items-start">
-        {heroPhotoUrl ? (
-          <img
-            src={heroPhotoUrl}
-            alt={`${yarn.brand} ${yarn.name}`}
-            className="h-36 w-36 rounded-xl object-cover border border-border shrink-0"
-          />
-        ) : yarn.color_hex ? (
-          <div
-            className="h-36 w-36 rounded-xl border border-border shrink-0"
-            style={{ backgroundColor: yarn.color_hex }}
-          />
-        ) : (
-          <div className="h-36 w-36 rounded-xl border border-dashed border-border flex items-center justify-center text-xs text-muted-foreground shrink-0">
-            {t("yarnDetailPage.noPhoto")}
-          </div>
-        )}
+        {heroContent}
 
         <div className="flex-1 min-w-0 space-y-1.5 pt-1">
           <h1 className="text-xl font-semibold text-card-foreground leading-tight">{yarn.brand}</h1>

--- a/frontend/src/pages/YarnPage.tsx
+++ b/frontend/src/pages/YarnPage.tsx
@@ -142,12 +142,10 @@ function isStashPushEligible(yarn: YarnSummary) {
 
 function YarnCard({ yarn, connected }: { readonly yarn: YarnSummary; readonly connected: boolean }) {
   const { t } = useTranslation();
-  const skeinLabel =
-    yarn.skein_count === 0
-      ? t("yarnPage.noSkeins")
-      : yarn.available_count === yarn.skein_count
-        ? t("yarnPage.allAvailable", { count: yarn.skein_count })
-        : t("yarnPage.someAvailable", { available: yarn.available_count, total: yarn.skein_count });
+  let skeinLabel: string;
+  if (yarn.skein_count === 0) skeinLabel = t("yarnPage.noSkeins");
+  else if (yarn.available_count === yarn.skein_count) skeinLabel = t("yarnPage.allAvailable", { count: yarn.skein_count });
+  else skeinLabel = t("yarnPage.someAvailable", { available: yarn.available_count, total: yarn.skein_count });
 
   return (
     <Link
@@ -268,15 +266,15 @@ function SortHeader({
 }) {
   const isActive = currentSort === ascKey || currentSort === descKey;
   const isAsc = currentSort === ascKey;
+  let sortIcon = <ArrowUpDown className="h-3 w-3 opacity-40" />;
+  if (isActive) sortIcon = isAsc ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />;
   return (
     <button type="button"
       onClick={() => onSort(isActive && descKey && isAsc ? descKey : ascKey)}
       className="flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
     >
       {label}
-      {isActive
-        ? (isAsc ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />)
-        : <ArrowUpDown className="h-3 w-3 opacity-40" />}
+      {sortIcon}
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- Fixes all 80 SonarCloud S3358 findings ("nested ternary operations should be extracted") across 20 files
- Mechanical, behavior-preserving conversions: if/else statement chains for simple value selection, `Record<string,string>` lookup tables for threshold/state color mappings, small extracted sub-components for JSX buried several layers deep, and independent `&&`-guarded JSX blocks for mutually-exclusive boolean conditions
- Excludes `ProjectDetailPage.tsx` (13 findings) and `DraftDetailPage.tsx` (9 findings) per #1061's own guidance — these overlap with the `ProjectDetailPage.tsx` complexity-101 function tracked in #1063 and will be handled together in that pass, with a dedicated browser verification given the traffic/risk profile of those two pages

## Notes for reviewers
- The `dev`-branch SonarCloud snapshot was stale relative to merged PRs when this work started (predated the #1067 TS long-tail sweep landing). Triggered a fresh `sonarcloud-full-scan.yml` run and re-verified the new analysis's revision matched current `dev` HEAD before trusting fetched line numbers — worth doing again before starting #1063 or any other #1047 sub-issue.
- A handful of AST-detectable nested ternaries were intentionally left alone (e.g. buried several JSX layers deep inside a sibling ternary's branch) since SonarCloud's S3358 doesn't flag those in practice — only the 80 officially-tracked findings were addressed, to avoid unbounded scope creep.
- One unrelated build-mode-only type error surfaced during Docker rebuild (`AdminPage.tsx` `formFromRef`'s `foldable` field widened to `string` instead of the literal union `"" | "true" | "false"`) — introduced by my own earlier ternary→`String()` simplification in this same PR, not pre-existing; fixed with an explicit if/else instead of `String()`.

## Test plan
- [x] `tsc -b` clean (Docker build-mode, matches CI)
- [x] `eslint` clean across `frontend/src`
- [x] Full Docker rebuild (frontend + backend + worker + worker2) succeeds
- [x] Backend `/api/health` reports the new version post-rebuild
- [x] Playwright e2e suite: 32/32 runnable tests pass (dashboard, admin, looms, projects, drafts, tag-filter) — 12 skipped are data-conditional, not failures