### PR TITLE
refactor: reduce cognitive complexity in health probes and PyWeaving rendering (S3776)

### DIFF
--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -125,39 +125,29 @@ async def health_detailed() -> JSONResponse:
 # ---------------------------------------------------------------------------
 
 
+def _readiness_service_from_probe_result(result, critical_names: set[str]) -> ReadinessService:
+    if isinstance(result, BaseException):
+        return ReadinessService(name="unknown", ok=False, critical=True, message=str(result)[:120])
+
+    critical = result.service in critical_names
+    ok = result.status == "ok"
+
+    detail = ""
+    if not ok:
+        failed_check = next((c for c in result.checks if c.status == "error"), None)
+        if failed_check:
+            detail = failed_check.message[:120]
+
+    return ReadinessService(name=result.service, ok=ok, critical=critical, message=result.message, detail=detail)
+
+
 def _build_readiness_from_results(
     results: list,
     webhook_result,
     checked_at: str,
 ) -> ReadinessResponse:
     critical_names = {"PostgreSQL", "Clerk"}
-    services: list[ReadinessService] = []
-    has_hard_failure = False
-    has_soft_failure = False
-
-    for result in results:
-        if isinstance(result, BaseException):
-            services.append(ReadinessService(name="unknown", ok=False, critical=True, message=str(result)[:120]))
-            has_hard_failure = True
-            continue
-
-        critical = result.service in critical_names
-        ok = result.status == "ok"
-
-        detail = ""
-        if not ok:
-            failed_check = next((c for c in result.checks if c.status == "error"), None)
-            if failed_check:
-                detail = failed_check.message[:120]
-
-        services.append(
-            ReadinessService(name=result.service, ok=ok, critical=critical, message=result.message, detail=detail)
-        )
-        if not ok:
-            if critical:
-                has_hard_failure = True
-            else:
-                has_soft_failure = True
+    services: list[ReadinessService] = [_readiness_service_from_probe_result(r, critical_names) for r in results]
 
     if webhook_result is not None:
         webhook_ok = webhook_result.status in ("ok", "skipped")
@@ -169,8 +159,9 @@ def _build_readiness_from_results(
                 message=webhook_result.message,
             )
         )
-        if not webhook_ok:
-            has_soft_failure = True
+
+    has_hard_failure = any(not s.ok and s.critical for s in services)
+    has_soft_failure = any(not s.ok and not s.critical for s in services)
 
     if has_hard_failure:
         status: Literal["ok", "degraded", "error"] = "error"
@@ -380,6 +371,35 @@ async def _record_health_transition(prev_status: str | None, result: ReadinessRe
         log.debug("Could not record health transition event", exc_info=True)
 
 
+def _next_alert_state(
+    prev_status: str | None,
+    new_status: str,
+    last_alert_at: datetime | None,
+    now: datetime,
+) -> tuple[bool, bool, datetime | None]:
+    """Decide whether to fire a health alert for this status transition.
+
+    Returns (should_alert, is_recovery, next_last_alert_at).
+    """
+    if prev_status is None:
+        # First detailed cycle — startup alert already covered initial state
+        return False, False, (now if new_status != "ok" else None)
+
+    if new_status in ("degraded", "error"):
+        if prev_status != new_status:
+            # ok → bad, or a degraded ↔ error transition
+            return True, False, now
+        if last_alert_at and (now - last_alert_at).total_seconds() >= _HEALTH_ALERT_COOLDOWN_S:
+            # Same bad state for >1 h — re-alert
+            return True, False, now
+        return False, False, last_alert_at
+
+    if new_status == "ok" and prev_status in ("degraded", "error"):
+        return True, True, None
+
+    return False, False, last_alert_at
+
+
 async def _detailed_refresh_loop() -> None:
     global _detailed_cache, _last_alert_status, _last_alert_at, _consecutive_failures
     await asyncio.sleep(DETAILED_REFRESH_INTERVAL_S)  # skip transient startup failures
@@ -415,32 +435,10 @@ async def _detailed_refresh_loop() -> None:
             now = datetime.now(timezone.utc)
             prev_status = _last_alert_status
 
-            if prev_status is None:
-                # First detailed cycle — startup alert already covered initial state
-                _last_alert_status = new_status
-                if new_status != "ok":
-                    _last_alert_at = now
-            else:
-                should_alert = False
-                is_recovery = False
-
-                if new_status in ("degraded", "error"):
-                    if prev_status != new_status:
-                        # ok → bad, or a degraded ↔ error transition
-                        should_alert = True
-                    elif _last_alert_at and (now - _last_alert_at).total_seconds() >= _HEALTH_ALERT_COOLDOWN_S:
-                        # Same bad state for >1 h — re-alert
-                        should_alert = True
-                elif new_status == "ok" and prev_status in ("degraded", "error"):
-                    should_alert = True
-                    is_recovery = True
-
-                if should_alert:
-                    fire_and_forget(_dispatch_health_alert(confirmed_result, is_recovery))
-                    _last_alert_status = new_status
-                    _last_alert_at = now if new_status != "ok" else None
-                else:
-                    _last_alert_status = new_status
+            should_alert, is_recovery, _last_alert_at = _next_alert_state(prev_status, new_status, _last_alert_at, now)
+            _last_alert_status = new_status
+            if should_alert:
+                fire_and_forget(_dispatch_health_alert(confirmed_result, is_recovery))
 
             _detailed_cache = confirmed_result
         except Exception:

--- a/backend/app/services/rendering.py
+++ b/backend/app/services/rendering.py
@@ -361,6 +361,22 @@ def render_drawdown_only(
     return out.getvalue(), weft_count, scale
 
 
+def _fill_row_with_weft_color(pixels, w: int, y0: int, scale: int, weft_rgb: tuple) -> None:
+    for dy in range(scale):
+        for x in range(w):
+            pixels[x, y0 + dy] = weft_rgb  # type: ignore[index]
+
+
+def _paint_warp_up_threads(pixels, draft: Draft, warp_rgbs: list, connected: set, y0: int, scale: int) -> None:
+    warp_up = (x for x, wt in enumerate(draft.warp) if (wt.shaft not in connected) ^ draft.rising_shed)
+    for x in warp_up:
+        rgb = warp_rgbs[x]
+        x0 = x * scale
+        for dy in range(scale):
+            for dx in range(scale):
+                pixels[x0 + dx, y0 + dy] = rgb  # type: ignore[index]
+
+
 def render_drawdown_png(draft: Draft, scale: int = 1) -> bytes:
     """Render just the drawdown grid as a PNG, without cropping from a full draft image.
 
@@ -388,20 +404,8 @@ def render_drawdown_png(draft: Draft, scale: int = 1) -> bytes:
 
         weft_rgb = weft_thread.color.rgb if weft_thread.color else (255, 255, 255)
 
-        # Fill entire row with weft color.
-        for dy in range(scale):
-            for x in range(w):
-                pixels[x, y0 + dy] = weft_rgb  # type: ignore[index]
-
-        # Paint warp-up threads on top.
-        connected = weft_thread.connected_shafts
-        warp_up = (x for x, wt in enumerate(draft.warp) if (wt.shaft not in connected) ^ draft.rising_shed)
-        for x in warp_up:
-            rgb = warp_rgbs[x]
-            x0 = x * scale
-            for dy in range(scale):
-                for dx in range(scale):
-                    pixels[x0 + dx, y0 + dy] = rgb  # type: ignore[index]
+        _fill_row_with_weft_color(pixels, w, y0, scale, weft_rgb)
+        _paint_warp_up_threads(pixels, draft, warp_rgbs, weft_thread.connected_shafts, y0, scale)
 
     out = io.BytesIO()
     img.save(out, format="PNG")

--- a/backend/app/weaving/_render.py
+++ b/backend/app/weaving/_render.py
@@ -166,6 +166,29 @@ class ImageRenderer:
                     fill=self.numbering,
                 )
 
+    def _paint_tieup_cell(self, draw: ImageDraw.ImageDraw, treadle, shaft, box: tuple) -> None:
+        draw.rectangle(box, outline=self.foreground)
+        if shaft in treadle.shafts:
+            self.paint_fill_marker(draw, box)
+
+    def _paint_tieup_shaft_number(
+        self, draw: ImageDraw.ImageDraw, endx: int, starty: int, pps: int, shaft_no: int
+    ) -> None:
+        if shaft_no != 0 and shaft_no % 4 == 0:
+            lx = endx
+            draw.line((lx, starty, lx + 2 * pps, starty), fill=self.numbering)
+            draw.text((lx + 2, starty + 2), str(shaft_no), font=self.font, fill=self.numbering)
+
+    def _paint_tieup_treadle_number(self, draw: ImageDraw.ImageDraw, treadle_no: int, offsetx: int, pps: int) -> None:
+        if treadle_no != 0 and treadle_no % 4 == 0:
+            tick_x = treadle_no * pps + offsetx
+            tick_ys, tick_ye = 3 * pps, 5 * pps - 1
+            draw.line((tick_x, tick_ys, tick_x, tick_ye), fill=self.numbering)
+            # textbbox replaces removed textsize (Pillow ≥10)
+            bbox = draw.textbbox((0, 0), str(treadle_no), font=self.font)
+            textw = bbox[2] - bbox[0]
+            draw.text((tick_x - textw - 2, tick_ys + 2), str(treadle_no), font=self.font, fill=self.numbering)
+
     def paint_tieup(self, draw: ImageDraw.ImageDraw) -> None:
         pps = self.pixels_per_square
         offsetx = (1 + len(self.draft.warp)) * pps
@@ -181,25 +204,12 @@ class ImageRenderer:
             for jj, shaft in enumerate(self.draft.shafts):
                 starty = (num_shafts - jj - 1) * pps + offsety
                 endy = starty + pps
-                draw.rectangle((startx, starty, endx, endy), outline=self.foreground)
-                if shaft in treadle.shafts:
-                    self.paint_fill_marker(draw, (startx, starty, endx, endy))
+                self._paint_tieup_cell(draw, treadle, shaft, (startx, starty, endx, endy))
 
                 if treadle_no == num_treadles:
-                    shaft_no = jj + 1
-                    if shaft_no != 0 and shaft_no % 4 == 0:
-                        lx = endx
-                        draw.line((lx, starty, lx + 2 * pps, starty), fill=self.numbering)
-                        draw.text((lx + 2, starty + 2), str(shaft_no), font=self.font, fill=self.numbering)
+                    self._paint_tieup_shaft_number(draw, endx, starty, pps, jj + 1)
 
-            if treadle_no != 0 and treadle_no % 4 == 0:
-                tick_x = treadle_no * pps + offsetx
-                tick_ys, tick_ye = 3 * pps, 5 * pps - 1
-                draw.line((tick_x, tick_ys, tick_x, tick_ye), fill=self.numbering)
-                # textbbox replaces removed textsize (Pillow ≥10)
-                bbox = draw.textbbox((0, 0), str(treadle_no), font=self.font)
-                textw = bbox[2] - bbox[0]
-                draw.text((tick_x - textw - 2, tick_ys + 2), str(treadle_no), font=self.font, fill=self.numbering)
+            self._paint_tieup_treadle_number(draw, treadle_no, offsetx, pps)
 
     def paint_treadling(self, draw: ImageDraw.ImageDraw) -> None:
         pps = self.pixels_per_square
@@ -442,13 +452,55 @@ class SVGRenderer:
                 )
         doc.append(_SVG.g(*grp))
 
+    def _paint_tieup_cell(
+        self, grp: list, treadle, shaft, startx: int, starty: int, endx: int, endy: int, s: int
+    ) -> None:
+        grp.append(
+            _SVG.rect(
+                x=startx,
+                y=starty,
+                width=s,
+                height=s,
+                style=f"stroke:{self.foreground}; fill:{self.background}",
+            )
+        )
+        if shaft in treadle.shafts:
+            self.paint_fill_marker(grp, (startx, starty, endx, endy))
+
+    def _paint_tieup_shaft_number(self, grp: list, endx: int, starty: int, s: int, shaft_no: int) -> None:
+        if shaft_no != 0 and shaft_no % 4 == 0:
+            lx = endx
+            grp.append(_SVG.line(x1=lx, y1=starty, x2=lx + 2 * s, y2=starty, style=f"stroke:{self.numbering}"))
+            grp.append(
+                _SVG.text(
+                    str(shaft_no),
+                    x=lx + 3,
+                    y=starty + 2 + self.font_size,
+                    style=f"font-family:{self.font_family}; font-size:{self.font_size}; fill:{self.numbering}",
+                )
+            )
+
+    def _paint_tieup_treadle_number(self, grp: list, treadle_no: int, offsetx: int, s: int) -> None:
+        if treadle_no != 0 and treadle_no % 4 == 0:
+            tx = treadle_no * s + offsetx
+            grp.append(_SVG.line(x1=tx, y1=3 * s, x2=tx, y2=5 * s - 1, style=f"stroke:{self.numbering}"))
+            grp.append(
+                _SVG.text(
+                    str(treadle_no),
+                    x=tx - 3,
+                    y=3 * s + self.font_size,
+                    text_anchor="end",
+                    style=f"font-family:{self.font_family}; font-size:{self.font_size}; fill:{self.numbering}",
+                )
+            )
+
     def paint_tieup(self, doc) -> None:
         s = self.scale
         offsetx = (1 + len(self.draft.warp)) * s
         offsety = 5 * s
         num_treadles = len(self.draft.treadles)
         num_shafts = len(self.draft.shafts)
-        grp = []
+        grp: list = []
         for ii, treadle in enumerate(self.draft.treadles):
             startx = ii * s + offsetx
             endx = startx + s
@@ -456,46 +508,10 @@ class SVGRenderer:
             for jj, shaft in enumerate(self.draft.shafts):
                 starty = (num_shafts - jj - 1) * s + offsety
                 endy = starty + s
-                grp.append(
-                    _SVG.rect(
-                        x=startx,
-                        y=starty,
-                        width=s,
-                        height=s,
-                        style=f"stroke:{self.foreground}; fill:{self.background}",
-                    )
-                )
-                if shaft in treadle.shafts:
-                    self.paint_fill_marker(grp, (startx, starty, endx, endy))
+                self._paint_tieup_cell(grp, treadle, shaft, startx, starty, endx, endy, s)
                 if treadle_no == num_treadles:
-                    shaft_no = jj + 1
-                    if shaft_no != 0 and shaft_no % 4 == 0:
-                        lx = endx
-                        grp.append(
-                            _SVG.line(x1=lx, y1=starty, x2=lx + 2 * s, y2=starty, style=f"stroke:{self.numbering}")
-                        )
-                        grp.append(
-                            _SVG.text(
-                                str(shaft_no),
-                                x=lx + 3,
-                                y=starty + 2 + self.font_size,
-                                style=(
-                                    f"font-family:{self.font_family}; font-size:{self.font_size}; fill:{self.numbering}"
-                                ),
-                            )
-                        )
-            if treadle_no != 0 and treadle_no % 4 == 0:
-                tx = treadle_no * s + offsetx
-                grp.append(_SVG.line(x1=tx, y1=3 * s, x2=tx, y2=5 * s - 1, style=f"stroke:{self.numbering}"))
-                grp.append(
-                    _SVG.text(
-                        str(treadle_no),
-                        x=tx - 3,
-                        y=3 * s + self.font_size,
-                        text_anchor="end",
-                        style=f"font-family:{self.font_family}; font-size:{self.font_size}; fill:{self.numbering}",
-                    )
-                )
+                    self._paint_tieup_shaft_number(grp, endx, starty, s, jj + 1)
+            self._paint_tieup_treadle_number(grp, treadle_no, offsetx, s)
         doc.append(_SVG.g(*grp))
 
     def paint_treadling(self, doc) -> None:

--- a/backend/app/weaving/_wif.py
+++ b/backend/app/weaving/_wif.py
@@ -65,42 +65,47 @@ class WIFReader:
                 shaft = next(iter(shafts))
             draft.add_warp_thread(color=color, shaft=shaft)
 
-    def put_weft(self, draft: Draft, wif_palette: dict) -> None:
-        weft_thread_count = self.config.getint("WEFT", "Threads")
-        weft_units = self.config.get("WEFT", "Units").lower()
-        assert weft_units in self.allowed_units, f"Weft Units of {weft_units!r} is not understood"
-
-        has_weft_colors = self.getbool("CONTENTS", "WEFT COLORS")
+    def _read_weft_color_source(self) -> tuple[dict[int, int] | None, int | None]:
         weft_color_map: dict[int, int] | None = None
-        if has_weft_colors:
+        if self.getbool("CONTENTS", "WEFT COLORS"):
             weft_color_map = {}
             for thread_no, value in self.config.items("WEFT COLORS"):
                 weft_color_map[int(thread_no)] = int(value)
 
         weft_color = None
         if not weft_color_map:
-            has_weft_colors = False
+            weft_color_map = None
             weft_color = self.config.getint("WEFT", "Color")
 
-        has_liftplan = self.getbool("CONTENTS", "LIFTPLAN")
-        liftplan_map: dict[int, list[int]] = {}
-        if has_liftplan:
-            for thread_no, value in self.config.items("LIFTPLAN"):
-                liftplan_map[int(thread_no)] = [int(sn) for sn in value.split(",")]
+        return weft_color_map, weft_color
 
-        has_treadling = self.getbool("CONTENTS", "TREADLING")
-        treadling_map: dict[int, list[int]] = {}
-        if has_treadling:
-            for thread_no, value in self.config.items("TREADLING"):
-                try:
-                    treadling_map[int(thread_no)] = [int(tn) for tn in value.split(",")]
-                except ValueError:
-                    pass
+    def _read_indexed_thread_map(self, section: str, tolerant: bool = False) -> tuple[bool, dict[int, list[int]]]:
+        has_section = self.getbool("CONTENTS", section)
+        result: dict[int, list[int]] = {}
+        if has_section:
+            for thread_no, value in self.config.items(section):
+                if tolerant:
+                    try:
+                        result[int(thread_no)] = [int(tn) for tn in value.split(",")]
+                    except ValueError:
+                        pass
+                else:
+                    result[int(thread_no)] = [int(sn) for sn in value.split(",")]
+        return has_section, result
+
+    def put_weft(self, draft: Draft, wif_palette: dict) -> None:
+        weft_thread_count = self.config.getint("WEFT", "Threads")
+        weft_units = self.config.get("WEFT", "Units").lower()
+        assert weft_units in self.allowed_units, f"Weft Units of {weft_units!r} is not understood"
+
+        weft_color_map, weft_color = self._read_weft_color_source()
+        has_liftplan, liftplan_map = self._read_indexed_thread_map("LIFTPLAN")
+        has_treadling, treadling_map = self._read_indexed_thread_map("TREADLING", tolerant=True)
 
         for thread_no in range(1, weft_thread_count + 1):
             if not ((has_liftplan and thread_no in liftplan_map) or (has_treadling and thread_no in treadling_map)):
                 continue
-            color = wif_palette.get(weft_color_map[thread_no] if has_weft_colors else weft_color, [0, 0, 0])
+            color = wif_palette.get(weft_color_map[thread_no] if weft_color_map is not None else weft_color, [0, 0, 0])
             shafts = {draft.shafts[sn - 1] for sn in liftplan_map[thread_no]} if has_liftplan else set()
             treadles = {draft.treadles[tn - 1] for tn in treadling_map[thread_no]} if has_treadling else set()
             draft.add_weft_thread(color=color, shafts=shafts, treadles=treadles)

--- a/backend/tests/routers/test_health.py
+++ b/backend/tests/routers/test_health.py
@@ -913,6 +913,54 @@ class TestDetailedRefreshLoop:
 
         mock_fire_and_forget.assert_called_once()
 
+    async def test_same_bad_status_no_realert_before_cooldown(self, monkeypatch):
+        """Status stays 'error' and the last alert was recent — must not re-alert."""
+        from app.routers.health import _detailed_refresh_loop
+
+        result = ReadinessResponse(
+            status="error",
+            services=[ReadinessService(name="PostgreSQL", ok=False, critical=True)],
+        )
+        monkeypatch.setattr(health_module, "_consecutive_failures", 3)
+        monkeypatch.setattr(health_module, "_last_alert_status", "error")
+        monkeypatch.setattr(health_module, "_last_alert_at", datetime.now(timezone.utc) - timedelta(seconds=60))
+
+        with patch("app.routers.health.asyncio.sleep", side_effect=self._make_fake_sleep()):
+            with patch("app.routers.health._run_detailed_probes", new_callable=AsyncMock, return_value=result):
+                with patch("app.routers.health._refresh_superuser_email_cache", new_callable=AsyncMock):
+                    with patch("app.routers.health._record_health_transition", new_callable=AsyncMock):
+                        with patch("app.routers.health.fire_and_forget") as mock_fire_and_forget:
+                            with pytest.raises(asyncio.CancelledError):
+                                await _detailed_refresh_loop()
+
+        mock_fire_and_forget.assert_not_called()
+        assert health_module._last_alert_status == "error"
+
+    async def test_same_bad_status_realerts_after_cooldown(self, monkeypatch):
+        """Status stays 'error' but the last alert was over an hour ago — must re-alert."""
+        from app.routers.health import _detailed_refresh_loop
+
+        result = ReadinessResponse(
+            status="error",
+            services=[ReadinessService(name="PostgreSQL", ok=False, critical=True)],
+        )
+        monkeypatch.setattr(health_module, "_consecutive_failures", 3)
+        monkeypatch.setattr(health_module, "_last_alert_status", "error")
+        stale_alert_at = datetime.now(timezone.utc) - timedelta(seconds=health_module._HEALTH_ALERT_COOLDOWN_S + 60)
+        monkeypatch.setattr(health_module, "_last_alert_at", stale_alert_at)
+
+        with patch("app.routers.health.asyncio.sleep", side_effect=self._make_fake_sleep()):
+            with patch("app.routers.health._run_detailed_probes", new_callable=AsyncMock, return_value=result):
+                with patch("app.routers.health._refresh_superuser_email_cache", new_callable=AsyncMock):
+                    with patch("app.routers.health._record_health_transition", new_callable=AsyncMock):
+                        with patch("app.routers.health.fire_and_forget") as mock_fire_and_forget:
+                            with pytest.raises(asyncio.CancelledError):
+                                await _detailed_refresh_loop()
+
+        mock_fire_and_forget.assert_called_once()
+        assert health_module._last_alert_status == "error"
+        assert health_module._last_alert_at > stale_alert_at
+
     async def test_loop_catches_probe_exception_and_continues(self):
         from app.routers.health import _detailed_refresh_loop
 


### PR DESCRIPTION
## Summary
Third slice of #1063 — the "needs care" backend batch: 6 functions across 4 files, flagged for extra caution rather than pure mechanical extraction:
- `health.py` — background monitoring loop, don't change probe/alert semantics
- `rendering.py` / `_wif.py` / `_render.py` — PyWeaving core rendering engine, a bug here could silently corrupt rendered drawdowns without throwing

## health.py
- **`_build_readiness_from_results`** (complexity 37 → well under threshold): simplified from manually-threaded `has_hard_failure`/`has_soft_failure` booleans updated inline during the loop, to computing them via `any()` over the already-built services list's own `ok`/`critical` fields. Verified against the existing 11-test `TestBuildReadinessFromResults` suite (all pass).
- **`_detailed_refresh_loop`** (complexity 20): extracted the alert-decision branching into a pure `_next_alert_state()` helper, carefully checked branch-by-branch against the original to confirm exact behavioral equivalence (including the "no alert → `_last_alert_at` stays unchanged" case, easy to get wrong). Found the cooldown re-alert path (same bad status persisting >1h) had **zero test coverage** — added two tests (`test_same_bad_status_no_realert_before_cooldown`, `test_same_bad_status_realerts_after_cooldown`) verified against the pre-refactor code first, then confirmed still passing after.

## PyWeaving rendering engine
Pure mechanical extraction only — no logic changes. Verified via **real golden-output byte comparison**, not just pytest: rendered the same WIF files with the pre- and post-refactor code and diffed the raw output bytes.

- `rendering.py` `render_drawdown_png` (18) — byte-identical PNG output on a minimal fixture and a real 133×133 overshot pattern.
- `_wif.py` `put_weft` (25) — identical parsed-and-rendered output across both a liftplan-based and a treadling-based real WIF file (the two mutually-exclusive code paths this function has to handle).
- `_render.py` `ImageRenderer.paint_tieup` + `SVGRenderer.paint_tieup` (17 each — same method name, two different classes, PNG vs SVG renderers) — byte-identical PNG *and* SVG output on a real 16-shaft/16-treadle twill pattern, chosen specifically because it's large enough to exercise the `% 4 == 0` numbering tick-mark branches in both renderers.

## Test plan
- [x] `ruff` + `mypy` clean across the whole `app/` tree
- [x] App imports cleanly
- [x] Golden-output byte comparison (pre- vs post-refactor) for every PyWeaving rendering path touched — PNG drawdown, PNG full-draft, SVG full-draft, both liftplan and treadling WIF variants
- [x] 2 new tests added closing a real coverage gap in the alert-cooldown logic, verified against pre-refactor code before applying the refactor
- [x] Full backend test suite against a freshly-recreated test DB: 2841 passed, 1 failed — the failure (`TestNeonDashboardEndpoint::test_returns_not_configured_by_default`) is in `test_admin.py`, a file untouched by this PR; it fails because this local dev container has real Neon credentials configured (the test expects "not configured"), reproducible in isolation and unrelated to any of this PR's changes.