### PR TITLE
fix: resolve #1087 long-tail v2 SonarCloud findings

### DIFF
--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -190,22 +190,17 @@ async def _preregister_user(
 async def _poll_for_clerk_attach(
     session_factory: async_sessionmaker,
     user_id: uuid.UUID,
-    timeout: int,
 ) -> User:
-    """Poll until the webhook attaches a clerk_user_id to the pre-created User."""
-    try:
-        async with asyncio.timeout(timeout):
-            while True:
-                async with session_factory() as session:
-                    user = await session.get(User, user_id)
-                    if user and user.clerk_user_id is not None:
-                        return user  # type: ignore[no-any-return]
-                await asyncio.sleep(1)
-    except TimeoutError:
-        raise TimeoutError(
-            f"user_id={user_id} never received a clerk_user_id after {timeout}s — "
-            "is the webhook configured and reachable?"
-        ) from None
+    """Poll until the webhook attaches a clerk_user_id to the pre-created User.
+
+    Callers must bound this with an `asyncio.timeout(...)` context manager.
+    """
+    while True:
+        async with session_factory() as session:
+            user = await session.get(User, user_id)
+            if user and user.clerk_user_id is not None:
+                return user  # type: ignore[no-any-return]
+        await asyncio.sleep(1)
 
 
 # ---------------------------------------------------------------------------
@@ -341,10 +336,14 @@ async def _seed_users(
 
         # 3. Poll until the webhook attaches the Clerk ID to the pre-created User.
         try:
-            db_user = await _poll_for_clerk_attach(session_factory, pre_user.id, poll_timeout)
+            async with asyncio.timeout(poll_timeout):
+                db_user = await _poll_for_clerk_attach(session_factory, pre_user.id)
             _ok(f"{email} confirmed in DB (clerk_user_id={db_user.clerk_user_id})")
-        except TimeoutError as exc:
-            _err(str(exc))
+        except TimeoutError:
+            _err(
+                f"user_id={pre_user.id} never received a clerk_user_id after {poll_timeout}s — "
+                "is the webhook configured and reachable?"
+            )
             await engine.dispose()
             sys.exit(1)
 

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for the CLI seed command (app.cli)."""
 
+import asyncio
 import json
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -300,7 +301,7 @@ async def test_poll_for_clerk_attach_returns_user_when_attached():
     session.get = AsyncMock(return_value=mock_user)
     factory = MagicMock(return_value=session)
 
-    result = await _poll_for_clerk_attach(factory, user_id, timeout=5)
+    result = await _poll_for_clerk_attach(factory, user_id)
 
     assert result is mock_user
 
@@ -322,7 +323,8 @@ async def test_poll_for_clerk_attach_raises_timeout_when_never_attached():
     factory = MagicMock(return_value=session)
 
     with pytest.raises(TimeoutError):
-        await _poll_for_clerk_attach(factory, user_id, timeout=0)
+        async with asyncio.timeout(0):
+            await _poll_for_clerk_attach(factory, user_id)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -261,6 +261,42 @@ async def test_seed_deletes_clerk_users_before_alembic(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Users: poll-for-attach timeout aborts
+# ---------------------------------------------------------------------------
+
+
+async def test_seed_aborts_when_poll_for_clerk_attach_times_out(tmp_path):
+    """If the webhook never attaches a clerk_user_id, cmd_seed exits 1."""
+    settings = _make_settings()
+    factory, _session = _make_session_factory()
+    config = tmp_path / "seed.json"
+    config.write_text(json.dumps({"users": [{"email": "a@b.com", "username": "a", "role": "user"}]}))
+
+    engine = _make_engine()
+    pre_user = MagicMock()
+    pre_user.id = uuid.uuid4()
+
+    with (
+        patch("app.cli.get_settings", return_value=settings),
+        patch("app.cli._clerk_list_users", AsyncMock(return_value=[])),
+        patch("app.cli._clerk_delete_all_users", AsyncMock(return_value=0)),
+        patch("app.cli.create_async_engine", return_value=engine),
+        patch("app.cli.async_sessionmaker", return_value=factory),
+        patch("app.cli._alembic_reset"),
+        patch("app.cli._clear_storage"),
+        patch("app.cli._preregister_user", AsyncMock(return_value=pre_user)),
+        patch("app.cli._clerk_create_user", AsyncMock(return_value={"id": "user_new"})),
+        patch("app.cli._poll_for_clerk_attach", AsyncMock(side_effect=TimeoutError)),
+        patch("app.cli._BACKEND_DIR", tmp_path),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            await cmd_seed(str(config), 5)
+
+    assert exc_info.value.code == 1
+    engine.dispose.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
 # Reset: Clerk deletion failure aborts
 # ---------------------------------------------------------------------------
 

--- a/frontend/src/components/FeedbackModal.tsx
+++ b/frontend/src/components/FeedbackModal.tsx
@@ -41,12 +41,12 @@ async function getAppVersion(): Promise<string | null> {
 }
 
 function extractProjectId(pathname: string): string | null {
-  const m = pathname.match(/^\/projects\/([0-9a-f-]{36})/i);
+  const m = /^\/projects\/([0-9a-f-]{36})/i.exec(pathname);
   return m ? m[1] : null;
 }
 
 function extractDraftId(pathname: string): string | null {
-  const m = pathname.match(/^\/drafts\/([0-9a-f-]{36})/i);
+  const m = /^\/drafts\/([0-9a-f-]{36})/i.exec(pathname);
   return m ? m[1] : null;
 }
 

--- a/frontend/src/components/ui/AuthedImage.tsx
+++ b/frontend/src/components/ui/AuthedImage.tsx
@@ -3,6 +3,7 @@ import { getAuthToken } from "@/api/client";
 
 interface Props extends React.ImgHTMLAttributes<HTMLImageElement> {
   readonly src: string;
+  readonly alt: string;
   readonly loadingContent?: React.ReactNode;
 }
 

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1713,7 +1713,10 @@ function FeedbackTab() {
                 <p className="font-medium text-foreground">Diagnostics</p>
                 {Object.entries(detail.diagnostics).map(([k, v]) => {
                   if (!v) return null;
-                  const display = typeof v === "object" ? JSON.stringify(v) : String(v);
+                  const display =
+                    typeof v === "string" || typeof v === "number" || typeof v === "boolean"
+                      ? String(v)
+                      : JSON.stringify(v);
                   return <p key={k}><span className="font-mono">{k}:</span> {display}</p>;
                 })}
               </div>

--- a/frontend/src/pages/YarnDetailPage.tsx
+++ b/frontend/src/pages/YarnDetailPage.tsx
@@ -282,7 +282,7 @@ function RavelrySection({ ry, companyUrl, permalink }: {
   const fibers = ry.fiber_contents?.filter(f => f.fiber_category?.name) ?? [];
 
   const ratingStr = ry.rating_average && ry.rating_count
-    ? t("yarnDetailPage.rating", { avg: parseFloat(ry.rating_average).toFixed(2), count: ry.rating_count.toLocaleString() })
+    ? t("yarnDetailPage.rating", { avg: Number.parseFloat(ry.rating_average).toFixed(2), count: ry.rating_count.toLocaleString() })
     : null;
 
   const attributes: string[] = [


### PR DESCRIPTION
## Summary

Closes #1087. Fixes the 6 remaining long-tail v2 SonarCloud findings (down from 8 originally — `python:S1871` in `health.py` was resolved incidentally by #1092's refactor).

| Rule | File | Fix |
| --- | --- | --- |
| `typescript:S6594` ×2 | `FeedbackModal.tsx` | `.match()` → `RegExp.exec()` in `extractProjectId`/`extractDraftId` |
| `typescript:S6551` | `AdminPage.tsx` | Explicitly check for primitive types before `String()`; `JSON.stringify()` for everything else, avoiding accidental `"[object Object]"` |
| `typescript:S7773` | `YarnDetailPage.tsx` | `parseFloat` → `Number.parseFloat` |
| `typescript:S1077` | `AuthedImage.tsx` | Made `alt` a required prop — all existing call sites already pass it, so this is a static-enforcement-only change with no behavior diff |
| `python:S7483` | `cli.py` | Removed the `timeout` param from `_poll_for_clerk_attach`; the caller (`_seed_users`) now owns the `asyncio.timeout(...)` context manager and produces the same timeout error message |

**Deferred:** `typescript:S1082` (`SuperuserPage.tsx:1800`, click handler on a non-interactive element) — per #1087's own issue body, this shares its fix pattern and verification approach with #1064's keyboard-accessibility batch, so it's left for that PR rather than fixed standalone here.

## Test plan

- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy app/` clean
- [x] Full Docker rebuild (frontend + backend + worker + worker2)
- [x] `npm run build` (includes `tsc -b`) clean
- [x] `eslint` clean
- [x] Updated `test_cli.py::test_poll_for_clerk_attach_*` for the new signature/caller-owned timeout
- [x] Full backend pytest: 2874 passed, 2 skipped, 1 failed (`test_returns_not_configured_by_default` — known local-only artifact from this dev container's real Neon credentials, unrelated to this diff, passes in CI)
- [x] Coverage 93.08%, gate is 65%