### PR TITLE
fix: keyboard support for non-native interactive elements — yarn area (#1064)

### DIFF
--- a/frontend/src/components/ui/ColorPicker.tsx
+++ b/frontend/src/components/ui/ColorPicker.tsx
@@ -452,8 +452,18 @@ export function ColorPicker({ value, onChange, size = "md", className }: ColorPi
                     {suggestions.map((name) => (
                       <li
                         key={name}
+                        role="button"
+                        tabIndex={0}
                         className="flex items-center gap-2 px-2 py-1 text-xs text-card-foreground cursor-pointer hover:bg-muted"
                         onMouseDown={(e) => {
+                          e.preventDefault();
+                          setNameInput(name);
+                          setNameError(false);
+                          const hex = resolveColorName(name);
+                          if (hex) { syncAllInputs(hex); onChange(hex); }
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key !== "Enter" && e.key !== " ") return;
                           e.preventDefault();
                           setNameInput(name);
                           setNameError(false);

--- a/frontend/src/components/ui/TagInput.tsx
+++ b/frontend/src/components/ui/TagInput.tsx
@@ -41,11 +41,7 @@ export function TagInput({ tags, onChange, placeholder = "Add a tag…", disable
   }
 
   return (
-    <div
-      className="flex flex-wrap gap-1.5 rounded-md border border-input bg-background px-2 py-1.5 cursor-text min-h-[36px]"
-      onClick={() => inputRef.current?.focus()}
-      onKeyDown={(e) => e.key === "Enter" && inputRef.current?.focus()}
-    >
+    <div className="flex flex-wrap gap-1.5 rounded-md border border-input bg-background px-2 py-1.5 cursor-text min-h-[36px]">
       {tags.map((tag) => (
         <span
           key={tag}

--- a/frontend/src/components/yarn/AddFromRavelryModal.tsx
+++ b/frontend/src/components/yarn/AddFromRavelryModal.tsx
@@ -363,15 +363,14 @@ export function AddFromRavelryModal({ onSuccess, onClose }: Props) {
 
   return (
     <div
+      role="button"
+      tabIndex={0}
+      aria-label="Close"
       className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-16 px-4"
-      onClick={onClose}
-      onKeyDown={(e) => e.key === "Escape" && onClose()}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      onKeyDown={(e) => { if (e.key === "Escape" || e.key === "Enter" || e.key === " ") onClose(); }}
     >
-      <div
-        className="w-full max-w-md rounded-xl border border-border bg-card shadow-xl"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => { e.stopPropagation(); if (e.key === "Escape") onClose(); }}
-      >
+      <div className="w-full max-w-md rounded-xl border border-border bg-card shadow-xl">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border px-5 py-4">
           <div>

--- a/frontend/src/components/yarn/AddYarnModal.tsx
+++ b/frontend/src/components/yarn/AddYarnModal.tsx
@@ -157,8 +157,13 @@ export function AddYarnModal({ onSuccess, onClose }: Props) {
                   {brandSuggestions.map((b) => (
                     <li
                       key={b}
+                      role="button"
+                      tabIndex={0}
                       className="cursor-pointer px-3 py-1.5 hover:bg-accent hover:text-accent-foreground"
                       onMouseDown={() => { setBrand(b); setBrandOpen(false); }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setBrand(b); setBrandOpen(false); }
+                      }}
                     >
                       {b}
                     </li>
@@ -185,8 +190,13 @@ export function AddYarnModal({ onSuccess, onClose }: Props) {
                   {nameSuggestions.map((n) => (
                     <li
                       key={n}
+                      role="button"
+                      tabIndex={0}
                       className="cursor-pointer px-3 py-1.5 hover:bg-accent hover:text-accent-foreground"
                       onMouseDown={() => { setName(n); setNameOpen(false); }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setName(n); setNameOpen(false); }
+                      }}
                     >
                       {n}
                     </li>

--- a/frontend/src/pages/YarnDetailPage.tsx
+++ b/frontend/src/pages/YarnDetailPage.tsx
@@ -11,15 +11,14 @@ import { ColorwayGrid } from "@/components/yarn/ColorwayGrid";
 function DevJsonModal({ data, onClose }: { readonly data: unknown; readonly onClose: () => void }) {
   return (
     <div
+      role="button"
+      tabIndex={0}
+      aria-label="Close"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      onClick={onClose}
-      onKeyDown={(e) => e.key === "Escape" && onClose()}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      onKeyDown={(e) => { if (e.key === "Escape" || e.key === "Enter" || e.key === " ") onClose(); }}
     >
-      <div
-        className="relative bg-card border border-border rounded-xl shadow-lg max-w-2xl w-full max-h-[80vh] overflow-auto m-4"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => { e.stopPropagation(); if (e.key === "Escape") onClose(); }}
-      >
+      <div className="relative bg-card border border-border rounded-xl shadow-lg max-w-2xl w-full max-h-[80vh] overflow-auto m-4">
         <div className="flex items-center justify-between px-4 py-3 border-b border-border">
           <span className="text-xs font-mono font-semibold text-accent">DEV — raw data</span>
           <button type="button" onClick={onClose} className="text-muted-foreground hover:text-foreground text-lg leading-none">×</button>
@@ -124,17 +123,18 @@ function EditColorwayModal({
 
   return (
     <div
+      role="button"
+      tabIndex={0}
+      aria-label="Close"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      onClick={onClose}
-      onKeyDown={(e) => e.key === "Escape" && onClose()}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      onKeyDown={(e) => { if (e.key === "Escape" || e.key === "Enter" || e.key === " ") onClose(); }}
     >
       <div
         role="dialog"
         aria-modal="true"
         aria-labelledby="edit-colorway-title"
         className="w-full max-w-sm rounded-xl border border-border bg-card shadow-xl"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => { e.stopPropagation(); if (e.key === "Escape") onClose(); }}
       >
         <div className="flex items-center justify-between px-5 py-4 border-b border-border">
           <h2 id="edit-colorway-title" className="text-sm font-semibold">{t("yarnDetailPage.editColorwayTitle")}</h2>


### PR DESCRIPTION
## Summary

Part of #1064 (`typescript:S6848` + `typescript:S6847`, 27 findings total). This PR covers the 10 findings in the yarn-related files — first of 3 planned PRs (yarn / project / admin-misc) to keep each one independently reviewable and keyboard-testable.

| File | Findings | Fix |
| --- | --- | --- |
| `YarnDetailPage.tsx` (DevJsonModal, EditColorwayModal) | 4 | Backdrop → `role="button"`/`tabIndex=0`, `onClick` uses `target === currentTarget` instead of relying on the inner panel's `stopPropagation`. Inner panel's now-redundant click/keydown handlers removed. |
| `AddFromRavelryModal.tsx` | 2 | Same backdrop pattern. |
| `AddYarnModal.tsx` (brand/name suggestions) | 2 | Suggestion `<li>` items were mouse-only (`onMouseDown`, needed to win the race against the input's `onBlur`). Added `role="button"`, `tabIndex=0`, `onKeyDown` so Enter/Space selects the same way a click does. |
| `ColorPicker.tsx` (color-name suggestions) | 1 | Same suggestion-list fix. |
| `TagInput.tsx` | 1 | Wrapper div's `onClick`/`onKeyDown` (click-anywhere-to-focus) removed entirely — the input is `flex-1` and already independently reachable via Tab, so no keyboard path was lost. |

## Verification

Per #1064's own guidance ("needs real keyboard-nav testing, not a blind fix"), I verified live in a browser rather than relying on tsc/eslint alone — rebuilt the Docker frontend/backend/worker stack and ran an ad hoc Playwright script (not committed) against the eqauser account:

- [x] `EditColorwayModal` backdrop: Escape closes it, click-outside closes it
- [x] `AddFromRavelryModal` backdrop: Escape closes it, click-outside closes it
- [x] `AddYarnModal` brand suggestion: reachable via Tab, Enter selects it (fills the field, closes the dropdown) — confirmed the fix actually works end-to-end, not just that the attributes are present
- [x] `tsc -b --noEmit` clean
- [x] `eslint` clean
- [x] Docker build (frontend + backend) clean

No backend changes in this PR, so backend pytest wasn't re-run.

## Notes

- `SuperuserPage.tsx:1800` (`S6848`, reported as `S1082` when originally scoped under #1087) is part of #1064's remaining scope — planned for PR 3 (admin/misc) of this batch, not yet fixed.