### PR TITLE
fix: keyboard support for non-native interactive elements — project area (#1064)

### DIFF
--- a/frontend/src/components/projects/ShareModal.tsx
+++ b/frontend/src/components/projects/ShareModal.tsx
@@ -76,11 +76,14 @@ export function ShareModal({
 
   return (
     <div
+      role="button"
+      tabIndex={0}
+      aria-label="Close"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
-      onKeyDown={(e) => e.key === "Escape" && onClose()}
+      onKeyDown={(e) => { if (e.key === "Escape" || e.key === "Enter" || e.key === " ") onClose(); }}
     >
       <div className="bg-card rounded-xl border border-border shadow-2xl flex flex-col max-w-md w-full">
         <div className="flex items-center justify-between px-4 py-3 border-b border-border">

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -848,15 +848,17 @@ function PhotoGrid({
       )}
       {lightbox && (
         <div
+          role="button"
+          tabIndex={0}
+          aria-label="Close"
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
-          onClick={() => setLightbox(null)}
-          onKeyDown={(e) => e.key === "Escape" && setLightbox(null)}
+          onClick={(e) => { if (e.target === e.currentTarget) setLightbox(null); }}
+          onKeyDown={(e) => { if (e.key === "Escape" || e.key === "Enter" || e.key === " ") setLightbox(null); }}
         >
           <AuthedImage
             src={projectPhotoUrl(projectId, lightbox)}
             alt=""
             className="max-h-full max-w-full rounded-lg shadow-2xl"
-            onClick={(e) => e.stopPropagation()}
           />
           <button
             type="button"
@@ -2198,9 +2200,12 @@ export function ProjectDetailPage() {
       {settingsOpen && (
         <>
           <div
+            role="button"
+            tabIndex={0}
+            aria-label="Close"
             className="fixed inset-0 z-40 bg-black/40"
             onClick={() => setSettingsOpen(false)}
-            onKeyDown={(e) => e.key === "Escape" && setSettingsOpen(false)}
+            onKeyDown={(e) => { if (e.key === "Escape" || e.key === "Enter" || e.key === " ") setSettingsOpen(false); }}
           />
           <div className="fixed inset-y-0 right-0 z-50 flex w-72 flex-col border-l border-border bg-card shadow-xl">
             <div className="flex items-center justify-between border-b border-border px-4 py-3">

--- a/frontend/src/pages/ProjectLandingPage.tsx
+++ b/frontend/src/pages/ProjectLandingPage.tsx
@@ -296,15 +296,16 @@ function DrawdownModal({ svgUrl, title = "Design preview", onClose }: {
   return (
     <div
       ref={backdropRef}
+      role="button"
+      tabIndex={0}
+      aria-label="Close"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
-      onClick={onClose}
-      onKeyDown={(e) => e.key === "Escape" && onClose()}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      onKeyDown={(e) => { if (e.key === "Escape" || e.key === "Enter" || e.key === " ") onClose(); }}
     >
       <div
         className="bg-card rounded-xl border border-border shadow-xl flex flex-col"
         style={{ width: "min(96vw, 1400px)", height: "min(92vh, 1200px)" }}
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => { e.stopPropagation(); if (e.key === "Escape") onClose(); }}
       >
         {/* Toolbar */}
         <div className="flex items-center gap-2 px-3 py-2 border-b border-border shrink-0">
@@ -382,9 +383,12 @@ function TieUpModal({ projectId, draftName, onClose }: {
 
   return (
     <div
+      role="button"
+      tabIndex={0}
+      aria-label="Close"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
-      onKeyDown={(e) => e.key === "Escape" && onClose()}
+      onKeyDown={(e) => { if (e.key === "Escape" || e.key === "Enter" || e.key === " ") onClose(); }}
     >
       <div className="bg-card rounded-xl border border-border shadow-2xl flex flex-col max-w-lg w-full max-h-[80vh]">
         <div className="flex items-center justify-between px-4 py-3 border-b border-border">

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -134,15 +134,14 @@ function ProjectCard({ project, onAssign }: {
       )}
       {showPreview && (
         <div
+          role="button"
+          tabIndex={0}
+          aria-label="Close"
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
-          onClick={() => setShowPreview(false)}
-          onKeyDown={(e) => e.key === "Escape" && setShowPreview(false)}
+          onClick={(e) => { if (e.target === e.currentTarget) setShowPreview(false); }}
+          onKeyDown={(e) => { if (e.key === "Escape" || e.key === "Enter" || e.key === " ") setShowPreview(false); }}
         >
-          <div
-            className="relative max-w-xl w-full"
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => { e.stopPropagation(); if (e.key === "Escape") setShowPreview(false); }}
-          >
+          <div className="relative max-w-xl w-full">
             <button
               type="button"
               onClick={() => setShowPreview(false)}


### PR DESCRIPTION
## Summary

Part of #1064 (`typescript:S6848` + `typescript:S6847`, 27 findings total). Second of 3 planned PRs — see #1095 for the first (yarn area). All 8 findings here use the same backdrop pattern established there: `role="button"`/`tabIndex=0`/`aria-label="Close"` on the backdrop, `onClick` using `target === currentTarget` instead of relying on the inner panel's `stopPropagation`, and `onKeyDown` handling Escape/Enter/Space.

| File | Findings | Notes |
| --- | --- | --- |
| `ShareModal.tsx` | 1 | Already used `target===currentTarget`; just needed `role`/`tabIndex` added. |
| `ProjectsPage.tsx` | 2 | Preview lightbox backdrop + inner content pair. |
| `ProjectLandingPage.tsx` | 3 | Zoom/pan preview modal (ref-based wheel listener preserved) + tie-up preview modal. |
| `ProjectDetailPage.tsx` | 2 | Photo lightbox (backdrop + inner `AuthedImage`'s now-redundant `stopPropagation` removed) and the view-settings drawer — the drawer's backdrop is a childless sibling div, the simplest case in this batch. |

## Verification

Rebuilt the Docker frontend/backend/worker stack and ran an ad hoc Playwright script (not committed) against the eqauser account:

- [x] `ShareModal`: Escape closes it, click-outside closes it — confirmed across two separate live runs
- [x] The other three modals reuse the identical, already-proven backdrop mechanism (verified structurally + via `tsc`/`eslint`); the settings-drawer button was conditionally hidden for the fixture project's current state, so I couldn't drive that one specific trigger through the UI, but its fix is structurally simpler than `ShareModal`'s (no propagation concern at all — no children under the backdrop)
- [x] `tsc -b --noEmit` clean
- [x] `eslint` clean
- [x] Docker build (frontend + backend) clean

No backend changes in this PR.