### PR TITLE
fix: keyboard support for non-native interactive elements — admin/misc (#1064)

### DIFF
--- a/frontend/src/components/FeedbackModal.tsx
+++ b/frontend/src/components/FeedbackModal.tsx
@@ -105,15 +105,14 @@ export function FeedbackModal({ onClose }: Props) {
 
   return (
     <div
+      role="button"
+      tabIndex={0}
+      aria-label="Close"
       className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 p-4"
-      onClick={onClose}
-      onKeyDown={(e) => e.key === "Escape" && onClose()}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      onKeyDown={(e) => { if (e.key === "Escape" || e.key === "Enter" || e.key === " ") onClose(); }}
     >
-      <div
-        className="w-full max-w-lg rounded-lg border border-border bg-background shadow-xl p-6 space-y-4"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => { e.stopPropagation(); if (e.key === "Escape") onClose(); }}
-      >
+      <div className="w-full max-w-lg rounded-lg border border-border bg-background shadow-xl p-6 space-y-4">
         {/* Header */}
         <div className="flex items-center justify-between">
           <h2 className="text-base font-semibold flex items-center gap-2">

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -384,9 +384,12 @@ export function Sidebar({ open, onClose, desktopCollapsed = false, onDesktopExpa
       {/* Mobile backdrop */}
       {open && (
         <div
+          role="button"
+          tabIndex={0}
+          aria-label="Close"
           className="fixed inset-0 z-20 bg-black/40 lg:hidden"
           onClick={onClose}
-          onKeyDown={(e) => e.key === "Escape" && onClose()}
+          onKeyDown={(e) => { if (e.key === "Escape" || e.key === "Enter" || e.key === " ") onClose(); }}
         />
       )}
 

--- a/frontend/src/components/looms/CatalogRequestButton.tsx
+++ b/frontend/src/components/looms/CatalogRequestButton.tsx
@@ -98,15 +98,16 @@ export function CatalogRequestButton({ loom }: Props) {
 
       {showModal && (
         <div
+          role="button"
+          tabIndex={0}
+          aria-label="Close"
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
-          onClick={() => { if (!mutation.isPending) setShowModal(false); }}
-          onKeyDown={(e) => { if (e.key === "Escape" && !mutation.isPending) setShowModal(false); }}
+          onClick={(e) => { if (e.target === e.currentTarget && !mutation.isPending) setShowModal(false); }}
+          onKeyDown={(e) => {
+            if ((e.key === "Escape" || e.key === "Enter" || e.key === " ") && !mutation.isPending) setShowModal(false);
+          }}
         >
-          <div
-            className="w-full max-w-md rounded-lg border border-border bg-background shadow-xl p-6 space-y-4"
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => { e.stopPropagation(); if (e.key === "Escape" && !mutation.isPending) setShowModal(false); }}
-          >
+          <div className="w-full max-w-md rounded-lg border border-border bg-background shadow-xl p-6 space-y-4">
             <div className="flex items-center justify-between">
               <h2 className="text-base font-semibold">Request catalog addition</h2>
               <button

--- a/frontend/src/components/ui/ZoomablePreviewModal.tsx
+++ b/frontend/src/components/ui/ZoomablePreviewModal.tsx
@@ -79,9 +79,12 @@ export function ZoomablePreviewModal({ src, title, onClose, gateConfirmed = true
 
   return (
     <div
+      role="button"
+      tabIndex={0}
+      aria-label="Close"
       className="fixed inset-0 z-50 flex flex-col bg-black/60"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
-      onKeyDown={(e) => e.key === "Escape" && onClose()}
+      onKeyDown={(e) => { if (e.key === "Escape" || e.key === "Enter" || e.key === " ") onClose(); }}
     >
       <div className="flex flex-col w-full h-full max-w-7xl mx-auto bg-background shadow-xl rounded-none sm:rounded-lg sm:my-6 sm:h-[calc(100vh-3rem)] overflow-hidden">
 

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1687,15 +1687,14 @@ function FeedbackTab() {
       {/* Detail modal */}
       {detail && (
         <div
+          role="button"
+          tabIndex={0}
+          aria-label="Close"
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
-          onClick={() => setDetail(null)}
-          onKeyDown={(e) => e.key === "Escape" && setDetail(null)}
+          onClick={(e) => { if (e.target === e.currentTarget) setDetail(null); }}
+          onKeyDown={(e) => { if (e.key === "Escape" || e.key === "Enter" || e.key === " ") setDetail(null); }}
         >
-          <div
-            className="w-full max-w-lg rounded-lg border border-border bg-background shadow-xl p-6 space-y-4 max-h-[80vh] overflow-y-auto"
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => { e.stopPropagation(); if (e.key === "Escape") setDetail(null); }}
-          >
+          <div className="w-full max-w-lg rounded-lg border border-border bg-background shadow-xl p-6 space-y-4 max-h-[80vh] overflow-y-auto">
             <div className="flex items-center justify-between">
               <h3 className="font-semibold">
                 {SUBMISSION_TYPE_LABELS[detail.submission_type as SubmissionType] ?? detail.submission_type}

--- a/frontend/src/pages/SuperuserPage.tsx
+++ b/frontend/src/pages/SuperuserPage.tsx
@@ -1798,8 +1798,15 @@ function ConfigFieldControl({
   if (showMasked) {
     return (
       <div
+        role="button"
+        tabIndex={0}
         className={`${CONFIG_INPUT_CLS} text-muted-foreground cursor-text select-none`}
         onClick={() => setEditingFields((prev) => new Set([...prev, field]))}
+        onKeyDown={(e) => {
+          if (e.key !== "Enter" && e.key !== " ") return;
+          e.preventDefault();
+          setEditingFields((prev) => new Set([...prev, field]));
+        }}
         title="Click to change"
       >
         {state?.secret_prefix ? state.secret_prefix + "••••••••" : "••••••••"}


### PR DESCRIPTION
## Summary

Closes #1064 (`typescript:S6848` + `typescript:S6847`, 27 findings total). Last of 3 planned PRs — see #1095 (yarn) and #1096 (project). Covers the remaining 9 findings.

| File | Findings | Notes |
| --- | --- | --- |
| `Sidebar.tsx` | 1 | Mobile nav backdrop — childless sibling div, simplest case. |
| `ZoomablePreviewModal.tsx` | 1 | Already used `target===currentTarget`; just needed `role`/`tabIndex` added. |
| `CatalogRequestButton.tsx` | 2 | Backdrop pair; preserves the `mutation.isPending` guard blocking close mid-submit. |
| `FeedbackModal.tsx` | 2 | Backdrop pair (also has its own document-level Escape listener, unaffected). |
| `AdminPage.tsx` | 2 | Feedback detail modal backdrop pair. |
| `SuperuserPage.tsx:1800` | 1 | Not a modal — the masked-config-value "click to change" element (reported as `S1082` when originally scoped under #1087, now correctly attributed to `S6848`; deferred here per #1087's own PR notes). Fixed with the same `role="button"`/`tabIndex=0`/`onKeyDown` pattern already proven on the suggestion lists in #1095. |

## A note on Escape-key reliability

While verifying `AdminPage`'s detail modal live, I found that pressing Escape **immediately** after clicking its trigger button doesn't close it — focus stays on the trigger button (outside the backdrop), and the backdrop's `onKeyDown` only fires on bubbled events from focused descendants.

This is a **pre-existing gap, not a regression** — the original code had the identical bubbling-only `onKeyDown` before this PR. It happens to "work" in a couple of the other modals fixed across this 3-PR batch only because those specific modals coincidentally auto-focus an input inside the backdrop on open (e.g. `EditColorwayModal`'s rename field) — not because of anything this fix added.

The behavior actually required by these SonarCloud findings — the backdrop being directly reachable via Tab and operable via Enter/Space — is verified working correctly (confirmed live: focusing the backdrop directly and pressing Enter closes the modal). Full Escape-reliability everywhere would need a document-level keydown listener added consistently across every backdrop modal in the app — a broader change than these 27 findings call for. Flagging it here in case it's worth a dedicated follow-up issue; happy to open one if so.

## Verification

Rebuilt the Docker frontend/backend/worker stack and ran ad hoc Playwright scripts (not committed) against the eqaadmin account:

- [x] `FeedbackModal`: Escape closes it, click-outside closes it
- [x] `AdminPage` detail modal: backdrop is directly Tab-focusable, Enter closes it, click-outside closes it
- [x] `tsc -b --noEmit` clean
- [x] `eslint` clean
- [x] Docker build (frontend + backend) clean

No backend changes in this PR. `SuperuserPage.tsx` requires a superuser-role test account not currently wired into the e2e harness, so it wasn't driven through the UI directly — its fix reuses the identical, already-proven suggestion-list pattern from #1095.