### PR TITLE
fix: associate form labels with their controls — NewLoomModal (#1062)

### DIFF
--- a/frontend/src/components/looms/NewLoomModal.tsx
+++ b/frontend/src/components/looms/NewLoomModal.tsx
@@ -288,8 +288,9 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
           {/* ── Search (visible in search and catalog modes) ── */}
           {mode !== "manual" && (
             <div ref={searchRef} className="relative">
-              <label className="mb-1 block text-sm font-medium">Find your loom</label>
+              <label htmlFor="loom-search" className="mb-1 block text-sm font-medium">Find your loom</label>
               <input
+                id="loom-search"
                 className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                 value={searchQuery}
                 onChange={(e) => {
@@ -419,9 +420,10 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
                 <div className="grid grid-cols-2 gap-3">
                   {showsShafts(loomType) && (
                     <div>
-                      <label className="mb-1 block text-sm font-medium">Shafts</label>
+                      <label htmlFor="loom-shafts-catalog" className="mb-1 block text-sm font-medium">Shafts</label>
                       {shaftOptions && shaftOptions.length > 1 ? (
                         <select
+                          id="loom-shafts-catalog"
                           className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                           value={numShafts}
                           onChange={(e) => handleShaftOptionChange(e.target.value)}
@@ -441,7 +443,7 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
                   )}
                   {showsTreadles(loomType) && (
                     <div>
-                      <label className="mb-1 block text-sm font-medium">Treadles</label>
+                      <span className="mb-1 block text-sm font-medium">Treadles</span>
                       <p className="rounded-md border bg-muted/40 px-3 py-2 text-sm text-foreground">
                         {numTreadles}
                       </p>
@@ -453,10 +455,11 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
               {/* Heddles (rigid heddle / other) */}
               {showsHeddles(loomType) && (
                 <div>
-                  <label className="mb-1 block text-sm font-medium">
+                  <label htmlFor="loom-heddles-catalog" className="mb-1 block text-sm font-medium">
                     Heddles (optional)
                   </label>
                   <input
+                    id="loom-heddles-catalog"
                     type="number"
                     min={1}
                     className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
@@ -469,11 +472,12 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
               {/* Weaving width — paired cm/in dropdown */}
               {loomType !== "inkle" && (
                 <div>
-                  <label className="mb-1 block text-sm font-medium">
+                  <label htmlFor="loom-width-catalog" className="mb-1 block text-sm font-medium">
                     Weaving width
                   </label>
                   {widthOptions.length > 0 ? (
                     <select
+                      id="loom-width-catalog"
                       className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                       value={weavingWidth}
                       onChange={(e) => {
@@ -494,6 +498,7 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
                   ) : (
                     <div className="flex gap-2">
                       <input
+                        id="loom-width-catalog"
                         type="number"
                         min={0}
                         step="0.1"
@@ -521,8 +526,9 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
           {mode === "manual" && (
             <>
               <div>
-                <label className="mb-1 block text-sm font-medium">Loom type</label>
+                <label htmlFor="loom-type" className="mb-1 block text-sm font-medium">Loom type</label>
                 <select
+                  id="loom-type"
                   className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                   value={loomType}
                   onChange={(e) => handleTypeChange(e.target.value as LoomType)}
@@ -558,8 +564,9 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
 
               <div className="grid grid-cols-2 gap-3">
                 <div>
-                  <label className="mb-1 block text-sm font-medium">Manufacturer</label>
+                  <label htmlFor="loom-manufacturer" className="mb-1 block text-sm font-medium">Manufacturer</label>
                   <input
+                    id="loom-manufacturer"
                     className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                     value={manufacturer}
                     onChange={(e) => setManufacturer(e.target.value)}
@@ -568,8 +575,9 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
                   />
                 </div>
                 <div>
-                  <label className="mb-1 block text-sm font-medium">Model</label>
+                  <label htmlFor="loom-model" className="mb-1 block text-sm font-medium">Model</label>
                   <input
+                    id="loom-model"
                     className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                     value={modelName}
                     onChange={(e) => setModelName(e.target.value)}
@@ -583,8 +591,9 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
                 <div className="grid grid-cols-2 gap-3">
                   {showsShafts(loomType) && (
                     <div>
-                      <label className="mb-1 block text-sm font-medium">Shafts</label>
+                      <label htmlFor="loom-shafts-manual" className="mb-1 block text-sm font-medium">Shafts</label>
                       <input
+                        id="loom-shafts-manual"
                         type="number"
                         min={1}
                         className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
@@ -596,8 +605,9 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
                   )}
                   {showsTreadles(loomType) && (
                     <div>
-                      <label className="mb-1 block text-sm font-medium">Treadles</label>
+                      <label htmlFor="loom-treadles-manual" className="mb-1 block text-sm font-medium">Treadles</label>
                       <input
+                        id="loom-treadles-manual"
                         type="number"
                         min={0}
                         className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
@@ -612,10 +622,11 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
                   )}
                   {showsHeddles(loomType) && (
                     <div>
-                      <label className="mb-1 block text-sm font-medium">
+                      <label htmlFor="loom-heddles-manual" className="mb-1 block text-sm font-medium">
                         Heddles (optional)
                       </label>
                       <input
+                        id="loom-heddles-manual"
                         type="number"
                         min={1}
                         className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
@@ -629,11 +640,12 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
 
               {loomType !== "inkle" && (
                 <div>
-                  <label className="mb-1 block text-sm font-medium">
+                  <label htmlFor="loom-width-manual" className="mb-1 block text-sm font-medium">
                     Weaving width (optional)
                   </label>
                   <div className="flex gap-2">
                     <input
+                      id="loom-width-manual"
                       type="number"
                       min={0}
                       step="0.1"
@@ -660,10 +672,11 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
           {showForm && (
             <>
               <div>
-                <label className="mb-1 block text-sm font-medium">
+                <label htmlFor="loom-serial" className="mb-1 block text-sm font-medium">
                   Serial number (optional)
                 </label>
                 <input
+                  id="loom-serial"
                   className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                   value={serialNumber}
                   onChange={(e) => setSerialNumber(e.target.value)}
@@ -672,10 +685,11 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
               </div>
 
               <div>
-                <label className="mb-1 block text-sm font-medium">
+                <label htmlFor="loom-effective-date" className="mb-1 block text-sm font-medium">
                   Configuration as of
                 </label>
                 <input
+                  id="loom-effective-date"
                   type="date"
                   className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                   value={effectiveDate}
@@ -685,11 +699,12 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
               </div>
 
               <div>
-                <label className="mb-1 block text-sm font-medium">
+                <label htmlFor="loom-warp-waste" className="mb-1 block text-sm font-medium">
                   Warp waste (optional)
                 </label>
                 <div className="flex gap-2">
                   <input
+                    id="loom-warp-waste"
                     type="number"
                     min={0}
                     step="0.1"
@@ -710,10 +725,11 @@ export function NewLoomModal({ onSuccess, onClose }: Props) {
               </div>
 
               <div>
-                <label className="mb-1 block text-sm font-medium">
+                <label htmlFor="loom-notes" className="mb-1 block text-sm font-medium">
                   Notes (optional)
                 </label>
                 <textarea
+                  id="loom-notes"
                   className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                   value={notes}
                   onChange={(e) => setNotes(e.target.value)}


### PR DESCRIPTION
## Summary

Part of #1062 (`typescript:S6853`, 74 findings total). First of several planned PRs — one per modal/small-group given the volume, starting with `NewLoomModal.tsx`, the largest file (16 findings), per the issue's own suggestion.

`htmlFor`/`id` pairs added for all 16 fields across search, catalog, and manual modes, plus the shared fields (serial number, effective date, warp waste, notes).

## Two fields needed special handling

- **Shafts (catalog mode)** conditionally renders either a `<select>` (multiple catalog options) or a read-only `<p>` (single fixed value). Gave the label a stable `htmlFor` and only the `<select>` branch an `id` — when the read-only branch renders, the label's for-reference points at nothing (same as it did before this fix), which is a no-op for screen readers, not a regression.
- **Treadles (catalog mode)** is always a read-only `<p>` display, never an editable control. Demoted its `<label>` to a plain `<span>` instead of adding a nonsensical `htmlFor`, since there's no control to associate it with.

## Verification

Rebuilt the Docker frontend/backend/worker stack and ran an ad hoc Playwright script (not committed) against the eqauser account:

- [x] Every manual-mode field (Loom type, Manufacturer, Model, Shafts, Serial number, Configuration as of, Notes) is reachable via Playwright's `getByLabel()` — this locator only resolves through a real label/control association, so a successful fill is direct proof the fix works, not just that the `id`/`htmlFor` strings match syntactically
- [x] Full golden path (fill all fields, submit) verified working end-to-end
- [x] `tsc -b --noEmit` clean
- [x] `eslint` clean
- [x] Docker build (frontend + backend) clean

No backend changes in this PR.