### PR TITLE
fix: associate form labels with their controls — EditLoomModal, AddVersionModal (#1062)

### DIFF
--- a/frontend/src/components/looms/AddVersionModal.tsx
+++ b/frontend/src/components/looms/AddVersionModal.tsx
@@ -63,8 +63,9 @@ export function AddVersionModal({ loomId, loomType, onSuccess, onClose }: Props)
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="mb-1 block text-sm font-medium">Configuration name (optional)</label>
+            <label htmlFor="version-name" className="mb-1 block text-sm font-medium">Configuration name (optional)</label>
             <input
+              id="version-name"
               className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
               value={versionName}
               onChange={(e) => setVersionName(e.target.value)}
@@ -73,8 +74,9 @@ export function AddVersionModal({ loomId, loomType, onSuccess, onClose }: Props)
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium">Effective date</label>
+            <label htmlFor="version-effective-date" className="mb-1 block text-sm font-medium">Effective date</label>
             <input
+              id="version-effective-date"
               type="date"
               className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
               value={effectiveDate}
@@ -84,8 +86,9 @@ export function AddVersionModal({ loomId, loomType, onSuccess, onClose }: Props)
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium">Description (optional)</label>
+            <label htmlFor="version-description" className="mb-1 block text-sm font-medium">Description (optional)</label>
             <input
+              id="version-description"
               className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
@@ -97,8 +100,9 @@ export function AddVersionModal({ loomId, loomType, onSuccess, onClose }: Props)
             <div className="grid grid-cols-3 gap-3">
               {showsShafts(loomType) && (
                 <div>
-                  <label className="mb-1 block text-sm font-medium">Shafts</label>
+                  <label htmlFor="version-shafts" className="mb-1 block text-sm font-medium">Shafts</label>
                   <input
+                    id="version-shafts"
                     type="number"
                     min={1}
                     className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
@@ -110,8 +114,9 @@ export function AddVersionModal({ loomId, loomType, onSuccess, onClose }: Props)
               )}
               {showsTreadles(loomType) && (
                 <div>
-                  <label className="mb-1 block text-sm font-medium">Treadles</label>
+                  <label htmlFor="version-treadles" className="mb-1 block text-sm font-medium">Treadles</label>
                   <input
+                    id="version-treadles"
                     type="number"
                     min={0}
                     className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
@@ -123,8 +128,9 @@ export function AddVersionModal({ loomId, loomType, onSuccess, onClose }: Props)
               )}
               {showsHeddles(loomType) && (
                 <div>
-                  <label className="mb-1 block text-sm font-medium">Heddles (optional)</label>
+                  <label htmlFor="version-heddles" className="mb-1 block text-sm font-medium">Heddles (optional)</label>
                   <input
+                    id="version-heddles"
                     type="number"
                     min={1}
                     className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
@@ -138,9 +144,10 @@ export function AddVersionModal({ loomId, loomType, onSuccess, onClose }: Props)
 
           {showsWarpWaste(loomType) && (
             <div>
-              <label className="mb-1 block text-sm font-medium">Warp waste (optional)</label>
+              <label htmlFor="version-warp-waste" className="mb-1 block text-sm font-medium">Warp waste (optional)</label>
               <div className="flex gap-2">
                 <input
+                  id="version-warp-waste"
                   type="number"
                   min={0}
                   step="0.1"

--- a/frontend/src/components/looms/EditLoomModal.tsx
+++ b/frontend/src/components/looms/EditLoomModal.tsx
@@ -57,8 +57,9 @@ export function EditLoomModal({ loom, onSuccess, onClose }: Props) {
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="mb-1 block text-sm font-medium">Loom type</label>
+            <label htmlFor="edit-loom-type" className="mb-1 block text-sm font-medium">Loom type</label>
             <select
+              id="edit-loom-type"
               className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
               value={loomType}
               onChange={(e) => setLoomType(e.target.value as LoomType)}
@@ -78,8 +79,9 @@ export function EditLoomModal({ loom, onSuccess, onClose }: Props) {
 
           <div className="grid grid-cols-2 gap-3">
             <div>
-              <label className="mb-1 block text-sm font-medium">Manufacturer</label>
+              <label htmlFor="edit-loom-manufacturer" className="mb-1 block text-sm font-medium">Manufacturer</label>
               <input
+                id="edit-loom-manufacturer"
                 className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                 value={manufacturer}
                 onChange={(e) => setManufacturer(e.target.value)}
@@ -87,8 +89,9 @@ export function EditLoomModal({ loom, onSuccess, onClose }: Props) {
               />
             </div>
             <div>
-              <label className="mb-1 block text-sm font-medium">Model</label>
+              <label htmlFor="edit-loom-model" className="mb-1 block text-sm font-medium">Model</label>
               <input
+                id="edit-loom-model"
                 className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                 value={modelName}
                 onChange={(e) => setModelName(e.target.value)}
@@ -98,8 +101,9 @@ export function EditLoomModal({ loom, onSuccess, onClose }: Props) {
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium">Serial number</label>
+            <label htmlFor="edit-loom-serial" className="mb-1 block text-sm font-medium">Serial number</label>
             <input
+              id="edit-loom-serial"
               className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
               value={serialNumber}
               onChange={(e) => setSerialNumber(e.target.value)}
@@ -111,8 +115,9 @@ export function EditLoomModal({ loom, onSuccess, onClose }: Props) {
             <legend className="text-sm font-medium text-muted-foreground">Purchase info</legend>
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <label className="mb-1 block text-sm font-medium">Purchase date</label>
+                <label htmlFor="edit-loom-purchase-date" className="mb-1 block text-sm font-medium">Purchase date</label>
                 <input
+                  id="edit-loom-purchase-date"
                   type="date"
                   className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                   value={purchaseDate}
@@ -120,8 +125,9 @@ export function EditLoomModal({ loom, onSuccess, onClose }: Props) {
                 />
               </div>
               <div>
-                <label className="mb-1 block text-sm font-medium">Purchase price</label>
+                <label htmlFor="edit-loom-purchase-price" className="mb-1 block text-sm font-medium">Purchase price</label>
                 <input
+                  id="edit-loom-purchase-price"
                   type="number"
                   min={0}
                   step="0.01"
@@ -133,8 +139,9 @@ export function EditLoomModal({ loom, onSuccess, onClose }: Props) {
               </div>
             </div>
             <div>
-              <label className="mb-1 block text-sm font-medium">Purchased from</label>
+              <label htmlFor="edit-loom-vendor" className="mb-1 block text-sm font-medium">Purchased from</label>
               <input
+                id="edit-loom-vendor"
                 className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                 value={vendor}
                 onChange={(e) => setVendor(e.target.value)}
@@ -144,8 +151,9 @@ export function EditLoomModal({ loom, onSuccess, onClose }: Props) {
           </fieldset>
 
           <div>
-            <label className="mb-1 block text-sm font-medium">Notes</label>
+            <label htmlFor="edit-loom-notes" className="mb-1 block text-sm font-medium">Notes</label>
             <textarea
+              id="edit-loom-notes"
               className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
               value={notes}
               onChange={(e) => setNotes(e.target.value)}


### PR DESCRIPTION
## Summary

Part of #1062 (\`typescript:S6853\`, 74 findings total). Fourth of several planned PRs — see #1099 (NewLoomModal), #1100 (AdminPage), #1101 (CreateProjectModal). All 15 findings across two loom-equipment modals — batched together since both are small, thematically related, and none of the fields are conditionally-rendered controls (unlike NewLoomModal/CreateProjectModal), so this is a mechanically straightforward \`htmlFor\`/\`id\` pass.

- **\`EditLoomModal.tsx\`** (8): Loom type, Manufacturer, Model, Serial number, Purchase date, Purchase price, Purchased from, Notes.
- **\`AddVersionModal.tsx\`** (7): Configuration name, Effective date, Description, Shafts, Treadles, Heddles, Warp waste.

## Verification

Rebuilt the Docker frontend/backend/worker stack and ran an ad hoc Playwright script (not committed) against the eqauser account:

- [x] All 15 fields across both modals reachable via Playwright's \`getByLabel()\` — this locator only resolves through a real label/control association
- [x] Cancelled rather than saved in both modals to avoid mutating existing loom data
- [x] \`tsc -b --noEmit\` clean
- [x] \`eslint\` clean
- [x] Docker build (frontend + backend) clean

No backend changes in this PR.