### PR TITLE
fix: associate form labels with their controls — LinkToCatalogModal, CloneVersionModal (#1062)

### DIFF
--- a/frontend/src/components/looms/CloneVersionModal.tsx
+++ b/frontend/src/components/looms/CloneVersionModal.tsx
@@ -52,8 +52,9 @@ export function CloneVersionModal({ loomId, source, onSuccess, onClose }: Props)
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="mb-1 block text-sm font-medium">Configuration name (optional)</label>
+            <label htmlFor="clone-version-name" className="mb-1 block text-sm font-medium">Configuration name (optional)</label>
             <input
+              id="clone-version-name"
               className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
               value={name}
               onChange={(e) => setName(e.target.value)}
@@ -62,8 +63,9 @@ export function CloneVersionModal({ loomId, source, onSuccess, onClose }: Props)
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium">Effective date</label>
+            <label htmlFor="clone-version-effective-date" className="mb-1 block text-sm font-medium">Effective date</label>
             <input
+              id="clone-version-effective-date"
               type="date"
               className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
               value={effectiveDate}
@@ -73,8 +75,9 @@ export function CloneVersionModal({ loomId, source, onSuccess, onClose }: Props)
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium">Description (optional)</label>
+            <label htmlFor="clone-version-description" className="mb-1 block text-sm font-medium">Description (optional)</label>
             <input
+              id="clone-version-description"
               className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
               value={description}
               onChange={(e) => setDescription(e.target.value)}

--- a/frontend/src/components/looms/LinkToCatalogModal.tsx
+++ b/frontend/src/components/looms/LinkToCatalogModal.tsx
@@ -349,8 +349,9 @@ export function LinkToCatalogModal({ loom, version, onSuccess, onClose }: Props)
         {/* ── Step: search ── */}
         {step === "search" && (
           <div ref={searchContainerRef} className="relative">
-            <label className="mb-1 block text-sm font-medium">Search loom catalog</label>
+            <label htmlFor="link-catalog-search" className="mb-1 block text-sm font-medium">Search loom catalog</label>
             <input
+              id="link-catalog-search"
               type="search"
               className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
               value={displayQuery}
@@ -430,9 +431,10 @@ export function LinkToCatalogModal({ loom, version, onSuccess, onClose }: Props)
 
             {showsShafts(newLoomType) && shaftOptions.length > 0 && (
               <div>
-                <label className="mb-1 block text-sm font-medium">Shafts</label>
+                <label htmlFor="link-catalog-shafts" className="mb-1 block text-sm font-medium">Shafts</label>
                 {shaftOptions.length > 1 ? (
                   <select
+                    id="link-catalog-shafts"
                     className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                     value={selectedShaftIdx}
                     onChange={(e) => setSelectedShaftIdx(Number(e.target.value))}
@@ -453,7 +455,7 @@ export function LinkToCatalogModal({ loom, version, onSuccess, onClose }: Props)
 
             {showsTreadles(newLoomType) && derivedTreadles != null && (
               <div>
-                <label className="mb-1 block text-sm font-medium">Treadles</label>
+                <span className="mb-1 block text-sm font-medium">Treadles</span>
                 <p className="rounded-md border bg-muted/40 px-3 py-2 text-sm">
                   {derivedTreadles}
                 </p>
@@ -462,9 +464,10 @@ export function LinkToCatalogModal({ loom, version, onSuccess, onClose }: Props)
 
             {widthOptions.length > 0 && (
               <div>
-                <label className="mb-1 block text-sm font-medium">Weaving width</label>
+                <label htmlFor="link-catalog-width" className="mb-1 block text-sm font-medium">Weaving width</label>
                 {widthOptions.length > 1 ? (
                   <select
+                    id="link-catalog-width"
                     className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                     value={selectedWidthIdx}
                     onChange={(e) => setSelectedWidthIdx(Number(e.target.value))}


### PR DESCRIPTION
## Summary

Part of #1062 (\`typescript:S6853\`, 74 findings total). Fifth of several planned PRs — see #1099, #1100, #1101, #1102. All 7 findings across two more loom-equipment modals, batched together.

- **\`CloneVersionModal.tsx\`** (3): Configuration name, Effective date, Description — all straightforward.
- **\`LinkToCatalogModal.tsx\`** (4): Search loom catalog (straightforward), Shafts and Weaving width (same conditional select-vs-read-only-\`<p>\` pattern as NewLoomModal's Shafts field — \`htmlFor\` added to the label, \`id\` added only to the \`<select>\` branch), and Treadles (always a read-only \`<p>\`, label demoted to \`<span>\` since there's no control to associate — same as NewLoomModal's Treadles field).

## Verification

Rebuilt the Docker frontend/backend/worker stack and ran an ad hoc Playwright script (not committed) against the eqauser account:

- [x] Search loom catalog field and all three CloneVersionModal fields reachable via Playwright's \`getByLabel()\` — this locator only resolves through a real label/control association
- [x] Cancelled rather than saved in both modals to avoid mutating existing loom data
- [x] \`tsc -b --noEmit\` clean
- [x] \`eslint\` clean
- [x] Docker build (frontend + backend) clean

No backend changes in this PR.