### PR TITLE
fix: associate form labels with their controls — small forms batch (#1062)

### DIFF
--- a/frontend/src/components/FeedbackModal.tsx
+++ b/frontend/src/components/FeedbackModal.tsx
@@ -140,8 +140,8 @@ export function FeedbackModal({ onClose }: Props) {
         {!submitted && user && (
           <form onSubmit={handleSubmit} className="space-y-4">
             {/* Type selector */}
-            <div>
-              <label className="mb-1.5 block text-sm font-medium">Type</label>
+            <fieldset>
+              <legend className="mb-1.5 block text-sm font-medium">Type</legend>
               <div className="flex gap-2 flex-wrap">
                 {(Object.keys(SUBMISSION_TYPE_LABELS) as SubmissionType[]).map((t) => (
                   <button
@@ -158,14 +158,15 @@ export function FeedbackModal({ onClose }: Props) {
                   </button>
                 ))}
               </div>
-            </div>
+            </fieldset>
 
             {/* Subject */}
             <div>
-              <label className="mb-1 block text-sm font-medium">
+              <label htmlFor="feedback-subject" className="mb-1 block text-sm font-medium">
                 Subject <span className="text-muted-foreground font-normal">(optional)</span>
               </label>
               <input
+                id="feedback-subject"
                 className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                 placeholder="Brief summary"
                 value={subject}
@@ -176,10 +177,11 @@ export function FeedbackModal({ onClose }: Props) {
 
             {/* Body */}
             <div>
-              <label className="mb-1 block text-sm font-medium">
+              <label htmlFor="feedback-body" className="mb-1 block text-sm font-medium">
                 Details <span className="text-destructive">*</span>
               </label>
               <textarea
+                id="feedback-body"
                 className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring resize-none"
                 rows={5}
                 placeholder={TYPE_PLACEHOLDERS[type]}

--- a/frontend/src/components/drafts/UploadWifModal.tsx
+++ b/frontend/src/components/drafts/UploadWifModal.tsx
@@ -39,8 +39,9 @@ export function UploadWifModal({ onSuccess, onClose }: Props) {
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="mb-1 block text-sm font-medium">Draft name</label>
+            <label htmlFor="wif-name" className="mb-1 block text-sm font-medium">Draft name</label>
             <input
+              id="wif-name"
               className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
               value={name}
               onChange={(e) => setName(e.target.value)}
@@ -50,8 +51,9 @@ export function UploadWifModal({ onSuccess, onClose }: Props) {
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium">Description (optional)</label>
+            <label htmlFor="wif-description" className="mb-1 block text-sm font-medium">Description (optional)</label>
             <textarea
+              id="wif-description"
               className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
@@ -61,13 +63,14 @@ export function UploadWifModal({ onSuccess, onClose }: Props) {
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium">Tags <span className="text-muted-foreground font-normal">(optional)</span></label>
-            <TagInput tags={tags} onChange={setTags} placeholder="twill, cotton…" />
+            <label htmlFor="wif-tags" className="mb-1 block text-sm font-medium">Tags <span className="text-muted-foreground font-normal">(optional)</span></label>
+            <TagInput id="wif-tags" tags={tags} onChange={setTags} placeholder="twill, cotton…" />
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium">WIF file</label>
+            <label htmlFor="wif-file" className="mb-1 block text-sm font-medium">WIF file</label>
             <input
+              id="wif-file"
               ref={fileRef}
               type="file"
               accept=".wif"

--- a/frontend/src/components/projects/AssignLoomModal.tsx
+++ b/frontend/src/components/projects/AssignLoomModal.tsx
@@ -124,8 +124,8 @@ export function AssignLoomModal({ projectId, activeProjects, projectType, draftN
 
         <div className="px-6 py-4 space-y-4">
           <div>
-            <label className="mb-1 block text-sm font-medium">Loom <span className="text-destructive">*</span></label>
-            <select className={f} value={loomId} onChange={(e) => handleLoomChange(e.target.value)}>
+            <label htmlFor="assign-loom" className="mb-1 block text-sm font-medium">Loom <span className="text-destructive">*</span></label>
+            <select id="assign-loom" className={f} value={loomId} onChange={(e) => handleLoomChange(e.target.value)}>
               <option value="">Select a loom…</option>
               {looms.filter((l) => SUPPORTED_LOOM_TYPES.has(l.loom_type)).map((l) => (
                 <option key={l.id} value={l.id}>{l.manufacturer} {l.model_name}</option>
@@ -138,8 +138,8 @@ export function AssignLoomModal({ projectId, activeProjects, projectType, draftN
 
           {loomVersions.length > 1 && (
             <div>
-              <label className="mb-1 block text-sm font-medium">Loom configuration</label>
-              <select className={f} value={loomVersionId} onChange={(e) => setLoomVersionId(e.target.value)}>
+              <label htmlFor="assign-loom-version" className="mb-1 block text-sm font-medium">Loom configuration</label>
+              <select id="assign-loom-version" className={f} value={loomVersionId} onChange={(e) => setLoomVersionId(e.target.value)}>
                 <option value="">Latest ({loomVersions.at(-1)?.name ?? `v${loomVersions.at(-1)?.version_number}`})</option>
                 {loomVersions.map((v) => (
                   <option key={v.id} value={v.id}>{v.name ?? `Version ${v.version_number}`}</option>

--- a/frontend/src/components/projects/ShareModal.tsx
+++ b/frontend/src/components/projects/ShareModal.tsx
@@ -152,8 +152,9 @@ export function ShareModal({
                 Create a read-only link — anyone with it can view this project without an account.
               </p>
               <div className="flex items-center gap-2 text-sm">
-                <label className="text-muted-foreground text-xs shrink-0">Expires after</label>
+                <label htmlFor="share-expiry" className="text-muted-foreground text-xs shrink-0">Expires after</label>
                 <select
+                  id="share-expiry"
                   value={expiryDays}
                   onChange={(e) => setExpiryDays(e.target.value)}
                   className="rounded border border-border bg-background px-2 py-1 text-xs"

--- a/frontend/src/components/ui/TagInput.tsx
+++ b/frontend/src/components/ui/TagInput.tsx
@@ -13,9 +13,10 @@ interface Props {
   readonly onChange: (tags: string[]) => void;
   readonly placeholder?: string;
   readonly disabled?: boolean;
+  readonly id?: string;
 }
 
-export function TagInput({ tags, onChange, placeholder = "Add a tag…", disabled = false }: Props) {
+export function TagInput({ tags, onChange, placeholder = "Add a tag…", disabled = false, id }: Props) {
   const [input, setInput] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -63,6 +64,7 @@ export function TagInput({ tags, onChange, placeholder = "Add a tag…", disable
       ))}
       {!disabled && (
         <input
+          id={id}
           ref={inputRef}
           value={input}
           onChange={(e) => setInput(e.target.value.replace(",", ""))}

--- a/frontend/src/components/yarn/CloneYarnModal.tsx
+++ b/frontend/src/components/yarn/CloneYarnModal.tsx
@@ -45,8 +45,9 @@ export function CloneYarnModal({ yarn, onSuccess, onClose }: Props) {
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="mb-1 block text-sm font-medium">Color name</label>
+            <label htmlFor="clone-color-name" className="mb-1 block text-sm font-medium">Color name</label>
             <input
+              id="clone-color-name"
               className={f}
               value={colorName}
               onChange={(e) => setColorName(e.target.value)}
@@ -55,8 +56,8 @@ export function CloneYarnModal({ yarn, onSuccess, onClose }: Props) {
             />
           </div>
 
-          <div>
-            <label className="mb-1 block text-sm font-medium">Color swatch</label>
+          <fieldset>
+            <legend className="mb-1 block text-sm font-medium">Color swatch</legend>
             <div className="flex items-center gap-2 pt-1">
               <input
                 type="checkbox"
@@ -69,7 +70,7 @@ export function CloneYarnModal({ yarn, onSuccess, onClose }: Props) {
                 <ColorPicker value={colorHex} onChange={setColorHex} />
               )}
             </div>
-          </div>
+          </fieldset>
 
           {error && <p className="text-sm text-destructive">{error}</p>}
 

--- a/frontend/src/pages/SuperuserPage.tsx
+++ b/frontend/src/pages/SuperuserPage.tsx
@@ -216,8 +216,9 @@ function EulaTab() {
         </p>
 
         <div className="space-y-1">
-          <label className="text-xs font-medium">Version string</label>
+          <label htmlFor="eula-version" className="text-xs font-medium">Version string</label>
           <input
+            id="eula-version"
             className={`w-full rounded border bg-background px-3 py-1.5 text-sm ${version && !versionValid ? "border-destructive" : ""}`}
             placeholder="e.g. 0.4"
             value={version}
@@ -229,8 +230,9 @@ function EulaTab() {
         </div>
 
         <div className="space-y-1">
-          <label className="text-xs font-medium">Effective date</label>
+          <label htmlFor="eula-effective-date" className="text-xs font-medium">Effective date</label>
           <input
+            id="eula-effective-date"
             type="datetime-local"
             className="w-full rounded border bg-background px-3 py-1.5 text-sm"
             value={effectiveDate}
@@ -240,7 +242,7 @@ function EulaTab() {
 
         <div className="space-y-1">
           <div className="flex items-center justify-between mb-1">
-            <label className="text-xs font-medium">Body HTML</label>
+            <label htmlFor="eula-body-html" className="text-xs font-medium">Body HTML</label>
             {current && (
               <Button variant="outline" size="sm" type="button" onClick={() => {
                 const html = current.body_html.replace(/Version \d+\.\d+/, `Version ${version}`);
@@ -252,6 +254,7 @@ function EulaTab() {
             )}
           </div>
           <textarea
+            id="eula-body-html"
             className="w-full rounded border bg-background px-3 py-1.5 text-sm font-mono min-h-[240px]"
             placeholder="<p>Paste full EULA HTML here…</p>"
             value={bodyHtml}


### PR DESCRIPTION
## Summary

Closes #1062 (\`typescript:S6853\`, 74 findings total). Last of 6 planned PRs — see #1099, #1100, #1101, #1102, #1103. All 15 remaining findings across 6 small forms.

| File | Findings | Notes |
| --- | --- | --- |
| \`UploadWifModal.tsx\` | 4 | Draft name, Description straightforward. Tags uses \`TagInput\`'s id-forwarding (added alongside #1101, reapplied here since this branch forked before that merged). WIF file — the real \`<input type="file">\` is visually hidden behind a styled trigger button, labeled directly via \`htmlFor\`/\`id\` (a standard pattern; screen readers can associate a label with a hidden-but-present input). |
| \`SuperuserPage.tsx\` | 3 | Version string, Effective date, Body HTML — straightforward, single-instance admin form. |
| \`FeedbackModal.tsx\` | 3 | Subject and Details straightforward. Type is a label over a group of toggle buttons (not a single control) — converted to \`<fieldset>\`/\`<legend>\`, the same semantic pattern already used in EditLoomModal's "Purchase info" group (#1102). |
| \`AssignLoomModal.tsx\` | 2 | Loom, Loom configuration — same conditional-select pattern as CreateProjectModal (#1101). |
| \`CloneYarnModal.tsx\` | 2 | Color name straightforward. Color swatch is a label over a checkbox + conditional color picker — same fieldset/legend treatment as FeedbackModal's Type group. |
| \`ShareModal.tsx\` | 1 | Expires after — straightforward. |

## Verification

Rebuilt the Docker frontend/backend/worker stack and ran ad hoc Playwright scripts (not committed) against the eqauser account:

- [x] \`UploadWifModal\`: Draft name/Description/Tags/WIF file all reachable via Playwright's \`getByLabel()\`
- [x] \`FeedbackModal\`: Subject/Details reachable via \`getByLabel()\`, Type group reachable via \`getByRole("group")\` — only resolves through a real fieldset/legend association
- [x] \`tsc -b --noEmit\` clean
- [x] \`eslint\` clean
- [x] Docker build (frontend + backend) clean

**Gaps, noted honestly:**
- \`CloneYarnModal.tsx\` could not be exercised live — grepping the codebase confirms it isn't currently imported or rendered anywhere in the app (the \`cloneYarn\` API function it calls exists, but no UI wires this component up yet). Its fix uses the identical, already-proven patterns applied everywhere else in this PR.
- \`AssignLoomModal.tsx\` and \`ShareModal.tsx\`'s new field weren't driven through the UI this session (no planning-status project was available for the former; a timing race prevented reaching the Share button for the latter). Both reuse patterns already verified elsewhere in this batch — AssignLoomModal's fields are identical to CreateProjectModal's tested Loom/Loom-configuration fields, and ShareModal's backdrop mechanism was already verified twice in #1096.

No backend changes in this PR.